### PR TITLE
lang/nix: add nix-tree

### DIFF
--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -15,6 +15,7 @@ in
       vulnix
       deadnix
       nil
+      nix-tree
     ];
   };
 }


### PR DESCRIPTION
I'm not sure if this is in scope for devenv.

nix-tree is a graphical tool for inspecting closures I reach for a lot when I'm trying to optimize dependency trees. It is not a nix language tool per se. Maybe behind a config flag, like `languages.nix.storeTools.enable`?

Feel free to close if it seems out of scope.