### PR TITLE
Add the correct RUST_SRC_PATH

### DIFF
--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, inputs, ... }:
 
 {
   languages.rust = {
@@ -11,4 +11,6 @@
     clippy.enable = true;
     rustfmt.enable = true;
   };
+
+  env.RUST_SRC_PATH = "${inputs.fenix.packages.${pkgs.system}.${config.languages.rust.version}.rust-src}/lib/rustlib/src/rust/library";
 }

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, inputs, ... }:
+{ pkgs, ... }:
 
 {
   languages.rust = {

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -11,6 +11,4 @@
     clippy.enable = true;
     rustfmt.enable = true;
   };
-
-  env.RUST_SRC_PATH = "${inputs.fenix.packages.${pkgs.system}.${config.languages.rust.version}.rust-src}/lib/rustlib/src/rust/library";
 }

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -47,6 +47,8 @@ in
         pre-commit.tools.cargo = lib.mkForce rustPackages.cargo;
         pre-commit.tools.rustfmt = lib.mkForce rustPackages.rustfmt;
         pre-commit.tools.clippy = lib.mkForce rustPackages.clippy;
+
+        env.RUST_SRC_PATH = "${inputs.fenix.packages.${pkgs.system}.${cfg.version}.rust-src}/lib/rustlib/src/rust/library";
       }
     ))
   ];


### PR DESCRIPTION
Required for the rust-analyzer to work.

It's a bit of a questionable approach, but I feel like hacking around fenix's env generation would be even more tricky. At least it's explicit this way.