### PR TITLE
[feature]: Add ability for process.exec to be multiline

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -4,7 +4,7 @@ let
   processType = types.submodule ({ config, ... }: {
     options = {
       exec = lib.mkOption {
-        type = types.str;
+        type = types.lines;
         description = "Bash code to run the process.";
       };
 
@@ -125,7 +125,7 @@ in
 
     procfile =
       pkgs.writeText "procfile" (lib.concatStringsSep "\n"
-        (lib.mapAttrsToList (name: process: "${name}: ${process.exec}")
+        (lib.mapAttrsToList (name: process: "${name}: ${pkgs.writeShellScript name process.exec}")
           config.processes));
 
     procfileEnv =

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -4,7 +4,7 @@ let
   processType = types.submodule ({ config, ... }: {
     options = {
       exec = lib.mkOption {
-        type = types.lines;
+        type = types.str;
         description = "Bash code to run the process.";
       };
 


### PR DESCRIPTION
Small teak to allow multi-line bash strings for processes.exec