### PR TITLE
fix(docs): add some whitespace under hero CTA button

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -11,3 +11,8 @@
 .image-wrapper {
     overflow: auto!important;
 }
+
+/* add some whitespace under hero CTA button */
+.md-main__inner {
+    padding-bottom: 1rem;
+}


### PR DESCRIPTION
Adds some padding under `Get Started` button to balance the whitespace.

Before & After:

![Shot_2022-11-21_10 29 55](https://user-images.githubusercontent.com/3243482/202990742-64c4c69e-e61d-4c38-8f03-8f5fabaa525c.gif)
