### PR TITLE
python: allow venv to be used in recursive devenv

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -5,7 +5,7 @@ let
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
     if [ ! -L ${config.env.DEVENV_STATE}/venv/devenv-profile ] \
-    || [ "$(${pkgs.coreutils}/bin/readlink ${config.env.DEVENV_STATE}/venv/devenv-profile)" != "$DEVENV_PROFILE" ]
+    || [ "$(${pkgs.coreutils}/bin/readlink ${config.env.DEVENV_STATE}/venv/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
     then
       if [ -d ${config.env.DEVENV_STATE}/venv ]
       then
@@ -16,7 +16,7 @@ let
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
       python -m venv ${config.env.DEVENV_STATE}/venv
-      ln -sf $DEVENV_PROFILE ${config.env.DEVENV_STATE}/venv/devenv-profile
+      ln -sf ${config.env.DEVENV_PROFILE} ${config.env.DEVENV_STATE}/venv/devenv-profile
     fi
     source ${config.env.DEVENV_STATE}/venv/bin/activate
   '';


### PR DESCRIPTION
Currently whenever you have a project structure like:

```
.envrc
devenv.nix
subproject/.envrc
subproject/devenv.nix
```

And you navigate into subproject, you'll get both environment variables from the root and from subproject. This works surprisingly well, however venv doesn't.

It seems as if `DEVENV_ROOT` from the subproject is being concatenated to `DEVENV_ROOT` of the parent project by envrc.

To circumvent this venv should stop relying on the runtime DEVENV_ROOT and DEVENV_PROFILE and start relying on the variable from Nix.
