### PR TITLE
python: automatic virtualenv activation for poetry

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -71,6 +71,9 @@ let
       ${lib.optionalString cfg.poetry.install.enable ''
         _devenv-poetry-install
       ''}
+      ${lib.optionalString cfg.poetry.activate.enable ''
+        source ${venvPath}/bin/activate
+      ''}
     fi
   '';
 in
@@ -108,6 +111,7 @@ in
           description = "Whether `poetry install` should avoid outputting messages during devenv initialisation.";
         };
       };
+      activate.enable = lib.mkEnableOption "activate the poetry virtual environment automatically";
 
       package = lib.mkOption {
         type = lib.types.package;
@@ -123,6 +127,8 @@ in
     languages.python.poetry.install.arguments =
       lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
       lib.optional cfg.poetry.install.quiet "--quiet";
+
+    languages.python.poetry.activate.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
 
     packages = [
       cfg.package


### PR DESCRIPTION
Currently when poetry is enabled, a virtualenv is created by poetry and `poetry run` is able to operate correctly. However, it currently only works with `poetry run` while most users will expect to have the virtualenv already activated.

This patch adds automatic activation for poetry and enables it by default. This behavior is in line with poetry's behavior before https://github.com/cachix/devenv/pull/522 was introduced.