### PR TITLE
refactor(dotnet): add package option and needed environment variables

### DIFF
--- a/src/modules/languages/dotnet.nix
+++ b/src/modules/languages/dotnet.nix
@@ -6,11 +6,21 @@ in
 {
   options.languages.dotnet = {
     enable = lib.mkEnableOption "tools for .NET development";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.dotnetCorePackages.sdk_7_0;
+      defaultText = lib.literalExpression "pkgs.dotnet-sdk";
+      description = "The .NET SDK package to use.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      dotnet-sdk
+      cfg.package
     ];
+
+    env.DOTNET_ROOT = "${cfg.package}";
+    env.LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:${lib.makeLibraryPath [ pkgs.icu ]}";
   };
 }


### PR DESCRIPTION
This PR introduces:

- `package` option
- [DOTNET_ROOT](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_root-dotnet_rootx86) environment variable
- `icu` package on the `LD_LIBRARY_PATH` for [globalization](https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu)