### PR TITLE
ci: add access token to NIX_CONFIG

### DIFF
--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -7,6 +7,9 @@ on:
   pull_request:
   push:
 
+env:
+  NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
+  
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
Hey there,

I got rate limited on running `nix profile install github:cachix/devenv/v0.5` & found a `NIX_CONFIG` setting to define an access token for `GitHub` in https://nixos.org/manual/nix/unstable/command-ref/conf-file.html#conf-access-tokens 

Let me know what you think 😉 