### PR TITLE
raku.nix: fixed lib.mkEnableOption string to not break web documentation

### DIFF
--- a/src/modules/languages/raku.nix
+++ b/src/modules/languages/raku.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.languages.raku = {
-    enable = lib.mkEnableOption "Enable tools for Raku development.";
+    enable = lib.mkEnableOption "tools for Raku development";
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
The description string set in `lib.mkEnableOption` breaks the documentation logic of https://devenv.sh/reference/options/#languagesrakuenable as it is displayed there as `Whether to enable Enable tools for Raku development..`, this PR fixes this.