### PR TITLE
devenv: use explicit package paths for executables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,7 @@
       systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
       mkPackage = pkgs: import ./src/devenv.nix {
-        inherit pkgs;
-        nix = nix.packages.${pkgs.stdenv.system}.nix;
+        inherit pkgs nix;
       };
       mkDevShellPackage = config: pkgs: import ./src/devenv-devShell.nix { inherit config pkgs; };
       mkDocOptions = pkgs:

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,10 @@
     let
       systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
-      mkPackage = pkgs: import ./src/devenv.nix { inherit pkgs nix; };
+      mkPackage = pkgs: import ./src/devenv.nix {
+        inherit pkgs;
+        nix = nix.packages.${pkgs.stdenv.system}.nix;
+      };
       mkDevShellPackage = config: pkgs: import ./src/devenv-devShell.nix { inherit config pkgs; };
       mkDocOptions = pkgs:
         let

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -4,6 +4,7 @@ let
   lib = pkgs.lib;
   version = lib.fileContents ./modules/latest-version;
   inherit (pkgs)
+    bash
     coreutils
     findutils
     gnugrep
@@ -13,7 +14,7 @@ let
   devenv-yaml = import ./devenv-yaml.nix { inherit pkgs; };
 in
 pkgs.writeScriptBin "devenv" ''
-  #!/usr/bin/env bash
+  #!${bash}/bin/bash
 
   # we want subshells to fail the program
   set -e

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, nix }:
+{ pkgs, ... } @ args:
 let
   examples = ../examples;
   lib = pkgs.lib;
@@ -12,6 +12,7 @@ let
     docopts
     util-linuxMinimal;
   devenv-yaml = import ./devenv-yaml.nix { inherit pkgs; };
+  nix = args.nix.packages.${pkgs.stdenv.system}.nix;
 in
 pkgs.writeScriptBin "devenv" ''
   #!${bash}/bin/bash

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -10,6 +10,7 @@ let
     jq
     docopts
     util-linuxMinimal;
+  devenv-yaml = import ./devenv-yaml.nix { inherit pkgs; };
 in
 pkgs.writeScriptBin "devenv" ''
   #!/usr/bin/env bash
@@ -35,7 +36,7 @@ pkgs.writeScriptBin "devenv" ''
     export DEVENV_GC="$DEVENV_DIR/gc"
     ${coreutils}/bin/mkdir -p "$DEVENV_GC"
     if [[ -f devenv.yaml ]]; then
-      ${import ./devenv-yaml.nix { inherit pkgs; }}/bin/devenv-yaml "$DEVENV_DIR"
+      ${devenv-yaml}/bin/devenv-yaml "$DEVENV_DIR"
     else
       [[ -f "$DEVENV_DIR/devenv.json" ]] && ${coreutils}/bin/rm "$DEVENV_DIR/devenv.json"
       [[ -f "$DEVENV_DIR/flake.json" ]] && ${coreutils}/bin/rm "$DEVENV_DIR/flake.json"

--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -23,7 +23,7 @@ pkgs.writeScriptBin "devenv" ''
   export FLAKE_FILE=.devenv.flake.nix
   export FLAKE_LOCK=devenv.lock
 
-  CUSTOM_NIX=${nix.packages.${pkgs.stdenv.system}.nix}
+  CUSTOM_NIX=${nix}
 
   function assemble {
     if [[ ! -f devenv.nix ]]; then


### PR DESCRIPTION
As a follow-up from #545 I thought there might be more instances where executable were used from the global system. This turned out to be true.

I'm not sure whether any of the currently used executables result in incompatiblities, but I thought to avoid such potential problems in the future.

I also took the liberty to align the nix and devenv-yaml calls so they look the same as calls to other packages.

I checked for usage of other external commands by using `PATH=""` in the top of the devenv-script and look for command not found errors.