### PR TITLE
improve postgres

### DIFF
--- a/src/modules/postgres.nix
+++ b/src/modules/postgres.nix
@@ -83,8 +83,6 @@ in
     env.PGHOST = config.env.PGDATA;
     env.PGPORT = cfg.port;
 
-    scripts."psql-devenv".exec = "${cfg.package}/bin/psql $@";
-
     processes.postgres = {
       exec = "${startScript}/bin/start-postgres";
 

--- a/src/modules/postgres.nix
+++ b/src/modules/postgres.nix
@@ -45,6 +45,7 @@ in
       type = types.str;
       description = "Listen address";
       default = "";
+      example = "127.0.0.1";
     };
 
     port = lib.mkOption {


### PR DESCRIPTION
Config was updated only once

Added two new options

```nix
postgres.listen_addresses = "127.0.0.1";
postgres.port = 5000;
```

By default, postgres still listens socket only with default port. With that options you can enable tcp again.

Also configured the default env vars for postgres to `psql` by default works https://www.postgresql.org/docs/current/libpq-envars.html 