### PR TITLE
devenv: add devenv.debug option

### DIFF
--- a/src/modules/debug.nix
+++ b/src/modules/debug.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+{
+  options.devenv = {
+    debug = lib.mkEnableOption "debug mode of devenv enterShell script";
+  };
+  config = {
+    enterShell = lib.mkOrder 100 ''
+      set -x
+    '';
+  };
+}

--- a/src/modules/debug.nix
+++ b/src/modules/debug.nix
@@ -3,9 +3,4 @@
   options.devenv = {
     debug = lib.mkEnableOption "debug mode of devenv enterShell script";
   };
-  config = {
-    enterShell = lib.mkOrder 100 ''
-      set -x
-    '';
-  };
 }

--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -53,6 +53,7 @@ in
 , shellHook ? ""
 , meta ? { }
 , passthru ? { }
+, debug ? false
 }:
 let
   # simpler version of https://github.com/numtide/devshell/blob/20d50fc6adf77fd8a652fc824c6e282d7737b85d/modules/env.nix#L41
@@ -74,6 +75,7 @@ let
     # The shellHook is loaded directly by `nix develop`. But nix-shell
     # requires that other trampoline.
     shellHook = ''
+      ${lib.optionalString debug "set -x"}
       # Remove all the unnecessary noise that is set by the build env
       unset NIX_BUILD_TOP NIX_BUILD_CORES NIX_STORE
       unset TEMP TEMPDIR TMP ${lib.optionalString (!pkgs.stdenv.isDarwin) "TMPDIR"}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -141,6 +141,7 @@ in
         env = config.env;
         profile = profile;
         shellHook = config.enterShell;
+        debug = config.devenv.debug;
       }
     );
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -95,6 +95,7 @@ in
     ./scripts.nix
     ./update-check.nix
     ./containers.nix
+    ./debug.nix
   ]
   ++ (listEntries ./languages)
   ++ (listEntries ./services)


### PR DESCRIPTION
Currently when there are problems it is hard to reproduce and hard to find out which parts of `enterShell` are at fault. To get more information about what is going on I thought it was nice to have a debug option in devenv that enables debugging in bash when running the shellHook/enterShell scripts.

This was done in response to https://github.com/cachix/devenv/issues/555, which seemed like an issue that was hard to reproduce.

This allows people to add `devenv.debug = true;` to their configuration and it would show all lines that were executed by bash.

I thought about adding a test, but I couldn't find a good/nice way to do so. Suggestions are welcome!