### PR TITLE
docs: strip colons from help text

### DIFF
--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -38,8 +38,8 @@ pkgs.writeScriptBin "devenv" ''
       echo
       echo "Commands:"
       echo
-      echo "up:             Starts processes in foreground. See http://devenv.sh/processes"
-      echo "version:        Display devenv version"
+      echo "up              Starts processes in foreground. See http://devenv.sh/processes"
+      echo "version         Display devenv version"
       echo
       exit 1
   esac

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -270,18 +270,18 @@ pkgs.writeScriptBin "devenv" ''
       echo
       echo "Commands:"
       echo
-      echo "init:                     Scaffold devenv.yaml, devenv.nix, and .envrc inside the current directory."
-      echo "init TARGET:              Scaffold devenv.yaml, devenv.nix, and .envrc inside TARGET directory."
-      echo "search NAME:              Search packages matching NAME in nixpkgs input."
-      echo "shell:                    Activate the developer environment."
-      echo "shell CMD [args]:         Run CMD with ARGS in the developer environment. Useful when scripting."
+      echo "init                      Scaffold devenv.yaml, devenv.nix, and .envrc inside the current directory."
+      echo "init TARGET               Scaffold devenv.yaml, devenv.nix, and .envrc inside TARGET directory."
+      echo "search NAME               Search packages matching NAME in nixpkgs input."
+      echo "shell                     Activate the developer environment."
+      echo "shell CMD [args]          Run CMD with ARGS in the developer environment. Useful when scripting."
       echo "container [options] NAME  Generate a container for NAME. See devenv container --help and http://devenv.sh/containers"
-      echo "info:                     Print information about the current developer environment."
-      echo "update:                   Update devenv.lock from devenv.yaml inputs. See http://devenv.sh/inputs/#locking-and-updating-inputs"
-      echo "up:                       Starts processes in foreground. See http://devenv.sh/processes"
-      echo "gc:                       Removes old devenv generations. See http://devenv.sh/garbage-collection"
-      echo "ci:                       Builds your developer environment and make sure all checks pass."
-      echo "version:                  Display devenv version"
+      echo "info                      Print information about the current developer environment."
+      echo "update                    Update devenv.lock from devenv.yaml inputs. See http://devenv.sh/inputs/#locking-and-updating-inputs"
+      echo "up                        Starts processes in foreground. See http://devenv.sh/processes"
+      echo "gc                        Removes old devenv generations. See http://devenv.sh/garbage-collection"
+      echo "ci                        Builds your developer environment and make sure all checks pass."
+      echo "version                   Display devenv version"
       echo
       exit 1
   esac


### PR DESCRIPTION
This removes the (inconsistent) colons at the end of commands in the help text, to make the help text a bit more readable.

Before:

```
[...]
Commands:

init:                     Scaffold devenv.yaml, devenv.nix, and .envrc inside the current directory.
init TARGET:              Scaffold devenv.yaml, devenv.nix, and .envrc inside TARGET directory.
search NAME:              Search packages matching NAME in nixpkgs input.
shell:                    Activate the developer environment.
shell CMD [args]:         Run CMD with ARGS in the developer environment. Useful when scripting.
container [options] NAME  Generate a container for NAME. See devenv container --help and http://devenv.sh/containers
info:                     Print information about the current developer environment.
[...]
```

After:


```
[...]
Commands:

init                      Scaffold devenv.yaml, devenv.nix, and .envrc inside the current directory.
init TARGET               Scaffold devenv.yaml, devenv.nix, and .envrc inside TARGET directory.
search NAME               Search packages matching NAME in nixpkgs input.
shell                     Activate the developer environment.
shell CMD [args]          Run CMD with ARGS in the developer environment. Useful when scripting.
container [options] NAME  Generate a container for NAME. See devenv container --help and http://devenv.sh/containers
info                      Print information about the current developer environment.
[...]
```
