### PR TITLE
[FEAT] Do not use single-user mode when initializing postgres

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -82,21 +82,21 @@ let
     set -euo pipefail
     export PATH=${postgresPkg}/bin:${pkgs.coreutils}/bin
 
-    SEED_DATABASES="false"
+    POSTGRES_RUN_INITIAL_SCRIPT="false"
     if [[ ! -d "$PGDATA" ]]; then
       initdb ${lib.concatStringsSep " " cfg.initdbArgs}
-      SEED_DATABASES="true"
+      POSTGRES_RUN_INITIAL_SCRIPT="true"
       echo
-      echo "PostgreSQL init process complete; ready for start up."
+      echo "PostgreSQL initdb process complete."
       echo
     fi
 
     # Setup config
     cp ${configFile} "$PGDATA/postgresql.conf"
 
-    if [[ "$SEED_DATABASES" = "true" ]]; then
+    if [[ "$POSTGRES_RUN_INITIAL_SCRIPT" = "true" ]]; then
       echo
-      echo "PostgreSQL recently initialized; going to seed databases."
+      echo "PostgreSQL is setting up the initial database."
       echo
       OLDPGHOST="$PGHOST"
       PGHOST="$DEVENV_STATE/$(mktemp -d "pg-init-XXXXXX")"
@@ -104,9 +104,6 @@ let
 
       function remove_tmp_pg_init_sock_dir() {
         if [[ -d "$1" ]]; then
-          echo
-          echo "Removing temporary socket directory for initialization/seeding: $1"
-          echo
           rm -rf "$1"
         fi
       }
@@ -125,6 +122,7 @@ let
       echo "PostgreSQL Database directory appears to contain a database; Skipping initialization"
       echo
     fi
+    unset POSTGRES_RUN_INITIAL_SCRIPT
   '';
   startScript = pkgs.writeShellScriptBin "start-postgres" ''
     set -euo pipefail


### PR DESCRIPTION
This makes the initialization process for `postgres` use the "multi-user" mode instead of "single-user" mode. This change allows for creating extensions automatically on first boot (like `timescaledb`).

[Initial log output](https://raw.githubusercontent.com/penguincoder/devenv-timescaledb-test/main/log-output.txt)
[Minimal reproduction git repo](https://github.com/penguincoder/devenv-timescaledb-test)

You should be able to clone the reproduction repo and then do a `devenv shell` then `devenv up` and it should have a bunch of TimescaleDB in the output. I haven't tested this much more extensively than that, but it does appear to be reliable.

The process more or less mimics the pattern from the Docker library, but it's not much more than using `pg_ctl` to start the server at the beginning of the process (just _after_ `initdb` has been called and the `postgresql.conf` has been written in place) and then shutting the temporary server down using `pg_ctl` again.

This should resolve cachix/devenv#696