### PR TITLE
fix: postgres not starting, because of wrong socket dir

### DIFF
--- a/src/modules/postgres.nix
+++ b/src/modules/postgres.nix
@@ -14,7 +14,7 @@ let
     initdb ${lib.concatStringsSep " " cfg.initdbArgs}
     cat >> "$PGDATA/postgresql.conf" <<EOF
       listen_addresses = '''
-      unix_socket_directories = '`pwd`/$PGDATA'
+      unix_socket_directories = '$PGDATA'
     EOF
     ${createDatabase}
   '';


### PR DESCRIPTION
- $PGDATA is already an absolute path, no need to prefix with `pwd`