### PR TITLE
feat: add blackfire support

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -1,5 +1,135 @@
 # devenv.nix options
 
+## blackfire.client-id
+Sets the client id used to authenticate with Blackfire
+You can find your personal client-id at https://blackfire.io/my/settings/credentials
+
+
+*_Type_*:
+string
+
+
+*_Default_*
+```
+""
+```
+
+
+
+
+## blackfire.client-token
+Sets the client token used to authenticate with Blackfire
+You can find your personal client-token at https://blackfire.io/my/settings/credentials
+
+
+*_Type_*:
+string
+
+
+*_Default_*
+```
+""
+```
+
+
+
+
+## blackfire.enable
+Whether to enable Blackfire profiler agent
+
+For PHP you need to install and configure the Blackfire PHP extension.
+
+<programlisting language="nix">
+languages.php.package = pkgs.php.buildEnv {
+  extensions = { all, enabled }: with all; enabled ++ [ (blackfire// { extensionName = "blackfire"; }) ];
+  extraConfig = ''
+    memory_limit = 256M
+    blackfire.agent_socket = "tcp://127.0.0.1:8307";
+  '';
+};
+</programlisting>.
+
+*_Type_*:
+boolean
+
+
+*_Default_*
+```
+false
+```
+
+
+*_Example_*
+```
+true
+```
+
+
+## blackfire.package
+Which package of blackfire to use
+
+*_Type_*:
+package
+
+
+*_Default_*
+```
+"pkgs.blackfire"
+```
+
+
+
+
+## blackfire.server-id
+Sets the server id used to authenticate with Blackfire
+You can find your personal server-id at https://blackfire.io/my/settings/credentials
+
+
+*_Type_*:
+string
+
+
+*_Default_*
+```
+""
+```
+
+
+
+
+## blackfire.server-token
+Sets the server token used to authenticate with Blackfire
+You can find your personal server-token at https://blackfire.io/my/settings/credentials
+
+
+*_Type_*:
+string
+
+
+*_Default_*
+```
+""
+```
+
+
+
+
+## blackfire.socket
+Sets the server socket path
+
+
+*_Type_*:
+string
+
+
+*_Default_*
+```
+"tcp://127.0.0.1:8307"
+```
+
+
+
+
 ## caddy.adapter
 Name of the config adapter to use.
 See https://caddyserver.com/docs/config-adapters for the full list.

--- a/src/modules/blackfire.nix
+++ b/src/modules/blackfire.nix
@@ -12,7 +12,21 @@ let
 in
 {
   options.blackfire = {
-    enable = lib.mkEnableOption (lib.mdDoc "Blackfire profiler agent");
+    enable = lib.mkEnableOption (lib.mdDoc ''
+      Blackfire profiler agent
+
+      For PHP you need to install and configure the Blackfire PHP extension.
+
+      ```nix
+      languages.php.package = pkgs.php.buildEnv {
+        extensions = { all, enabled }: with all; enabled ++ [ (blackfire// { extensionName = "blackfire"; }) ];
+        extraConfig = '''
+          memory_limit = 256M
+          blackfire.agent_socket = "${config.blackfire.socket}";
+        ''';
+      };
+      ```
+    '');
 
     client-id = lib.mkOption {
       type = lib.types.str;

--- a/src/modules/blackfire.nix
+++ b/src/modules/blackfire.nix
@@ -1,0 +1,80 @@
+{ pkgs, lib, config, ... }:
+
+let
+  cfg = config.blackfire;
+
+  configFile = pkgs.writeText "blackfire.conf" ''
+    [blackfire]
+    server-id=${cfg.server-id}
+    server-token=${cfg.server-token}
+    socket=${cfg.socket}
+  '';
+in
+{
+  options.blackfire = {
+    enable = lib.mkEnableOption (lib.mdDoc "Blackfire profiler agent");
+
+    client-id = lib.mkOption {
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        Sets the client id used to authenticate with Blackfire
+        You can find your personal client-id at https://blackfire.io/my/settings/credentials
+      '';
+      default = "";
+    };
+
+    client-token = lib.mkOption {
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        Sets the client token used to authenticate with Blackfire
+        You can find your personal client-token at https://blackfire.io/my/settings/credentials
+      '';
+      default = "";
+    };
+
+    server-id = lib.mkOption {
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        Sets the server id used to authenticate with Blackfire
+        You can find your personal server-id at https://blackfire.io/my/settings/credentials
+      '';
+      default = "";
+    };
+
+    server-token = lib.mkOption {
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        Sets the server token used to authenticate with Blackfire
+        You can find your personal server-token at https://blackfire.io/my/settings/credentials
+      '';
+      default = "";
+    };
+
+    socket = lib.mkOption {
+      type = lib.types.str;
+      default = "tcp://127.0.0.1:8307";
+      description = lib.mdDoc ''
+        Sets the server socket path
+      '';
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Which package of blackfire to use";
+      default = pkgs.blackfire;
+      defaultText = "pkgs.blackfire";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = [
+      cfg.package
+    ];
+
+    env.BLACKFIRE_AGENT_SOCKET = cfg.socket;
+    env.BLACKFIRE_CLIENT_ID = cfg.client-id;
+    env.BLACKFIRE_CLIENT_TOKEN = cfg.client-token;
+
+    processes.blackfire-agent.exec = "${cfg.package}/bin/blackfire agent:start --config=${configFile}";
+  };
+}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -33,6 +33,7 @@ in
   };
 
   imports = [
+    ./blackfire.nix
     ./caddy.nix
     ./postgres.nix
     ./redis.nix


### PR DESCRIPTION
Allows to use https://blackfire.io together with PHP. Didn't tested Go / Python profiling.

Example Bllackfire together with PHP:

```diff
{ pkgs, config, ... }:

let
  phpPackage = pkgs.php.buildEnv {
   # Will be fixed with https://github.com/NixOS/nixpkgs/pull/202934
+   extensions = { all, enabled }: with all; enabled ++ [ (blackfire// { extensionName = "blackfire"; }) ];
    extraConfig = ''
      memory_limit = 256M
+     blackfire.agent_socket = "${config.blackfire.socket}";
    '';
  };
in
{
+ blackfire.enable = true;
+ blackfire.server-id = "xxxxxxxx";
+ blackfire.server-token = "xxxxxxxx";
+ blackfire.client-id = "xxxxxxxx";
+ blackfire.client-token = "xxxxxxxx";

  languages.php.enable = true;
  languages.php.package = phpPackage;
  languages.php.fpm.pools.web = {
    settings = {
      "pm" = "dynamic";
      "pm.max_children" = 5;
      "pm.start_servers" = 2;
      "pm.min_spare_servers" = 1;
      "pm.max_spare_servers" = 5;
    };
  };

  caddy.enable = true;
  caddy.virtualHosts."http://localhost:8000" = {
    extraConfig = ''
      root * public
      php_fastcgi unix/${config.languages.php.fpm.pools.web.socket}
      file_server
    '';
  };
}
```

![image](https://user-images.githubusercontent.com/6224096/205313671-838a9a6d-c7a0-4ebc-9a27-ced42e776e28.png)
![image](https://user-images.githubusercontent.com/6224096/205313733-32466ecd-df5b-45b8-b117-b3409d36a610.png)

