### PR TITLE
fix(process-compose): do not escape strings for process-compose env vars

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -33,9 +33,10 @@ let
 
   implementation = config.process.implementation;
   implementation-options = config.process.${implementation};
+  envValSerializer = if implementation == "process-compose" then toString else builtins.toJSON;
   envList =
     lib.mapAttrsToList
-      (name: value: "${name}=${builtins.toJSON value}")
+      (name: value: "${name}=${envValSerializer value}")
       (if config.devenv.flakesIntegration then
       # avoid infinite recursion in the scenario the `config` parameter is
       # used in a `processes` declaration inside a devenv module.


### PR DESCRIPTION
fixes breakage caused by https://github.com/cachix/devenv/commit/8bc83de411910ec5ed9759f8478c49639326e5f0

Bug caused `"/` folders to be created in `$DEVENV_ROOT`.
