### PR TITLE
Add background processes

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -98,6 +98,9 @@ pkgs.writeScriptBin "devenv" ''
         echo "" 1>&2
         kill $(cat "$DEVENV_DIR/honcho.pid")
         rm "$DEVENV_DIR/honcho.pid"
+      else
+        echo "No running processes were found." 1>&2
+        echo "" 1>&2
       fi;
     ;;
     logs)


### PR DESCRIPTION
Use `devenv up -d` to run honcho with `nohup`.

`devenv down` and `devenv logs` are also included and are analog to their `docker-compose` counterparts.