### PR TITLE
Using `[` instead of `[[` with (maybe) empty bash vars can cause errors.

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -122,7 +122,7 @@ pkgs.writeScriptBin "devenv" ''
 
       paths=$($CUSTOM_NIX/bin/nix $NIX_FLAGS build --impure --no-link --print-out-paths "''${builds[@]}")
  
-      if [ $exec -eq 1 ]; then
+      if [[ $exec -eq 1 ]]; then
         $paths "$@"
       else
         echo "$paths"


### PR DESCRIPTION
e.g.
When I tried to run `devenv build`, this caused this error:
```
/nix/store/[...]-devenv-profile/bin/devenv: line 118: [: -eq: unary operator expected
```

... even though the code suggested it should default to running as `devenv build shell`