### PR TITLE
Add -p option to redis rediness check

### DIFF
--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -74,7 +74,7 @@ in
 
       process-compose = {
         readiness_probe = {
-          exec.command = "${cfg.package}/bin/redis-cli ping";
+          exec.command = "${cfg.package}/bin/redis-cli -p ${toString cfg.port} ping";
           initial_delay_seconds = 2;
           period_seconds = 10;
           timeout_seconds = 4;


### PR DESCRIPTION
This allows the user to use a non-default port