### PR TITLE
Fix direnv with strict_env enabled

### DIFF
--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -96,10 +96,10 @@ let
       export PATH="$DEVENV_PROFILE/bin:$PATH"
 
       # prepend common compilation lookup paths
-      export PKG_CONFIG_PATH="$DEVENV_PROFILE/lib/pkgconfig:$PKG_CONFIG_PATH"
-      export LD_LIBRARY_PATH="$DEVENV_PROFILE/lib:$LD_LIBRARY_PATH"
-      export LIBRARY_PATH="$DEVENV_PROFILE/lib:$LIBRARY_PATH"
-      export C_INCLUDE_PATH="$DEVENV_PROFILE/include:$C_INCLUDE_PATH"
+      export PKG_CONFIG_PATH="$DEVENV_PROFILE/lib/pkgconfig:''${PKG_CONFIG_PATH-}"
+      export LD_LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LD_LIBRARY_PATH-}"
+      export LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LIBRARY_PATH-}"
+      export C_INCLUDE_PATH="$DEVENV_PROFILE/include:''${C_INCLUDE_PATH-}"
 
       # these provide shell completions / default config options
       export XDG_DATA_DIRS="$DEVENV_PROFILE/share:$XDG_DATA_DIRS"

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -72,11 +72,11 @@ in
     env.DEVENV_PROFILE = profile;
 
     enterShell = ''
-      export PS1="\e[0;34m(devenv)\e[0m $PS1"
-      
+      export PS1="\e[0;34m(devenv)\e[0m ''${PS1-}"
+
       # note what environments are active, but make sure we don't repeat them
-      if [[ ! "$DIRENV_ACTIVE" =~ (^|:)"$PWD"(:|$) ]]; then
-        export DIRENV_ACTIVE="$PWD:$DIRENV_ACTIVE"
+      if [[ ! "''${DIRENV_ACTIVE-}" =~ (^|:)"$PWD"(:|$) ]]; then
+        export DIRENV_ACTIVE="$PWD:''${DIRENV_ACTIVE-}"
       fi
 
       # devenv helper


### PR DESCRIPTION
I use nix-darwin + home-manager, and the home-manager zsh + direnv modules to configure my shell. I had to make these changes to get the devenv environment to load using direnv. I believe that's down to me having `strict_env` enabled globally in my home-manager config:

```nix
  programs.direnv = {
    enable = true;
    config.global.strict_env = true;
  };
```

Per direnv docs, this may become the default in the future: https://direnv.net/man/direnv.toml.1.html#codestrictenvcode