### PR TITLE
env: support runtime evaluation

### DIFF
--- a/src/modules/integrations/devcontainer.nix
+++ b/src/modules/integrations/devcontainer.nix
@@ -56,7 +56,7 @@ in
 
   config = lib.mkIf config.devcontainer.enable {
     enterShell = ''
-      cat ${file} > ${config.env.DEVENV_ROOT}/.devcontainer.json
+      cat ${file} > "$DEVENV_ROOT/.devcontainer.json"
     '';
   };
 }

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -11,7 +11,7 @@ let
           url: github:cachix/nixpkgs-python
   '');
 
-  venvPath = "${config.env.DEVENV_STATE}/venv";
+  venvPath = "$DEVENV_STATE/venv";
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
     # Make sure any tools are not attempting to use the python interpreter from any
@@ -19,7 +19,7 @@ let
     unset VIRTUAL_ENV
 
     if [ ! -L ${venvPath}/devenv-profile ] \
-    || [ "$(${pkgs.coreutils}/bin/readlink ${venvPath}/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
+    || [ "$(${pkgs.coreutils}/bin/readlink ${venvPath}/devenv-profile)" != "$DEVENV_PROFILE" ]
     then
       if [ -d ${venvPath} ]
       then
@@ -27,10 +27,10 @@ let
         ${pkgs.coreutils}/bin/rm -rf ${venvPath}
       fi
       ${lib.optionalString cfg.poetry.enable ''
-        [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
+        [ -f "$DEVENV_STATE/poetry.lock.checksum" ] && rm $DEVENV_STATE/poetry.lock.checksum
       ''}
       ${cfg.package.interpreter} -m venv ${venvPath}
-      ${pkgs.coreutils}/bin/ln -sf ${config.env.DEVENV_PROFILE} ${venvPath}/devenv-profile
+      ${pkgs.coreutils}/bin/ln -sf $DEVENV_PROFILE ${venvPath}/devenv-profile
     fi
     source ${venvPath}/bin/activate
     ${lib.optionalString (cfg.venv.requirements != null) ''
@@ -45,9 +45,9 @@ let
       # existing virtual environment. For instance if devenv was started within an venv.
       unset VIRTUAL_ENV
 
-      if [ ! -L ${config.env.DEVENV_ROOT}/.venv ]
+      if [ ! -L $DEVENV_ROOT/.venv ]
       then
-        ${pkgs.coreutils}/bin/ln --symbolic --no-target-directory --force ${venvPath} ${config.env.DEVENV_ROOT}/.venv
+        ${pkgs.coreutils}/bin/ln --symbolic --no-target-directory --force ${venvPath} $DEVENV_ROOT/.venv
       fi
 
       if [ ! -d ${venvPath} ] \

--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -57,7 +57,11 @@ in
 }:
 let
   # simpler version of https://github.com/numtide/devshell/blob/20d50fc6adf77fd8a652fc824c6e282d7737b85d/modules/env.nix#L41
-  envToBash = name: value: "export ${name}=${lib.escapeShellArg (toString value)}";
+  envToBash = name: value:
+    let
+      str = value.envToBashValue or (lib.escapeShellArg (toString value));
+    in
+    "export ${name}=${str}";
   startupEnv = lib.concatStringsSep "\n" (lib.mapAttrsToList envToBash env);
   derivationArg = {
     inherit name;


### PR DESCRIPTION
An attempt at getting rid of the call to `builtins.getEnv` to determine the current working directory. Taking inspiration from the implementation in https://github.com/numtide/devshell.

Things to implement:
- [ ] Replace all remaining eval-time uses of environment variables (`${config.env....}`)

Things to invent:
- [ ] Find a way to splice environment variables into config files that don't support environment variable substitution
- [ ] Find a way to make this work for containers
- [ ] Find a way to deal with ordering (for example, `AN_EXAMPLE_DATA_DIR` gets set before `DEVENV_STATE`, thus cannot reference it with `$DEVENV_STATE/example`)