### PR TITLE
use util-linuxMinimal instead of util-linux for column

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -150,14 +150,14 @@ pkgs.writeScriptBin "devenv" ''
       if [ "$results" = "{}" ]; then
         echo "No packages found for '$name'."
       else
-        ${pkgs.jq}/bin/jq -r '[to_entries[] | {name: ("pkgs." + (.key | split(".") | del(.[0, 1]) | join("."))) } * (.value | { version, description})] | (.[0] |keys_unsorted | @tsv) , (["----", "-------", "-----------"] | @tsv), (.[]  |map(.) |@tsv)' <<< "$results" | ${pkgs.util-linux}/bin/column -ts $'\t'
+        ${pkgs.jq}/bin/jq -r '[to_entries[] | {name: ("pkgs." + (.key | split(".") | del(.[0, 1]) | join("."))) } * (.value | { version, description})] | (.[0] |keys_unsorted | @tsv) , (["----", "-------", "-----------"] | @tsv), (.[]  |map(.) |@tsv)' <<< "$results" | ${pkgs.util-linuxMinimal}/bin/column -ts $'\t'
         echo
       fi
       echo
       if [ "$results_options" = "{}" ]; then
         echo "No options found for '$name'."
       else
-        ${pkgs.jq}/bin/jq -r '["option","type","default", "description"], ["------", "----", "-------", "-----------"],(to_entries[] | [.key, .value.type, .value.default, .value.description[0:80]]) | @tsv' <<< "$results_options" | ${pkgs.util-linux}/bin/column -ts $'\t'
+        ${pkgs.jq}/bin/jq -r '["option","type","default", "description"], ["------", "----", "-------", "-----------"],(to_entries[] | [.key, .value.type, .value.default, .value.description[0:80]]) | @tsv' <<< "$results_options" | ${pkgs.util-linuxMinimal}/bin/column -ts $'\t'
       fi
       echo
       echo "Found $(${pkgs.jq}/bin/jq 'length' <<< "$results") packages and $(${pkgs.jq}/bin/jq 'length' <<< "$results_options") options for '$name'."


### PR DESCRIPTION
Currently the util-linux package is used for the column cli. This is the only dependency for which util-linux is used. It results in quite a significant addition to the closure size.

util-linuxMinimal is somewhat smaller and also includes the column command.

I used `nix-tree` to check the closure size of the devenv command:

Before:

![devenv](https://user-images.githubusercontent.com/6375609/223764453-b0ed8874-a595-4524-8ca5-1a25d1eb4dce.png)

After:
![devenv2](https://user-images.githubusercontent.com/6375609/223764495-afa14428-416c-43b6-993c-ec8d56c727d3.png)

It is still big, but at least it is smaller :sweat_smile:

Since python is already part of the closure, it might be a good idea to base everything on python and remove dependencies on util-linux-minimal, findutils, coreutils and jq.

This could help CI builds quite a bit in reducing the time it takes to fetch devenv.sh.