### PR TITLE
python: rework how venv and poetry are handled

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -104,14 +104,8 @@ in
 
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.poetry.override {
-          python3 = cfg.package;
-        };
-        defaultText = lib.literalExpression ''
-          pkgs.poetry.override {
-            python3 = config.languages.python.package;
-          }
-        '';
+        default = pkgs.poetry;
+        defaultText = lib.literalExpression "pkgs.poetry";
         description = "The Poetry package to use.";
       };
     };

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -22,18 +22,22 @@ let
   '';
 
   initPoetryScript = pkgs.writeShellScript "init-poetry.sh" ''
-    if [ ! -f pyproject.toml ]
-    then
-      echo "No pyproject.toml found. Run 'poetry init' to create one." >&2
-    elif [ ! -f poetry.lock ]
-    then
-      echo "No poetry.lock found. Run 'poetry install' to create one from pyproject.toml." >&2
-    else
+    function _devenv-init-poetry-venv()
+    {
+      if [ ! -d ${config.env.DEVENV_ROOT}/.venv ] \
+        || [ ! "$(readlink ${config.env.DEVENV_ROOT}/.venv/bin/python)" -ef "${cfg.package.interpreter}" ]
+      then
+        poetry env use --no-interaction ${cfg.package.interpreter}
+      fi
+    }
+
+    function _devenv-poetry-install()
+    {
       # Avoid running "poetry install" for every shell.
-      # Only run it when the "poetry.lock" file has changed.
-      # We do this by storing a hash of "poetry.lock" in venv.
-      ACTUAL_POETRY_CHECKSUM="$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock)"
-      POETRY_CHECKSUM_FILE="${config.env.DEVENV_STATE}/poetry.lock.checksum"
+      # Only run it when the "poetry.lock" file or python interpreter has changed.
+      # We do this by storing the interpreter path and a hash of "poetry.lock" in venv.
+      local ACTUAL_POETRY_CHECKSUM="${cfg.package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock)"
+      local POETRY_CHECKSUM_FILE="${config.env.DEVENV_ROOT}/.venv/poetry.lock.checksum"
       if [ -f "$POETRY_CHECKSUM_FILE" ]
       then
         read -r EXPECTED_POETRY_CHECKSUM < "$POETRY_CHECKSUM_FILE"
@@ -43,13 +47,23 @@ let
 
       if [ "$ACTUAL_POETRY_CHECKSUM" != "$EXPECTED_POETRY_CHECKSUM" ]
       then
-        if ${cfg.poetry.package}/bin/poetry install --no-interaction --quiet
+        if ${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments}
         then
           echo "$ACTUAL_POETRY_CHECKSUM" > "$POETRY_CHECKSUM_FILE"
         else
           echo "Poetry install failed. Run 'poetry install' manually."
         fi
       fi
+    }
+
+    if [ ! -f pyproject.toml ]
+    then
+      echo "No pyproject.toml found. Run 'poetry init' to create one." >&2
+    else
+      _devenv-init-poetry-venv
+      ${lib.optionalString cfg.poetry.install.enable ''
+        _devenv-poetry-install
+      ''}
     fi
   '';
 in
@@ -68,6 +82,26 @@ in
 
     poetry = {
       enable = lib.mkEnableOption "poetry";
+      install = {
+        enable = lib.mkEnableOption "poetry install during devenv initialisation";
+        arguments = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Command line arguments pass to `poetry install` during devenv initialisation.";
+          internal = true;
+        };
+        installRootPackage = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether the root package (your project) should be installed. See `--no-root`";
+        };
+        quiet = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether `poetry install` should avoid outputting messages during devenv initialisation.";
+        };
+      };
+
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.poetry.override {
@@ -84,18 +118,30 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    languages.python.venv.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
+    languages.python.poetry.install.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
+    languages.python.poetry.install.arguments =
+      lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
+      lib.optional cfg.poetry.install.quiet "--quiet";
 
     packages = [
       cfg.package
     ] ++ (lib.optional cfg.poetry.enable cfg.poetry.package);
 
-    env.PYTHONPATH = "${config.env.DEVENV_PROFILE}/${cfg.package.sitePackages}";
+    env = {
+      PYTHONPATH = "${config.env.DEVENV_PROFILE}/${cfg.package.sitePackages}";
+    } // (lib.optionalAttrs cfg.poetry.enable {
+      # Make poetry use DEVENV_ROOT/.venv
+      POETRY_VIRTUALENVS_IN_PROJECT = "true";
+      # Make poetry create the local virtualenv when it does not exist.
+      POETRY_VIRTUALENVS_CREATE = "true";
+      # Make poetry stop accessing any other virtualenvs in $HOME.
+      POETRY_VIRTUALENVS_PATH = "/var/empty";
+    });
 
     enterShell = lib.concatStringsSep "\n" (
       (lib.optional cfg.venv.enable ''
         source ${initVenvScript}
-      '') ++ (lib.optional cfg.poetry.enable ''
+      '') ++ (lib.optional cfg.poetry.install.enable ''
         source ${initPoetryScript}
       '')
     );

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -4,21 +4,21 @@ let
   cfg = config.languages.python;
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
-    if [ ! -L ${config.env.DEVENV_STATE}/venv/devenv-profile ] \
-    || [ "$(${pkgs.coreutils}/bin/readlink ${config.env.DEVENV_STATE}/venv/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
+    if [ ! -L ${config.env.DEVENV_ROOT}/.venv/devenv-profile ] \
+    || [ "$(${pkgs.coreutils}/bin/readlink ${config.env.DEVENV_ROOT}/.venv/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
     then
-      if [ -d ${config.env.DEVENV_STATE}/venv ]
+      if [ -d ${config.env.DEVENV_ROOT}/.venv ]
       then
         echo "Rebuilding Python venv..."
-        ${pkgs.coreutils}/bin/rm -rf ${config.env.DEVENV_STATE}/venv
+        ${pkgs.coreutils}/bin/rm -rf ${config.env.DEVENV_ROOT}/.venv
       fi
       ${lib.optionalString cfg.poetry.enable ''
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
-      python -m venv ${config.env.DEVENV_STATE}/venv
-      ln -sf ${config.env.DEVENV_PROFILE} ${config.env.DEVENV_STATE}/venv/devenv-profile
+      python -m venv ${config.env.DEVENV_ROOT}/.venv
+      ln -sf ${config.env.DEVENV_PROFILE} ${config.env.DEVENV_ROOT}/.venv/devenv-profile
     fi
-    source ${config.env.DEVENV_STATE}/venv/bin/activate
+    source ${config.env.DEVENV_ROOT}/.venv/bin/activate
   '';
 
   initPoetryScript = pkgs.writeShellScript "init-poetry.sh" ''

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.languages.python;
 
-  venvPath = "${config.env.DEVENV_ROOT}/.venv";
+  venvPath = "${config.env.DEVENV_STATE}/venv";
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
     if [ ! -L ${venvPath}/devenv-profile ] \
@@ -26,6 +26,11 @@ let
   initPoetryScript = pkgs.writeShellScript "init-poetry.sh" ''
     function _devenv-init-poetry-venv()
     {
+      if [ ! -L ${config.env.DEVENV_ROOT}/.venv ]
+      then
+        ln -sf ${venvPath} ${config.env.DEVENV_ROOT}/.venv
+      fi
+
       if [ ! -d ${venvPath} ] \
         || [ ! "$(readlink ${venvPath}/bin/python)" -ef "${cfg.package.interpreter}" ]
       then

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -43,8 +43,12 @@ let
 
       if [ "$ACTUAL_POETRY_CHECKSUM" != "$EXPECTED_POETRY_CHECKSUM" ]
       then
-        ${cfg.poetry.package}/bin/poetry install --no-interaction --quiet
-        echo "$ACTUAL_POETRY_CHECKSUM" > "$POETRY_CHECKSUM_FILE"
+        if ${cfg.poetry.package}/bin/poetry install --no-interaction --quiet
+        then
+          echo "$ACTUAL_POETRY_CHECKSUM" > "$POETRY_CHECKSUM_FILE"
+        else
+          echo "Poetry install failed. Run 'poetry install' manually."
+        fi
       fi
     fi
   '';


### PR DESCRIPTION
Currently devenv manages its own virtualenv in DEVENV_STATE/venv. In most circumstances this works fine. However, since poetry in some cases wants to manage its own virtualenv it breaks down.

To reproduce the bug:

* Initialize devenv with venv and poetry.
* Initialize pyproject.toml
* Change the python version in pyproject.toml to one that doesn't match the python version in devenv.
* Run poetry install _or_ rerun devenv

Poetry will (by default) create a new virtualenv in $HOME and use that, instead of the DEVENV_STATE/venv one from devenv.

[It is not possible to instruct poetry to specifically use the virtualenv that devenv created](https://github.com/python-poetry/poetry/issues/1579). However, it is possible to instruct poetry to use `PROJECT_ROOT/.venv` and it is able to create it when it's gone.

I opted to also use `PROJECT_ROOT/.venv` when `languages.python.venv.enable` is set instead of `DEVENV_STATE/venv`. I found that it is a convention to use `PROJECT_ROOT/.venv` and tools (like poetry) are presuming this is the case.

Lastly, the change also includes a fix for an issue that happens when poetry install fails. When it failed previously the checksum of the lock file was still stored. This results in devenv not running poetry install anymore the next time devenv runs. Now devenv tells the user that installation fails and to run `devenv install` manually.