### PR TITLE
rust: feature parity with fenix

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -1,8 +1,10 @@
 { pkgs, config, lib, inputs, ... }:
 
 let
-  inherit (lib.attrsets) attrValues getAttrs;
+  inherit (lib.attrsets) attrValues genAttrs getAttrs;
+
   cfg = config.languages.rust;
+  tools = [ "rustc" "cargo" "rustfmt" "clippy" "rust-analyzer" ];
   setup = ''
     inputs:
       fenix:
@@ -17,8 +19,14 @@ in
     enable = lib.mkEnableOption "Enable tools for Rust development.";
 
     packages = lib.mkOption {
-      type = lib.types.attrsOf lib.types.package;
-      default = { inherit (pkgs) rustc cargo rustfmt clippy rust-analyzer; };
+      type = lib.types.submodule ({ ... }: {
+        options = genAttrs tools (name: lib.mkOption {
+          type = lib.types.package;
+          default = pkgs.${name};
+          defaultText = "pkgs.${name}";
+          description = "${name} package";
+        });
+      });
       defaultText = "pkgs";
       description = "Attribute set of packages including rustc and cargo";
     };
@@ -32,7 +40,7 @@ in
 
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
-      packages = attrValues (getAttrs [ "rustc" "cargo" "rustfmt" "clippy" "rust-analyzer" ] cfg.packages);
+      packages = attrValues (getAttrs tools cfg.packages);
       pre-commit.tools.cargo = lib.mkForce cfg.packages.cargo;
       pre-commit.tools.rustfmt = lib.mkForce cfg.packages.rustfmt;
       pre-commit.tools.clippy = lib.mkForce cfg.packages.clippy;
@@ -46,7 +54,7 @@ in
         rustPackages = fenix.packages.${pkgs.system}.${cfg.version} or (throw "languages.rust.version is set to ${cfg.version}, but should be one of: stable, beta or latest.");
       in
       {
-        languages.rust.packages = rustPackages;
+        languages.rust.packages = genAttrs tools (package: lib.mkDefault rustPackages.${package});
         env.RUST_SRC_PATH = "${inputs.fenix.packages.${pkgs.system}.${cfg.version}.rust-src}/lib/rustlib/src/rust/library";
       }
     ))


### PR DESCRIPTION
The rust language support in devenv has two "backends" (nixpkgs and fenix). It's surprising to me that setting the `languages.rust.version` changes the backend. I think ideally this should be more obvious to the user, or there should just be a single backend for simplicity's sake. I have to wonder whether maintaining both is worth the effort.

Regardless, I ported the missing functionality into the nixpkgs backend, so now rust-analyzer and pre-commit hooks work there as well. I also added `rustfmt`, `clippy` and `rust-analyzer` to `PATH` so they can be picked up by editors (i.e. vscode). All packages are now overridable (e.g. i can use the nightly rustfmt with the stable rust toolchain).

You can override a package like so:
```nix
{ languages.rust.packages.rustfmt = inputs.fenix.packages.${pkgs.system}.latest.rustfmt; }
```
