### PR TITLE
Use nixpkgs#gleam package instead of vic/gleam-nix

### DIFF
--- a/examples/gleam/devenv.yaml
+++ b/examples/gleam/devenv.yaml
@@ -1,15 +1,3 @@
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
-
-  gleam:
-    url: github:gleam-lang/gleam/v0.28.3 # or any other release
-    flake: false
-
-  gleam-nix:
-    url: github:vic/gleam-nix
-    overlays:
-      - default
-    inputs:
-      gleam:
-        follows: gleam


### PR DESCRIPTION
The nixpkgs repository already has a community maintained derivation for Gleam. Use that in the example Gleam project.

People would only need to use vic/gleam-nix flake when building non-released Gleam versions or contributing to Gleam itself.

Closes #610 by using already pre-cached nixpkgs gleam.