### PR TITLE
python: avoid using existing virtual env or poetry binary

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -17,7 +17,7 @@ let
       ${lib.optionalString cfg.poetry.enable ''
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
-      python -m venv ${venvPath}
+      ${cfg.package.interpreter} -m venv ${venvPath}
       ln -sf ${config.env.DEVENV_PROFILE} ${venvPath}/devenv-profile
     fi
     source ${venvPath}/bin/activate
@@ -34,7 +34,7 @@ let
       if [ ! -d ${venvPath} ] \
         || [ ! "$(readlink ${venvPath}/bin/python)" -ef "${cfg.package.interpreter}" ]
       then
-        poetry env use --no-interaction ${cfg.package.interpreter}
+        ${cfg.poetry.package}/bin/poetry env use --no-interaction ${cfg.package.interpreter}
       fi
     }
 

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -6,6 +6,10 @@ let
   venvPath = "${config.env.DEVENV_STATE}/venv";
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
+    # Make sure any tools are not attempting to use the python interpreter from any
+    # existing virtual environment. For instance if devenv was started within an venv.
+    unset VIRTUAL_ENV
+
     if [ ! -L ${venvPath}/devenv-profile ] \
     || [ "$(${pkgs.coreutils}/bin/readlink ${venvPath}/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
     then
@@ -26,6 +30,10 @@ let
   initPoetryScript = pkgs.writeShellScript "init-poetry.sh" ''
     function _devenv-init-poetry-venv()
     {
+      # Make sure any tools are not attempting to use the python interpreter from any
+      # existing virtual environment. For instance if devenv was started within an venv.
+      unset VIRTUAL_ENV
+
       if [ ! -L ${config.env.DEVENV_ROOT}/.venv ]
       then
         ${pkgs.coreutils}/bin/ln --symbolic --no-target-directory --force ${venvPath} ${config.env.DEVENV_ROOT}/.venv

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -18,7 +18,7 @@ let
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
       ${cfg.package.interpreter} -m venv ${venvPath}
-      ln -sf ${config.env.DEVENV_PROFILE} ${venvPath}/devenv-profile
+      ${pkgs.coreutils}/bin/ln -sf ${config.env.DEVENV_PROFILE} ${venvPath}/devenv-profile
     fi
     source ${venvPath}/bin/activate
   '';
@@ -28,11 +28,11 @@ let
     {
       if [ ! -L ${config.env.DEVENV_ROOT}/.venv ]
       then
-        ln --symbolic --no-target-directory --force ${venvPath} ${config.env.DEVENV_ROOT}/.venv
+        ${pkgs.coreutils}/bin/ln --symbolic --no-target-directory --force ${venvPath} ${config.env.DEVENV_ROOT}/.venv
       fi
 
       if [ ! -d ${venvPath} ] \
-        || [ ! "$(readlink ${venvPath}/bin/python)" -ef "${cfg.package.interpreter}" ]
+        || [ ! "$(${pkgs.coreutils}/bin/readlink ${venvPath}/bin/python)" -ef "${cfg.package.interpreter}" ]
       then
         ${cfg.poetry.package}/bin/poetry env use --no-interaction ${cfg.package.interpreter}
       fi

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -28,7 +28,7 @@ let
     {
       if [ ! -L ${config.env.DEVENV_ROOT}/.venv ]
       then
-        ln -sf ${venvPath} ${config.env.DEVENV_ROOT}/.venv
+        ln --symbolic --no-target-directory --force ${venvPath} ${config.env.DEVENV_ROOT}/.venv
       fi
 
       if [ ! -d ${venvPath} ] \


### PR DESCRIPTION
Currently `poetry` is called in one instance with just `poetry`. There were cases where the poetry binary from `devenv`'s root project leaked into the devenv of the python-poetry test. This often is not a problem, but in this case it was a poetry version that was built against a different glibc, resulting in an error.

I've tried to harden the poetry module a bit more by explicitly calling all executables to avoid leakage of executables from a parent environment.

While debugging also found a minor issue when manually executing poetry after removing `.venv`, poetry will create a new `.venv` directory. In this case devenv should remove it and create a new symlink. This is what `ln -sf` was meant to do, however it instead created a symlink inside the `.venv` directory. I tried to avoid this by using `--no-target-directory`.

Lastly, this resets the `VIRTUAL_ENV` so that poetry won't try to use `python` from a `VIRTUAL_ENV` that was already active before devenv shell started.