### PR TITLE
Use nc for healthcheck

### DIFF
--- a/src/modules/services/memcached.nix
+++ b/src/modules/services/memcached.nix
@@ -55,7 +55,7 @@ in
       process-compose = {
         readiness_probe = {
           exec.command = ''
-            3<>/dev/tcp/${cfg.bind}/${toString cfg.port}; printf "stats\nquit\n" >&3; cat <&3
+            echo stats | ${pkgs.netcat}/bin/nc ${cfg.bind} ${toString cfg.port} > /dev/null 2>&1
           '';
           initial_delay_seconds = 2;
           period_seconds = 10;


### PR DESCRIPTION
This is an alternative healthcheck for memcached. The prior one worked when executed with `bash -c 'healthcheck'` but failed silently when I removed the `bash` wrapper. This changes the healthcheck to use `echo | nc`, and I have tested this locally by taking the generated `process-compose.yaml` and modifying the command in the YAML. I have also tested using both `127.0.0.1` and `::1` for the `listen` parameter. I was not as rigorous as I should have been after I modified the last `memcached` PR from feedback.