### PR TITLE
Allow the user to use a different version of OCaml

### DIFF
--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -6,13 +6,25 @@ in
 {
   options.languages.ocaml = {
     enable = lib.mkEnableOption "tools for OCaml development";
+
+    packages = lib.mkOption
+      {
+        type = lib.types.attrs;
+        description = "The package set of OCaml to use";
+        default = pkgs.ocaml-ng.ocamlPackages;
+        defaultText = lib.literalExpression "pkgs.ocaml-ng.ocamlPackages_4_12";
+      };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
-      pkgs.ocaml
-      pkgs.ocaml-ng.ocamlPackages.dune_3
-      pkgs.ocaml-ng.ocamlPackages.ocaml-lsp
+      cfg.packages.ocaml
+      cfg.packages.dune_3
+      cfg.packages.ocaml-lsp
+      cfg.packages.merlin
+      cfg.packages.utop
+      cfg.packages.odoc
+      pkgs.ocamlformat
     ];
   };
 }


### PR DESCRIPTION
This will allow the user to specify which version of OCaml and associated tools that they would like to use for their project.

This will also include a few extra common tools within the OCaml ecosystem.