### PR TITLE
Convert integer to string in elasticsearch healthcheck

### DIFF
--- a/src/modules/services/elasticsearch.nix
+++ b/src/modules/services/elasticsearch.nix
@@ -184,7 +184,7 @@ in
 
       process-compose = {
         readiness_probe = {
-          exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.listenAddress}:${cfg.port}";
+          exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.listenAddress}:${toString cfg.port}";
           initial_delay_seconds = 15;
           period_seconds = 10;
           timeout_seconds = 2;


### PR DESCRIPTION
Humble apologies. My rigor in testing was not complete in my last elasticsearch PR. This will correct the error when running `devenv up` with `services.elasticsearch.enable = true`.

```
at «github:cachix/devenv/c51a56bac8853c019241fe8d821c0a0d82422835»/src/modules/services/elasticsearch.nix:187:83:

   186|         readiness_probe = {
   187|           exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.listenAddress}:${cfg.port}";
      |                                                                                   ^
   188|           initial_delay_seconds = 15;

error: cannot coerce an integer to a string
```