### PR TITLE
python: poetry: add groups and extras options

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -118,6 +118,11 @@ in
           default = false;
           description = "Whether `poetry install` should avoid outputting messages during devenv initialisation.";
         };
+        groups = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Which dependency-groups to install. See `--with`.";
+        };
       };
       activate.enable = lib.mkEnableOption "activate the poetry virtual environment automatically";
 
@@ -134,7 +139,8 @@ in
     languages.python.poetry.install.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
     languages.python.poetry.install.arguments =
       lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
-      lib.optional cfg.poetry.install.quiet "--quiet";
+      lib.optional cfg.poetry.install.quiet "--quiet" ++
+      lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" "${lib.concatStringsSep "," cfg.poetry.install.groups}" ];
 
     languages.python.poetry.activate.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
 

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -48,10 +48,11 @@ let
 
     function _devenv-poetry-install()
     {
+      local POETRY_INSTALL_COMMAND=(${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments})
       # Avoid running "poetry install" for every shell.
       # Only run it when the "poetry.lock" file or python interpreter has changed.
       # We do this by storing the interpreter path and a hash of "poetry.lock" in venv.
-      local ACTUAL_POETRY_CHECKSUM="${cfg.package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock)"
+      local ACTUAL_POETRY_CHECKSUM="${cfg.package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock):''${POETRY_INSTALL_COMMAND[@]}"
       local POETRY_CHECKSUM_FILE="${venvPath}/poetry.lock.checksum"
       if [ -f "$POETRY_CHECKSUM_FILE" ]
       then
@@ -62,7 +63,7 @@ let
 
       if [ "$ACTUAL_POETRY_CHECKSUM" != "$EXPECTED_POETRY_CHECKSUM" ]
       then
-        if ${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments}
+        if ''${POETRY_INSTALL_COMMAND[@]}
         then
           echo "$ACTUAL_POETRY_CHECKSUM" > "$POETRY_CHECKSUM_FILE"
         else

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -123,6 +123,11 @@ in
           default = [ ];
           description = "Which dependency-groups to install. See `--with`.";
         };
+        extras = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Which extras to install. See `--extras`.";
+        };
       };
       activate.enable = lib.mkEnableOption "activate the poetry virtual environment automatically";
 
@@ -140,7 +145,8 @@ in
     languages.python.poetry.install.arguments =
       lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
       lib.optional cfg.poetry.install.quiet "--quiet" ++
-      lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" "${lib.concatStringsSep "," cfg.poetry.install.groups}" ];
+      lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" "${lib.concatStringsSep "," cfg.poetry.install.groups}" ] ++
+      lib.optionals (cfg.poetry.install.extras != [ ]) [ "--extras" "${lib.concatStringsSep " " cfg.poetry.install.extras}" ];
 
     languages.python.poetry.activate.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
 


### PR DESCRIPTION
Resolves https://github.com/cachix/devenv/issues/621

This adds two options.

`groups = [ <group> ]` is the equivalent of using `poetry install --with <group>`.
It only supports adding groups, as I have not looked into supporting `--only` nor `--without`. Maybe someone else could give an opinion of this, as I have never used these cli options before :sweat_smile:.

`extras = [ <extra> ]` is the equivalent of using `poetry install --extras <extra>`.

I have now also made sure that the command line option of `poetry install` are included in the checksum that determines whether `poetry install` should be re-run. If any of the arguments changes, it will run poetry install the next time devenv shell initializes.