### PR TITLE
.envrc: use own devenv and direnvrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,13 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+#!/usr/bin/env bash
+# ^ for code highlighting
+# Used by https://direnv.net
+set -euo pipefail
 
-# use our own last built devenv/nix in CLI
-PATH_add result/bin
+# Use our own last built devenv/nix in CLI
+devenv_bin=$(nix build --print-out-paths)
+PATH_add "$devenv_bin/bin"
+
+# External users should use `source_url` to load this file
+source_env ./direnvrc
 
 use devenv


### PR DESCRIPTION
This makes it easier to iterate on devenv and the direnvrc. Run `direnv
reload` and get the latest version.
