### PR TITLE
fix error when devenv ci in devcontainer

### DIFF
--- a/devcontainer/nix.conf
+++ b/devcontainer/nix.conf
@@ -3,3 +3,4 @@ max-jobs = auto
 build-users-group = nixbld
 experimental-features = nix-command flakes
 sandbox = false
+filter-syscalls = false


### PR DESCRIPTION
Correctly run devenv.sh in a devcontainer.

Solution provided at https://github.com/NixOS/nix/issues/5258#issuecomment-921030592

Closes #560

I have now tested my changes and it works perfectly on my M1 Mac book.

My only concern is that the docker image is 1.47GB which is much bigger than the official image at 944MB. I am not sure what happened there since the only difference is a single line in the nix.conf.