### PR TITLE
env: fix infinite recursion errors

### DIFF
--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -18,7 +18,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=${config.procfileScript}
+      procfilescript=$(nix build '.#devShells.${pkgs.stdenv.system}.default.config.procfileScript' --impure)
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -19,7 +19,7 @@ let
     unset VIRTUAL_ENV
 
     if [ ! -L ${venvPath}/devenv-profile ] \
-    || [ "$(${pkgs.coreutils}/bin/readlink ${venvPath}/devenv-profile)" != "${config.env.DEVENV_PROFILE}" ]
+    || [ "$(${pkgs.coreutils}/bin/readlink ${venvPath}/devenv-profile)" != "${config.devenv.profile}" ]
     then
       if [ -d ${venvPath} ]
       then
@@ -30,7 +30,7 @@ let
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
       ${cfg.package.interpreter} -m venv ${venvPath}
-      ${pkgs.coreutils}/bin/ln -sf ${config.env.DEVENV_PROFILE} ${venvPath}/devenv-profile
+      ${pkgs.coreutils}/bin/ln -sf ${config.devenv.profile} ${venvPath}/devenv-profile
     fi
     source ${venvPath}/bin/activate
     ${lib.optionalString (cfg.venv.requirements != null) ''

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -61,9 +61,9 @@ in
       pre-commit.tools.clippy = lib.mkForce cfg.packages.clippy;
     })
     (lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
-      env.RUSTFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
-      env.RUSTDOCFLAGS = [ "-L framework=${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
-      env.CFLAGS = [ "-iframework ${config.env.DEVENV_PROFILE}/Library/Frameworks" ];
+      env.RUSTFLAGS = [ "-L framework=${config.devenv.profile}/Library/Frameworks" ];
+      env.RUSTDOCFLAGS = [ "-L framework=${config.devenv.profile}/Library/Frameworks" ];
+      env.CFLAGS = [ "-iframework ${config.devenv.profile}/Library/Frameworks" ];
     })
     (lib.mkIf (cfg.version != null) (
       let

--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -54,12 +54,7 @@ in
         tui = lib.mkDefault true;
         environment = lib.mapAttrsToList
           (name: value: "${name}=${toString value}")
-          (if config.devenv.flakesIntegration then
-          # avoid infinite recursion in the scenario the `config` parameter is
-          # used in a `processes` declaration inside a devenv module.
-            builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]
-          else
-            config.env);
+          config.env;
         processes = lib.mapAttrs
           (name: value: { command = value.exec; } // value.process-compose)
           config.processes;

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -37,12 +37,7 @@ let
   envList =
     lib.mapAttrsToList
       (name: value: "${name}=${builtins.toJSON value}")
-      (if config.devenv.flakesIntegration then
-      # avoid infinite recursion in the scenario the `config` parameter is
-      # used in a `processes` declaration inside a devenv module.
-        builtins.removeAttrs config.env [ "DEVENV_PROFILE" ]
-      else
-        config.env);
+      config.env;
 in
 {
   options = {
@@ -109,8 +104,8 @@ in
     };
 
     procfileEnv = lib.mkOption {
-      type = types.package;
       internal = true;
+      type = types.package;
     };
 
     procfileScript = lib.mkOption {

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -99,6 +99,29 @@ in
         display a warning message when a renamed option is used.
       '';
     };
+
+    devenv = {
+      root = lib.mkOption {
+        type = types.str;
+        internal = true;
+      };
+
+      dotfile = lib.mkOption {
+        type = types.str;
+        internal = true;
+      };
+
+      state = lib.mkOption {
+        type = types.str;
+        internal = true;
+      };
+
+      profile = lib.mkOption {
+        type = types.package;
+        internal = true;
+      };
+
+    };
   };
 
   imports = [
@@ -117,7 +140,7 @@ in
 
   config = {
     # TODO: figure out how to get relative path without impure mode
-    env.DEVENV_ROOT =
+    devenv.root =
       let
         pwd = builtins.getEnv "PWD";
       in
@@ -129,9 +152,14 @@ in
           See https://devenv.sh/guides/using-with-flakes/
         ''
       else pwd;
-    env.DEVENV_DOTFILE = config.env.DEVENV_ROOT + "/.devenv";
-    env.DEVENV_STATE = config.env.DEVENV_DOTFILE + "/state";
-    env.DEVENV_PROFILE = profile;
+    devenv.dotfile = config.devenv.root + "/.devenv";
+    devenv.state = config.devenv.dotfile + "/state";
+    devenv.profile = profile;
+
+    env.DEVENV_PROFILE = config.devenv.profile;
+    env.DEVENV_STATE = config.devenv.state;
+    env.DEVENV_DOTFILE = config.devenv.dotfile;
+    env.DEVENV_ROOT = config.devenv.root;
 
     enterShell = ''
       export PS1="\[\e[0;34m\](devenv)\[\e[0m\] ''${PS1-}"


### PR DESCRIPTION
The best way to solve this for now is to set these as part of config.devenv.* namespace and reference these instead of from config.env when setting env.

Also, when using flakes integration let's evaluate the whole config when invoking `devenv up` instead of when building the devenv cli.

Fixes #580