### PR TITLE
envrc: give explanation on failing devenv builds

### DIFF
--- a/templates/simple/.envrc
+++ b/templates/simple/.envrc
@@ -5,4 +5,7 @@ fi
 nix_direnv_watch_file devenv.nix
 nix_direnv_watch_file devenv.lock
 nix_direnv_watch_file devenv.yaml
-use flake . --impure
+if ! use flake . --impure
+then
+  echo "devenv could not be build. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
+fi


### PR DESCRIPTION
Resolves #463

This changes .envrc so that it won't exit with code 1. This keeps envrc intact and will allow envrc to reload devenv.nix automatically when the file has changed.

In addition, this shows an additional stderr line to explain to the user that the devenv build has failed and the devenv environment is not available.