### PR TITLE
Make devenv.root be overridable

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -146,7 +146,7 @@ in
 
   config = {
     # TODO: figure out how to get relative path without impure mode
-    devenv.root =
+    devenv.root = lib.mkDefault (
       let
         pwd = builtins.getEnv "PWD";
       in
@@ -157,7 +157,8 @@ in
 
           See https://devenv.sh/guides/using-with-flakes/
         ''
-      else pwd;
+      else pwd
+    );
     devenv.dotfile = config.devenv.root + "/.devenv";
     devenv.state = config.devenv.dotfile + "/state";
     devenv.profile = profile;


### PR DESCRIPTION
This PR allows the user to set `devenv.root` to `.` as a workaround to #658