### PR TITLE
feat(blackfire): add option to enable apm

### DIFF
--- a/src/modules/services/blackfire.nix
+++ b/src/modules/services/blackfire.nix
@@ -22,6 +22,10 @@ in
       It automatically installs Blackfire PHP extension.
     '';
 
+    enableApm = lib.mkEnableOption ''
+      Enables application performance monitoring, requires special subscription.
+    '';
+
     client-id = lib.mkOption {
       type = lib.types.str;
       description = ''
@@ -82,6 +86,7 @@ in
     env.BLACKFIRE_AGENT_SOCKET = cfg.socket;
     env.BLACKFIRE_CLIENT_ID = cfg.client-id;
     env.BLACKFIRE_CLIENT_TOKEN = cfg.client-token;
+    env.BLACKFIRE_APM_ENABLED = (if cfg.enableApm then "1" else "0");
 
     processes.blackfire-agent.exec = "${cfg.package}/bin/blackfire agent:start --config=${configFile}";
   };


### PR DESCRIPTION
By default is Blackfire Application performance monitoring enabled and this produces a lot of logs:

```
Error detected during APM traces upload: Cannot send an HTTP request to the Blackfire API.
```

So this disables this by default and adds an option to enable. It makes only sense to enable it for an live website 😅 