### PR TITLE
cli: suppress dirty git repository warnings

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -9,7 +9,7 @@ pkgs.writeScriptBin "devenv" ''
   # we want subshells to fail the program
   set -e
 
-  NIX_FLAGS="--show-trace --extra-experimental-features nix-command --extra-experimental-features flakes"
+  NIX_FLAGS="--show-trace --extra-experimental-features nix-command --extra-experimental-features flakes --option warn-dirty false"
 
   # current hack to test if we have resolved all Nix annoyances
   export FLAKE_FILE=.devenv.flake.nix


### PR DESCRIPTION
Currently executing devenv in many cases looks like this:

```
$ devenv shell
Building shell ...
warning: Git tree '/home/bob.vanderlinden/projects/devenv' is dirty
evaluating derivation 'git+file:///home/bob.vanderlinden/projects/devenv#devShells.x86_64-linux.default'computing lock!computing lock!computing lock!computing lock!computing lock!computing lock!computing lock!com
Entering shell ...
```

I heard a collegue being a bit confused about the warning for a dirty git repo. I wanted to avoid this. After this change it looks like:

```
$ result/bin/devenv shell
Building shell ...
evaluating derivation 'git+file:///home/bob.vanderlinden/projects/devenv#devShells.x86_64-linux.default'computing lock!computing lock!computing lock!computing lock!computing lock!computing lock!computing lock!com
Entering shell ...
(devenv) $ 
```

Still figuring out what the `computing lock!` is all about, but this is at least an improvement to the UX :sweat_smile: 