### PR TITLE
Remove extra spaces for CI

### DIFF
--- a/src/modules/languages/deno.nix
+++ b/src/modules/languages/deno.nix
@@ -12,7 +12,7 @@ in
     packages = [
       pkgs.deno
     ];
-    
+
     env.DENO_INSTALL_ROOT = config.env.DEVENV_STATE + "/deno";
     env.DENO_DIR = config.env.DENO_INSTALL_ROOT + "/cache";
 


### PR DESCRIPTION
The `nixpkgs-fmt` is returning an error when run on the `deno` language file. I noticed in the CI runs for my other PR that this was failing. This is another super simple fix to get the board all 🟢 again.