### PR TITLE
services/minio: add buckets option

### DIFF
--- a/src/modules/services/minio.nix
+++ b/src/modules/services/minio.nix
@@ -12,6 +12,10 @@ let
       mkdir -p "$MINIO_CONFIG_DIR"
     fi
 
+    for bucket in ${lib.escapeShellArgs cfg.ensureBuckets}; do
+      mkdir -p "$MINIO_DATA_DIR/$bucket"
+    done
+
     exec ${cfg.package}/bin/minio server --json --address ${cfg.listenAddress} --console-address ${cfg.consoleAddress} "--config-dir=$MINIO_CONFIG_DIR" "$MINIO_DATA_DIR"
   '';
 in
@@ -71,6 +75,14 @@ in
       defaultText = lib.literalExpression "pkgs.minio";
       type = types.package;
       description = lib.mdDoc "Minio package to use.";
+    };
+
+    ensureBuckets = lib.mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = lib.mdDoc ''
+        List of buckets to ensure exist on startup.
+      '';
     };
   };
 

--- a/src/modules/services/minio.nix
+++ b/src/modules/services/minio.nix
@@ -12,7 +12,7 @@ let
       mkdir -p "$MINIO_CONFIG_DIR"
     fi
 
-    for bucket in ${lib.escapeShellArgs cfg.ensureBuckets}; do
+    for bucket in ${lib.escapeShellArgs cfg.buckets}; do
       mkdir -p "$MINIO_DATA_DIR/$bucket"
     done
 
@@ -77,7 +77,7 @@ in
       description = lib.mdDoc "Minio package to use.";
     };
 
-    ensureBuckets = lib.mkOption {
+    buckets = lib.mkOption {
       default = [ ];
       type = types.listOf types.str;
       description = lib.mdDoc ''


### PR DESCRIPTION
```nix
services.minio.enable = true;
services.minio.buckets = [ "some-test" ];
```

Allows me to create buckets on start.

![image](https://user-images.githubusercontent.com/6224096/213250956-e120443b-088e-4398-a5a2-c60967ce43e7.png)
