### PR TITLE
hostctl: init module

### DIFF
--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -19,7 +19,6 @@ pkgs.writeScriptBin "devenv" ''
   case $command in
     up)
       procfilescript=${config.procfileScript}
-      cat $procfilescript
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -71,7 +71,6 @@ pkgs.writeScriptBin "devenv" ''
       shell
       eval "$env"
       procfilescript=$($CUSTOM_NIX/bin/nix $NIX_FLAGS build --no-link --print-out-paths --impure '.#procfileScript')
-      cat $procfilescript
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"  
         exit 1

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -10,9 +10,9 @@ let
 in
 {
   options = {
-    hostsProfile = lib.mkOption {
+    hostsProfileName = lib.mkOption {
       type = lib.types.str;
-      default = "devenv";
+      default = "devenv-${builtins.hashString "sha256" config.env.DEVENV_ROOT}";
       description = "Profile name to use.";
     };
 
@@ -27,14 +27,14 @@ in
     packages = [
       (pkgs.writeShellScriptBin "deactivate-hosts" ''
         rm -f "$DEVENV_STATE/hostctl"
-        exec sudo ${pkgs.hostctl}/bin/hostctl remove ${config.hostsProfile} 
+        exec sudo ${pkgs.hostctl}/bin/hostctl remove ${config.hostsProfileName} 
       ''
       )
     ];
 
     enterShell = ''
       if [[ ! -f "$DEVENV_STATE/hostctl" || "$(cat "$DEVENV_STATE/hostctl")" != "${hostHash}" ]]; then
-        sudo ${pkgs.hostctl}/bin/hostctl replace ${config.hostsProfile} --from ${file}
+        sudo ${pkgs.hostctl}/bin/hostctl replace ${config.hostsProfileName} --from ${file}
         echo "Hosts file updated. Run 'deactivate-hosts' to revert changes."
         mkdir -p "$DEVENV_STATE"
         echo "${hostHash}" > "$DEVENV_STATE/hostctl"

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -31,16 +31,15 @@ in
   };
 
   config = lib.mkIf (hostContent != "") {
-    beforeUp = ''
+    process.before = ''
       if [[ ! -f "$DEVENV_STATE/hostctl" || "$(cat "$DEVENV_STATE/hostctl")" != "${hostHash}" ]]; then
         sudo ${pkgs.hostctl}/bin/hostctl replace ${config.hostsProfileName} --from ${file}
-        echo "Hosts file updated. Run 'deactivate-hosts' to revert changes."
         mkdir -p "$DEVENV_STATE"
         echo "${hostHash}" > "$DEVENV_STATE/hostctl"
       fi
     '';
 
-    afterUp = ''
+    process.after = ''
       rm -f "$DEVENV_STATE/hostctl"
       sudo ${pkgs.hostctl}/bin/hostctl remove ${config.hostsProfileName} 
     '';

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -1,0 +1,46 @@
+{ pkgs, lib, config, ... }:
+
+let
+  hostContent = lib.concatStringsSep "\n" config.hostctl.hosts;
+  hostHash = builtins.hashString "sha256" hostContent;
+  file = pkgs.writeText "hosts" ''
+    # ${hostHash}
+    ${hostContent}
+  '';
+in
+{
+  options.hostctl = {
+    enable = lib.mkEnableOption "Adjust /etc/hosts using hostctl.";
+
+    profile = lib.mkOption {
+      type = lib.types.str;
+      default = "devenv";
+      description = "Profile name to use.";
+    };
+
+    hosts = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "List of hosts entries.";
+    };
+  };
+
+  config = lib.mkIf config.hostctl.enable {
+    packages = [
+      (pkgs.writeShellScriptBin "deactivate-hosts" ''
+        rm -f "$DEVENV_STATE/hostctl"
+        exec sudo ${pkgs.hostctl}/bin/hostctl remove ${config.hostctl.profile} 
+      ''
+      )
+    ];
+
+    enterShell = ''
+      if [[ ! -f "$DEVENV_STATE/hostctl" || "$(cat "$DEVENV_STATE/hostctl")" != "${hostHash}" ]]; then
+        sudo ${pkgs.hostctl}/bin/hostctl replace ${config.hostctl.profile} --from ${file}
+        echo "Hosts file updated. Run 'deactivate-hosts' to revert changes."
+        mkdir -p "$DEVENV_STATE"
+        echo "${hostHash}" > "$DEVENV_STATE/hostctl"
+      fi
+    '';
+  };
+}

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -22,7 +22,7 @@ in
 
     hosts = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
-      default = {};
+      default = { };
       description = "List of hosts entries.";
       example = {
         "example.com" = "127.0.0.1";

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -22,7 +22,7 @@ in
 
     hosts = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
-      default = [ ];
+      default = {};
       description = "List of hosts entries.";
       example = {
         "example.com" = "127.0.0.1";

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -97,6 +97,18 @@ in
           log_level = "fatal";
         };
       };
+
+      before = lib.mkOption {
+        type = types.lines;
+        description = "Bash code to execute before starting processes.";
+        default = "";
+      };
+
+      after = lib.mkOption {
+        type = types.lines;
+        description = "Bash code to execute after stopping processes.";
+        default = "";
+      };
     };
 
     # INTERNAL
@@ -138,7 +150,7 @@ in
       pkgs.writeText "procfile-env" (lib.concatStringsSep "\n" envList);
 
     procfileScript = pkgs.writeShellScript "devenv-up" ''
-      ${config.beforeUp}
+      ${config.process.before}
 
       ${procfileScripts.${implementation}}
 
@@ -151,7 +163,7 @@ in
         kill -TERM $(cat "$DEVENV_STATE/devenv.pid")
         rm "$DEVENV_STATE/devenv.pid"
         wait
-        ${config.afterUp}
+        ${config.process.after}
         echo "Processes stopped."
       }
 

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -42,6 +42,26 @@ let
         builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]
       else
         config.env);
+
+  procfileScripts = {
+    honcho = ''
+      ${pkgs.honcho}/bin/honcho start -f ${config.procfile} --env ${config.procfileEnv} & 
+    '';
+
+    overmind = ''
+      OVERMIND_ENV=${config.procfileEnv} ${pkgs.overmind}/bin/overmind start --procfile ${config.procfile} &
+    '';
+
+    process-compose = ''
+      ${pkgs.process-compose}/bin/process-compose --config ${config.procfile} \
+         --port $PC_HTTP_PORT \
+         --tui=$PC_TUI_ENABLED &
+    '';
+
+    hivemind = ''
+      ${pkgs.hivemind}/bin/hivemind --print-timestamps ${config.procfile} &
+    '';
+  };
 in
 {
   options = {
@@ -117,27 +137,30 @@ in
     procfileEnv =
       pkgs.writeText "procfile-env" (lib.concatStringsSep "\n" envList);
 
-    procfileScript = {
-      honcho = pkgs.writeShellScript "honcho-up" ''
-        echo "Starting processes ..." 1>&2
-        echo "" 1>&2
-        ${pkgs.honcho}/bin/honcho start -f ${config.procfile} --env ${config.procfileEnv}
-      '';
+    procfileScript = pkgs.writeShellScript "devenv-up" ''
+      ${config.beforeUp}
 
-      overmind = pkgs.writeShellScript "overmind-up" ''
-        OVERMIND_ENV=${config.procfileEnv} ${pkgs.overmind}/bin/overmind start --procfile ${config.procfile}
-      '';
+      ${procfileScripts.${implementation}}
 
-      process-compose = pkgs.writeShellScript "process-compose-up" ''
-        ${pkgs.process-compose}/bin/process-compose --config ${config.procfile} \
-           --port $PC_HTTP_PORT \
-           --tui=$PC_TUI_ENABLED
-      '';
+      if [[ ! -d "$DEVENV_STATE" ]]; then
+        mkdir -p "$DEVENV_STATE"
+      fi
 
-      hivemind = pkgs.writeShellScript "hivemind-up" ''
-        ${pkgs.hivemind}/bin/hivemind --print-timestamps ${config.procfile}
-      '';
-    }.${implementation};
+      stop_up() {
+        echo "Stopping processes..."
+        kill -TERM $(cat "$DEVENV_STATE/devenv.pid")
+        rm "$DEVENV_STATE/devenv.pid"
+        wait
+        ${config.afterUp}
+        echo "Processes stopped."
+      }
+
+      trap stop_up SIGINT SIGTERM
+
+      echo $! > "$DEVENV_STATE/devenv.pid"
+
+      wait
+    '';
 
     ci = [ config.procfileScript ];
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -25,18 +25,6 @@ in
       default = { };
     };
 
-    beforeUp = lib.mkOption {
-      type = types.lines;
-      description = "Bash code to execute before starting processes.";
-      default = "";
-    };
-
-    afterUp = lib.mkOption {
-      type = types.lines;
-      description = "Bash code to execute after stopping processes.";
-      default = "";
-    };
-
     enterShell = lib.mkOption {
       type = types.lines;
       description = "Bash code to execute when entering the shell.";

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -25,6 +25,18 @@ in
       default = { };
     };
 
+    beforeUp = lib.mkOption {
+      type = types.lines;
+      description = "Bash code to execute before starting processes.";
+      default = "";
+    };
+
+    afterUp = lib.mkOption {
+      type = types.lines;
+      description = "Bash code to execute after stopping processes.";
+      default = "";
+    };
+
     enterShell = lib.mkOption {
       type = types.lines;
       description = "Bash code to execute when entering the shell.";


### PR DESCRIPTION
Fixes #227

Config looks like

```
hosts = [
    "127.0.0.1 foo.de"
    "127.0.0.1 bla.de"
];
```

It will be setup by entering the shell. I did add a proper "caching" so it's calling only hostctl when required because we need to run `sudo`.

To deactivate, the user has to run `deactivate-hosts` in the shell and leave the shell. Next opening of the shell readds them