### PR TITLE
[Bugfix]: Escape shell args so quotes don't get removed in intialScript

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -62,7 +62,7 @@ let
   runInitialScript =
     if cfg.initialScript != null then
       ''
-        echo "${cfg.initialScript}" | postgres --single -E postgres
+        echo "${lib.escapeShellArg cfg.initialScript}" | postgres --single -E postgres
       ''
     else
       "";


### PR DESCRIPTION
I ran into an issue where I couldn't create a db user named "default"