### PR TITLE
[bugfix]: remove extra quotes because escapeShellArg adds them

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -62,7 +62,7 @@ let
   runInitialScript =
     if cfg.initialScript != null then
       ''
-        echo "${lib.escapeShellArg cfg.initialScript}" | postgres --single -E postgres
+        echo ${lib.escapeShellArg cfg.initialScript} | postgres --single -E postgres
       ''
     else
       "";


### PR DESCRIPTION
So sorry, but I messed up the bugfix and made it even worse 😅 This version I tested fully locally and it's working well!