### PR TITLE
allow examples to have custom tests

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -81,7 +81,12 @@
     set -e
     pushd examples/$1 
     devenv ci
-    devenv shell ls
+    if [ -f .test.sh ]
+    then
+      devenv shell ./.test.sh
+    else
+      devenv shell ls
+    fi
     popd
   '';
   scripts."devenv-generate-doc-options".exec = ''

--- a/examples/python-venv/.test.sh
+++ b/examples/python-venv/.test.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -ex
+[ "$(command -v python)" = "$PWD/.devenv/state/venv/bin/python" ]
+[ "$VIRTUAL_ENV" = "$PWD/.devenv/state/venv" ]
+python --version

--- a/examples/ruby/.test.sh
+++ b/examples/ruby/.test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -ex
+ruby --version | grep "$(cat .ruby-version)"
+ruby -e "require 'puma'"


### PR DESCRIPTION
Resolves https://github.com/cachix/devenv/issues/542

Currently during the tests the devenvs of the examples are build, but there isn't a check to see whether the options of the example are behaving as they were intended.

This changes allows examples to have a `.test.sh` file that is executed.

As an example (meta) I've added a test for python-venv to check whether the virtual environment has loaded correctly and a test for ruby to check whether Ruby can require gems in Gemfile.