### PR TITLE
devenv: assert --impure is used

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -95,7 +95,7 @@
   '';
   scripts."devenv-generate-doc-options".exec = ''
     set -e
-    options=$(nix build --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
+    options=$(nix build --impure --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
     echo "# devenv.nix options" > docs/reference/options.md
     echo >> docs/reference/options.md
     cat $options >> docs/reference/options.md

--- a/devenv.nix
+++ b/devenv.nix
@@ -26,6 +26,7 @@
   '';
   scripts.devenv-run-tests.exec = ''
     set -xe
+    set -o pipefail
 
     pushd examples/simple
       # this should fail since files already exist
@@ -48,6 +49,14 @@
       nix develop --impure --command echo nix-develop started succesfully |& tee ./console
       grep -F 'nix-develop started succesfully' <./console
       grep -F "$(${lib.getExe pkgs.hello})" <./console
+
+      # Assert that nix-develop fails in pure mode.
+      if nix develop --command echo nix-develop started in pure mode |& tee ./console
+      then
+        echo "nix-develop was able to start in pure mode. This is explicitly not supported at the moment."
+        exit 1
+      fi
+      grep -F 'devenv was not able to determine the current directory.' <./console
     popd
     rm -rf "$tmp"
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -45,7 +45,7 @@
       nix flake init --template ''${DEVENV_ROOT}#simple
       nix flake update \
         --override-input devenv ''${DEVENV_ROOT}
-      nix develop --command echo nix-develop started succesfully |& tee ./console
+      nix develop --impure --command echo nix-develop started succesfully |& tee ./console
       grep -F 'nix-develop started succesfully' <./console
       grep -F "$(${lib.getExe pkgs.hello})" <./console
     popd
@@ -57,11 +57,11 @@
       nix flake init --template ''${DEVENV_ROOT}#flake-parts
       nix flake update \
         --override-input devenv ''${DEVENV_ROOT}
-      nix develop --command echo nix-develop started succesfully |& tee ./console
+      nix develop --impure --command echo nix-develop started succesfully |& tee ./console
       grep -F 'nix-develop started succesfully' <./console
       grep -F "$(${lib.getExe pkgs.hello})" <./console
       # Test that a container can be built
-      nix build .#container-processes
+      nix build --impure .#container-processes
     popd
     rm -rf "$tmp"
 

--- a/docs/guides/using-with-flake-parts.md
+++ b/docs/guides/using-with-flake-parts.md
@@ -19,7 +19,7 @@ This will create a `flake.nix` with devenv configuration, as well as a `.envrc` 
 Open the devenv shell using:
 
 ```console
-$ nix develop
+$ nix develop --impure
 ```
 
 This will create a lock file and open up a new shell that adheres to the devenv configuration stated in `flake.nix`.
@@ -120,7 +120,7 @@ Here you can see that there are 2 shells defined. Each one with a devenv configu
 To enter the shell of `projectA`:
 
 ```console
-$ nix develop .#projectA
+$ nix develop --impure .#projectA
 this is project A
 (devenv) $ 
 ```
@@ -128,7 +128,7 @@ this is project A
 To enter the shell of `projectB`:
 
 ```console
-$ nix develop .#projectB
+$ nix develop --impure .#projectB
 this is project B
 (devenv) $ 
 ```
@@ -136,7 +136,7 @@ this is project B
 The last line makes `projectA` the default shell:
 
 ```console
-$ nix develop .
+$ nix develop --impure .
 this is project A
 (devenv) $ 
 ```
@@ -148,7 +148,7 @@ Whenever you have projects where you cannot (or don't want to) add a flake.nix t
 You can create a repository with a flake.nix like the one above. However, in a different project you can now refer to this flake using:
 
 ```console
-$ nix develop file:/path/to/central/flake#projectA
+$ nix develop --impure file:/path/to/central/flake#projectA
 this is project A
 (devenv) $ 
 ```

--- a/docs/guides/using-with-flakes.md
+++ b/docs/guides/using-with-flakes.md
@@ -143,7 +143,7 @@ Here we define two shells, each with a `devenv` configuration and differently de
 To enter the shell of `project A`:
 
 ```console
-$ nix develop .#projectA
+$ nix develop --impure .#projectA
 this is project A
 (devenv) $ 
 ```
@@ -151,7 +151,7 @@ this is project A
 To enter the shell of `project B`:
 
 ```console
-$ nix develop .#projectB
+$ nix develop --impure .#projectB
 this is project B
 (devenv) $ 
 ```
@@ -163,7 +163,7 @@ If you cannot or don't want to add a `flake.nix` file to your project's reposito
 You can create a repository with a `flake.nix` file as in the example above. You can now refer to this flake in a different project:
 
 ```console
-$ nix develop file:/path/to/central/flake#projectA
+$ nix develop --impure file:/path/to/central/flake#projectA
 this is project A
 (devenv) $ 
 ```

--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -24,7 +24,7 @@
 
 { bashInteractive
 , coreutils
-, system
+, stdenv
 , writeTextFile
 , pkgs
 , lib
@@ -60,7 +60,8 @@ let
   envToBash = name: value: "export ${name}=${lib.escapeShellArg (toString value)}";
   startupEnv = lib.concatStringsSep "\n" (lib.mapAttrsToList envToBash env);
   derivationArg = {
-    inherit name system;
+    inherit name;
+    inherit (stdenv) system;
 
     # `nix develop` actually checks and uses builder. And it must be bash.
     builder = bashPath;

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -104,7 +104,18 @@ in
 
   config = {
     # TODO: figure out how to get relative path without impure mode
-    env.DEVENV_ROOT = builtins.getEnv "PWD";
+    env.DEVENV_ROOT =
+      let
+        pwd = builtins.getEnv "PWD";
+      in
+      if pwd == "" then
+        throw ''
+          devenv was not able to determine the current directory.
+          Make sure Nix runs with the `--impure` flag.
+
+          See https://devenv.sh/guides/using-with-flakes/
+        ''
+      else pwd;
     env.DEVENV_DOTFILE = config.env.DEVENV_ROOT + "/.devenv";
     env.DEVENV_STATE = config.env.DEVENV_DOTFILE + "/state";
     env.DEVENV_PROFILE = profile;


### PR DESCRIPTION
Currently it is possible to run devenv without `--impure`. However, strange things may happen, because `$PWD` is not set. This results in `env.DEVENV_ROOT` being `""`, which results in various other variables to contain an invalid path (like `/.devenv`).
This will go unnoticed, but can cause problems.

This PR makes fetchign `env.DEVENV_ROOT` throw an error whenever it is fetched without Nix running in `--impure` mode.

I can imagine this can also cause annoyances for people who are using devenv without _actually_ depending on `DEVENV_ROOT`. So it isn't a clear win in that regard. I thought I'd just suggest the change.

This was in response to https://github.com/cachix/devenv/issues/550