### PR TITLE
feat(php): allow disabling pre-enabled php extensions

### DIFF
--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -18,9 +18,11 @@ let
 
   phps = inputs.phps or (throw "To use languages.php.version, you need to add the following to your devenv.yaml:\n\n${setup}");
 
+  filterDefaultExtensions = ext: builtins.length (builtins.filter (inner: inner == ext.extensionName) cfg.disableExtensions) == 0;
+
   configurePackage = package:
     package.buildEnv {
-      extensions = { all, enabled }: with all; enabled ++ attrValues (getAttrs cfg.extensions package.extensions);
+      extensions = { all, enabled }: with all; (builtins.filter filterDefaultExtensions (enabled ++ attrValues (getAttrs cfg.extensions package.extensions)));
       extraConfig = cfg.ini;
     };
 
@@ -221,6 +223,14 @@ in
       default = [ ];
       description = ''
         PHP extensions to enable.
+      '';
+    };
+
+    disableExtensions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        PHP extensions to disable.
       '';
     };
 


### PR DESCRIPTION
Tailscale + PHP imap is right now evil see https://github.com/php/php-src/issues/11673

Right now it's not possible to disable "builtin" extensions. So I added a additional option to do this