### PR TITLE
Import devenv.local.nix if it exists.

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -90,8 +90,9 @@ pkgs.writeScriptBin "devenv" ''
       cat ${examples}/$example/devenv.nix > devenv.nix 
       echo "Creating devenv.yaml"
       cat ${examples}/$example/devenv.yaml > devenv.yaml
-      echo "Appending .devenv* to .gitignore"
+      echo "Appending .devenv* and devenv.local.nix to .gitignore"
       echo ".devenv*" >> .gitignore
+      echo "devenv.local.nix" >> .gitignore
       echo "Done."
       ;;
     update)

--- a/src/flake.nix
+++ b/src/flake.nix
@@ -32,6 +32,7 @@
             ${./modules}/top-level.nix
             ./devenv.nix
             (devenv.devenv or {})
+            (if builtins.pathExists ./devenv.local.nix then ./devenv.local.nix else {})
           ] ++ (map toModule (devenv.imports or []));
         };
         config = project.config;


### PR DESCRIPTION
This allows overriding devenv.nix with changes that are local.

Think secrets, flipping flags, etc.

Fixes #37 