### PR TITLE
rust: evaluate $DEVENV_PROFILE at runtime instead of in nix

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -61,9 +61,9 @@ in
       pre-commit.tools.clippy = lib.mkForce cfg.packages.clippy;
     })
     (lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
-      env.RUSTFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
-      env.RUSTDOCFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
-      env.CFLAGS = [ "-iframework ${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
+      env.RUSTFLAGS = [ "-L framework=$DEVENV_PROFILE/Library/Frameworks" ];
+      env.RUSTDOCFLAGS = [ "-L framework=$DEVENV_PROFILE/Library/Frameworks" ];
+      env.CFLAGS = [ "-iframework $DEVENV_PROFILE/Library/Frameworks" ];
     })
     (lib.mkIf (cfg.version != null) (
       let


### PR DESCRIPTION
Fixes #580. This appears to be another instance of the underlying issue causing #558 and #396.

"This fixes an infinite recursion error that originated as a result of trying to set an environment variable using the output of another environment variable." - @anoadragon453