### PR TITLE
fix: php-fpm termination

### DIFF
--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -43,7 +43,7 @@ let
     ${optionalString (poolOpts.extraConfig != null) poolOpts.extraConfig}
   '';
 
-  startScript = pool: poolOpts: pkgs.writeShellScriptBin "start-phpfpm" ''
+  startScript = pool: poolOpts: ''
     set -euo pipefail
 
     if [[ ! -d "$PHPFPMDIR" ]]; then


### PR DESCRIPTION
Since #692 PHP does not stop anymore and hangs.

![image](https://github.com/cachix/devenv/assets/6224096/ed5b8779-2f11-45a0-b13d-89cb5494ef93)

This is because the multilining added an additional shell wrapper around which does not exec. As wrapping is not nesscarry anymore, I removed it for PHP so it works like before