### PR TITLE
postgres: add an `extensions` option

### DIFF
--- a/examples/postgres/devenv.nix
+++ b/examples/postgres/devenv.nix
@@ -2,4 +2,10 @@
 
 {
   services.postgres.enable = true;
+
+  # Enable the optional PostGIS extension.
+  services.postgres.extensions = extensions: [ extensions.postgis ];
+  services.postgres.initialScript = ''
+    CREATE EXTENSION IF NOT EXISTS postgis;
+  '';
 }


### PR DESCRIPTION
This is a convenience option to install a list of PostgreSQL extensions. The set of available extensions is provided as an argument.

```nix
{
  services.postgres.enable = true;
  services.postgres.extensions = extensions: [ extensions.postgis ];
}
```

You could already do this by modifying the package with `withPackages` and then overriding `services.postgres.package`. The new option has two advantages over the existing approach:

1. It's easier to find in the documentation.

2. Users unfamiliar with nixpkgs are unlikely to be aware of
   `pkgs.postgresql.withPackages` specifically, or the pattern in
   general.

The NixOS services calls this option `extraPlugins`. First of all, that's not what PostgreSQL calls them. Second, you have to manually source the extensions from `pkgs.postgresql.pkgs` and ensure that the PostgreSQL version matches whatever is specified in `services.postgres.package`.

The description for the option contains a list of available extensions generated from the current version of PostgreSQL.

<img width="1512" alt="Screenshot 2023-05-18 at 21 27 43" src="https://github.com/cachix/devenv/assets/7572407/9c61a83b-25eb-4c26-ad6d-578c3e338a21">
