### PR TITLE
add starship integration

### DIFF
--- a/examples/starship/devenv.lock
+++ b/examples/starship/devenv.lock
@@ -1,0 +1,132 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671458120,
+        "narHash": "sha256-2+k/OONN4OF21TeoNjKB5sXVZv6Zvm/uEyQIW9OYCg8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e37ef84b478fa8da0ced96522adfd956fde9047a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1671271954,
+        "narHash": "sha256-cSvu+bnvN08sOlTBWbBrKaBHQZq8mvk8bgpt0ZJ2Snc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d513b448cc2a6da2c8803e3c197c9fc7e67b19e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1671452357,
+        "narHash": "sha256-HqzXiQEegpRQ4VEl9pEPgHSIxhJrNJ27HfN1wOc7w2E=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "200790e9c77064c53eaf95805b013d96615ecc27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/starship/devenv.nix
+++ b/examples/starship/devenv.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  starship.enable = true;
+
+  # You can change `enableConfig` to true to override Starship default values.
+  # By default, it looks for a configuration file next to your `devenv.yaml`. 
+  #starship.config.enable = true;
+  # If you don't want to place your configuration file next to your `devenv.yaml`,
+  # change `config.path` to point to the Starship configuration file you want to use.
+  #starship.config.path = ~/.config/custom_starship.toml;
+
+  # With `enableConfig` set to `false`, Starship will still look for a configuration
+  # file in '~/.config/starship.toml'.
+}

--- a/examples/starship/devenv.yaml
+++ b/examples/starship/devenv.yaml
@@ -1,0 +1,5 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  devenv:
+    url: path:../../src/modules

--- a/examples/starship/starship.toml
+++ b/examples/starship/starship.toml
@@ -1,0 +1,3 @@
+# Replace the '❯' symbol in the prompt with '➜'
+[character] # The name of the module we are configuring is 'character'
+success_symbol = '[➜](bold green)' # The 'success_symbol' segment is being set to '➜' with the color 'bold green'

--- a/src/modules/integrations/starship.nix
+++ b/src/modules/integrations/starship.nix
@@ -1,0 +1,45 @@
+{ pkgs, config, lib, ... }:
+
+{
+  options.starship = {
+    enable = lib.mkEnableOption "Enable the Starship command prompt.";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.starship;
+      defaultText = "pkgs.starship";
+      description = "The Starship package to use.";
+    };
+
+    config.enable = lib.mkEnableOption "Enable Starship config override.";
+
+    config.path = lib.mkOption {
+      type = lib.types.path;
+      default = config.env.DEVENV_ROOT + "/starship.toml";
+      defaultText = "\${config.env.DEVENV_ROOT}/starship.toml";
+      description = "The starship configuration file to use.";
+    };
+  };
+
+  config = lib.mkIf config.starship.enable {
+    packages = [
+      config.starship.package
+    ];
+
+    enterShell =
+      let
+        starshipConfExport =
+          if config.starship.config.enable
+          then ''export STARSHIP_CONFIG=${config.starship.config.path}''
+          else '''';
+      in
+      starshipConfExport + ''
+        		  # Identify user's terminal to call the appropiate 'starship init' command
+                  _DEVENV_SHELL=$(ps -o cmd= $$ | awk '{print $1}')
+
+                  eval "$(starship init $_DEVENV_SHELL)"
+
+                  unset _DEVENV_SHELL
+      '';
+  };
+}


### PR DESCRIPTION
This PR adds a module to integrate the cross-shell prompt `Starship`.

The example inside the `examples` folder provides basic documentation about the options available in this module. The comments can easily be copied into a .md file to add it to the documentation website once the integration is reviewed and merged. 