### PR TITLE
javascript: add corepack option

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -13,11 +13,18 @@ in
       defaultText = lib.literalExpression "pkgs.nodejs";
       description = "The Node package to use.";
     };
+
+    corepack = {
+      enable = lib.mkEnableOption "shims for package managers besides npm";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.corepack.enable (pkgs.runCommand "corepack-enable" { } ''
+      mkdir -p $out/bin
+      ${cfg.package}/bin/corepack enable --install-directory $out/bin
+    '');
   };
 }


### PR DESCRIPTION
```nix
# Before: 
{
  languages.javascript.enable = true;
  languages.javascript.package = pkgs.nodejs-16_x;
  packages = [ (pkgs.yarn.override { nodejs = pkgs.nodejs-16_x; }) ];
}

# Or alternatively:
{
  languages.javascript.enable = true;
  languages.javascript.package = pkgs.nodejs-16_x;
  scripts.yarn.exec = ''exec corepack yarn "$@"'';
}

# But with this change:
{
  languages.javascript.enable = true;
  languages.javascript.package = pkgs.nodejs-16_x;
  languages.javascript.corepack.enable = true;
}
```