### PR TITLE
ruby: fix macos tests

### DIFF
--- a/examples/ruby/Gemfile.lock
+++ b/examples/ruby/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.1-x86_64-linux)
       racc (~> 1.4)
     puma (6.0.1)
@@ -142,6 +144,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/examples/ruby/devenv.nix
+++ b/examples/ruby/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
   languages.ruby.enable = true;
@@ -16,4 +16,12 @@
     # Automatically run bundler upon enterting the shell.
     bundle
   '';
+
+  # Add required dependencies for macOS. These packages are usually provided as
+  # part of the Xcode command line developer tools, in which case they can be
+  # removed.
+  # For more information, see the `--install` flag in `man xcode-select`.
+  packages = lib.optionals pkgs.stdenv.isDarwin [
+    pkgs.libllvm
+  ];
 }


### PR DESCRIPTION
Add the missing native dependencies to the ruby example on macOS.

Resolves #564.