### PR TITLE
fix: mysql init with userland my.cnf

### DIFF
--- a/src/modules/mysql.nix
+++ b/src/modules/mysql.nix
@@ -43,7 +43,7 @@ let
                 cat ${database.schema}/mysql-databases/*.sql
             fi
             ''}
-          ) | ${cfg.package}/bin/mysql --socket=$MYSQL_UNIX_PORT -u root -N
+          ) | ${cfg.package}/bin/mysql ${mysqlOptions} -u root -N
       fi
     '') cfg.initialDatabases}
 


### PR DESCRIPTION
When the user have an `/etc/my.cnf` the mysql command will read it and pass default parameters like username and password

This will break the mysql server. So I added the forgotten parameter like on all other commands to here