### PR TITLE
fix: postgres startup if folder is missing

### DIFF
--- a/src/modules/postgres.nix
+++ b/src/modules/postgres.nix
@@ -10,17 +10,17 @@ let
     set -euo pipefail
     export PATH=${cfg.package}/bin:${pkgs.coreutils}/bin
 
+    if [[ ! -d "$PGDATA" ]]; then
+      initdb ${lib.concatStringsSep " " cfg.initdbArgs}
+      ${createDatabase}
+    fi
+
     # Setup config
     cat >> "$PGDATA/postgresql.conf" <<EOF
       listen_addresses = '${cfg.listen_addresses}'
       port = ${toString cfg.port}
       unix_socket_directories = '$PGDATA'
     EOF
-
-    # Abort if the data dir already exists
-    [[ ! -d "$PGDATA" ]] || exit 0
-    initdb ${lib.concatStringsSep " " cfg.initdbArgs}
-    ${createDatabase}
   '';
   startScript = pkgs.writeShellScriptBin "start-postgres" ''
     set -euo pipefail


### PR DESCRIPTION
the cat fails on first start as the folder is missing. I reordered the commands. Sorry 🙈 

```
After update: 16:09:09 postgres.1 | /nix/store/37c74ks31daya5p7xzjc3vdl1cf4n7j6-setup-postgres/bin/setup-postgres: line 6: .../.devenv/state/postgres/postgresql.conf: No such file or directory.
```
