### PR TITLE
Make rust.nix accept toolchain options.

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -452,8 +452,11 @@ Starting processes ...
   {
     languages.rust = {
       enable = true;
-      # https://devenv.sh/reference/options/#languagesrustversion
-      version = "nightly";
+      # https://devenv.sh/reference/options/#languagesrusttoolchain
+      toolchain = {
+        channel = "nightly";
+        profile = "default";
+      };
     };
 
     pre-commit.hooks = {

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -7,8 +7,11 @@
 
   languages.rust = {
     enable = true;
-    # https://devenv.sh/reference/options/#languagesrustversion
-    version = "latest";
+    # https://devenv.sh/reference/options/#languagesrusttoolchain
+    toolchain = {
+      channel = "nightly";
+      profile = "default";
+    };
   };
 
   pre-commit.hooks = {

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -12,7 +12,6 @@
       channel = "nightly";
       profile = "default";
     };
-    sha256 = "sha256-6Q90iheJHltM1tvGGhjMGbRKkJtdTEJ6RTFOUoHxrjg=";
   };
 
   pre-commit.hooks = {

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -12,6 +12,7 @@
       channel = "nightly";
       profile = "default";
     };
+    sha256 = "sha256-6Q90iheJHltM1tvGGhjMGbRKkJtdTEJ6RTFOUoHxrjg=";
   };
 
   pre-commit.hooks = {

--- a/examples/supported-languages/devenv.yaml
+++ b/examples/supported-languages/devenv.yaml
@@ -1,3 +1,8 @@
 inputs:
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -1,10 +1,10 @@
-{
-  pkgs,
-  config,
-  lib,
-  inputs,
-  ...
-}: let
+{ pkgs
+, config
+, lib
+, inputs
+, ...
+}:
+let
   inherit (lib.attrsets) attrValues genAttrs getAttrs;
   cfg = config.languages.rust;
   setup = ''
@@ -15,7 +15,8 @@
           nixpkgs:
             follows: nixpkgs
   '';
-in {
+in
+{
   options.languages.rust = {
     enable = lib.mkEnableOption "tools for Rust development";
     toolchain = lib.mkOption {
@@ -43,13 +44,13 @@ in {
             type = lib.types.nullOr (lib.types.listOf lib.types.str);
             default = null;
             description = ''See https://rust-lang.github.io/rustup/concepts/components.html for a list of valid components.'';
-            example = ["rust-src" "rust-analyzer"];
+            example = [ "rust-src" "rust-analyzer" ];
           };
           targets = lib.mkOption {
             type = lib.types.nullOr (lib.types.listOf lib.types.str);
             default = null;
             description = "See https://github.com/nix-community/fenix#supported-platforms-and-targets for a list of valid targets.";
-            example = ["wasm32-unknown-unknown"];
+            example = [ "wasm32-unknown-unknown" ];
           };
         };
       };
@@ -63,56 +64,71 @@ in {
     };
   };
   config = lib.mkMerge [
-    (lib.mkIf cfg.enable (let
-      fenix = inputs.fenix.packages.${pkgs.stdenv.system} or (throw "To use languages.rust, you need to add the following to your devenv.yaml:\n\n${setup}");
-      listify = lib.concatMapStringsSep "," (a: ''"${a}"'');
-      toolchain_toml =
-        if cfg.toolchain == null
-        then builtins.toFile "rust-toolchain.toml" ''[toolchain]''
-        else let 
-        channel =
-          if cfg.toolchain.channel != null && cfg.toolchain.channel != ""
-          then ''channel = "${cfg.toolchain.channel
-            + (
-              if cfg.toolchain.date != null && cfg.toolchain.date != ""
-              then "-" +  cfg.toolchain.date
-              else ""
-            )}"''
-          else ''channel = "stable"'';
-        components =
-          if cfg.toolchain.components != null && lib.length cfg.toolchain.components > 0
-          then ''components = [${listify cfg.toolchain.components}]''
-          else "";
-        targets =
-          if cfg.toolchain.targets != null && lib.length cfg.toolchain.targets > 0
-          then ''targets = [${listify cfg.toolchain.targets}]''
-          else "";
-        profile =
-          if cfg.toolchain.profile != null && cfg.toolchain.profile != ""
-          then ''profile = "${cfg.toolchain.profile}"''
-          else "";
-        in builtins.toFile "rust-toolchain.toml" ''[toolchain]
+    (lib.mkIf cfg.enable (
+      let
+        fenix = inputs.fenix.packages.${pkgs.stdenv.system} or (throw "To use languages.rust, you need to add the following to your devenv.yaml:\n\n${setup}");
+        listify = lib.concatMapStringsSep "," (a: ''"${a}"'');
+        toolchain_toml =
+          if cfg.toolchain == null
+          then builtins.toFile "rust-toolchain.toml" ''[toolchain]''
+          else
+            let
+              channel =
+                if cfg.toolchain.channel != null && cfg.toolchain.channel != ""
+                then ''channel = "${cfg.toolchain.channel
+                + (
+                  if cfg.toolchain.date != null && cfg.toolchain.date != ""
+                  then "-" + cfg.toolchain.date
+                  else ""
+                )}"''
+                else ''channel = "stable"'';
+              components =
+                if cfg.toolchain.components != null && lib.length cfg.toolchain.components > 0
+                then ''components = [${listify cfg.toolchain.components}]''
+                else "";
+              targets =
+                if cfg.toolchain.targets != null && lib.length cfg.toolchain.targets > 0
+                then ''targets = [${listify cfg.toolchain.targets}]''
+                else "";
+              profile =
+                if cfg.toolchain.profile != null && cfg.toolchain.profile != ""
+                then ''profile = "${cfg.toolchain.profile}"''
+                else "";
+            in
+            builtins.toFile "rust-toolchain.toml" ''[toolchain]
 ${channel}
 ${components}
 ${targets}
 ${profile}
 '';
-      toolchain_derivation = fenix.fromToolchainFile {
-        file = toolchain_toml;
-        sha256 =
-          if cfg.sha256 == null
-          then lib.fakeSha256
-          else cfg.sha256;
-      };
-    in {
-      packages = [toolchain_derivation] ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv;
-      # enable compiler tooling by default to expose things like cc
-      languages.c.enable = lib.mkDefault true;
-    }))
+        toolchain_derivation = fenix.fromToolchainFile {
+          file = toolchain_toml;
+          sha256 =
+            if cfg.sha256 == null
+            then lib.fakeSha256
+            else cfg.sha256;
+        };
+      in
+      {
+        packages = [ toolchain_derivation ] ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv;
+        # enable compiler tooling by default to expose things like cc
+        languages.c.enable = lib.mkDefault true;
+        pre-commit.tools.cargo = lib.mkForce toolchain_derivation;
+        # Use the packages from the toolchain derivation if it contains them, otherwise use default packages.
+        pre-commit.tools.clippy =
+          if cfg.toolchain.profile == "default" || cfg.toolchain.profile == "complete" || (cfg.toolchain.components != null && builtins.elem "clippy" cfg.toolchain.components)
+          then lib.mkForce toolchain_derivation
+          else lib.mkForce pkgs.clippy;
+        pre-commit.tools.rustfmt =
+          if cfg.toolchain.profile == "default" || cfg.toolchain.profile == "complete" || (cfg.toolchain.components != null && builtins.elem "rustfmt" cfg.toolchain.components)
+          then lib.mkForce toolchain_derivation
+          else lib.mkForce pkgs.rustfmt;
+      }
+    ))
     (lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
-      env.RUSTFLAGS = ["-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks"];
-      env.RUSTDOCFLAGS = ["-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks"];
-      env.CFLAGS = ["-iframework ${config.env.DEVENV_PROFILE}/Library/Frameworks"];
+      env.RUSTFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
+      env.RUSTDOCFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
+      env.CFLAGS = [ "-iframework ${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
     })
   ];
 }

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -57,11 +57,6 @@ in
       default = { };
       description = "Attribute set of toolchain file values. See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more information.";
     };
-    sha256 = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Paste the correct sha256 returned by the error.";
-    };
   };
   config = lib.mkMerge [
     (lib.mkIf cfg.enable (
@@ -103,10 +98,7 @@ ${profile}
 '';
         toolchain_derivation = fenix.fromToolchainFile {
           file = toolchain_toml;
-          sha256 =
-            if cfg.sha256 == null
-            then lib.fakeSha256
-            else cfg.sha256;
+          sha256 = null;
         };
       in
       {

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -108,7 +108,6 @@ ${profile}
       packages = [toolchain_derivation] ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv;
       # enable compiler tooling by default to expose things like cc
       languages.c.enable = lib.mkDefault true;
-      env.RUST_SRC_PATH = "${toolchain_derivation}/lib/rustlib/src/rust/library/";
     }))
     (lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
       env.RUSTFLAGS = ["-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks"];


### PR DESCRIPTION
This makes the Rust option accept toolchain override options in a similar format to [rust-toolchain.toml](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), which should be more familiar to Rust users and allow adding arbitrary components and targets, and is a step forward to addressing #530.

Changes:
* Remove `languages.rust.packages` and `languages.rust.version` options.
* Make nix-community/fenix a hard-requirement for `languages.rust.enable`.
* Add `languages.rust.toolchain` option.

~~This no longer includes rust-src by default and no longer has pre-commit hooks since the components may no longer be present. How should I handle rust-src and the pre-commit hooks instead?~~

According to the nix-community/fenix maintainer, rust-analyzer will automatically use the rust-src package if it exists. I've pushed a commit which causes the pre-commit hooks to use the rust components if they are added by the user, otherwise it defaults to the ones from nixpkgs.

[Matrix conversation about the topic](https://matrix.to/#/!plrRoZsBTUYBWzvzIq:matrix.org/$YPphSP3OyUVegK01ZV5MLjECbhHiEOL8buqzCytiNJc?via=matrix.org&via=glorifiedgluer.com&via=kde.org).