### PR TITLE
direnvrc: avoid errors where possible

### DIFF
--- a/direnvrc
+++ b/direnvrc
@@ -12,13 +12,13 @@ _nix_direnv_preflight () {
   if [[ -z ${DEVENV_BIN:-} ]]; then
     DEVENV_BIN=$(command -v devenv)
     if [[ -z "${DEVENV_BIN}" ]]; then
-      log_status "command not found: devenv, see https://devenv.sh/getting-started/"
+      log_error "command not found: devenv, see https://devenv.sh/getting-started/"
       exit 1
     fi
   fi
 
   if ! has direnv_version || ! direnv_version "$REQUIRED_DIRENV_VERSION" 2>/dev/null; then
-    log_status "base direnv version is older than the required v$REQUIRED_DIRENV_VERSION."
+    log_error "base direnv version is older than the required v$REQUIRED_DIRENV_VERSION."
     exit 1
   fi
 
@@ -111,7 +111,7 @@ use_devenv() {
     files_to_watch+=("$flake_dir/devenv.nix" "$flake_dir/devenv.lock" "$flake_dir/devenv.yaml" "$flake_dir/devenv.local.nix")
     if [[ -f "$flake_dir/devenv.yaml" ]]; then
       if ! devenv assemble; then
-        log_status "$(devenv version) failed to parse devenv.yaml, make sure to use version 0.6 or newer and fix the errors above."
+        log_error "$(devenv version) failed to parse devenv.yaml, make sure to use version 0.6 or newer and fix the errors above."
         exit 1
       fi
 

--- a/direnvrc
+++ b/direnvrc
@@ -143,15 +143,14 @@ use_devenv() {
   then
     # We need to update our cache
     local env
-    env=$("${DEVENV_BIN}" print-dev-env)
-    if [[ "$env" == *"DEVENV_ROOT"* ]]; then
-      echo "$env" > "$profile_rc"
-      log_status "updated devenv shell cache"
-      _nix_import_env "$profile_rc"
-    else
-      log_status "loading the environment failed"
-      exit 1
+    if ! env=$("${DEVENV_BIN}" print-dev-env); then
+      log_error "failed to build the devenv environment. devenv.nix may contain errors. see above."
+      exit 0
     fi
+
+    echo "$env" > "$profile_rc"
+    log_status "updated devenv shell cache"
+    _nix_import_env "$profile_rc"
   else
     log_status "using cached devenv shell"
     _nix_import_env "$profile_rc"

--- a/direnvrc
+++ b/direnvrc
@@ -112,7 +112,7 @@ use_devenv() {
     if [[ -f "$flake_dir/devenv.yaml" ]]; then
       if ! devenv assemble; then
         log_error "$(devenv version) failed to parse devenv.yaml, make sure to use version 0.6 or newer and fix the errors above."
-        exit 1
+        exit 0
       fi
 
       if [[ -f "$flake_dir/.devenv/imports.txt" ]]; then


### PR DESCRIPTION
Resolved https://github.com/cachix/devenv/issues/463

Currently whenever print-dev-env fails, direnvrc exits with a failure.
This makes watch_file and other direnv changes be rolled back. It results in the devenv.nix file not being watched anymore.

I did the same for failure to parse `devenv.yaml`.

In addition, the error message now directs the user to devenv.nix.

Lastly I saw some places where `log_error` seemed like a nicer alternative to `log_status`.