### PR TITLE
Fix mkcert Integration When nss Is Used

### DIFF
--- a/src/modules/integrations/mkcert.nix
+++ b/src/modules/integrations/mkcert.nix
@@ -22,7 +22,7 @@ in
       mkdir -p "${config.env.DEVENV_STATE}/mkcert"
 
       if [[ ! -f "$DEVENV_STATE/mkcert/rootCA.pem" ]]; then
-        ${pkgs.mkcert}/bin/mkcert -install
+        PATH="${pkgs.nssTools}/bin:$PATH" ${pkgs.mkcert}/bin/mkcert -install
       fi
 
       if [[ ! -f "$DEVENV_STATE/mkcert/hash" || "$(cat "$DEVENV_STATE/mkcert/hash")" != "${hash}" ]]; then
@@ -30,7 +30,7 @@ in
 
         pushd ${config.env.DEVENV_STATE}/mkcert > /dev/null
 
-        PATH="${pkgs.nss}/bin/certutil:$PATH" ${pkgs.mkcert}/bin/mkcert ${domainList} 2> /dev/null
+        PATH="${pkgs.nssTools}/bin:$PATH" ${pkgs.mkcert}/bin/mkcert ${domainList} 2> /dev/null
 
         popd > /dev/null
       fi


### PR DESCRIPTION
Hi everyone. Just want to begin with a huge thanks for devenv. I'm a new user
to nix in general, and devenv has been a _really_ nice to work with.

I did run into an issue with the `mkcert` integration when using Firefox. I think
this PR should fix the problem:
  * the `certutil` binary is in the `nssTools` package
  * Also includes the `certutil` binary in `PATH` during `mkcert -install` since that 
    appears to be when its actually required -- to trust the new certificate
    authority. I kept it in both lines in case I'm wrong about that or in the future
    `mkcert` changes that.