### PR TITLE
mysql: fix missing coreutils

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -20,6 +20,7 @@ let
     exec ${cfg.package}/bin/mysqld ${mysqldOptions}
   '';
   configureScript = pkgs.writeShellScriptBin "configure-mysql" ''
+    PATH="${lib.makeBinPath [ cfg.package pkgs.coreutils ]}:$PATH"
     set -euo pipefail
 
     while ! ${cfg.package}/bin/mysqladmin ping -u root --silent; do

--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -23,7 +23,7 @@ let
     PATH="${lib.makeBinPath [ cfg.package pkgs.coreutils ]}:$PATH"
     set -euo pipefail
 
-    while ! ${cfg.package}/bin/mysqladmin ping -u root --silent; do
+    while ! ${cfg.package}/bin/mysqladmin ping ${optionalString (!isMariaDB) "-u root"} --silent; do
       sleep 1
     done
 
@@ -44,7 +44,7 @@ let
                 cat ${database.schema}/mysql-databases/*.sql
             fi
             ''}
-          ) | ${cfg.package}/bin/mysql ${mysqlOptions} -u root -N
+          ) | ${cfg.package}/bin/mysql ${mysqlOptions} ${optionalString (!isMariaDB) "-u root"} -N
       fi
     '') cfg.initialDatabases}
 
@@ -54,7 +54,7 @@ let
           ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
             echo "GRANT ${permission} ON ${database} TO '${user.name}'@'localhost';"
           '') user.ensurePermissions)}
-        ) | ${cfg.package}/bin/mysql ${mysqlOptions} -u root -N
+        ) | ${cfg.package}/bin/mysql ${mysqlOptions} ${optionalString (!isMariaDB) "-u root"} -N
     '') cfg.ensureUsers}
 
     # We need to sleep until infinity otherwise all processes stop


### PR DESCRIPTION
`sleep infinity` does not work on macOS. So I adjusted the path to use always `coreutils`. fixes #223 