### PR TITLE
Avoid duplicate instances of dependencies by using follows.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,13 @@
   };
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.pre-commit-hooks = {
+    url = "github:cachix/pre-commit-hooks.nix";
+    inputs = {
+      nixpkgs.follows = "nixpkgs";
+      flake-compat.follows = "flake-compat";
+    };
+  };
   inputs.flake-compat = {
     url = "github:edolstra/flake-compat";
     flake = false;


### PR DESCRIPTION
Currently, devenv creates a lot of extra entries in my flake.lock file, which increases download size and evaluation time.
By setting all dependencies to the same value, we can reduce this overhead.