### PR TITLE
ruby: add bundler options

### DIFF
--- a/examples/ruby/.test.sh
+++ b/examples/ruby/.test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -ex
 ruby --version | grep "$(cat .ruby-version)"
+ruby -e "puts RUBY_VERSION" | grep "$(cat .ruby-version)"
 ruby -e "require 'puma'"
+bundle --version
+bundle exec ruby -e "puts RUBY_VERSION" | grep "$(cat .ruby-version)"

--- a/examples/ruby/Gemfile
+++ b/examples/ruby/Gemfile
@@ -2,5 +2,7 @@
 
 source "https://rubygems.org"
 
+ruby "3.2.1"
+
 gem "rails"
 gem "puma"

--- a/examples/ruby/Gemfile.lock
+++ b/examples/ruby/Gemfile.lock
@@ -151,5 +151,8 @@ DEPENDENCIES
   puma
   rails
 
+RUBY VERSION
+   ruby 3.2.1p31
+
 BUNDLED WITH
    2.3.24

--- a/examples/ruby/devenv.yaml
+++ b/examples/ruby/devenv.yaml
@@ -3,3 +3,6 @@ inputs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
   nixpkgs-ruby:
     url: github:bobvanderlinden/nixpkgs-ruby
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -48,6 +48,15 @@ in
         ./ruby-version
       '';
     };
+
+    bundler = {
+      enable = lib.mkEnableOption "bundler";
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.bundler;
+        description = "The bundler package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -63,6 +72,8 @@ in
 
     # enable C tooling by default so native extensions can be built
     languages.c.enable = lib.mkDefault true;
+
+    languages.ruby.bundler.enable = lib.mkDefault true;
 
     languages.ruby.package =
       let
@@ -81,9 +92,8 @@ in
         packageFromVersionFile
       ];
 
-    packages = with pkgs; [
+    packages = lib.optional cfg.bundler.enable cfg.bundler.package ++ [
       cfg.package
-      bundler
     ];
 
     env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -53,7 +53,8 @@ in
       enable = lib.mkEnableOption "bundler";
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.bundler;
+        default = pkgs.bundler.override { ruby = cfg.package; };
+        defaultText = lib.literalExpression "pkgs.bundler.override { ruby = cfg.package; }";
         description = "The bundler package to use.";
       };
     };


### PR DESCRIPTION
Currently there is no way to disable bundler nor is it possible to alter the bundler package.

In addition, there was a problem with the prioritization of the ruby/bundler packages, as modern ruby packages include a bundler executable.

This was reported here: https://github.com/bobvanderlinden/nixpkgs-ruby/issues/72

I also wanted to avoid regressions, so I added a stricter example/test.

Resolves https://github.com/bobvanderlinden/nixpkgs-ruby/issues/72