### PR TITLE
lang/shell: Add bats libs to bats package

### DIFF
--- a/src/modules/languages/shell.nix
+++ b/src/modules/languages/shell.nix
@@ -10,7 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      bats
+      (pkgs.bats.withLibraries (p: [ p.bats-assert p.bats-file p.bats-support ]))
       nodePackages.bash-language-server
       shellcheck
       shfmt


### PR DESCRIPTION
Makes usage of bats nicer if the blessed libs are easily available. I didn't notice that these weren't automatically part of bats. 