### PR TITLE
python: evaluate $DEVENV_PROFILE at runtime instead of in nix

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -143,7 +143,7 @@ in
     ] ++ (lib.optional cfg.poetry.enable cfg.poetry.package);
 
     env = {
-      PYTHONPATH = "${config.env.DEVENV_PROFILE}/${cfg.package.sitePackages}";
+      PYTHONPATH = "$DEVENV_PROFILE/${cfg.package.sitePackages}";
     } // (lib.optionalAttrs cfg.poetry.enable {
       # Make poetry use DEVENV_ROOT/.venv
       POETRY_VIRTUALENVS_IN_PROJECT = "true";


### PR DESCRIPTION
Fixes #558.

This fixes an infinite recursion error that originated as a result of trying to set an environment variable using the output of another environment variable.