### PR TITLE
fix(postgres): remove override options, as currently they are serialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ result
 /include
 /lib
 pyvenv.cfg
+/.direnv

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -229,7 +229,7 @@ in
 
       process-compose = {
         # SIGINT (= 2) for faster shutdown: https://www.postgresql.org/docs/current/server-shutdown.html
-        shutdown.signal = lib.mkDefault 2;
+        shutdown.signal = 2;
 
         readiness_probe = {
           exec.command = "${cfg.package}/bin/pg_isready -h $PGDATA -d template1";
@@ -241,7 +241,7 @@ in
         };
 
         # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
-        availability.restart = lib.mkDefault "on_failure";
+        availability.restart = "on_failure";
       };
     };
   };


### PR DESCRIPTION
fixes https://github.com/cachix/devenv/issues/453

I tried to fix this properly by modifying the offending line:
https://github.com/cachix/devenv/blob/main/src/modules/processes.nix#L142

But regardless, the YAML file was written with the non-merged values (despite the NixOS module system stating that `config` should be always the final resolved value).
Given the severity of the bug, this is an intermediate quick fix. We should investigate where the override serialization problem exists.