### PR TITLE
add devenv info command

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -137,6 +137,8 @@ pkgs.writeScriptBin "devenv" ''
       ;;
     info)
       assemble
+      $CUSTOM_NIX/bin/nix $NIX_FLAGS flake metadata | grep Inputs -A10000
+      echo
       $CUSTOM_NIX/bin/nix $NIX_FLAGS eval --raw '.#info' --impure
       ;;
     update)

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -135,6 +135,10 @@ pkgs.writeScriptBin "devenv" ''
       echo "devenv.local.nix" >> .gitignore
       echo "Done."
       ;;
+    info)
+      assemble
+      $CUSTOM_NIX/bin/nix $NIX_FLAGS eval --raw '.#info' --impure
+      ;;
     update)
       assemble
       $CUSTOM_NIX/bin/nix $NIX_FLAGS flake update
@@ -194,6 +198,7 @@ pkgs.writeScriptBin "devenv" ''
       echo "search NAME:    Search packages matching NAME in nixpkgs input."
       echo "shell:          Activate the developer environment."
       echo "shell CMD ARGS: Run CMD with ARGS in the developer environment. Useful when scripting."
+      echo "info:           Print information about the current developer environment."
       echo "update:         Update devenv.lock from devenv.yaml inputs. See http://devenv.sh/inputs/#locking-and-updating-inputs"
       echo "up:             Starts processes in foreground. See http://devenv.sh/processes"
       echo "gc:             Removes old devenv generations. See http://devenv.sh/garbage-collection"

--- a/src/flake.nix
+++ b/src/flake.nix
@@ -47,6 +47,7 @@
           ci = pkgs.runCommand "ci" {} ("ls " + toString config.ci + " && touch $out");
           procfile = config.procfile;
           procfileEnv = config.procfileEnv;
+          info = config.info;
         };
         devShell."${pkgs.system}" = config.shell;
       };

--- a/src/modules/info.nix
+++ b/src/modules/info.nix
@@ -1,0 +1,27 @@
+{ lib, config, ... }:
+
+{
+  options = {
+    info = lib.mkOption {
+      type = lib.types.lines;
+      internal = true;
+    };
+  };
+
+  # TODO: show scripts path
+  # TODO: make this pluggable so any option can be shown
+
+  config.info = ''
+    # env
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "- ${name}: ${toString value}") config.env)}
+
+    # packages
+    ${lib.concatStringsSep "\n" (builtins.map (package: "- ${package.name}") (builtins.filter (package: !(builtins.elem package.name (builtins.attrNames config.scripts))) config.packages))}
+
+    # scripts
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: script: "- ${name}") config.scripts)}
+
+    # processes
+    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: process: "- ${name}: ${process.exec}") config.processes)}
+  '';
+}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -65,6 +65,7 @@ in
     ./redis.nix
     ./mysql.nix
     ./pre-commit.nix
+    ./info.nix
     ./scripts.nix
     ./update-check.nix
   ] ++ map (name: ./. + "/languages/${name}") (builtins.attrNames (builtins.readDir ./languages));


### PR DESCRIPTION
```shell-session
$ devenv info
Inputs:
├───devenv: path:./src/modules
├───nix: github:domenkozar/nix/05c8b261e0b7848cc02c736d59316d7e02be8514
│   ├───lowdown-src: github:kristapsdz/lowdown/d2c2b44ff6c27b936ec27358a2653caaef8f73b8
│   ├───nixpkgs: github:NixOS/nixpkgs/365e1b3a859281cf11b94f87231adeabbdd878a2
│   └───nixpkgs-regression: github:NixOS/nixpkgs/215d4d0fd80ca5163643b03a33fde804a29cc1e2
├───nixpkgs: github:NixOS/nixpkgs/c6e5939c8fa2ab2230baf1378a34746e8db1aed7
└───pre-commit-hooks: github:cachix/pre-commit-hooks.nix/46fb5634676994bd333a94c8bd322eb1854ff223
    ├───flake-utils: github:numtide/flake-utils/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817
    └───nixpkgs follows input 'nixpkgs'

# env
- DEVENV_DOTFILE: /home/domen/dev/cachix/devenv/.devenv
- DEVENV_ROOT: /home/domen/dev/cachix/devenv
- DEVENV_STATE: /home/domen/dev/cachix/devenv/.devenv/state

# packages
- python3.10-pre-commit-2.20.0
- devenv
- python3.10-virtualenv-20.16.5
- python3.10-cairocffi-1.4.0
- yaml2json-1.3

# scripts
- bump-version
- generate-doc-options
- generate-languages-example
- run-devenv-tests

# processes
- build: /nix/store/hpdm9ar9vp6fiihj23lfa38z526jac9x-watchexec-1.20.6/bin/watchexec -e nix nix build
- docs: bin/mkdocs serve
```