### PR TITLE
Add readiness check to elasticsearch

### DIFF
--- a/src/modules/services/elasticsearch.nix
+++ b/src/modules/services/elasticsearch.nix
@@ -179,6 +179,22 @@ in
 
     env.ELASTICSEARCH_DATA = config.env.DEVENV_STATE + "/elasticsearch";
 
-    processes.elasticsearch.exec = "${startScript}";
+    processes.elasticsearch = {
+      exec = "${startScript}";
+
+      process-compose = {
+        readiness_probe = {
+          exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.listenAddress}:${cfg.port}";
+          initial_delay_seconds = 15;
+          period_seconds = 10;
+          timeout_seconds = 2;
+          success_threshold = 1;
+          failure_threshold = 5;
+        };
+
+        # https://github.com/F1bonacc1/process-compose#-auto-restart-if-not-healthy
+        availability.restart = "on_failure";
+      };
+    };
   };
 }


### PR DESCRIPTION
This adds a readiness check that is exactly like the healthcheck in the official Docker library.