### PR TITLE
feat: lock deno to project scope

### DIFF
--- a/src/modules/languages/deno.nix
+++ b/src/modules/languages/deno.nix
@@ -12,5 +12,12 @@ in
     packages = [
       pkgs.deno
     ];
+    
+    env.DENO_INSTALL_ROOT = config.env.DEVENV_STATE + "/deno";
+    env.DENO_DIR = config.env.DENO_INSTALL_ROOT + "/cache";
+
+    enterShell = ''
+      export PATH="$PATH:$DENO_INSTALL_ROOT/bin"
+    '';
   };
 }


### PR DESCRIPTION
With this change, Deno cache and installed packages will be installed in the devenv state folder and be project-specific instead of global.