### PR TITLE
ruby: assert version and versionFile not both set at once

### DIFF
--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -51,6 +51,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.version == null || cfg.versionFile == null;
+        message = ''
+          `languages.ruby.version` and `languages.ruby.versionFile` are both set.
+          Only one of the two may be set. Remove one of the two options.
+        '';
+      }
+    ];
+
     # enable C tooling by default so native extensions can be built
     languages.c.enable = lib.mkDefault true;
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -20,11 +20,18 @@ let
   failedAssertions = builtins.map (x: x.message) (builtins.filter (x: !x.assertion) config.assertions);
 
   performAssertions =
+    let
+      formatAssertionMessage = message:
+        let
+          lines = lib.splitString "\n" message;
+        in
+        "- ${lib.concatStringsSep "\n  " lines}";
+    in
     if failedAssertions != [ ]
     then
       throw ''
         Failed assertions:
-        ${lib.concatStringsSep "\n" (builtins.map (x: "- ${x}") failedAssertions)}
+        ${lib.concatStringsSep "\n" (builtins.map formatAssertionMessage failedAssertions)}
       ''
     else lib.id;
 in


### PR DESCRIPTION
Currently whenever both `languages.ruby.version` and `languages.ruby.versionFile` are set, a confusing error message is shown:

```
       error: The option `languages.ruby.package' is defined multiple times while it's expected to be unique.

       Definition values:
       - In `«github:cachix/devenv/3f845b2aff58d0ae27d9777500fe0c80b837ffb2»/src/modules/languages/ruby.nix': <derivation ruby-3.2.1>
       - In `«github:cachix/devenv/3f845b2aff58d0ae27d9777500fe0c80b837ffb2»/src/modules/languages/ruby.nix': <derivation ruby-3.2.1>
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

After this PR it'll look like:

```
       error: Failed assertions:
       - `languages.ruby.version` and `languages.ruby.versionFile` are both set.
         Only one of the two may be set. Remove one of the two options.
```

The change to (top-level) assertions is to avoid the message not being aligned correct. Without that change the error would look like:

```
       error: Failed assertions:
       - `languages.ruby.version` and `languages.ruby.versionFile` are both set.
       Only one of the two may be set. Remove one of the two options.
```

Which I thought could throw people off without proper indentation.