### PR TITLE
processes: eliminate shell wrapper

### DIFF
--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -337,7 +337,7 @@ in
       processes = mapAttrs'
         (pool: poolOpts:
           nameValuePair "phpfpm-${pool}" {
-            exec = "${startScript pool poolOpts}/bin/start-phpfpm";
+            exec = startScript pool poolOpts;
           }
         )
         cfg.fpm.pools;

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -120,7 +120,7 @@ in
 
     procfile =
       pkgs.writeText "procfile" (lib.concatStringsSep "\n"
-        (lib.mapAttrsToList (name: process: "${name}: ${pkgs.writeShellScript name process.exec}")
+        (lib.mapAttrsToList (name: process: "${name}: exec ${pkgs.writeShellScript name process.exec}")
           config.processes));
 
     procfileEnv =


### PR DESCRIPTION
This appears to fix #595. Overmind [creates a shell wrapper](https://github.com/DarthSim/overmind/blob/7d970570e9208812eaf3782d695bc13700bee48e/start/command.go#L166-L181), but that shell process sticks and interferes with sending signals to PHP-FPM. The `exec` here appears to otherwise work fine with other process managers (tested with caddy-php example on macos)