### PR TITLE
move process implementations to separate modules

### DIFF
--- a/src/modules/process-managers/hivemind.nix
+++ b/src/modules/process-managers/hivemind.nix
@@ -1,0 +1,22 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.process-managers.hivemind;
+in
+{
+  options.process-managers.hivemind = {
+    enable = lib.mkEnableOption "hivemind as process-manager";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.hivemind;
+      defaultText = lib.literalExpression "pkgs.hivemind";
+      description = "The hivemind package to use.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    processManagerCommand = ''
+      ${cfg.package}/bin/hivemind --print-timestamps "$@" ${config.procfile} &
+    '';
+
+    packages = [ cfg.package ];
+  };
+}

--- a/src/modules/process-managers/honcho.nix
+++ b/src/modules/process-managers/honcho.nix
@@ -1,0 +1,22 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.process-managers.honcho;
+in
+{
+  options.process-managers.honcho = {
+    enable = lib.mkEnableOption "honcho as process-manager";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.honcho;
+      defaultText = lib.literalExpression "pkgs.honcho";
+      description = "The honcho package to use.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    processManagerCommand = ''
+      ${cfg.package}/bin/honcho start -f ${config.procfile} --env ${config.procfileEnv} "$@" &
+    '';
+
+    packages = [ cfg.package ];
+  };
+}

--- a/src/modules/process-managers/overmind.nix
+++ b/src/modules/process-managers/overmind.nix
@@ -1,0 +1,22 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.process-managers.overmind;
+in
+{
+  options.process-managers.overmind = {
+    enable = lib.mkEnableOption "overmind as process-manager";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.overmind;
+      defaultText = lib.literalExpression "pkgs.overmind";
+      description = "The overmind package to use.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    processManagerCommand = ''
+      OVERMIND_ENV=${config.procfileEnv} ${cfg.package}/bin/overmind start --root ${config.env.DEVENV_ROOT} --procfile ${config.procfile} "$@" &
+    '';
+
+    packages = [ cfg.package ];
+  };
+}

--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -1,0 +1,67 @@
+{ pkgs, config, lib, ... }:
+let
+  cfg = config.process-managers.process-compose;
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.process-managers.process-compose = {
+    enable = lib.mkEnableOption "process-compose as process-manager";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.process-compose;
+      defaultText = lib.literalExpression "pkgs.process-compose";
+      description = "The process-compose package to use.";
+    };
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      internal = true;
+    };
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      description = ''
+        process-compose.yaml specific process attributes.
+
+        Example: https://github.com/F1bonacc1/process-compose/blob/main/process-compose.yaml`
+      '';
+      example = {
+        environment = [ "ENVVAR_FOR_THIS_PROCESS_ONLY=foobar" ];
+        availability = {
+          restart = "on_failure";
+          backoff_seconds = 2;
+          max_restarts = 5; # default: 0 (unlimited)
+        };
+        depends_on.some-other-process.condition =
+          "process_completed_successfully";
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    processManagerCommand = ''
+      ${cfg.package}/bin/process-compose --config ${cfg.configFile}  up "$@" &
+    '';
+
+    packages = [ cfg.package ];
+
+    process-managers.process-compose = {
+      configFile = settingsFormat.generate "process-compose.yaml" cfg.settings;
+      settings = {
+        version = "0.5";
+        port = lib.mkDefault 9999;
+        tui = lib.mkDefault true;
+        environment = lib.mapAttrsToList
+          (name: value: "${name}=${toString value}")
+          (if config.devenv.flakesIntegration then
+          # avoid infinite recursion in the scenario the `config` parameter is
+          # used in a `processes` declaration inside a devenv module.
+            builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]
+          else
+            config.env);
+        processes = lib.mapAttrs
+          (name: value: { command = value.exec; } // value.process-compose)
+          config.processes;
+      };
+    };
+
+  };
+}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -112,6 +112,7 @@ in
   ++ (listEntries ./languages)
   ++ (listEntries ./services)
   ++ (listEntries ./integrations)
+  ++ (listEntries ./process-managers)
   ;
 
   config = {


### PR DESCRIPTION
As [discussed on Discord](https://discord.com/channels/1036369714731036712/1036369758024650792/1119268576206016576) this is a proposal implementation for splitting up the process-managers into separate modules.

I must say that this became a bit bigger than I initially anticipated, but it seemed like the refactorings were still useful and backwards-compatible.

There are a few todo's in here to propose further changes, but first wanted to get feedback on this proposal as-is.

While working on this I also felt it might be a good idea to move generating the Procfile and env-file into a `pkgs.formats.procfile` and `pkgs.formats.envfile`. That way these implementations can be reused, but do not need to reside as options (process-compose doesn't use them for instance, as do a number of other non-procfile-based process managers). Not really needed to worry about right now though.