### PR TITLE
language: robotframework

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -659,6 +659,38 @@ true
 ```
 
 
+## languages.robotframework.enable
+Whether to enable Enable tools for Robot Framework development..
+
+*_Type_*:
+boolean
+
+
+*_Default_*
+```
+false
+```
+
+
+*_Example_*
+```
+true
+```
+
+
+## languages.robotframework.python
+The Python package to use.
+
+*_Type_*:
+python
+
+
+*_Default_*
+```
+"pkgs.python3"
+```
+
+
 ## languages.ruby.enable
 Whether to enable Enable tools for Ruby development..
 

--- a/examples/supported-languages/devenv.nix
+++ b/examples/supported-languages/devenv.nix
@@ -22,6 +22,7 @@
   languages.purescript.enable = true;
   languages.python.enable = true;
   languages.r.enable = true;
+  languages.robotframework.enable = true;
   languages.ruby.enable = true;
   languages.rust.enable = true;
   languages.scala.enable = true;

--- a/src/modules/languages/robotframework.nix
+++ b/src/modules/languages/robotframework.nix
@@ -18,7 +18,7 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      (cfg.python.withPackages(ps: [
+      (cfg.python.withPackages (ps: [
         ps.robotframework
       ]))
     ];

--- a/src/modules/languages/robotframework.nix
+++ b/src/modules/languages/robotframework.nix
@@ -1,0 +1,30 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.robotframework;
+in
+{
+  options.languages.robotframework = {
+    enable = lib.mkEnableOption "Enable tools for Robot Framework development.";
+
+    python = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.python3;
+      defaultText = "pkgs.python3";
+      description = "The Python package to use.";
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      (cfg.python.withPackages(ps: [
+        ps.robotframework
+      ]))
+    ];
+
+    enterShell = ''
+      robot --version
+    '';
+  };
+}


### PR DESCRIPTION
Well... robotframework is based on Python, so it come with Python interpreter and could conflict with ``languages.python.enable = true`` if it has different interpreter.

For a second, I thought if robotframework should be a Python application instead of package, but it is usual for custom Robot Framework Python libraries to import some API modules from robot modules.

Of course, this gets useful in the real world only with additional packages, and Nixpkgs seems to already have a few (including geckodriver and chromedriver to be used with seleniumlibrary):

https://search.nixos.org/packages?channel=22.05type=packages&query=robotframework