### PR TITLE
remove version output on enterShell

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -13,9 +13,5 @@ in
     packages = with pkgs; [
       gcc
     ];
-
-    enterShell = ''
-      gcc --version
-    '';
   };
 }

--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -13,9 +13,5 @@ in
       clojure
       clojure-lsp
     ];
-
-    enterShell = ''
-      clojure --version
-    '';
   };
 }

--- a/src/modules/languages/cplusplus.nix
+++ b/src/modules/languages/cplusplus.nix
@@ -13,8 +13,5 @@ in
       cmake
       clang
     ];
-
-    enterShell = ''
-    '';
   };
 }

--- a/src/modules/languages/cue.nix
+++ b/src/modules/languages/cue.nix
@@ -19,9 +19,5 @@ in
     packages = [
       cfg.package
     ];
-
-    enterShell = ''
-      cue version
-    '';
   };
 }

--- a/src/modules/languages/dotnet.nix
+++ b/src/modules/languages/dotnet.nix
@@ -12,9 +12,5 @@ in
     packages = with pkgs; [
       dotnet-sdk
     ];
-
-    enterShell = ''
-      dotnet --version
-    '';
   };
 }

--- a/src/modules/languages/elixir.nix
+++ b/src/modules/languages/elixir.nix
@@ -21,9 +21,5 @@ in
         cfg.package
         elixir_ls
       ];
-
-      enterShell = ''
-        elixir --version
-      '';
     };
 }

--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -15,15 +15,5 @@ in
       elmPackages.elm-language-server
       elm2nix
     ];
-
-    enterShell = ''
-      echo elm --version
-      elm --version
-
-      which elm-format
-
-      echo elm2nix --version
-      which elm2nix
-    '';
   };
 }

--- a/src/modules/languages/erlang.nix
+++ b/src/modules/languages/erlang.nix
@@ -21,8 +21,5 @@ in
         cfg.package
         erlang-ls
       ];
-
-      enterShell = ''
-      '';
     };
 }

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -13,9 +13,5 @@ in
       go
       gotools
     ];
-
-    enterShell = ''
-      go version
-    '';
   };
 }

--- a/src/modules/languages/haskell.nix
+++ b/src/modules/languages/haskell.nix
@@ -15,14 +15,5 @@ in
       zlib
       hpack
     ];
-
-    enterShell = ''
-      echo stack --version
-      stack --version
-
-      cabal --version
-
-      hpack --version
-    '';
   };
 }

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -19,10 +19,5 @@ in
     packages = with pkgs; [
       cfg.package
     ];
-
-    enterShell = ''
-      echo node --version
-      node --version
-    '';
   };
 }

--- a/src/modules/languages/kotlin.nix
+++ b/src/modules/languages/kotlin.nix
@@ -13,9 +13,5 @@ in
       kotlin
       gradle
     ];
-
-    enterShell = ''
-      kotlin -version
-    '';
   };
 }

--- a/src/modules/languages/lua.nix
+++ b/src/modules/languages/lua.nix
@@ -19,9 +19,5 @@ in
     packages = [
       cfg.package
     ];
-
-    enterShell = ''
-      lua -v
-    '';
   };
 }

--- a/src/modules/languages/nim.nix
+++ b/src/modules/languages/nim.nix
@@ -20,10 +20,5 @@ in
       cfg.package
       pkgs.nimlsp
     ];
-
-    enterShell = ''
-      nim --version
-      nimlsp --version
-    '';
   };
 }

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -16,13 +16,5 @@ in
       deadnix
       nil
     ];
-
-    enterShell = ''
-      deadnix --version
-      cachix --version
-      statix --version
-      vulnix --version
-      nil --version
-    '';
   };
 }

--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -14,8 +14,5 @@ in
       pkgs.ocaml-ng.ocamlPackages.dune_3
       pkgs.ocaml-ng.ocamlPackages.ocaml-lsp
     ];
-
-    enterShell = ''
-    '';
   };
 }

--- a/src/modules/languages/perl.nix
+++ b/src/modules/languages/perl.nix
@@ -12,9 +12,5 @@ in
     packages = with pkgs; [
       perl
     ];
-
-    enterShell = ''
-      perl --version
-    '';
   };
 }

--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -237,11 +237,6 @@ in
 
     env.PHPFPMDIR = config.env.DEVENV_STATE + "/php-fpm";
 
-    enterShell = ''
-      php --version
-      composer --version
-    '';
-
     processes = mapAttrs'
       (pool: poolOpts:
         nameValuePair "phpfpm-${pool}" {

--- a/src/modules/languages/purescript.nix
+++ b/src/modules/languages/purescript.nix
@@ -25,9 +25,5 @@ in
       pkgs.purescript-psa
       pkgs.psc-package
     ];
-
-    enterShell = ''
-      purs --version
-    '';
   };
 }

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -19,9 +19,5 @@ in
     packages = with pkgs; [
       cfg.package
     ];
-
-    enterShell = ''
-      python --version
-    '';
   };
 }

--- a/src/modules/languages/r.nix
+++ b/src/modules/languages/r.nix
@@ -12,9 +12,5 @@ in
     packages = with pkgs; [
       R
     ];
-
-    enterShell = ''
-      R --version
-    '';
   };
 }

--- a/src/modules/languages/robotframework.nix
+++ b/src/modules/languages/robotframework.nix
@@ -22,9 +22,5 @@ in
         ps.robotframework
       ]))
     ];
-
-    enterShell = ''
-      robot --version
-    '';
   };
 }

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -22,11 +22,5 @@ in
     ];
 
     env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
-
-    enterShell = ''
-      ruby --version
-
-      bundler --version
-    '';
   };
 }

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -35,11 +35,6 @@ in
         cfg.packages.rustc
         cfg.packages.cargo
       ];
-
-      enterShell = ''
-        rustc --version
-        cargo --version
-      '';
     })
     (lib.mkIf (cfg.version != null) (
       let

--- a/src/modules/languages/scala.nix
+++ b/src/modules/languages/scala.nix
@@ -18,14 +18,5 @@ in
     ];
 
     languages.java.enable = true;
-
-    enterShell = ''
-      scala --version
-      scala-cli --version
-      sbt --version
-      scalafmt --version
-      echo cs version
-      cs version
-    '';
   };
 }

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -21,11 +21,5 @@ in
       terraform-ls
       tfsec
     ];
-
-    enterShell = ''
-      terraform version
-      terraform-ls --version
-      tfsec --version
-    '';
   };
 }

--- a/src/modules/languages/typescript.nix
+++ b/src/modules/languages/typescript.nix
@@ -12,10 +12,5 @@ in
     packages = [
       pkgs.typescript
     ];
-
-    enterShell = ''
-      echo tsc --version
-      tsc --version
-    '';
   };
 }

--- a/src/modules/languages/v.nix
+++ b/src/modules/languages/v.nix
@@ -19,9 +19,5 @@ in
     packages = [
       cfg.package
     ];
-
-    enterShell = ''
-      v --version
-    '';
   };
 }


### PR DESCRIPTION
Resolves https://github.com/cachix/devenv/issues/199

This removes all `{tool} --version` in `enterShell`. `devenv info` is a better alternative at the moment.