### PR TITLE
ruby: add "follows: nixpkgs" in assertion message

### DIFF
--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -9,6 +9,9 @@ let
       inputs:
         nixpkgs-ruby:
           url: github:bobvanderlinden/nixpkgs-ruby
+          inputs:
+            nixpkgs:
+              follows: nixpkgs
   '');
 in
 {


### PR DESCRIPTION
Currently only the examples/ruby/devenv.yaml mention the use of `follows: nixpkgs`. This was not the case yet for the assertion message if nixpkgs-ruby input doesn't exist. 