### PR TITLE
docs: add missing build dependency

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -4,6 +4,7 @@
   packages = [
     (import ./src/devenv.nix { inherit pkgs; nix = inputs.nix; })
     pkgs.cairo
+    pkgs.xorg.libxcb
     pkgs.yaml2json
   ];
 


### PR DESCRIPTION
Tested on both NixOS and macOS.

macOS also requires #607 to work.