### PR TITLE
docs/github-actions: use devenv version 0.5.1

### DIFF
--- a/docs/integrations/github-actions.md
+++ b/docs/integrations/github-actions.md
@@ -20,7 +20,7 @@ jobs:
       with:
         name: devenv
     - name: Install devenv.sh
-      run: nix profile install github:cachix/devenv/v0.5
+      run: nix profile install github:cachix/devenv/v0.5.1
       shell: sh
     - run: devenv ci
     - run: devenv shell echo ok


### PR DESCRIPTION
Currently the documented version to install in GitHub Actions is 0.5, where-as 0.5.1 is the latest version. I was contemplating whether `latest` needed to be used, but I don't know whether that is a good idea already, since parts of devenv still rely on the cli itself.