### PR TITLE
languages/python: add virtual environment option

### DIFF
--- a/examples/python-venv/.gitignore
+++ b/examples/python-venv/.gitignore
@@ -1,0 +1,5 @@
+
+# Devenv
+.devenv*
+devenv.local.nix
+

--- a/examples/python-venv/README.md
+++ b/examples/python-venv/README.md
@@ -1,0 +1,8 @@
+# python-venv
+
+```console
+$ devenv shell
+(devenv)$ command -V pip
+.../.devenv/state/venv/bin/pip
+(devenv)$ pip install numpy
+```

--- a/examples/python-venv/devenv.lock
+++ b/examples/python-venv/devenv.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../src/modules",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1668852955,
+        "narHash": "sha256-1ozaNW9uFRvm3cP9M6FPx+hdqyFQnf49M3HrLQ6nqrk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fb6f9fb0ef3ca727cbd9ae30b90d1ce49d5fcca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668880995,
+        "narHash": "sha256-1pohNJx6MIVeYpXmsugZG3fUKPSIKpQouttWFVfqsNU=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "364568e63556045ea9d08d29fafa46febbdb015b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/examples/python-venv/devenv.nix
+++ b/examples/python-venv/devenv.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+
+{
+  languages.python.enable = true;
+  languages.python.venv.enable = true;
+}

--- a/examples/python-venv/devenv.yaml
+++ b/examples/python-venv/devenv.yaml
@@ -1,0 +1,5 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  devenv:
+    url: path:../../src/modules

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -25,7 +25,10 @@ in
     env.PYTHONPATH = "${config.env.DEVENV_PROFILE}/${cfg.package.sitePackages}";
 
     enterShell = lib.mkIf cfg.venv.enable ''
-      python -m venv ${config.env.DEVENV_STATE}/venv
+      if [ ! -d ${config.env.DEVENV_STATE}/venv ]
+      then
+        python -m venv ${config.env.DEVENV_STATE}/venv
+      fi
       source ${config.env.DEVENV_STATE}/venv/bin/activate
     '';
   };

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -13,6 +13,8 @@ in
       defaultText = lib.literalExpression "pkgs.python3";
       description = "The Python package to use.";
     };
+
+    venv.enable = lib.mkEnableOption "Python virtual environment";
   };
 
   config = lib.mkIf cfg.enable {
@@ -21,5 +23,10 @@ in
     ];
 
     env.PYTHONPATH = "${config.env.DEVENV_PROFILE}/${cfg.package.sitePackages}";
+
+    enterShell = lib.mkIf cfg.venv.enable ''
+      python -m venv ${config.env.DEVENV_STATE}/venv
+      source ${config.env.DEVENV_STATE}/venv/bin/activate
+    '';
   };
 }


### PR DESCRIPTION
Currently Python always needs manually creating and activating a virtual environment. This can be done using `virtualenv`, but also `python -m venv venv`. It would be nice if this was done upon entering the devenv shell.

I previously also had poetry on top of this, but I thought it was better to split it up. First venv, maybe later poetry.

This also adds an example named `python-venv` to show how it would work.