### PR TITLE
Add Crystal Language

### DIFF
--- a/src/modules/languages/crystal.nix
+++ b/src/modules/languages/crystal.nix
@@ -1,0 +1,22 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.crystal;
+in
+{
+  options.languages.crystal = {
+    enable = lib.mkEnableOption "Enable tools for Crystal development.";
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = [
+      pkgs.crystal
+      pkgs.shards
+    ];
+
+    enterShell = ''
+      crystal --version
+      shards --version
+    '';
+  };
+}


### PR DESCRIPTION
This attempts to re-add crystal support. Based on #53, the compiler was missing.

Since crystal compiler support is based on nixpkgs currently building the package on some distros might fail. 

- When building on x86_64-darwin crystal 1.0 is attempted which lead to the following [make: *** [Makefile:93: compiler_spec] Illegal instruction: 4](https://gist.github.com/bcardiff/4531e4f9606692e9f531007880251cce). 
- On aarch64-darwin crystal 1.2.2 seems to be working, as long as `NIXPKGS_ALLOW_BROKEN=1` is set.
- On aarch64-linux crystal 1.2.2 seems to be working.

The latest release of crystal in nixpkg is 1.2.2, yet in https://github.com/crystal-lang/crystal is 1.6.2 .

I hope this will help to push the support of crystal in nixpkg.

If the state of the art of crystal in nixpkg is not good enough, please close the PR and we can discuss either

1. how to improve crystal in nixpkg
2. alternative routes to support the crystal compiler (maybe by a hosted flake somewhere else)?

If accepted, should I update some documentation/examples artifacts also?