### PR TITLE
Always provide a node name to rabbitmq

### DIFF
--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -141,6 +141,7 @@ in
     env.RABBITMQ_CONFIG_FILE = config_file;
     env.RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
     env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
+    env.RABBITMQ_NODENAME = "rabbit@localhost";
 
     processes.rabbitmq.exec = "${cfg.package}/bin/rabbitmq-server";
   };


### PR DESCRIPTION
When booting, the processes expect that whatever host is in the "node name" is resolvable by DNS. Disabling reverse DNS lookups does not refute this requirement. This change provides an environment variable that RabbitMQ is expecting to find with a value that should be resolvable on all machines: `localhost`.

Resolves #356 