### PR TITLE
properly escape color codes to avoid long command lines wraping back on themselves

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -72,7 +72,7 @@ in
     env.DEVENV_PROFILE = profile;
 
     enterShell = ''
-      export PS1="\e[0;34m(devenv)\e[0m ''${PS1-}"
+      export PS1="\[\e[0;34m\](devenv)\[\e[0m\] ''${PS1-}"
 
       # note what environments are active, but make sure we don't repeat them
       if [[ ! "''${DIRENV_ACTIVE-}" =~ (^|:)"$PWD"(:|$) ]]; then


### PR DESCRIPTION
I've noticed that since `v0.5` long command lines wrap around and start overwriting the previous line.

Wrapping the color codes in a `\[..\]` seem to do the trick. Not a bash expert, so there might be a better way of doing this :shrug: 

going off https://askubuntu.com/questions/24358/how-do-i-get-long-command-lines-to-wrap-to-the-next-line