### PR TITLE
languages/r: add option for R package

### DIFF
--- a/src/modules/languages/r.nix
+++ b/src/modules/languages/r.nix
@@ -6,11 +6,17 @@ in
 {
   options.languages.r = {
     enable = lib.mkEnableOption "Enable tools for R development.";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.R;
+      defaultText = lib.literalExpression "pkgs.R";
+      description = "The R package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      R
+      cfg.package
     ];
   };
 }


### PR DESCRIPTION
Hello,

I added a config option to specify the R package. It is similar at how it is done for python.
I did that to be able to add additional dependencies to my R installation using  `rWrapper` such as:
```nix
  languages.r = {
    enable = true;
    package = (pkgs.rWrapper.override{packages = with pkgs.rPackages; [ viridis tidyverse ];});
  };
```