### PR TITLE
Let Postgres support relative $DEVENV_ROOT

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -258,7 +258,7 @@ in
     services.postgres.settings = {
       listen_addresses = cfg.listen_addresses;
       port = cfg.port;
-      unix_socket_directories = lib.mkDefault config.env.PGDATA;
+      unix_socket_directories = lib.mkDefault ".";
     };
 
     processes.postgres = {


### PR DESCRIPTION
`unix_socket_directories` is by default relative to $PGDATA, therefore `unix_socket_directories=.` should work the same as `unix_socket_directories=$PGDATA` when `$PGDATA` is absolute. However, `unix_socket_directories=.` also works with relative `$PGDATA` because it does not depend on `$PGDATA`