### PR TITLE
add v language support

### DIFF
--- a/src/modules/languages/v.nix
+++ b/src/modules/languages/v.nix
@@ -1,0 +1,27 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.v;
+in
+{
+  options.languages.v = {
+    enable = lib.mkEnableOption "Enable tools for v development.";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.vlang;
+      defaultText = "pkgs.vlang";
+      description = "The v package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = [
+      cfg.package
+    ];
+
+    enterShell = ''
+      v --version
+    '';
+  };
+}


### PR DESCRIPTION
This PR adds support for [v](https://vlang.io/)!

Also, I wasn't sure if we'd be okay with the filename `v.nix` or if we wanted to go with `vlang.nix` to match the nixpkgs naming.