### PR TITLE
ruby: add on-by-default compiler tooling for native extensions, fix packages output unrolling

### DIFF
--- a/examples/ruby/devenv.nix
+++ b/examples/ruby/devenv.nix
@@ -3,6 +3,9 @@
 {
   languages.ruby.enable = true;
 
+  # turn off C tooling if you do not intend to compile native extensions, enabled by default
+  # languages.c.enable = false;
+
   enterShell = ''
     echo 'Making sure the basics for native compilation are available:'
 

--- a/examples/ruby/devenv.nix
+++ b/examples/ruby/devenv.nix
@@ -1,9 +1,23 @@
 { pkgs, ... }:
 
 {
-  languages.ruby.enable = true;
+  languages.ruby = {
+    enable = true;
+    compilers.enable = true;
+  };
 
   enterShell = ''
+    echo 'Making sure the basics for native compilation are available:'
+
+    which gcc
+    gcc --version
+
+    which clang
+    clang --version
+
+    which make
+    make --version
+
     bundle
   '';
 }

--- a/examples/ruby/devenv.nix
+++ b/examples/ruby/devenv.nix
@@ -1,10 +1,7 @@
 { pkgs, ... }:
 
 {
-  languages.ruby = {
-    enable = true;
-    compilers.enable = true;
-  };
+  languages.ruby.enable = true;
 
   enterShell = ''
     echo 'Making sure the basics for native compilation are available:'

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -8,10 +8,13 @@ in
     enable = lib.mkEnableOption "Enable tools for C development.";
   };
 
-
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      stdenv
+      gnumake
+      clang
       gcc
+      pkg-config
     ];
   };
 }

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -13,14 +13,26 @@ in
       defaultText = "pkgs.ruby_3_1";
       description = "The Ruby package to use.";
     };
+
+    compilers = {
+      enable = lib.mkEnableOption "Enable common compiler packages for gem compilation";
+      packages = lib.mkOption {
+        default = [ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ];
+        defaultText = lib.literalExpression "[ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ]";
+        type = lib.types.listOf lib.types.package;
+        description = lib.mdDoc ''
+          Packages to add to the PATH, so the bundler native extensions can build.
+          Expected to be extended per project, based on the bundler dependencies.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       cfg.package
       bundler
-      gnumake # needed for native extensions
-    ];
+    ] ++ (lib.optionals cfg.compilers.enable cfg.compilers.packages);
 
     env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
 

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -15,7 +15,10 @@ in
     };
 
     compilers = {
-      enable = lib.mkEnableOption "Enable common compiler packages for gem compilation";
+      enable = (lib.mkEnableOption "Enable common compiler packages for gem compilation") // {
+        # enable by default for better DX
+        enable = cfg.enable;
+      };
       packages = lib.mkOption {
         default = [ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ];
         defaultText = lib.literalExpression "[ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ]";

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -13,29 +13,16 @@ in
       defaultText = "pkgs.ruby_3_1";
       description = "The Ruby package to use.";
     };
-
-    compilers = {
-      enable = (lib.mkEnableOption "Enable common compiler packages for gem compilation") // {
-        # enable by default for better DX
-        enable = cfg.enable;
-      };
-      packages = lib.mkOption {
-        default = [ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ];
-        defaultText = lib.literalExpression "[ pkgs.stdenv pkgs.gnumake pkgs.clang pkgs.gcc ]";
-        type = lib.types.listOf lib.types.package;
-        description = lib.mdDoc ''
-          Packages to add to the PATH, so the bundler native extensions can build.
-          Expected to be extended per project, based on the bundler dependencies.
-        '';
-      };
-    };
   };
 
   config = lib.mkIf cfg.enable {
+    # enable C tooling by default so native extensions can be built
+    languages.c.enable = lib.mkDefault true;
+
     packages = with pkgs; [
       cfg.package
       bundler
-    ] ++ (lib.optionals cfg.compilers.enable cfg.compilers.packages);
+    ];
 
     env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -5,9 +5,15 @@ let
   # Returns a list of all the entries in a folder
   listEntries = path:
     map (name: path + "/${name}") (builtins.attrNames (builtins.readDir path));
+
+  drvOrPackageToPaths = drvOrPackage:
+    if drvOrPackage ? outputs then
+      builtins.map (output: drvOrPackage.${output}) drvOrPackage.outputs
+    else
+      [ drvOrPackage ];
   profile = pkgs.buildEnv {
     name = "devenv-profile";
-    paths = lib.flatten (builtins.map (package: builtins.map (output: lib.getOutput output package) package.outputs) config.packages);
+    paths = lib.flatten (builtins.map drvOrPackageToPaths config.packages);
     ignoreCollisions = true;
   };
 in


### PR DESCRIPTION
fixes #239 properly, based on feedback from #241
`nix-tree $DEVENV_PROFILE`
Before:
![image](https://user-images.githubusercontent.com/2217181/209444360-fd001a20-e114-47f8-8d54-a127c0e7651c.png)


After:
![image](https://user-images.githubusercontent.com/2217181/209444178-5e8bf4fb-e988-45b2-803f-ea8e4ce75751.png)
