### PR TITLE
python: fix PYTHONPATH using literal "$DEVENV_PROFILE"

### DIFF
--- a/examples/python-poetry/.test.sh
+++ b/examples/python-poetry/.test.sh
@@ -7,3 +7,4 @@ python --version
 poetry --version
 poetry run python -c 'import numpy'
 python -c 'import numpy'
+python -c 'import pjsua2'

--- a/examples/python-poetry/devenv.nix
+++ b/examples/python-poetry/devenv.nix
@@ -1,7 +1,13 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
-  packages = [ pkgs.zlib ];
+  packages = [
+    # A native dependency of numpy
+    pkgs.zlib
+
+    # A python dependency outside of poetry.
+    config.languages.python.package.pkgs.pjsua2
+  ];
   languages.python = {
     enable = true;
     poetry.enable = true;

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -142,23 +142,25 @@ in
       cfg.package
     ] ++ (lib.optional cfg.poetry.enable cfg.poetry.package);
 
-    env = {
-      PYTHONPATH = "$DEVENV_PROFILE/${cfg.package.sitePackages}";
-    } // (lib.optionalAttrs cfg.poetry.enable {
+    env = lib.optionalAttrs cfg.poetry.enable {
       # Make poetry use DEVENV_ROOT/.venv
       POETRY_VIRTUALENVS_IN_PROJECT = "true";
       # Make poetry create the local virtualenv when it does not exist.
       POETRY_VIRTUALENVS_CREATE = "true";
       # Make poetry stop accessing any other virtualenvs in $HOME.
       POETRY_VIRTUALENVS_PATH = "/var/empty";
-    });
+    };
 
-    enterShell = lib.concatStringsSep "\n" (
-      (lib.optional cfg.venv.enable ''
-        source ${initVenvScript}
-      '') ++ (lib.optional cfg.poetry.install.enable ''
-        source ${initPoetryScript}
-      '')
+    enterShell = lib.concatStringsSep "\n" ([
+      ''
+        export PYTHONPATH="$DEVENV_PROFILE/${cfg.package.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}"
+      ''
+    ] ++
+    (lib.optional cfg.venv.enable ''
+      source ${initVenvScript}
+    '') ++ (lib.optional cfg.poetry.install.enable ''
+      source ${initPoetryScript}
+    '')
     );
   };
 }


### PR DESCRIPTION
Currently when using python, the `PYTHONPATH` always contains the literal string `$DEVENV_PROFILE`. This is incorrect, as the variable is not resolved.

In addition, it would be nice to add to any `PYTHONPATH` that is already there, just like we're doing with `PATH`.

I've added a test that fails in the current implementation and succeeds with the patch.