### PR TITLE
Language Support: Raku

### DIFF
--- a/src/modules/languages/raku.nix
+++ b/src/modules/languages/raku.nix
@@ -4,7 +4,7 @@ let
   cfg = config.languages.raku;
 in
 {
-  options.languages.perl = {
+  options.languages.raku = {
     enable = lib.mkEnableOption "Enable tools for Raku development.";
   };
 

--- a/src/modules/languages/raku.nix
+++ b/src/modules/languages/raku.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.perl = {
-    enable = lib.mkEnableOption "tools for Raku development";
+    enable = lib.mkEnableOption "Enable tools for Raku development.";
   };
 
   config = lib.mkIf cfg.enable {

--- a/src/modules/languages/raku.nix
+++ b/src/modules/languages/raku.nix
@@ -1,0 +1,16 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.raku;
+in
+{
+  options.languages.perl = {
+    enable = lib.mkEnableOption "tools for Raku development";
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      rakudo
+    ];
+  };
+}


### PR DESCRIPTION
Adds simple language support for the [Raku Programming Language](https://www.raku.org/) by providing the [Rakudo Compiler - Rakudo Compiler for Raku Programming Language](https://rakudo.org/) implementation of Raku.