### PR TITLE
Javascript: use different node package 

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -6,11 +6,18 @@ in
 {
   options.languages.javascript = {
     enable = lib.mkEnableOption "Enable tools for JavaScript development.";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.nodejs;
+      defaultText = "pkgs.nodejs";
+      description = "The Node package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      nodejs
+      cfg.package
     ];
 
     enterShell = ''


### PR DESCRIPTION
This adds the ability to use a different node package with the javascript language enabled. I have used the same implementation as is used for Ruby.

I am not sure if this is the direction you are looking to go in to add support for different versions of packages but thought it was worth raising a PR and starting a conversation. 