### PR TITLE
examples: python-poetry: add test

### DIFF
--- a/examples/python-poetry/.test.sh
+++ b/examples/python-poetry/.test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -ex
+[ "$(readlink .venv)" = "$PWD/.devenv/state/venv" ]
+[ "$(poetry env info --path)" = "$PWD/.devenv/state/venv" ]
+[ "$(command -v python)" = "$PWD/.devenv/state/venv/bin/python" ]
+python --version
+poetry --version
+poetry run python -c 'import numpy'
+python -c 'import numpy'


### PR DESCRIPTION
As a follow-up from both https://github.com/cachix/devenv/pull/543 and https://github.com/cachix/devenv/pull/544, this adds a test for python-poetry that checks whether poetry packages can be imported.