### PR TITLE
caddy: fix unused dataDir option

### DIFF
--- a/src/modules/services/caddy.nix
+++ b/src/modules/services/caddy.nix
@@ -178,6 +178,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    processes.caddy.exec = "${cfg.package}/bin/caddy run ${optionalString cfg.resume "--resume"} --config ${configJSON}";
+    processes.caddy.exec = "XDG_DATA_HOME=${cfg.dataDir}/data XDG_CONFIG_HOME=${cfg.dataDir}/config ${cfg.package}/bin/caddy run ${optionalString cfg.resume "--resume"} --config ${configJSON}";
   };
 }


### PR DESCRIPTION
The `services.caddy.dataDir` option was not being applied causing caddy to pollute state in the default locations - `~/.local/share/caddy` and `~/.config/caddy`