### PR TITLE
use date from coreutils

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -47,7 +47,7 @@ pkgs.writeScriptBin "devenv" ''
   fi
 
   mkdir -p "$GC_ROOT"
-  GC_DIR="$GC_ROOT/$(date +%s%3N)"
+  GC_DIR="$GC_ROOT/$(${pkgs.coreutils}/bin/date +%s%3N)"
 
   function add_gc {
     name=$1


### PR DESCRIPTION
Currently devenv uses the date executable that is available in PATH. This means that under OSX a date executable is used that doesn't support `N` formatting, which leads to `gc` directories being stored in seconds instead of milliseconds.

This patch makes sure that date from coreutils is always used. This should fix problems with conflicting gc files when multiple devenv's are building in parallel.

I ran into this issue because collegues under MacOS were getting the following error:

![image](https://user-images.githubusercontent.com/6375609/233629817-85cd4d9e-82dc-47ea-a78e-b07dde771ddd.png)

Notice the `N` at the end :cry:
