### PR TITLE
Set LOCALE_ARCHIVE if missing on non-NixOS hosts

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -74,6 +74,13 @@ in
     enterShell = ''
       export PS1="\e[0;34m(devenv)\e[0m ''${PS1-}"
 
+      # set path to locales on non-NixOS Linux hosts
+      ${lib.optionalString pkgs.stdenv.isLinux ''
+        if [ -z "$LOCALE_ARCHIVE" ]; then
+          export LOCALE_ARCHIVE=${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive
+        fi
+      ''}
+
       # note what environments are active, but make sure we don't repeat them
       if [[ ! "''${DIRENV_ACTIVE-}" =~ (^|:)"$PWD"(:|$) ]]; then
         export DIRENV_ACTIVE="$PWD:''${DIRENV_ACTIVE-}"


### PR DESCRIPTION
Set `LOCALE_ARCHIVE` if missing to avoid locale issues on non-NixOS  systems. Resolves #353.

@domenkozar, there's a second solution here, which is to use the archive that already ships with the OS: `/usr/lib/locale/locale-archive`.  I tested it out on Ubuntu, but I have no idea how trustworthy this location is. If we really wanted to, we could first check the local path and then set it to `glibcLocalesUtf8` as fallback. Thoughts?

| Before | After |
| -------| ------|
| <img width="1512" alt="Screenshot 2023-02-07 at 21 38 55" src="https://user-images.githubusercontent.com/7572407/217331569-c70da3f6-a777-4bf7-90a7-bd34fd63ad1d.png"> |  <img width="1512" alt="Screenshot 2023-02-07 at 22 14 20" src="https://user-images.githubusercontent.com/7572407/217331600-c2f46d42-ddb1-427f-a906-111fa5fc93a0.png"> |
