### PR TITLE
fix: mysql starting with empty folder

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -12,7 +12,7 @@ let
   startScript = pkgs.writeShellScriptBin "start-mysql" ''
     set -euo pipefail
 
-    if [[ ! -d "$MYSQL_HOME" ]]; then
+    if [[ ! -d "$MYSQL_HOME" || ! -f "$MYSQL_HOME/ibdata1" ]]; then
       mkdir -p "$MYSQL_HOME"
       ${
         if isMariaDB


### PR DESCRIPTION
When you mount tmpfs to `.devenv/state/mysql` folder the MySQL server won't start because the DB will be only created if the entire folder is missing.

