### PR TITLE
add wiremock module

### DIFF
--- a/examples/wiremock/devenv.lock
+++ b/examples/wiremock/devenv.lock
@@ -1,0 +1,132 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670751203,
+        "narHash": "sha256-XdoH1v3shKDGlrwjgrNX/EN8s3c+kQV7xY6cLCE8vcI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64e0bf055f9d25928c31fb12924e59ff8ce71e60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1668984258,
+        "narHash": "sha256-0gDMJ2T3qf58xgcSbYoXiRGUkPWmKyr5C3vcathWhKs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf63ade6f74bbc9d2a017290f1b2e33e8fbfa70a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1670413394,
+        "narHash": "sha256-M7sWqrKtOqUv9euX1t3HCxis8cPy9MNiZxQmUf0KF1o=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "1303a1a76e9eb074075bfe566518c413f6fc104e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/wiremock/devenv.nix
+++ b/examples/wiremock/devenv.nix
@@ -1,0 +1,20 @@
+{ ... }:
+
+{
+  services.wiremock = {
+    enable = true;
+    mappings = [
+      {
+        request = {
+          method = "GET";
+          url = "/";
+        };
+        response = {
+          status = 200;
+          headers."Content-Type" = "text/plain";
+          body = "Hello World!";
+        };
+      }
+    ];
+  };
+}

--- a/examples/wiremock/devenv.yaml
+++ b/examples/wiremock/devenv.yaml
@@ -1,0 +1,5 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-unstable
+  devenv:
+    url: path:../../src/modules

--- a/src/modules/services/wiremock.nix
+++ b/src/modules/services/wiremock.nix
@@ -1,0 +1,95 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let
+  cfg = config.services.wiremock;
+  mappingsFormat = pkgs.formats.json { };
+  rootDir = pkgs.linkFarm "wiremock-root" [
+    {
+      name = "mappings/mappings.json";
+      path = mappingsFormat.generate "mappings.json" {
+        mappings = cfg.mappings;
+      };
+    }
+  ];
+in
+{
+  options.services.wiremock = {
+    enable = mkEnableOption "wiremock";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.wiremock;
+      description = mdDoc ''
+        Which package of wiremock to use.
+      '';
+    };
+    port = mkOption {
+      type = types.int;
+      default = 8080;
+      description = ''
+        The port number for the HTTP server to listen on.
+      '';
+    };
+    disableBanner = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to disable print banner logo
+      '';
+    };
+    verbose = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to log verbosely to stdout
+      '';
+    };
+    mappings = mkOption {
+      type = mappingsFormat.type;
+      description = ''
+        The mappings to mock.
+        See the JSON examples on https://wiremock.org/docs/stubbing/ for more information.
+      '';
+      default = [ ];
+      example = [
+        {
+          request = {
+            method = "GET";
+            url = "/body";
+          };
+          response = {
+            status = 200;
+            headers."Content-Type" = "text/plain";
+            body = "Literal text to put in the body";
+          };
+        }
+        {
+          request = {
+            method = "GET";
+            url = "/json";
+          };
+          response = {
+            status = 200;
+            jsonBody = {
+              someField = "someValue";
+            };
+          };
+        }
+      ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    processes.wiremock.exec =
+      let
+        arguments = [
+          "--port ${toString cfg.port}"
+          "--root-dir ${rootDir}"
+        ]
+        ++ lib.optional cfg.disableBanner "--disable-banner"
+        ++ lib.optional cfg.verbose "--verbose";
+      in
+      ''
+        ${cfg.package}/bin/wiremock ${lib.concatStringsSep " " arguments} "$@"
+      '';
+  };
+}


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/203800, wiremock was added to nixpkgs. This is a HTTP(S) mock server to create a HTTP API endpoints. Useful for projects that need one or more other HTTP services to operate.

~The wiremock package is not yet on nixos-unstable, so I'll leave this PR in draft for now.~

The package is in nixpkgs-unstable and nixos-unstable now.