### PR TITLE
Add adminer

### DIFF
--- a/src/modules/adminer.nix
+++ b/src/modules/adminer.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, config, ... }:
+
+let
+  cfg = config.adminer;
+  types = lib.types;
+in
+{
+  options.adminer = {
+    enable = lib.mkEnableOption "Add adminer process.";
+
+    package = lib.mkOption {
+      type = types.package;
+      description = "Which package of adminer to use";
+      default = pkgs.adminer;
+      defaultText = "pkgs.adminer";
+    };
+
+    listen = lib.mkOption {
+      type = types.str;
+      description = "Listen address for adminer.";
+      default = "127.0.0.1:8080";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    processes.adminer.exec = "${config.languages.php.package}/bin/php ${lib.optionalString config.mysql.enable "-dmysqli.default_socket=${config.env.MYSQL_UNIX_PORT}"} -S ${cfg.listen} -t ${cfg.package} ${cfg.package}/adminer.php";
+  };
+}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -33,6 +33,7 @@ in
   };
 
   imports = [
+    ./adminer.nix
     ./blackfire.nix
     ./caddy.nix
     ./postgres.nix


### PR DESCRIPTION
Adds adminer module

With adminer is like phpmyadmin phppgadmin but in a smaller file.

Can be enabled with

```
adminer.enable = true;
```

It disallows by default accessing users without password. https://www.adminer.org/en/password/

So I added a new option ensureUsers to create additional MySQL users

```
mysql.enable = true;
mysql.ensureUsers = [
  {
    name = "devenv";
    password = "devenv";
    ensurePermissions = {
      "devenv.*" = "ALL PRIVILEGES";
    };
  }
];
```

**password** is optional and can be omited