### PR TITLE
Added readiness_probe for Redis using redis-cli

### DIFF
--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -69,6 +69,22 @@ in
 
     env.REDISDATA = config.env.DEVENV_STATE + "/redis";
 
-    processes.redis.exec = "${startScript}/bin/start-redis";
+    processes.redis = {
+      exec = "${startScript}/bin/start-redis";
+
+      process-compose = {
+        readiness_probe = {
+          exec.command = "${cfg.package}/bin/redis-cli ping";
+          initial_delay_seconds = 2;
+          period_seconds = 10;
+          timeout_seconds = 4;
+          success_threshold = 1;
+          failure_threshold = 5;
+        };
+
+        # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
+        availability.restart = "on_failure";
+      };
+    };
   };
 }


### PR DESCRIPTION
Based on postgres `readiness_probe` with same timeouts and periods.