### PR TITLE
add devenv.cachix.org to nixConfig of flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "devenv - Developer Environments";
 
+  nixConfig = {
+    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
+    extra-substituters = "https://devenv.cachix.org";
+  };
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
   inputs.flake-compat = {


### PR DESCRIPTION
This allows to simple get devshell via `nix shell github:cachix/devenv` without having to build nix.