### PR TITLE
Fixed wrong url example

### DIFF
--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -13,7 +13,7 @@
 ## inputs.&lt;name&gt;.url
 
 - github:NixOS/nixpkgs/master
-- github:NixOS/nixpkgs/master?rev=238b18d7b2c8239f676358634bfb32693d3706f3
+- github:NixOS/nixpkgs?rev=238b18d7b2c8239f676358634bfb32693d3706f3
 - github:foo/bar?dir=subdir
 - git+ssh://git@github.com/NixOS/nix?ref=v1.2.3
 - git+https://git.somehost.tld/user/path?ref=branch&rev=fdc8ef970de2b4634e1b3dca296e1ed918459a9e


### PR DESCRIPTION
The example specifies both a revision and a branch name. This gives the following nix error:

URL 'github:NixOS/nixpkgs/master?rev=a95ed9fe764c3ba2bf2d2fa223012c379cd6b32e' contains both a commit hash and a branch/tag name master a95ed9fe764c3ba2bf2d2fa223012c379cd6b32e