### PR TITLE
add missing argument to container registry option

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -107,7 +107,7 @@ pkgs.writeScriptBin "devenv" ''
   Usage: container [options] CONTAINER-NAME
 
   Options:
-    --registry         Registry to copy the container to.
+    --registry=<reg>   Registry to copy the container to.
     --copy             Copy the container to the registry.
     --copy-args=<args> Arguments passed to `skopeo copy`.
     --docker-run       Execute `docker run`.


### PR DESCRIPTION
I tried exporting a shell container to a file. I ran into `error: --registry must not have an argument`. Or just `error:` without a message if you use a space instead of an equals sign.

Same error when you try to run the example from the docs (`devenv container shell --registry docker://ghcr.io/ --copy`)

This commit fixes it.