### PR TITLE
devenv: add build subcommand

### DIFF
--- a/src/devenv.nix
+++ b/src/devenv.nix
@@ -148,6 +148,24 @@ pkgs.writeScriptBin "devenv" ''
         $(${nix}/bin/nix $NIX_FLAGS build --print-out-paths --no-link --impure ".#devenv.containers.\"$container\".dockerRun")
       fi
       ;;
+    build)
+      assemble
+      help=$(${coreutils}/bin/cat << 'EOF'
+  Usage: build OPTION
+
+  Example:
+    $ devenv build languages.python.package
+    /nix/store/iw1vmh509hcbby8dbpsaanbri4zsq7dj-python3-3.10.10
+  EOF
+      )
+      eval "$(${docopts}/bin/docopts -A subcommand -h "$help" : "$@")"
+      ${nix}/bin/nix $NIX_FLAGS build \
+        --impure \
+        --print-out-paths \
+        --print-build-logs \
+        --no-link \
+        .#devenv.config."''${subcommand[OPTION]}"
+      ;;
     search)
       name=$1
       shift
@@ -290,6 +308,7 @@ pkgs.writeScriptBin "devenv" ''
       echo "shell                     Activate the developer environment."
       echo "shell CMD [args]          Run CMD with ARGS in the developer environment. Useful when scripting."
       echo "container [options] NAME  Generate a container for NAME. See devenv container --help and http://devenv.sh/containers"
+      echo "build OPTION              Build the package residing in OPTION. See devenv build --help"
       echo "info                      Print information about the current developer environment."
       echo "update                    Update devenv.lock from devenv.yaml inputs. See http://devenv.sh/inputs/#locking-and-updating-inputs"
       echo "up                        Starts processes in foreground. See http://devenv.sh/processes"

--- a/src/flake.nix
+++ b/src/flake.nix
@@ -75,6 +75,7 @@
           inherit (config) info procfileScript procfileEnv procfile;
           ci = config.ciDerivation;
         };
+        devenv.config = config;
         devenv.containers = config.containers;
         devShell."${pkgs.stdenv.system}" = config.shell;
       };


### PR DESCRIPTION
As discussed in https://discord.com/channels/1036369714731036712/1100034303913635860

This adds a `devenv build` command. It allows building derivations inside a devenv config. For instance:

```
$ devenv build languages.python.package
```

I explicitly did not pass through any options to `nix build`, as I wasn't sure of the use-cases and the future compatibility. We might want to explicitly add those once the use-case arises.

My use-case for this is to wrap some of the tests of my project into a Nix build, but I didn't want to migrate the project from using devenv to using devenv within flakes.