### PR TITLE
haskell: Fix error when `languageServer` is set to `null`

### DIFF
--- a/src/modules/languages/haskell.nix
+++ b/src/modules/languages/haskell.nix
@@ -34,11 +34,11 @@ in
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       cfg.package
-      cfg.languageServer
       stack
       cabal-install
       zlib
       hpack
-    ];
+    ]
+    ++ (lib.optional (cfg.languageServer != null) cfg.languageServer);
   };
 }


### PR DESCRIPTION
The `languageServer` option type inside the `haskell` language module is set to  `lib.types.nullOr lib.types.package`, however, the `packages` section does not check for `null` values causing the following error:

```
error: A definition for option `perSystem.aarch64-darwin.devenv.shells.default.packages."[definition 1-entry 2]"' is not of type `package'. Definition values:
       - In `/nix/store/95czchz5fgjcak3y1y5cizx22irqa09w-source/src/modules/languages/haskell.nix': null
```

Relevant code snippet:

```nix
languages.haskell = {
  enable = true;
  languageServer = null;
};
```

