### PR TITLE
feat(go): use correct go version for tools

### DIFF
--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -2,6 +2,12 @@
 
 let
   cfg = config.languages.go;
+
+  goVersion = (lib.versions.major cfg.package.version) + (lib.versions.minor cfg.package.version);
+
+  buildWithSpecificGo = pkg: pkg.override {
+    buildGoModule = pkgs."buildGo${goVersion}Module";
+  };
 in
 {
   options.languages.go = {
@@ -16,14 +22,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
+    packages = [
       cfg.package
-      gotools
-      gotests
-      gomodifytags
-      impl
-      delve
-      gopls
+
+      # Required by vscode-go
+      pkgs.delve
+
+      # vscode-go expects all tool compiled with the same used go version, see: https://github.com/golang/vscode-go/blob/72249dc940e5b6ec97b08e6690a5f042644e2bb5/src/goInstallTools.ts#L721
+      (buildWithSpecificGo pkgs.gotools)
+      (buildWithSpecificGo pkgs.gomodifytags)
+      (buildWithSpecificGo pkgs.impl)
+      (buildWithSpecificGo pkgs.go-tools)
+      (buildWithSpecificGo pkgs.gopls)
+      (buildWithSpecificGo pkgs.gotests)
     ];
 
     env.GOROOT = cfg.package + "/share/go/";


### PR DESCRIPTION
Installed Go Tools must have the same version as the installed toolchain. 
![image](https://user-images.githubusercontent.com/6224096/221360747-113614fd-67e6-4c31-89d4-59419495d12a.png)

VSCode annoys always on any startup

