### PR TITLE
remove version output of crystal

### DIFF
--- a/src/modules/languages/crystal.nix
+++ b/src/modules/languages/crystal.nix
@@ -13,10 +13,5 @@ in
       pkgs.crystal
       pkgs.shards
     ];
-
-    enterShell = ''
-      crystal --version
-      shards --version
-    '';
   };
 }


### PR DESCRIPTION
We removed from a while ago all version outputs in the terminal. Seems like forgotten here