### PR TITLE
init: support target directory argument

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -171,7 +171,7 @@ pkgs.writeScriptBin "devenv" ''
       echo
       echo "Commands:"
       echo
-      echo "init:           Scaffold devenv.yaml, devenv.nix, and .envrc."
+      echo "init TARGET:    Scaffold devenv.yaml, devenv.nix, and .envrc inside TARGET directory."
       echo "search NAME:    Search packages matching NAME in nixpkgs input."
       echo "shell:          Activate the developer environment."
       echo "shell CMD ARGS: Run CMD with ARGS in the developer environment. Useful when scripting."

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -100,6 +100,13 @@ pkgs.writeScriptBin "devenv" ''
       fi
       ;;
     init)
+      if [ "$#" -eq "1" ]
+      then
+        target="$1"
+        mkdir -p "$target"
+        cd "$target"
+      fi
+
       # TODO: allow selecting which example and list them
       example=simple
       echo "Creating .envrc"


### PR DESCRIPTION
I started using devenv and intuitively used `devenv init myproject`, thinking it would create a new directory. It creates the files in my current directory.

This PR should add such support:

```console
$ devenv init myproject
$ cd myproject
```

I have not done full argument parsing/validation, as I wasn't sure you wanted to bother with that yet.