### PR TITLE
Add elm-format when using elm

### DIFF
--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -11,12 +11,15 @@ in
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       elmPackages.elm
+      elmPackages.elm-format
       elm2nix
     ];
 
     enterShell = ''
       echo elm --version
       elm --version
+
+      which elm-format
 
       echo elm2nix --version
       which elm2nix


### PR DESCRIPTION
elm-format is widely used so I think it does not need to be configurable whether you want it or not.

I see scala includes scalafmt directly, so this follows the same pattern.
Unfortunately `elm-format --version` is not a valid option for this cli.

I'm not sure if it would be good to have a pre-commit hook to run the formatter, but this should be configurable since it's more opinionated which folders should be formatted, and at that point maybe I'm not sure what's a sensible default for devenv.