### PR TITLE
Move example path overrides to CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -33,15 +33,15 @@ jobs:
         devenv shell devenv-run-tests
   generate-examples:
     runs-on: ubuntu-latest
-    outputs:                                                                                                            
-      examples: ${{ steps.set-examples.outputs.examples }}                                                                    
-    steps:                                                                                                              
-      - name: Checkout base repo                                                                                        
-        uses: actions/checkout@v3                                                                                      
-      - id: set-examples                                                                                                  
-        run: |                                                                                                          
-          json=$(tree -J -L 1 examples | jq -c '[.[0].contents[] | .name]')
-          echo "examples=$json" >> $GITHUB_OUTPUT                     
+    outputs:
+      examples: ${{ steps.set-examples.outputs.examples }}
+    steps:
+    - name: Checkout base repo
+      uses: actions/checkout@v3
+    - id: set-examples
+      run: |
+        json=$(tree -J -L 1 examples | jq -c '[.[0].contents[] | .name]')
+        echo "examples=$json" >> $GITHUB_OUTPUT
   examples:
     name: example ${{ matrix.example }} (${{ join(matrix.os) }})
     needs: [generate-examples]
@@ -51,19 +51,19 @@ jobs:
         example: ${{ fromJSON(needs.generate-examples.outputs.examples) }}
     runs-on: ${{ matrix.os }}
     steps:
-     - uses: actions/checkout@v3
-     - uses: cachix/install-nix-action@v19
-       with:
-         extra_nix_config: |
-           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-     - uses: cachix/cachix-action@v12
-       with:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - uses: cachix/cachix-action@v12
+      with:
         name: devenv
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-     - run: |
-          nix profile remove '.*'
-          nix profile install .
-     - run: devenv shell devenv-test-example ${{ matrix.example }}
+    - run: |
+        nix profile remove '.*'
+        nix profile install .
+    - run: devenv shell devenv-test-example ${{ matrix.example }}
   direnv:
     name: direnv (${{ join(matrix.os) }})
     strategy:
@@ -71,21 +71,21 @@ jobs:
         os: [[ubuntu-latest], [macos-latest], [self-hosted, macOS]]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v19
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v12
-        with:
-          name: devenv
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: |
-          nix profile remove '.*'
-          nix profile install . 'nixpkgs#direnv'
-          mkdir -p ~/.config/direnv/
-          cat > ~/.config/direnv/direnv.toml << 'EOF'
-          [global]
-          strict_env = true
-          EOF
-          direnv allow ./examples/simple
-          direnv exec ./examples/simple true
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v19
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v12
+      with:
+        name: devenv
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: |
+        nix profile remove '.*'
+        nix profile install . 'nixpkgs#direnv'
+        mkdir -p ~/.config/direnv/
+        cat > ~/.config/direnv/direnv.toml << 'EOF'
+        [global]
+        strict_env = true
+        EOF
+        direnv allow ./examples/simple
+        direnv exec ./examples/simple true

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -63,6 +63,16 @@ jobs:
     - run: |
         nix profile remove '.*'
         nix profile install .
+    - run: |
+        cd examples/${{ matrix.example }}/
+        mv devenv.yaml devenv.yaml.orig
+        awk '
+          { print }
+          /^inputs:$/ {
+            print "  devenv:";
+            print "    url: path:../../src/modules";
+          }
+        ' devenv.yaml.orig > devenv.yaml
     - run: devenv shell devenv-test-example ${{ matrix.example }}
   direnv:
     name: direnv (${{ join(matrix.os) }})

--- a/devenv.nix
+++ b/devenv.nix
@@ -55,7 +55,6 @@
     popd
     rm -rf "$tmp"
 
-    # TODO: test direnv integration
     # TODO: test DIRENV_ACTIVE
   '';
   scripts.devenv-test-all-examples.exec = ''

--- a/examples/caddy-php/devenv.lock
+++ b/examples/caddy-php/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/hivemind/devenv.lock
+++ b/examples/hivemind/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/hivemind/devenv.yaml
+++ b/examples/hivemind/devenv.yaml
@@ -1,6 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules
-

--- a/examples/mysql/devenv.lock
+++ b/examples/mysql/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/mysql/devenv.yaml
+++ b/examples/mysql/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/nur/devenv.yaml
+++ b/examples/nur/devenv.yaml
@@ -3,5 +3,3 @@ inputs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
   nur:
     url: github:nix-community/NUR
-  devenv:
-    url: path:../../src/modules

--- a/examples/overmind/devenv.lock
+++ b/examples/overmind/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-utils": {
       "locked": {

--- a/examples/overmind/devenv.yaml
+++ b/examples/overmind/devenv.yaml
@@ -1,6 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules
-

--- a/examples/postgres/devenv.yaml
+++ b/examples/postgres/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/process-compose/devenv.lock
+++ b/examples/process-compose/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/process-compose/devenv.yaml
+++ b/examples/process-compose/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/python-poetry/devenv.lock
+++ b/examples/python-poetry/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-utils": {
       "locked": {

--- a/examples/python-poetry/devenv.yaml
+++ b/examples/python-poetry/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/python-venv/devenv.lock
+++ b/examples/python-venv/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-utils": {
       "locked": {

--- a/examples/python-venv/devenv.yaml
+++ b/examples/python-venv/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/racket/devenv.lock
+++ b/examples/racket/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/racket/devenv.yaml
+++ b/examples/racket/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/ruby/devenv.lock
+++ b/examples/ruby/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/ruby/devenv.yaml
+++ b/examples/ruby/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/rust/devenv.lock
+++ b/examples/rust/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "fenix": {
       "inputs": {

--- a/examples/rust/devenv.yaml
+++ b/examples/rust/devenv.yaml
@@ -4,5 +4,3 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
-  devenv:
-    url: path:../../src/modules

--- a/examples/scala/devenv.lock
+++ b/examples/scala/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/scala/devenv.yaml
+++ b/examples/scala/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/scripts/devenv.lock
+++ b/examples/scripts/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/scripts/devenv.yaml
+++ b/examples/scripts/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/simple-remote/devenv.yaml
+++ b/examples/simple-remote/devenv.yaml
@@ -4,7 +4,5 @@ inputs:
   getting-started:
     url: github:nix-dot-dev/getting-started-nix-template
     flake: false
-  devenv:
-    url: path:../../src/modules
 imports:
   - getting-started

--- a/examples/simple/devenv.yaml
+++ b/examples/simple/devenv.yaml
@@ -1,4 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-# can't point to the local modules here as it's used as a template

--- a/examples/starship/devenv.lock
+++ b/examples/starship/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/starship/devenv.yaml
+++ b/examples/starship/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/supported-languages/devenv.lock
+++ b/examples/supported-languages/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/supported-languages/devenv.yaml
+++ b/examples/supported-languages/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-  devenv:
-    url: path:../../src/modules

--- a/examples/wiremock/devenv.lock
+++ b/examples/wiremock/devenv.lock
@@ -2,14 +2,20 @@
   "nodes": {
     "devenv": {
       "locked": {
-        "path": "../../src/modules",
-        "type": "path"
+        "dir": "src/modules",
+        "lastModified": 1675567441,
+        "narHash": "sha256-SGXaZkv/7MTt+iplexU2ZU2yY10G5lFsjGu4Q5j1p44=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "871faa3fee0f4550074212b3db180e62fa699ab4",
+        "type": "github"
       },
       "original": {
-        "path": "../../src/modules",
-        "type": "path"
-      },
-      "parent": []
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
     },
     "flake-compat": {
       "flake": false,

--- a/examples/wiremock/devenv.yaml
+++ b/examples/wiremock/devenv.yaml
@@ -1,5 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixos-unstable
-  devenv:
-    url: path:../../src/modules


### PR DESCRIPTION
Following on https://github.com/cachix/devenv/pull/347#issuecomment-1414286036, this makes the `simple` example again  test against the checkout, instead of what's in the lockfile. This benefits the direnv test, which can now pick up on any breakages.

I thought this also affected other examples, but noticed they all have a `devenv.yaml` path override. At the same time, there's [a todo](https://github.com/cachix/devenv/blob/871faa3fee0f4550074212b3db180e62fa699ab4/src/devenv.nix#L132-L133) to expand `devenv init` to other examples, so these would also be affected down the line.

This PR removes all those path overrides, and instead adds them in CI right before running the test. ~~This modification makes the lockfiles a little useless, so I've removed them. That also saves a few kb in releases, and helps us catch any breakages via nixpkgs or other inputs.~~

I also noticed [the comment in `examples/simple/devenv.yaml`](https://github.com/cachix/devenv/blob/871faa3fee0f4550074212b3db180e62fa699ab4/examples/simple/devenv.yaml#L4) was leaking in `devenv init`. This can be seen in the 0.5.1 release. With this change, we can get rid of it.