### PR TITLE
darwin: use nix readlink explicitly

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -58,7 +58,7 @@ pkgs.writeScriptBin "devenv" ''
     echo "Building shell ..." 1>&2
     env=$($CUSTOM_NIX/bin/nix $NIX_FLAGS print-dev-env --impure --profile "$DEVENV_GC/shell")
     $CUSTOM_NIX/bin/nix-env -p "$DEVENV_GC/shell" --delete-generations old 2>/dev/null
-    ln -sf $(readlink -f "$DEVENV_GC/shell") "$GC_DIR-shell"
+    ln -sf $(${pkgs.coreutils}/bin/readlink -f "$DEVENV_GC/shell") "$GC_DIR-shell"
   }
 
   command=$1


### PR DESCRIPTION
readlink on macos does not have the same arguments as on linux. More
explicitly, it does not have `-f` as used in the devenv script.
