### PR TITLE
Fix instruction for declarative installation w/o flakes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,7 @@ c) Install ``devenv``
 
     ```nix title="configuration.nix"
     environment.systemPackages = [ 
-      (import (fetchTarball https://github.com/cachix/devenv/archive/v{{ devenv.version }}.tar.gz))
+      (import (fetchTarball https://github.com/cachix/devenv/archive/v{{ devenv.version }}.tar.gz)).default
     ];
     ```
 


### PR DESCRIPTION
Add `default` parameter to systemPackages import statement