### PR TITLE
Avoid using DEVENV_ROOT

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -63,9 +63,9 @@
     # Test devenv integrated into flake-parts Nix flake
     tmp="$(mktemp -d)"
     pushd "$tmp"
-      nix flake init --template ''${DEVENV_ROOT}#flake-parts
+      nix flake init --template ${inputs.self}#flake-parts
       nix flake update \
-        --override-input devenv ''${DEVENV_ROOT}
+        --override-input devenv ${inputs.self}
       nix develop --impure --command echo nix-develop started succesfully |& tee ./console
       grep -F 'nix-develop started succesfully' <./console
       grep -F "$(${lib.getExe pkgs.hello})" <./console

--- a/devenv.nix
+++ b/devenv.nix
@@ -43,9 +43,9 @@
     # Test devenv integrated into bare Nix flake
     tmp="$(mktemp -d)"
     pushd "$tmp"
-      nix flake init --template ''${DEVENV_ROOT}#simple
+      nix flake init --template ${inputs.self}#simple
       nix flake update \
-        --override-input devenv ''${DEVENV_ROOT}
+        --override-input devenv ${inputs.self}
       nix develop --impure --command echo nix-develop started succesfully |& tee ./console
       grep -F 'nix-develop started succesfully' <./console
       grep -F "$(${lib.getExe pkgs.hello})" <./console


### PR DESCRIPTION
As mentioned in https://github.com/cachix/devenv/pull/566#issuecomment-1534909975, we want to allow for using devenv without `--impure`. This is an attempt to reduce the usage of absolute DEVENV_ROOT