### PR TITLE
processes: quote env vars

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -35,7 +35,7 @@ let
   implementation-options = config.process.${implementation};
   envList =
     lib.mapAttrsToList
-      (name: value: "${name}=${toString value}")
+      (name: value: "${name}=${builtins.toJSON value}")
       (if config.devenv.flakesIntegration then
       # avoid infinite recursion in the scenario the `config` parameter is
       # used in a `processes` declaration inside a devenv module.


### PR DESCRIPTION
Otherwise

```nix
{
  env = {
  ENVVAR = "Hello world";
};
processes.example.exec = "echo $ENVVAR";
}
```

results into

```
14:56:13 system    | example.1 started (pid=1518566)
14:56:13 example.1 | Helloworld
14:56:13 system    | example.1 stopped (rc=0)
```