### PR TITLE
[wip] improve c support

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -6,16 +6,29 @@ in
 {
   options.languages.c = {
     enable = lib.mkEnableOption "tools for C development";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.stdenv.cc;
+      example = "pkgs.clangStdenv.cc";
+      defaultText = "pkgs.stdenv.cc";
+      description = "C/C++ toolchain to use. Defaults to nixpkgs default C compiler (i.e. gcc on Linux and clang on macOS)";
+    };
+    languageServer = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = pkgs.clang-tools;
+      example = pkgs.ccls;
+      defaultText = "pkgs.clang-tools";
+      description = "Language server to use. Defaults to clangd from the clang-tools package.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      stdenv
       gnumake
-      clang
-      ccls
-      gcc
       pkg-config
+
+      cfg.package
+      cfg.languageServer
     ];
   };
 }


### PR DESCRIPTION
I would by default only provide the default toolchain from nixpkgs itself and also make
sure that CC/LD/STRIP/NM environment variables are set so that buildsystems pickup the devenv compiler rather than defaulting to impure /usr/bin/gcc etc.
Furthermore I would only provide one module for both c/c++ as these cannot be separated and configurations would conflict with each other.

Also interesting would be to have some sane abstraction for cross compiling as this is a complex topic where the nix documentation is not super helpful.
Let me know what you think about the direction.