### PR TITLE
Honor process-compose `port` and `tui` options

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -38,7 +38,10 @@ in
   };
   config = lib.mkIf cfg.enable {
     processManagerCommand = ''
-      ${cfg.package}/bin/process-compose --config ${cfg.configFile}  up "$@" &
+      ${cfg.package}/bin/process-compose --config ${cfg.configFile} \
+        --port ''${PC_HTTP_PORT:-${toString config.process.process-compose.port}} \
+        --tui=''${PC_TUI_ENABLED:-${toString config.process.process-compose.tui}} \
+        up "$@" &
     '';
 
     packages = [ cfg.package ];


### PR DESCRIPTION
Included on the original process-compose PR:
https://github.com/cachix/devenv/blob/095be0c31e4d90d515acee30bb95818cf19900ef/src/modules/processes.nix#L125-L126

But removed in this PR:
https://github.com/cachix/devenv/pull/668

See previous version:
https://github.com/cachix/devenv/blob/eae002528893ba224f88b35163ff3ec273f67784/src/modules/processes.nix#L56-L60