### PR TITLE
add workaround for tmpdir errors on Darwin, fixes #255

### DIFF
--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -26,6 +26,7 @@
 , coreutils
 , system
 , writeTextFile
+, pkgs
 , lib
 }:
 let
@@ -75,7 +76,7 @@ let
     shellHook = ''
       # Remove all the unnecessary noise that is set by the build env
       unset NIX_BUILD_TOP NIX_BUILD_CORES NIX_STORE
-      unset TEMP TEMPDIR TMP TMPDIR
+      unset TEMP TEMPDIR TMP ${lib.optionalString (!pkgs.stdenv.isDarwin) "TMPDIR"}
       # $name variable is preserved to keep it compatible with pure shell https://github.com/sindresorhus/pure/blob/47c0c881f0e7cfdb5eaccd335f52ad17b897c060/pure.zsh#L235
       unset builder out shellHook stdenv system
       # Flakes stuff


### PR DESCRIPTION
Darwin always sets a `TMPDIR`. As the mkNakedShell removes the shell the `TMPDIR` gets `null` and breaks a lot of applications like VSCode with Direnv.

Before:

![image](https://user-images.githubusercontent.com/6224096/210261275-34e68f47-1322-4dc9-8170-082693c16f84.png)

After:
![image](https://user-images.githubusercontent.com/6224096/210261398-c6acdd44-baf4-4cf0-92a8-008b2e86c9d9.png)
