### PR TITLE
add TeX Live support

### DIFF
--- a/examples/texlive/devenv.nix
+++ b/examples/texlive/devenv.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  languages.texlive = {
+    enable = true;
+    packages = [ "scheme-small" "biblatex" "latexmk" ];
+  };
+}

--- a/examples/texlive/devenv.yaml
+++ b/examples/texlive/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/languages/texlive.nix
+++ b/src/modules/languages/texlive.nix
@@ -1,0 +1,26 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.languages.texlive;
+
+  base = cfg.base;
+  packages = lib.genAttrs cfg.packages (name: base.${name} or (throw "No such texlive package ${name}"));
+  package = base.combine packages;
+in
+{
+  options.languages.texlive = {
+    enable = lib.mkEnableOption "TeX Live";
+    base = lib.mkOption {
+      default = pkgs.texlive;
+      defaultText = lib.literalExpression "pkgs.texlive";
+      description = "TeX Live package set to use";
+    };
+    packages = lib.mkOption {
+      type = lib.types.nonEmptyListOf lib.types.string;
+      default = [ "collection-basic" ];
+      description = "Packages available to TeX Live";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    packages = [ package ];
+  };
+}


### PR DESCRIPTION
This contains a new module for Tex Live under `languages.texlive`.
The module itself is taken almost verbatim from Home-Manager, hence the comment and license header.