### PR TITLE
cli: use column from util-linux package

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -104,14 +104,14 @@ pkgs.writeScriptBin "devenv" ''
       if [ "$results" = "{}" ]; then
         echo "No packages found for '$name'."
       else
-        ${pkgs.jq}/bin/jq -r '[to_entries[] | {name: ("pkgs." + (.key | split(".") | del(.[0, 1]) | join("."))) } * (.value | { version, description})] | (.[0] |keys_unsorted | @tsv) , (["----", "-------", "-----------"] | @tsv), (.[]  |map(.) |@tsv)' <<< "$results" | column -ts $'\t'
+        ${pkgs.jq}/bin/jq -r '[to_entries[] | {name: ("pkgs." + (.key | split(".") | del(.[0, 1]) | join("."))) } * (.value | { version, description})] | (.[0] |keys_unsorted | @tsv) , (["----", "-------", "-----------"] | @tsv), (.[]  |map(.) |@tsv)' <<< "$results" | ${pkgs.util-linux}/bin/column -ts $'\t'
         echo
       fi
       echo
       if [ "$results_options" = "{}" ]; then
         echo "No options found for '$name'."
       else
-        ${pkgs.jq}/bin/jq -r '["option","type","default", "description"], ["------", "----", "-------", "-----------"],(to_entries[] | [.key, .value.type, .value.default, .value.description[0:80]]) | @tsv' <<< "$results_options" | column -ts $'\t'
+        ${pkgs.jq}/bin/jq -r '["option","type","default", "description"], ["------", "----", "-------", "-----------"],(to_entries[] | [.key, .value.type, .value.default, .value.description[0:80]]) | @tsv' <<< "$results_options" | ${pkgs.util-linux}/bin/column -ts $'\t'
       fi
       echo
       echo "Found $(${pkgs.jq}/bin/jq 'length' <<< "$results") packages and $(${pkgs.jq}/bin/jq 'length' <<< "$results_options") options for '$name'."


### PR DESCRIPTION
Currently whenever a user doesn't have the `column` command, `devenv search` will fail.

For instance, I tried using devenv in `docker run -it ubuntu`. It resulted in the following output:

```
$ devenv search firefox
...
/home/me/.nix-profile/bin/devenv: line 100: column: command not found
```

This change should resolve that issue.