### PR TITLE
Add hivemind as a new Procfile interpreter

### DIFF
--- a/examples/hivemind/devenv.lock
+++ b/examples/hivemind/devenv.lock
@@ -1,0 +1,132 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669535121,
+        "narHash": "sha256-koZLM7oWVGrjyHnYDo7/w5qlmUn9UZUKSFNfmIjueE8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b45ec953794bb07922f0468152ad1ebaf8a084b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1668984258,
+        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1669152228,
+        "narHash": "sha256-FEDReoTLWJHXcNso7aaAlAUU7uOqIR6Hc/C/nqlfooE=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "078b0dee35e2da01334af682ec347463b70a9986",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/hivemind/devenv.nix
+++ b/examples/hivemind/devenv.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+
+{
+  process.implementation = "hivemind";
+  processes.foo.exec = "echo foo; sleep inf";
+  processes.bar.exec = "echo bar; sleep inf";
+}

--- a/examples/hivemind/devenv.yaml
+++ b/examples/hivemind/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  devenv:
+    url: path:../../src/modules
+

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -127,7 +127,7 @@ in
       '';
 
       hivemind = pkgs.writeShellScript "hivemind-up" ''
-        ${pkgs.hivemind}/bin/hivemind ${config.procfile}
+        ${pkgs.hivemind}/bin/hivemind --print-timestamps ${config.procfile}
       '';
     }.${implementation};
 

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -47,7 +47,7 @@ in
 
     process = {
       implementation = lib.mkOption {
-        type = types.enum [ "honcho" "overmind" "process-compose" ];
+        type = types.enum [ "honcho" "overmind" "process-compose" "hivemind" ];
         description = "The implementation used when performing ``devenv up``.";
         default = "honcho";
         example = "overmind";
@@ -124,6 +124,10 @@ in
         ${pkgs.process-compose}/bin/process-compose --config ${config.procfile} \
            --port $PC_HTTP_PORT \
            --tui=$PC_TUI_ENABLED
+      '';
+
+      hivemind = pkgs.writeShellScript "hivemind-up" ''
+        ${pkgs.hivemind}/bin/hivemind ${config.procfile}
       '';
     }.${implementation};
 


### PR DESCRIPTION
This PR adds [hivemind](https://github.com/DarthSim/hivemind) as a new option to run processes defined in a Procfile.

`hivemind` is the "little brother" of `overmind` and works without running processes in a tmux session.

I have tested this PR by creating a new example in the `examples` directory and running `devenv up` there, which correctly starts two processes with hivemind.