### PR TITLE
Configure additional `rabbitmq` listeners

### DIFF
--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -127,6 +127,7 @@ in
 
     services.rabbitmq.configItems = {
       "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString cfg.port}";
+      "distribution.listener.interface" = mkDefault cfg.listenAddress;
     } // optionalAttrs cfg.managementPlugin.enable {
       "management.tcp.port" = toString cfg.managementPlugin.port;
       "management.tcp.ip" = cfg.listenAddress;
@@ -142,6 +143,8 @@ in
     env.RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
     env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
     env.RABBITMQ_NODENAME = "rabbit@localhost";
+    env.RABBITMQ_HOST = cfg.listenAddress;
+    env.ERL_EPMD_ADDRESS = cfg.listenAddress;
 
     processes.rabbitmq = {
       exec = "${cfg.package}/bin/rabbitmq-server";


### PR DESCRIPTION
The rabbit server will listen for in-cluster communication and local administration on a port calculated as:
`${cfg.port} + 20000`

This configures that port to use the same listener address as the configuration option.

`epmd` is a companion process that is used to look up domain names by `rabbitmq-server` and this also configures that process to listen on the same listener address.

Without this change, the `rabbitmq-server` is available on all possible interfaces with default credentials. This will expose the server to security risks and compromise unless further configuration is made. To test this, I have configured a rabbitmq to only listen on `127.0.0.1` and I can verify that it is not listening on only a single interface with `rabbitmqctl cluster_status` and `lsof -nP -i | grep beam` (on a mac).