### PR TITLE
Fix poetry extras

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -129,6 +129,11 @@ in
           default = [ ];
           description = "Which extras to install. See `--extras`.";
         };
+        allExtras = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to install all extras. See `--all-extras`.";
+        };
       };
       activate.enable = lib.mkEnableOption "activate the poetry virtual environment automatically";
 
@@ -146,8 +151,9 @@ in
     languages.python.poetry.install.arguments =
       lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
       lib.optional cfg.poetry.install.quiet "--quiet" ++
-      lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" "${lib.concatStringsSep "," cfg.poetry.install.groups}" ] ++
-      lib.optionals (cfg.poetry.install.extras != [ ]) [ "--extras" "${lib.concatStringsSep " " cfg.poetry.install.extras}" ];
+      lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" ''"${lib.concatStringsSep "," cfg.poetry.install.groups}"'' ] ++
+      lib.optionals (cfg.poetry.install.extras != [ ]) [ "--extras" ''"${lib.concatStringsSep " " cfg.poetry.install.extras}"'' ] ++
+      lib.optional cfg.poetry.install.allExtras "--all-extras";
 
     languages.python.poetry.activate.enable = lib.mkIf cfg.poetry.enable (lib.mkDefault true);
 


### PR DESCRIPTION
In #631 poetry gained the ability to install extras and groups. I tested out the extras feature today and found a bug: If you specify multiple extras, then the following install command is generated:

`poetry install --extras extra1 extra2`

The problem is that poetry treats `extra2` as an argument to the install command. Thus, this PR adds quotation marks as follows:

`poetry install --extras "extra1 extra2"`

While I was at it, I also added another option to select `--all-extras`.