### PR TITLE
fix: avoid infinite recursion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
       systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
       mkPackage = pkgs: import ./src/devenv.nix { inherit pkgs nix; };
+      mkDevShellPackage = config: pkgs: import ./src/devenv-devShell.nix { inherit config pkgs; };
       mkDocOptions = pkgs:
         let
           eval = pkgs.lib.evalModules {
@@ -84,11 +85,13 @@
               };
               modules = [
                 (self.modules + /top-level.nix)
-                {
-                  packages = [ self.packages.${pkgs.system}.devenv ];
+                ({ config, ... }: {
+                  packages = [
+                    (mkDevShellPackage config pkgs)
+                  ];
                   devenv.warnOnNewVersion = false;
                   devenv.flakesIntegration = true;
-                }
+                })
               ] ++ modules;
             };
           in

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
                 {
                   packages = [ self.packages.${pkgs.system}.devenv ];
                   devenv.warnOnNewVersion = false;
+                  devenv.flakesIntegration = true;
                 }
               ] ++ modules;
             };

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -32,6 +32,8 @@ pkgs.writeScriptBin "devenv" ''
       ;;
     *)
       echo "https://devenv.sh (version ${version}): Fast, Declarative, Reproducible, and Composable Developer Environments"
+      echo 
+      echo "This is a flake integration wrapper that comes with a subset of functionality from the flakeless devenv CLI."
       echo
       echo "Usage: devenv command"
       echo

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -1,0 +1,45 @@
+{ config, pkgs }:
+let
+  lib = pkgs.lib;
+  version = lib.fileContents ./modules/latest-version;
+in
+pkgs.writeScriptBin "devenv" ''
+  #!/usr/bin/env bash
+
+  # we want subshells to fail the program
+  set -e
+
+  NIX_FLAGS="--show-trace --extra-experimental-features nix-command --extra-experimental-features flakes"
+
+  command=$1
+  if [[ ! -z $command ]]; then
+    shift
+  fi
+
+  case $command in
+    up)
+      procfilescript=${config.procfileScript}
+      cat $procfilescript
+      if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
+        echo "No 'processes' option defined: https://devenv.sh/processes/"
+        exit 1
+      else
+        $procfilescript
+      fi
+      ;;
+    version)
+      echo "devenv: ${version}"
+      ;;
+    *)
+      echo "https://devenv.sh (version ${version}): Fast, Declarative, Reproducible, and Composable Developer Environments"
+      echo
+      echo "Usage: devenv command"
+      echo
+      echo "Commands:"
+      echo
+      echo "up:             Starts processes in foreground. See http://devenv.sh/processes"
+      echo "version:        Display devenv version"
+      echo
+      exit 1
+  esac
+''

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -34,7 +34,11 @@ let
   implementation = config.process.implementation;
   implementation-options = config.process.${implementation};
   envList =
-    (lib.mapAttrsToList (name: value: "${name}=${toString value}") config.env);
+    lib.mapAttrsToList
+      (name: value: "${name}=${toString value}")
+      # avoid infinite recursion in the scenario the `config` parameter is used
+      # in a `processes` declaration inside a devenv module.
+      (builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]);
 in
 {
   options = {

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -36,9 +36,12 @@ let
   envList =
     lib.mapAttrsToList
       (name: value: "${name}=${toString value}")
-      # avoid infinite recursion in the scenario the `config` parameter is used
-      # in a `processes` declaration inside a devenv module.
-      (builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]);
+      (if config.devenv.flakesIntegration then
+      # avoid infinite recursion in the scenario the `config` parameter is
+      # used in a `processes` declaration inside a devenv module.
+        builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]
+      else
+        config.env);
 in
 {
   options = {

--- a/src/modules/update-check.nix
+++ b/src/modules/update-check.nix
@@ -14,6 +14,13 @@ let
 in
 {
   options.devenv = {
+    flakesIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Tells if devenv is being imported by a flake.nix file
+      '';
+    };
     warnOnNewVersion = lib.mkOption {
       type = lib.types.bool;
       default = true;


### PR DESCRIPTION
Remove the `DEVENV_PROFILE` entry from the processes `envList` set to avoid infinite recursions.

This happens when a devenv module uses the `config` parameter inside a scripts entry _and_ there are custom `processes` definitions. This is very common on projects that use devenv via the [nix flakes porcelain](https://github.com/cachix/devenv/blob/main/docs/guides/using-with-flakes.md).

## Reproducing infinite recursion

```nix
# devenv.nix
{ config, ... }: {
  processes.boom.exec = "echo boom";
  scripts.devenv-up.exec = ''
    ${config.procfileScript}
  '';
}
```