### PR TITLE
search: unpack Nix types when generating the options

### DIFF
--- a/src/flake.nix
+++ b/src/flake.nix
@@ -42,8 +42,20 @@
           ];
         };
         config = project.config;
+
         options = pkgs.nixosOptionsDoc {
           options = builtins.removeAttrs project.options [ "_module" ];
+          # Unpack Nix types, e.g. literalExpression, mDoc.
+          transformOptions =
+            let isDocType = v: builtins.elem v [ "literalDocBook" "literalExpression" "literalMD" "mdDoc" ];
+            in lib.attrsets.mapAttrs (_: v:
+              if v ? _type && isDocType v._type then
+                v.text
+              else if v ? _type && v._type == "derivation" then
+                v.name
+              else
+                v
+            );
         };
       in {
         packages."${pkgs.system}" = {


### PR DESCRIPTION
Yep. This again. 😂  Resolves #314.

Might be faster to do this in jq, after filtering the JSON. But that requires a @domenkozar level of jq hackery.

The docbook warning is annoying, but I guess we just have to wait for nixpkgs to migrate to markdown 🤷 Once that's done, we could consider pretty-printing the markdown.

### Before
```
❯ devenv search starship
trace: warning: literalDocBook is deprecated, use literalMD instead
name           version  description
----           -------  -----------
pkgs.starship  1.12.0   A minimal, blazing fast, and extremely customizable prompt for any shell


jq: error (at <stdin>:76): object ({"_type":"l...) is not valid in a csv row
option  type  default  description
------  ----  -------  -----------

Found 1 packages and 4 options for 'starship'.
```

### After
```
❯ ./result/bin/devenv search starship
trace: warning: literalDocBook is deprecated, use literalMD instead
name           version  description
----           -------  -----------
pkgs.starship  1.12.0   A minimal, blazing fast, and extremely customizable prompt for any shell


option                  type     default                                  description
------                  ----     -------                                  -----------
starship.config.enable  boolean  false                                    Whether to enable Starship config override.
starship.config.path    path     ${config.env.DEVENV_ROOT}/starship.toml  The Starship configuration file to use.
starship.enable         boolean  false                                    Whether to enable the Starship command prompt.
starship.package        package  pkgs.starship                            The Starship package to use.

Found 1 packages and 4 options for 'starship'.
```