### PR TITLE
Send `quit` to memcached to terminate healthcheck successfully

### DIFF
--- a/src/modules/services/memcached.nix
+++ b/src/modules/services/memcached.nix
@@ -55,7 +55,7 @@ in
       process-compose = {
         readiness_probe = {
           exec.command = ''
-            echo stats | ${pkgs.netcat}/bin/nc ${cfg.bind} ${toString cfg.port} > /dev/null 2>&1
+            echo -e "stats\nquit" | ${pkgs.netcat}/bin/nc ${cfg.bind} ${toString cfg.port} > /dev/null 2>&1
           '';
           initial_delay_seconds = 2;
           period_seconds = 10;


### PR DESCRIPTION
This is an improvement that was [found in a previous PR](https://github.com/cachix/devenv/pull/653#issuecomment-1620532170). If you don't send a `quit` it seems that the healthcheck process will sometimes hang and not exit, which will lead `process-compose` to thinking the healthcheck times out and fails.

Thanks @volker-schukai for the suggestion!