### PR TITLE
[WIP] Add propagated inputs to the profile

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -7,10 +7,11 @@ let
     map (name: path + "/${name}") (builtins.attrNames (builtins.readDir path));
 
   drvOrPackageToPaths = drvOrPackage:
-    if drvOrPackage ? outputs then
-      builtins.map (output: drvOrPackage.${output}) drvOrPackage.outputs
-    else
-      [ drvOrPackage ];
+    (if drvOrPackage ? outputs
+    then builtins.map (output: drvOrPackage.${output}) drvOrPackage.outputs
+    else [ drvOrPackage ])
+    ++ drvOrPackage.propagatedBuildInputs or [ ]
+    ++ drvOrPackage.propagatedNativeBuildInputs or [ ];
   profile = pkgs.buildEnv {
     name = "devenv-profile";
     paths = lib.flatten (builtins.map drvOrPackageToPaths config.packages);


### PR DESCRIPTION
Testing out solutions to #601.

List of propagated inputs we've found:

- `depsHostHostPropagated`
- `depsBuildBuildPropagated`
- `depsBuildTargetPropagated`
- `depsTargetTargetPropagated`
- `propagatedNativeBuildInputs` or `depsBuildHostPropagated`
- `propagatedBuildInputs` or `depsHostTargetPropagated`