### PR TITLE
Implement `aws-vault` integration

### DIFF
--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -4,6 +4,7 @@
   aws-vault = {
     enable = true;
     profile = "aws-profile";
+    awscli2WrapperEnable = true;
     terraformWrapperEnable = true;
   };
 }

--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }: {
+  aws-vault = {
+    enable = true;
+    profile = "aws-profile";
+    terraformWrapperEnable = true;
+  };
+}

--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -4,7 +4,7 @@
   aws-vault = {
     enable = true;
     profile = "aws-profile";
-    awscli2WrapperEnable = true;
-    terraformWrapperEnable = true;
+    awscli2Wrapper.enable = true;
+    terraformWrapper.enable = true;
   };
 }

--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -4,7 +4,7 @@
   aws-vault = {
     enable = true;
     profile = "aws-profile";
-    awscli2Wrapper.enable = true;
+    awscliWrapper.enable = true;
     terraformWrapper.enable = true;
   };
 }

--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -1,4 +1,6 @@
 { pkgs, ... }: {
+  languages.terraform.enable = true;
+
   aws-vault = {
     enable = true;
     profile = "aws-profile";

--- a/examples/aws-vault/devenv.yaml
+++ b/examples/aws-vault/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/integrations/aws-vault.nix
+++ b/src/modules/integrations/aws-vault.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.aws-vault;
+in
+{
+  options.aws-vault = {
+    enable = lib.mkEnableOption "aws-vault integration";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.aws-vault;
+      defaultText = lib.literalExpression "pkgs.aws-vault";
+      description = "The aws-vault package to use.";
+    };
+
+    profile = lib.mkOption {
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        The profile name to be passed to `aws-vault exec`.
+      '';
+    };
+
+    terraformWrapperEnable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Wraps terraform binary as `aws-vault exec <profile> -- terraform <args>`.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.terraformWrapperEnable) {
+    languages.terraform.package = pkgs.writeScriptBin "terraform" ''
+      ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${pkgs.terraform}/bin/terraform "$@"
+    '';
+  };
+}

--- a/src/modules/integrations/aws-vault.nix
+++ b/src/modules/integrations/aws-vault.nix
@@ -17,7 +17,7 @@ in
     profile = lib.mkOption {
       type = lib.types.str;
       description = lib.mdDoc ''
-        The profile name to be passed to `aws-vault exec`.
+        The profile name passed to `aws-vault exec`.
       '';
     };
 

--- a/src/modules/integrations/aws-vault.nix
+++ b/src/modules/integrations/aws-vault.nix
@@ -21,34 +21,58 @@ in
       '';
     };
 
-    awscli2WrapperEnable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Wraps awscli2 binary as `aws-vault exec <profile> -- aws <args>`.
-      '';
+    awscli2Wrapper = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption ''
+            Wraps awscli2 binary as `aws-vault exec <profile> -- aws <args>`.
+          '';
+
+          package = lib.mkOption {
+            type = lib.types.package;
+            default = pkgs.awscli2;
+            defaultText = lib.literalExpression "pkgs.awscli2";
+            description = "The awscli2 package to use.";
+          };
+        };
+      };
+      defaultText = lib.literalExpression "pkgs";
+      default = { };
+      description = "Attribute set of packages including awscli2";
     };
 
-    terraformWrapperEnable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = ''
-        Wraps terraform binary as `aws-vault exec <profile> -- terraform <args>`.
-      '';
+    terraformWrapper = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption ''
+            Wraps terraform binary as `aws-vault exec <profile> -- terraform <args>`.
+          '';
+
+          package = lib.mkOption {
+            type = lib.types.package;
+            default = pkgs.terraform;
+            defaultText = lib.literalExpression "pkgs.terraform";
+            description = "The terraform package to use.";
+          };
+        };
+      };
+      defaultText = lib.literalExpression "pkgs";
+      default = { };
+      description = "Attribute set of packages including terraform";
     };
   };
 
   config = lib.mkMerge [
-    (lib.mkIf (cfg.enable && cfg.awscli2WrapperEnable) {
+    (lib.mkIf (cfg.enable && cfg.awscli2Wrapper.enable) {
       packages = [
         (pkgs.writeScriptBin "aws" ''
-          ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${pkgs.awscli2}/bin/aws "$@"
+          ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${cfg.awscli2Wrapper.package}/bin/aws "$@"
         '')
       ];
     })
-    (lib.mkIf (cfg.enable && cfg.terraformWrapperEnable) {
+    (lib.mkIf (cfg.enable && cfg.terraformWrapper.enable) {
       languages.terraform.package = pkgs.writeScriptBin "terraform" ''
-        ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${pkgs.terraform}/bin/terraform "$@"
+        ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${cfg.terraformWrapper.package}/bin/terraform "$@"
       '';
     })
   ];

--- a/src/modules/integrations/aws-vault.nix
+++ b/src/modules/integrations/aws-vault.nix
@@ -21,7 +21,7 @@ in
       '';
     };
 
-    awscli2Wrapper = lib.mkOption {
+    awscliWrapper = lib.mkOption {
       type = lib.types.submodule {
         options = {
           enable = lib.mkEnableOption ''
@@ -63,10 +63,10 @@ in
   };
 
   config = lib.mkMerge [
-    (lib.mkIf (cfg.enable && cfg.awscli2Wrapper.enable) {
+    (lib.mkIf (cfg.enable && cfg.awscliWrapper.enable) {
       packages = [
         (pkgs.writeScriptBin "aws" ''
-          ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${cfg.awscli2Wrapper.package}/bin/aws "$@"
+          ${cfg.package}/bin/aws-vault exec ${cfg.profile} -- ${cfg.awscliWrapper.package}/bin/aws "$@"
         '')
       ];
     })

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -20,7 +20,7 @@ in
       description = lib.mdDoc ''
         Defines `AWS_PROFILE` environment variable if `enableAwsVaultWrapper`
         is set to `false`, otherwise, it becomes the name of the profile passed
-        to `aws-vault`.
+        to `aws-vault exec`.
       '';
     };
 

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -46,14 +46,14 @@ in
     };
 
     packages = with pkgs; [
-      terraform-ls
-      tfsec
       (if cfg.enableAwsVaultWrapper then
         writeScriptBin "terraform" ''
           ${aws-vault}/bin/aws-vault exec ${cfg.awsProfile} -- \
             ${cfg.package}/bin/terraform "$@"
         ''
       else cfg.package)
+      terraform-ls
+      tfsec
     ];
   };
 }

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -13,13 +13,47 @@ in
       defaultText = lib.literalExpression "pkgs.terraform";
       description = "The Terraform package to use.";
     };
+
+    awsProfile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = lib.mdDoc ''
+        Defines `AWS_PROFILE` environment variable if `enableAwsVaultWrapper`
+        is set to `false`, otherwise, it becomes the name of the profile passed
+        to `aws-vault`.
+      '';
+    };
+
+    enableAwsVaultWrapper = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Create a script that replaces the original Terraform binary with the
+        following wrapper if enabled:
+
+        ```sh
+        aws-vault exec <profile> -- terraform "$@"
+        ```
+
+        Where `<profile>` is the value coming from `awsProfile`.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    env = lib.mkIf (cfg.awsProfile != null && !cfg.enableAwsVaultWrapper) {
+      AWS_PROFILE = cfg.awsProfile;
+    };
+
     packages = with pkgs; [
-      cfg.package
       terraform-ls
       tfsec
+      (if cfg.enableAwsVaultWrapper then
+        writeScriptBin "terraform" ''
+          ${aws-vault}/bin/aws-vault exec ${cfg.awsProfile} -- \
+            ${cfg.package}/bin/terraform "$@"
+        ''
+      else cfg.package)
     ];
   };
 }


### PR DESCRIPTION
The following wrapper makes it more convenient to call `terraform` without the need of specifying the `AWS_PROFILE` environment variable or prefixing commands with `aws-vault exec`.