### PR TITLE
docs/getting-started: use latest branch instead of tag

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,13 +49,13 @@ c) Install ``devenv``
 === "Newcomers"
 
     ```
-    nix-env -if https://github.com/cachix/devenv/tarball/v{{ devenv.version }}
+    nix-env -if https://github.com/cachix/devenv/tarball/latest
     ```
 
 === "Advanced (flake profiles)"
 
     ```
-    nix profile install github:cachix/devenv/v{{ devenv.version }}
+    nix profile install github:cachix/devenv/latest
     ```
 
 === "Advanced (declaratively without flakes)"
@@ -70,7 +70,7 @@ c) Install ``devenv``
 
     ```nix title="flake.nix"
      {
-        inputs.devenv.url = "github:cachix/devenv/v{{ devenv.version }}";
+        inputs.devenv.url = "github:cachix/devenv/latest";
 
         outputs = { devenv, ... }: {
             packages.x86_64-linux = [devenv.packages.x86_64-linux.devenv];


### PR DESCRIPTION
Currently people starting with devenv are instructed to use an URL to a specific version of devenv (like `v0.5.1`). This makes upgrading using `nix-env` and `nix profile` a bit strange.

The UX looks as follows:

```console
$ nix profile install github:cachix/devenv/v0.5.1
...
$ nix profile list
0 github:cachix/devenv/latest#defaultPackage.x86_64-linux ...
$ nix profile remove 0
$ nix profile install github:cachix/devenv/v0.5.2
```

This can be improved a bit by using the stable branch:

```console
$ nix profile install github:cachix/devenv/latest
...
$ nix profile list
0 github:cachix/devenv/latest#defaultPackage.x86_64-linux ...
$ nix profile upgrade 0
```

This also aligns with what Nix suggests in `nix profile` configuration to upgrade all packages:

```console
$ nix profile install github:cachix/devenv/latest
...
$ nix profile upgrade '.*'
```

Before, this would not upgrade devenv.

I have left the following as-is, because `fetchTarball` doesn't lock the version, thus `latest` would be floating:

```
    environment.systemPackages = [ 
      (import (fetchTarball https://github.com/cachix/devenv/archive/latest.tar.gz)).default
    ];
```