### PR TITLE
Add readiness check for memcached

### DIFF
--- a/examples/process-compose/devenv.nix
+++ b/examples/process-compose/devenv.nix
@@ -6,6 +6,7 @@
   processes.foo.exec = "echo foo; sleep 5";
 
   services.postgres.enable = true;
+  services.memcached.enable = true;
 
   languages.ruby.enable = true;
 


### PR DESCRIPTION
This adds a simple bash-based readiness check. It will fail if the server is faulted for whatever reason. I chose `bash` over `nc` because it is fairly prevalent throughout all of `nixpkgs` and you are likely to have it already loaded in your store.