### PR TITLE
First class phps support

### DIFF
--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -293,7 +293,9 @@ in
 
   config =
     let
-      customPhpPackage = (if ((builtins.hasAttr "php${version}" pkgs) && (builtins.tryEval (toString pkgs."php${version}")).success) then pkgs."php${version}" else phps.packages.${pkgs.system}."php${version}");
+      phpsPackage = phps.packages.${pkgs.system}."php${version}" or (throw "PHP version ${cfg.version} is not available");
+      nixpkgsPackageExists = (builtins.tryEval (toString pkgs."php${version}")).success;
+      customPhpPackage = if ((builtins.hasAttr "php${version}" pkgs) && nixpkgsPackageExists) then pkgs."php${version}" else phpsPackage;
     in
     lib.mkIf cfg.enable {
       languages.php.package = lib.mkIf (cfg.version != "") (lib.mkForce (configurePackage customPhpPackage));


### PR DESCRIPTION
Depends on #301 

Allows to use phps by fossar directly

```
languages.php.enable = true;
languages.php.version = "8.1";
languages.php.ini = ''
    memory_limit = 2G
'';
languages.php.extensions = [ "redis" "amqp" ];
```

When you use a PHP version which is not in nixpkgs, you get:

```
       error: To use languages.php.version, you need to add the following to your devenv.yaml:

       inputs:
         phps:
           url: github:fossar/nix-phps
           inputs:
             nixpkgs:
               follows: nixpkgs
```

after adding phps to inputs it's working then