### PR TITLE
Set DYLD_LIBRARY_PATH so dyn libs can be loaded

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -64,6 +64,7 @@ in
       env.RUSTFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
       env.RUSTDOCFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
       env.CFLAGS = [ "-iframework ${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
+      env.DYLD_LIBRARY_PATH=[ "$(${config.env.DEVENV_PROFILE}/bin/rustc --print sysroot)/lib" ];
     })
     (lib.mkIf (cfg.version != null) (
       let


### PR DESCRIPTION
Running `rustfmt` when inside the environment created by `devenv` on a Mac fails for me with the following:

```console
$ rustfmt
dyld[3574]: Library not loaded: @rpath/librustc_driver-b3a4a775d2ec4bdd.dylib
  Referenced from: <no uuid> /nix/store/hf22ddbp9pqlgskriy9b16zmjwlcp3rc-rustfmt-1.68.2/bin/rustfmt
  Reason: tried: '/nix/store/1icn9va0m09gi8l64061f49gdwjq2pbd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/1icn9va0m09gi8l64061f49gdwjq2pbd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file), '/nix/store/1icn9va0m09gi8l64061f49gdwjq2pbd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/1icn9va0m09gi8l64061f49gdwjq2pbd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file), '/usr/local/lib/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file), '/usr/lib/librustc_driver-b3a4a775d2ec4bdd.dylib' (no such file, not in dyld cache)
[1]    3574 abort      rustfmt
```

Setting `DYLD_LIBRARY_PATH` as suggested in https://github.com/rust-lang/rustfmt/issues/1707#issuecomment-309975978 seems to fix the issue, although I'm not sure if my proposal could have other consequences. I have checked the issues but I haven't seen any mentioning this problem.

Perhaps setting `LD_LIBRARY_PATH` is also needed for Linux systems, but I have not tested it.