### PR TITLE
Mailpit: persist db, add sendmail binary, add example

### DIFF
--- a/examples/mailpit/.test.sh
+++ b/examples/mailpit/.test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -ex
+
+devenv up &
+DEVENV_PID=$!
+trap "pkill -P $DEVENV_PID" EXIT
+
+timeout 20 bash -c 'until echo > /dev/tcp/localhost/1025; do sleep 0.5; done'
+
+sendmail john@example.com <<EOF
+Subject: Hello
+
+Hello world!
+EOF

--- a/examples/mailpit/devenv.nix
+++ b/examples/mailpit/devenv.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  services.mailpit.enable = true;
+}

--- a/examples/mailpit/devenv.yaml
+++ b/examples/mailpit/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/services/mailpit.nix
+++ b/src/modules/services/mailpit.nix
@@ -38,6 +38,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    processes.mailpit.exec = "${cfg.package}/bin/mailpit --listen ${cfg.uiListenAddress} --smtp ${cfg.smtpListenAddress} ${lib.concatStringsSep " " cfg.additionalArgs}";
+    processes.mailpit.exec = ''
+      mkdir -p "$DEVENV_STATE/mailpit"
+      exec "${cfg.package}/bin/mailpit" \
+        --db-file "$DEVENV_STATE/mailpit/db.sqlite3" \
+        --listen ${lib.escapeShellArg cfg.uiListenAddress} \
+        --smtp ${lib.escapeShellArg cfg.smtpListenAddress} \
+        ${lib.escapeShellArgs cfg.additionalArgs}
+    '';
   };
 }

--- a/src/modules/services/mailpit.nix
+++ b/src/modules/services/mailpit.nix
@@ -38,6 +38,9 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # For `sendmail`
+    packages = [ cfg.package ];
+
     processes.mailpit.exec = ''
       mkdir -p "$DEVENV_STATE/mailpit"
       exec "${cfg.package}/bin/mailpit" \


### PR DESCRIPTION
cc @shyim 

I understand the argument handling was based on the mailhog module, and noticed it didn't uses `escapeShellArg(s)`. Not sure if that was intended?