### PR TITLE
fix descriptions for enable options

### DIFF
--- a/src/modules/integrations/devcontainer.nix
+++ b/src/modules/integrations/devcontainer.nix
@@ -15,7 +15,7 @@ let
 in
 {
   options.devcontainer = {
-    enable = lib.mkEnableOption "Generate .devcontainer.json for devenv integration.";
+    enable = lib.mkEnableOption "generation .devcontainer.json for devenv integration";
   };
 
   config = lib.mkIf config.devcontainer.enable {

--- a/src/modules/integrations/starship.nix
+++ b/src/modules/integrations/starship.nix
@@ -2,7 +2,7 @@
 
 {
   options.starship = {
-    enable = lib.mkEnableOption "Enable the Starship command prompt.";
+    enable = lib.mkEnableOption "the Starship command prompt";
 
     package = lib.mkOption {
       type = lib.types.package;
@@ -11,7 +11,7 @@
       description = "The Starship package to use.";
     };
 
-    config.enable = lib.mkEnableOption "Enable Starship config override.";
+    config.enable = lib.mkEnableOption "Starship config override";
 
     config.path = lib.mkOption {
       type = lib.types.path;

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.c = {
-    enable = lib.mkEnableOption "Enable tools for C development.";
+    enable = lib.mkEnableOption "tools for C development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.clojure = {
-    enable = lib.mkEnableOption "Enable tools for Clojure development.";
+    enable = lib.mkEnableOption "tools for Clojure development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/cplusplus.nix
+++ b/src/modules/languages/cplusplus.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.cplusplus = {
-    enable = lib.mkEnableOption "Enable tools for C++ development.";
+    enable = lib.mkEnableOption "tools for C++ development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/cue.nix
+++ b/src/modules/languages/cue.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.cue = {
-    enable = lib.mkEnableOption "Enable tools for Cue development.";
+    enable = lib.mkEnableOption "tools for Cue development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/deno.nix
+++ b/src/modules/languages/deno.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.deno = {
-    enable = lib.mkEnableOption "Enable tools for Deno development.";
+    enable = lib.mkEnableOption "tools for Deno development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/dotnet.nix
+++ b/src/modules/languages/dotnet.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.dotnet = {
-    enable = lib.mkEnableOption "Enable tools for .NET development.";
+    enable = lib.mkEnableOption "tools for .NET development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/elixir.nix
+++ b/src/modules/languages/elixir.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.elixir = {
-    enable = lib.mkEnableOption "Enable tools for Elixir development.";
+    enable = lib.mkEnableOption "tools for Elixir development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.elm = {
-    enable = lib.mkEnableOption "Enable tools for Elm development.";
+    enable = lib.mkEnableOption "tools for Elm development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/erlang.nix
+++ b/src/modules/languages/erlang.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.erlang = {
-    enable = lib.mkEnableOption "Enable tools for Erlang development.";
+    enable = lib.mkEnableOption "tools for Erlang development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.go = {
-    enable = lib.mkEnableOption "Enable tools for Go development.";
+    enable = lib.mkEnableOption "tools for Go development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/haskell.nix
+++ b/src/modules/languages/haskell.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.haskell = {
-    enable = lib.mkEnableOption "Enable tools for Haskell development.";
+    enable = lib.mkEnableOption "tools for Haskell development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.javascript = {
-    enable = lib.mkEnableOption "Enable tools for JavaScript development.";
+    enable = lib.mkEnableOption "tools for JavaScript development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/kotlin.nix
+++ b/src/modules/languages/kotlin.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.kotlin = {
-    enable = lib.mkEnableOption "Enable tools for Kotlin development.";
+    enable = lib.mkEnableOption "tools for Kotlin development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/lua.nix
+++ b/src/modules/languages/lua.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.lua = {
-    enable = lib.mkEnableOption "Enable tools for Lua development.";
+    enable = lib.mkEnableOption "tools for Lua development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/nim.nix
+++ b/src/modules/languages/nim.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.nim = {
-    enable = lib.mkEnableOption "Enable tools for nim development.";
+    enable = lib.mkEnableOption "tools for nim development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.nix = {
-    enable = lib.mkEnableOption "Enable tools for Nix development.";
+    enable = lib.mkEnableOption "tools for Nix development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.ocaml = {
-    enable = lib.mkEnableOption "Enable tools for OCaml development.";
+    enable = lib.mkEnableOption "tools for OCaml development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/perl.nix
+++ b/src/modules/languages/perl.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.perl = {
-    enable = lib.mkEnableOption "Enable tools for Perl development.";
+    enable = lib.mkEnableOption "tools for Perl development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -142,7 +142,7 @@ let
 in
 {
   options.languages.php = {
-    enable = lib.mkEnableOption "Enable tools for PHP development.";
+    enable = lib.mkEnableOption "tools for PHP development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/purescript.nix
+++ b/src/modules/languages/purescript.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options.languages.purescript = {
-    enable = lib.mkEnableOption "Enable tools for PureScript development.";
+    enable = lib.mkEnableOption "tools for PureScript development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.python = {
-    enable = lib.mkEnableOption "Enable tools for Python development.";
+    enable = lib.mkEnableOption "tools for Python development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/r.nix
+++ b/src/modules/languages/r.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.r = {
-    enable = lib.mkEnableOption "Enable tools for R development.";
+    enable = lib.mkEnableOption "tools for R development";
     package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.R;

--- a/src/modules/languages/robotframework.nix
+++ b/src/modules/languages/robotframework.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.robotframework = {
-    enable = lib.mkEnableOption "Enable tools for Robot Framework development.";
+    enable = lib.mkEnableOption "tools for Robot Framework development";
 
     python = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.ruby = {
-    enable = lib.mkEnableOption "Enable tools for Ruby development";
+    enable = lib.mkEnableOption "tools for Ruby development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -16,7 +16,7 @@ let
 in
 {
   options.languages.rust = {
-    enable = lib.mkEnableOption "Enable tools for Rust development.";
+    enable = lib.mkEnableOption "tools for Rust development";
 
     packages = lib.mkOption {
       type = lib.types.submodule ({

--- a/src/modules/languages/scala.nix
+++ b/src/modules/languages/scala.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.scala = {
-    enable = lib.mkEnableOption "Enable tools for Scala development.";
+    enable = lib.mkEnableOption "tools for Scala development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.terraform = {
-    enable = lib.mkEnableOption "Enable tools for terraform development.";
+    enable = lib.mkEnableOption "tools for terraform development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/typescript.nix
+++ b/src/modules/languages/typescript.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.typescript = {
-    enable = lib.mkEnableOption "Enable tools for TypeScript development.";
+    enable = lib.mkEnableOption "tools for TypeScript development";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/unison.nix
+++ b/src/modules/languages/unison.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.unison = {
-    enable = lib.mkEnableOption "Enable tools for Unison development.";
+    enable = lib.mkEnableOption "tools for Unison development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/v.nix
+++ b/src/modules/languages/v.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.v = {
-    enable = lib.mkEnableOption "Enable tools for v development.";
+    enable = lib.mkEnableOption "tools for v development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/languages/zig.nix
+++ b/src/modules/languages/zig.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.zig = {
-    enable = lib.mkEnableOption "Enable tools for Zig development.";
+    enable = lib.mkEnableOption "tools for Zig development";
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/src/modules/services/adminer.nix
+++ b/src/modules/services/adminer.nix
@@ -10,7 +10,7 @@ in
   ];
 
   options.services.adminer = {
-    enable = lib.mkEnableOption "Add adminer process.";
+    enable = lib.mkEnableOption "adminer process";
 
     package = lib.mkOption {
       type = types.package;

--- a/src/modules/services/mailhog.nix
+++ b/src/modules/services/mailhog.nix
@@ -6,7 +6,7 @@ let
 in
 {
   options.services.mailhog = {
-    enable = lib.mkEnableOption "Add mailhog process.";
+    enable = lib.mkEnableOption "mailhog process";
 
     package = lib.mkOption {
       type = types.package;

--- a/src/modules/services/memcached.nix
+++ b/src/modules/services/memcached.nix
@@ -10,7 +10,7 @@ in
   ];
 
   options.services.memcached = {
-    enable = lib.mkEnableOption "Add memcached process.";
+    enable = lib.mkEnableOption "memcached process";
 
     package = lib.mkOption {
       type = types.package;

--- a/src/modules/services/mongodb.nix
+++ b/src/modules/services/mongodb.nix
@@ -24,7 +24,7 @@ in
   ];
 
   options.services.mongodb = {
-    enable = mkEnableOption "Add MongoDB process and expose utilities.";
+    enable = mkEnableOption "MongoDB process and expose utilities";
 
     package = mkOption {
       type = types.package;

--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -68,7 +68,7 @@ in
   ];
 
   options.services.mysql = {
-    enable = mkEnableOption "Add mysql process and expose utilities.";
+    enable = mkEnableOption "mysql process and expose utilities";
 
     package = mkOption {
       type = types.package;

--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -27,7 +27,7 @@ in
   ];
 
   options.services.redis = {
-    enable = mkEnableOption "Add redis process and expose utilities.";
+    enable = mkEnableOption "redis process and expose utilities";
 
     package = mkOption {
       type = types.package;


### PR DESCRIPTION
Currently most of the descriptions for mkEnableOption are incorrect. One example is `languages.c.enable`, which is defined as:

```
lib.mkEnableOption "Enable tools for C development.";
```

This results in a description:

```
Whether to enable Enable tools for C development..
```

See https://devenv.sh/reference/options/#languagescenable

I've replaced the following patterns:

`mkEnableOption "Enable ` -> `mkEnableOption "`
`mkEnableOption ".*\."` -> `mkEnableOption "$1"`
`mkEnableOption "Add ` -> `mkEnableOption "`

and made some changes by hand.