### PR TITLE
haskell: Parameterize `stack` package

### DIFF
--- a/src/modules/languages/haskell.nix
+++ b/src/modules/languages/haskell.nix
@@ -29,16 +29,25 @@ in
         Haskell language server to use.
       '';
     };
+
+    stack = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = pkgs.stack;
+      defaultText = "pkgs.stack";
+      description = ''
+        Haskell stack to use.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       cfg.package
-      stack
       cabal-install
       zlib
       hpack
     ]
-    ++ (lib.optional (cfg.languageServer != null) cfg.languageServer);
+    ++ (lib.optional (cfg.languageServer != null) cfg.languageServer)
+    ++ (lib.optional (cfg.stack != null) cfg.stack);
   };
 }


### PR DESCRIPTION
This change makes `stack` package parameterizable so it could be customized or skipped if is set to `null`