### PR TITLE
info: make sections pluggable

### DIFF
--- a/src/modules/info.nix
+++ b/src/modules/info.nix
@@ -1,27 +1,25 @@
 { lib, config, ... }:
 
+let
+  renderSection = section: lib.concatStringsSep "\n" (builtins.map (entry: "- ${entry}") section);
+in
 {
   options = {
     info = lib.mkOption {
       type = lib.types.lines;
       internal = true;
     };
+
+    infoSections = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.listOf lib.types.str);
+      default = { };
+      description =
+        "Information about the environment";
+    };
   };
 
-  # TODO: show scripts path
-  # TODO: make this pluggable so any option can be shown
 
-  config.info = ''
-    # env
-    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "- ${name}: ${toString value}") config.env)}
-
-    # packages
-    ${lib.concatStringsSep "\n" (builtins.map (package: "- ${package.name}") (builtins.filter (package: !(builtins.elem package.name (builtins.attrNames config.scripts))) config.packages))}
-
-    # scripts
-    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: script: "- ${name}") config.scripts)}
-
-    # processes
-    ${lib.concatStringsSep "\n" (lib.mapAttrsToList (name: process: "- ${name}: ${process.exec}") config.processes)}
-  '';
+  config = {
+    info = lib.concatStringsSep "\n\n" (lib.mapAttrsToList (name: section: if (section != [ ]) then "# ${name}\n${renderSection section}" else "") config.infoSections);
+  };
 }

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -176,6 +176,8 @@ in
 
     ci = [ config.procfileScript ];
 
+    infoSections."processes" = lib.mapAttrsToList (name: process: "${name}: ${process.exec}") config.processes;
+
     env =
       if implementation == "process-compose" then {
         PC_HTTP_PORT = implementation-options.port;

--- a/src/modules/scripts.nix
+++ b/src/modules/scripts.nix
@@ -24,5 +24,8 @@ in
 
   config = {
     packages = lib.mapAttrsToList toPackage config.scripts;
+
+    # TODO: show scripts path
+    infoSections."scripts" = lib.mapAttrsToList (name: script: name) config.scripts;
   };
 }

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -104,6 +104,9 @@ in
       shellHook = config.enterShell;
     };
 
+    infoSections."env" = lib.mapAttrsToList (name: value: "${name}: ${toString value}") config.env;
+    infoSections."packages" = builtins.map (package: package.name) (builtins.filter (package: !(builtins.elem package.name (builtins.attrNames config.scripts))) config.packages);
+
     ci = [ config.shell.inputDerivation ];
     ciDerivation = pkgs.runCommand "ci" { } ("ls " + toString config.ci + " && touch $out");
   };


### PR DESCRIPTION
This allows extending `devenv info` by adding:

```
{
  sectionInfo."foo" = [ "myitem" ];
}
```

Still not sure about `sectionInfo` naming :)