### PR TITLE
language support: GNU Awk

### DIFF
--- a/src/modules/languages/gawk.nix
+++ b/src/modules/languages/gawk.nix
@@ -1,0 +1,17 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.gawk;
+in
+{
+  options.languages.gawk = {
+    enable = lib.mkEnableOption "tools for GNU Awk development";
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      gawk
+      gawkextlib.gawkextlib
+    ];
+  };
+}


### PR DESCRIPTION
WIP PR (still requires testing) to add GNU Awk language support including shared library extension provided by `gawkextlib`.