### PR TITLE
macos: point DYLD_LIBRARY_PATH to the devenv profile

### DIFF
--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -104,6 +104,10 @@ let
       export LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LIBRARY_PATH-}"
       export C_INCLUDE_PATH="$DEVENV_PROFILE/include:''${C_INCLUDE_PATH-}"
 
+      ${lib.optionalString pkgs.stdenv.isDarwin ''
+      export DYLD_LIBRARY_PATH="$DEVENV_PROFILE/lib:''${DYLD_LIBRARY_PATH-}";
+      ''}
+
       # these provide shell completions / default config options
       export XDG_DATA_DIRS="$DEVENV_PROFILE/share:''${XDG_DATA_DIRS-}"
       export XDG_CONFIG_DIRS="$DEVENV_PROFILE/etc/xdg:''${XDG_CONFIG_DIRS-}"


### PR DESCRIPTION
I would imagine that the same caveats as with `LD_LIBRARY_PATH` apply here, but this seems necessary as long as we're using the naked shell. 

This fixes the devenv docs build on MacOS. Here's the error I was running into:

```
Building shell ...
pre-commit-hooks.nix: hooks up to date
01:18:38 system  | docs.1 started (pid=63957)
01:18:38 system  | build.1 started (pid=63958)
01:18:38 build.1 | warning: Git tree '/Users/sander/code/cachix/devenv' is dirty
01:18:39 build.1 | warning: Using saved setting for 'extra-substituters = https://devenv.cachix.org' from ~/.local/share/nix/trusted-settings.json.
01:18:39 build.1 | warning: Using saved setting for 'extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=' from ~/.local/share/nix/trusted-settings.json.
01:18:39 docs.1  | Traceback (most recent call last):
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.devenv/state/venv/bin/mkdocs", line 8, in <module>
01:18:39 docs.1  |     sys.exit(cli())
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
01:18:39 docs.1  |     return self.main(*args, **kwargs)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
01:18:39 docs.1  |     rv = self.invoke(ctx)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
01:18:39 docs.1  |     return _process_result(sub_ctx.command.invoke(sub_ctx))
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
01:18:39 docs.1  |     return ctx.invoke(self.callback, **ctx.params)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
01:18:39 docs.1  |     return __callback(*args, **kwargs)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/__main__.py", line 234, in serve_command
01:18:39 docs.1  |     serve.serve(dev_addr=dev_addr, livereload=livereload, watch=watch, **kwargs)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/commands/serve.py", line 78, in serve
01:18:39 docs.1  |     config = get_config()
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/base.py", line 363, in load_config
01:18:39 docs.1  |     errors, warnings = cfg.validate()
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/base.py", line 228, in validate
01:18:39 docs.1  |     run_failed, run_warnings = self._validate()
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/base.py", line 186, in _validate
01:18:39 docs.1  |     self[key] = config_option.validate(value)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 147, in validate
01:18:39 docs.1  |     return self.run_validation(value)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 939, in run_validation
01:18:39 docs.1  |     self.load_plugin_with_namespace(name, cfg)
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 975, in load_plugin_with_namespace
01:18:39 docs.1  |     return (name, self.load_plugin(name, config))
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/mkdocs/config/config_options.py", line 993, in load_plugin
01:18:39 docs.1  |     plugin_cls = self.installed_plugins[name].load()
01:18:39 docs.1  |   File "/nix/store/7rjqb838snvvxcmpvck1smfxhkwzqal5-python3-3.10.10/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
01:18:39 docs.1  |     module = import_module(match.group('module'))
01:18:39 docs.1  |   File "/nix/store/7rjqb838snvvxcmpvck1smfxhkwzqal5-python3-3.10.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
01:18:39 docs.1  |     return _bootstrap._gcd_import(name[level:], package, level)
01:18:39 docs.1  |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
01:18:39 docs.1  |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
01:18:39 docs.1  |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
01:18:39 docs.1  |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
01:18:39 docs.1  |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
01:18:39 docs.1  |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/material/plugins/social/plugin.py", line 42, in <module>
01:18:39 docs.1  |     from cairosvg import svg2png
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/cairosvg/__init__.py", line 26, in <module>
01:18:39 docs.1  |     from . import surface  # noqa isort:skip
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/cairosvg/surface.py", line 9, in <module>
01:18:39 docs.1  |     import cairocffi as cairo
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/cairocffi/__init__.py", line 47, in <module>
01:18:39 docs.1  |     cairo = dlopen(
01:18:39 docs.1  |   File "/Users/sander/code/cachix/devenv/.venv/lib/python3.10/site-packages/cairocffi/__init__.py", line 44, in dlopen
01:18:39 docs.1  |     raise OSError(error_message)  # pragma: no cover
01:18:39 docs.1  | OSError: no library called "cairo-2" was found
01:18:39 docs.1  | no library called "cairo" was found
01:18:39 docs.1  | no library called "libcairo-2" was found
01:18:39 docs.1  | cannot load library 'libcairo.so.2': dlopen(libcairo.so.2, 0x0002): tried: 'libcairo.so.2' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibcairo.so.2' (no such file), '/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo.so.2' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo.so.2' (no such file), '/usr/lib/libcairo.so.2' (no such file, not in dyld cache), 'libcairo.so.2' (no such file), '/usr/local/lib/libcairo.so.2' (no such file), '/usr/lib/libcairo.so.2' (no such file, not in dyld cache)
01:18:39 docs.1  | cannot load library 'libcairo.2.dylib': dlopen(libcairo.2.dylib, 0x0002): tried: 'libcairo.2.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibcairo.2.dylib' (no such file), '/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo.2.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo.2.dylib' (no such file), '/usr/lib/libcairo.2.dylib' (no such file, not in dyld cache), 'libcairo.2.dylib' (no such file), '/usr/local/lib/libcairo.2.dylib' (no such file), '/usr/lib/libcairo.2.dylib' (no such file, not in dyld cache)
01:18:39 docs.1  | cannot load library 'libcairo-2.dll': dlopen(libcairo-2.dll, 0x0002): tried: 'libcairo-2.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibcairo-2.dll' (no such file), '/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo-2.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/nix/store/ylxc5aq56jqd19vmbqgpgbyjnjmw9qyd-apple-framework-CoreFoundation-11.0.0/Library/Frameworks/libcairo-2.dll' (no such file), '/usr/lib/libcairo-2.dll' (no such file, not in dyld cache), 'libcairo-2.dll' (no such file), '/usr/local/lib/libcairo-2.dll' (no such file), '/usr/lib/libcairo-2.dll' (no such file, not in dyld cache)
01:18:39 system  | docs.1 stopped (rc=1)
01:18:39 system  | sending SIGTERM to build.1 (pid 63958)
01:18:39 system  | build.1 stopped (rc=0)
```