### PR TITLE
Set default path for ruby bundler

### DIFF
--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -21,6 +21,8 @@ in
       bundler
     ];
 
+    env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
+
     enterShell = ''
       ruby --version
 


### PR DESCRIPTION
Set path by default to `env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";`
It could be changed in the `devenv.nix` file. Example:
```
{ pkgs, config, nixpkgs-ruby, ... }:

{
  env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
  packages = [ pkgs.imagemagick pkgs.pkg-config ];
  languages.ruby.enable = true;
  languages.ruby.package = nixpkgs-ruby.lib.mkRuby { inherit pkgs; rubyVersion = "2.6.6"; };
}
```