### PR TITLE
fix(flake-module): add devenv-up as a package

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -42,11 +42,14 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
       config.packages =
         lib.concatMapAttrs
           (shellName: devenv:
-            lib.concatMapAttrs
+            (lib.concatMapAttrs
               (containerName: container:
                 { "${shellPrefix shellName}container-${containerName}" = container.derivation; }
               )
               devenv.containers
+            ) // {
+              "${shellPrefix shellName}devenv-up" = devenv.procfileScript;
+            }
           )
           config.devenv.shells;
     });

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -19,7 +19,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=$(nix build '.#${shellPrefix config._module.args.name}devenv-up' --print-out-paths --impure)
+      procfilescript=$(nix build '.#${shellPrefix config._module.args.name}devenv-up' --no-link --print-out-paths --impure)
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -2,6 +2,7 @@
 let
   lib = pkgs.lib;
   version = lib.fileContents ./modules/latest-version;
+  shellPrefix = shellName: if shellName == "default" then "" else "${shellName}-";
 in
 pkgs.writeScriptBin "devenv" ''
   #!/usr/bin/env bash
@@ -18,7 +19,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=$(nix build '.#devShells.${pkgs.stdenv.system}.default.config.procfileScript' --print-out-paths --impure)
+      procfilescript=$(nix build '.#${shellPrefix config._module.args.name}devenv-up' --print-out-paths --impure)
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1


### PR DESCRIPTION
This PR adds devenv-up as a package so that it can be created from `nix build`, which fixes #711