### PR TITLE
Put `cfg.entrypoint` to`Entrypoint` instead of `Cmd`

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -30,7 +30,7 @@ let
     
     source ${shell.envScript}
 
-    exec ${toString cfg.startupCommand}
+    exec "$@"
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;
@@ -50,7 +50,8 @@ let
     ];
     config = {
       Env = lib.mapAttrsToList (name: value: "${name}=${lib.escapeShellArg (toString value)}") containerEnv;
-      Cmd = cfg.entrypoint;
+      Cmd = [ cfg.startupCommand ];
+      Entrypoint = cfg.entrypoint;
     };
   };
 


### PR DESCRIPTION
Currently when the image built by devenv is run with custom arguments, `Cmd` will be replaced. As a result, the script created by `mkEntrypoint` would not get executed. For example, the following command will fail because `bash` is not in the path:
``` bash
docker run -it my-image bash
```
even when bash is added to packages:
``` nix
packages = [pkg.bash];
```

This PR set `Entrypoint` to `cfg.entrypoint` so that is would not be overwritten by docker run arguments.

``` nix
Entrypoint = cfg.entrypoint;
```

Now docker run works:

``` bash
docker run -it my-image bash
```
