### PR TITLE
java: add package options

### DIFF
--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -2,24 +2,46 @@
 
 let
   cfg = config.languages.java;
-  inherit (lib) types mkEnableOption mkOption mkDefault mkIf optional;
+  inherit (lib) types mkEnableOption mkOption mkDefault mkIf mdDoc optional literalExpression;
 in
 {
   options.languages.java = {
-    enable = mkEnableOption "Enable tools for Java development.";
-    jdk.package = mkOption { type = types.package; };
+    enable = mkEnableOption "tools for Java development";
+    jdk.package = mkOption {
+      type = types.package;
+      example = pkgs.jdk8;
+      default = pkgs.jdk;
+      defaultText = literalExpression "pkgs.jdk";
+      description = mdDoc ''
+        The JDK package to use.
+        This will also become available as `JAVA_HOME`.
+      '';
+    };
     maven = {
       enable = mkEnableOption "maven";
-      package = mkOption { type = types.package; };
+      package = mkOption {
+        type = types.package;
+        defaultText = "pkgs.maven.override { jdk = cfg.jdk.package; }";
+        description = mdDoc ''
+          The maven package to use.
+          The maven package by default inherits the JDK from `languages.java.jdk.package`.
+        '';
+      };
     };
     gradle = {
       enable = mkEnableOption "gradle";
-      package = mkOption { type = types.package; };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.gradle;
+        defaultText = literalExpression "pkgs.gradle";
+        description = ''
+          The gradle package to use.
+        '';
+      };
     };
   };
 
   config = mkIf cfg.enable {
-    languages.java.jdk.package = mkDefault pkgs.jdk;
     languages.java.maven.package = mkDefault (pkgs.maven.override { jdk = cfg.jdk.package; });
     packages = (optional cfg.enable cfg.jdk.package)
       ++ (optional cfg.maven.enable cfg.maven.package)

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -7,17 +7,20 @@ in
 {
   options.languages.java = {
     enable = mkEnableOption "Enable tools for Java development.";
-    jdk.package = mkOption {
-      type = types.package;
+    jdk.package = mkOption { type = types.package; };
+    maven = {
+      enable = mkEnableOption "maven";
+      package = mkOption { type = types.package; };
     };
   };
 
   config = mkIf cfg.enable {
     languages.java.jdk.package = mkDefault pkgs.jdk;
+    languages.java.maven.package = mkDefault (pkgs.maven.override { jdk = cfg.jdk.package; });
     packages = with pkgs; [
-      maven
       gradle
-    ] ++ (optional cfg.enable cfg.jdk.package);
+    ] ++ (optional cfg.enable cfg.jdk.package)
+    ++ (optional cfg.maven.enable cfg.maven.package);
 
     enterShell = ''
       mvn -version

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -32,10 +32,10 @@ in
       enable = mkEnableOption "gradle";
       package = mkOption {
         type = types.package;
-        default = pkgs.gradle;
-        defaultText = literalExpression "pkgs.gradle";
+        defaultText = literalExpression "pkgs.gradle.override { jdk = cfg.jdk.package; }";
         description = ''
           The gradle package to use.
+          The gradle package by default inherits the JDK from `languages.java.jdk.package`.
         '';
       };
     };
@@ -43,6 +43,7 @@ in
 
   config = mkIf cfg.enable {
     languages.java.maven.package = mkDefault (pkgs.maven.override { jdk = cfg.jdk.package; });
+    languages.java.gradle.package = mkDefault (pkgs.gradle.override { java = cfg.jdk.package; });
     packages = (optional cfg.enable cfg.jdk.package)
       ++ (optional cfg.maven.enable cfg.maven.package)
       ++ (optional cfg.gradle.enable cfg.gradle.package);

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -25,9 +25,6 @@ in
       ++ (optional cfg.maven.enable cfg.maven.package)
       ++ (optional cfg.gradle.enable cfg.gradle.package);
 
-    enterShell = ''
-      mvn -version
-    '';
     env.JAVA_HOME = cfg.jdk.package.home;
   };
 }

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -22,5 +22,6 @@ in
     enterShell = ''
       mvn -version
     '';
+    env.JAVA_HOME = cfg.jdk.package.home;
   };
 }

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -12,15 +12,18 @@ in
       enable = mkEnableOption "maven";
       package = mkOption { type = types.package; };
     };
+    gradle = {
+      enable = mkEnableOption "gradle";
+      package = mkOption { type = types.package; };
+    };
   };
 
   config = mkIf cfg.enable {
     languages.java.jdk.package = mkDefault pkgs.jdk;
     languages.java.maven.package = mkDefault (pkgs.maven.override { jdk = cfg.jdk.package; });
-    packages = with pkgs; [
-      gradle
-    ] ++ (optional cfg.enable cfg.jdk.package)
-    ++ (optional cfg.maven.enable cfg.maven.package);
+    packages = (optional cfg.enable cfg.jdk.package)
+      ++ (optional cfg.maven.enable cfg.maven.package)
+      ++ (optional cfg.gradle.enable cfg.gradle.package);
 
     enterShell = ''
       mvn -version

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -7,14 +7,17 @@ in
 {
   options.languages.java = {
     enable = mkEnableOption "Enable tools for Java development.";
+    jdk.package = mkOption {
+      type = types.package;
+    };
   };
 
   config = mkIf cfg.enable {
+    languages.java.jdk.package = mkDefault pkgs.jdk;
     packages = with pkgs; [
-      gradle
-      jdk
       maven
-    ];
+      gradle
+    ] ++ (optional cfg.enable cfg.jdk.package);
 
     enterShell = ''
       mvn -version

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -2,13 +2,14 @@
 
 let
   cfg = config.languages.java;
+  inherit (lib) types mkEnableOption mkOption mkDefault mkIf optional;
 in
 {
   options.languages.java = {
-    enable = lib.mkEnableOption "Enable tools for Java development.";
+    enable = mkEnableOption "Enable tools for Java development.";
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     packages = with pkgs; [
       gradle
       jdk


### PR DESCRIPTION
Currently it is not possible to change the JDK package for Java.

When doing so it helps to run Maven and Gradle in the same JDK as defined. This is because Maven plugins may be run that sometimes need to run in the same JDK as your application. This is why it is needed to also allow redefining the Maven/Gradle packages. By default, the package is overridden to use the same JDK as the application.

Enable options were added for maven and gradle to avoid unnecessary rebuilding of these packages.

`JAVA_HOME` environment variable is defined. This helps IDEs and tools to pick the right JDK.

Lastly I took the liberty to remove the `enterShell`. It didn't seem useful to see the maven version specifically each time the shell is entered. The JDK version would be more useful.

If this is acceptable in a general sense, then I'd like to add some of the documentation to the different options.