### PR TITLE
Update the reference docs for the the new doc renderer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ extra:
 markdown_extensions:
   - tables
   - admonition
+  - pymdownx.escapeall
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite


### PR DESCRIPTION
* Escape carets in the headers (see pre-commit or container options).
* Rewrite the declarations field to point to the GitHub repo where these options are defined.

Closes #359.

| Before | After |
| ------- | ---- |
| <img width="1512" alt="Screenshot 2023-03-02 at 21 23 57" src="https://user-images.githubusercontent.com/7572407/222505711-61733fb4-f20c-415d-95cf-1d9f01f09ba6.png"> | <img width="1512" alt="Screenshot 2023-03-02 at 21 24 09" src="https://user-images.githubusercontent.com/7572407/222505829-11d9f22e-90ca-4190-991e-56590ca48720.png"> |


