### PR TITLE
Color `(devenv)` in PS1 blue

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -67,7 +67,7 @@ in
     env.DEVENV_PROFILE = profile;
 
     enterShell = ''
-      export PS1="(devenv) $PS1"
+      export PS1="\e[0;34m(devenv)\e[0m $PS1"
       
       # note what environments are active, but make sure we don't repeat them
       if [[ ! "$DIRENV_ACTIVE" =~ (^|:)"$PWD"(:|$) ]]; then


### PR DESCRIPTION
This makes it easier to visually parse the end of the previous command's output.