### PR TITLE
Enable `languages.c` for Crystal

### DIFF
--- a/src/modules/languages/crystal.nix
+++ b/src/modules/languages/crystal.nix
@@ -9,6 +9,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # enable compiler tooling by default to expose things like cc
+    languages.c.enable = lib.mkDefault true;
+
     packages = [
       pkgs.crystal
       pkgs.shards


### PR DESCRIPTION
Crystal needs at least a linker available and `pkg-config`, but other parts of the C toolchain are also often useful.

A more minimal implementation would be adding `pkgs.gcc` and `pkgs.pkg-config` as the bare minimum. The idea of enabling the entire C language is copied from the Rust configuration, so I figure it should be fine for Crystal as well.