### PR TITLE
Give go language more love

### DIFF
--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -20,5 +20,7 @@ in
       cfg.package
       gotools
     ];
+
+    env.GOROOT = cfg.package + "/share/go/";
   };
 }

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -19,6 +19,11 @@ in
     packages = with pkgs; [
       cfg.package
       gotools
+      gotests
+      gomodifytags
+      impl
+      delve
+      gopls
     ];
 
     env.GOROOT = cfg.package + "/share/go/";

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -6,11 +6,18 @@ in
 {
   options.languages.go = {
     enable = lib.mkEnableOption "tools for Go development";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.go;
+      defaultText = lib.literalExpression "pkgs.go";
+      description = "The Go package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      go
+      cfg.package
       gotools
     ];
   };

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -28,5 +28,9 @@ in
 
     env.GOROOT = cfg.package + "/share/go/";
     env.GOPATH = config.env.DEVENV_STATE + "/go";
+
+    enterShell = ''
+      export PATH=$GOPATH:$PATH
+    '';
   };
 }

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -22,5 +22,6 @@ in
     ];
 
     env.GOROOT = cfg.package + "/share/go/";
+    env.GOPATH = config.env.DEVENV_STATE + "/go";
   };
 }


### PR DESCRIPTION
- Allow changing the GO version
- Fix go version conflict when you have go already installed, fixes #346 
- Isolate installed go packages inside devenv into into state/go, fixes #389 
  - Isolated directory is also added to normal PATH
- Install all required go packages to use VSCode with language server (I guess other editors too)


```
languages.go = {
    enable = true;
    package = pkgs.go_1_20;
};
```