### PR TITLE
Use cfg.settings instead for opensearch readiness check

### DIFF
--- a/src/modules/services/opensearch.nix
+++ b/src/modules/services/opensearch.nix
@@ -155,7 +155,7 @@ in
 
       process-compose = {
         readiness_probe = {
-          exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.listenAddress}:${toString cfg.port}";
+          exec.command = "${pkgs.curl}/bin/curl -f -k http://${cfg.settings."network.host"}:${toString cfg.settings."http.port"}";
           initial_delay_seconds = 15;
           period_seconds = 10;
           timeout_seconds = 2;


### PR DESCRIPTION
This is hard to test locally, but the configuration for `opensearch` is different than `elasticsearch`. It uses `cfg.settings."network.host"` and `cfg.settings."http.port"` instead of `listenAddress` and `port`.