### PR TITLE
python: rebuild venv when devenv-profile is updated 

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -43,12 +43,11 @@ let
 
       if [ "$ACTUAL_POETRY_CHECKSUM" != "$EXPECTED_POETRY_CHECKSUM" ]
       then
-        poetry install --no-interaction --quiet
+        ${cfg.poetry.package}/bin/poetry install --no-interaction --quiet
         echo "$ACTUAL_POETRY_CHECKSUM" > "$POETRY_CHECKSUM_FILE"
       fi
     fi
   '';
-
 in
 {
   options.languages.python = {
@@ -67,8 +66,14 @@ in
       enable = lib.mkEnableOption "poetry";
       package = lib.mkOption {
         type = lib.types.package;
-        default = cfg.package.pkgs.poetry-core;
-        defaultText = lib.literalExpression "config.languages.python.package.pkgs.poetry";
+        default = pkgs.poetry.override {
+          python3 = cfg.package;
+        };
+        defaultText = lib.literalExpression ''
+          pkgs.poetry.override {
+            python3 = config.languages.python.package;
+          }
+        '';
         description = "The Poetry package to use.";
       };
     };


### PR DESCRIPTION
Resolves #336

This PR includes 3 changes

22adea33daf57df14debc6cf6bc55b9db1ddfad5 is to resolve #336. It recreates venv each time devenv-profile is updated.

While working on this change I ran into syntax errors in my enterShell script. This resulted in errors like:

```
$ devenv shell
Building shell ...
Entering shell ...

bash: eval: line 231: syntax error near unexpected token `devenv'
bash: eval: line 231: `export PS1="\[\e[0;34m\](devenv)\[\e[0m\] ${PS1-}"'
```

It was hard to pin down where the problem actually lays, so I decided to move the venv and poetry scripts from enterShell to separate .sh files. This made the error messages clearer and the enterShell code more readable. See 057b1c019ae27a4cfd5eef37b88a7b20b8ba8bef

Lastly I noticed that there could be problems with running poetry when venv is rebuild. I resolved these in 9590d815a059dfc1dc1a483ddcb21352e472e854.

See the commit messages of the individual commits for further explanation.