### PR TITLE
[BUG] fix python-poetry .test.sh to work with new .venv directory

### DIFF
--- a/examples/python-poetry/.test.sh
+++ b/examples/python-poetry/.test.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-set -ex
-[ "$(readlink .venv)" = "$PWD/.devenv/state/venv" ]
-[ "$(poetry env info --path)" = "$PWD/.devenv/state/venv" ]
-[ "$(command -v python)" = "$PWD/.devenv/state/venv/bin/python" ]
+set -exu
+POETRY_VENV="$PWD/.venv"
+[ -d "$POETRY_VENV" ]
+[ "$(poetry env info --path)" = "$POETRY_VENV" ]
+[ "$(command -v python)" = "$POETRY_VENV/bin/python" ]
 python --version
 poetry --version
 poetry run python -c 'import numpy'


### PR DESCRIPTION
The `.test.sh` has been broken in `examples/python-poetry` since I think 0d08083c19d1f03302ca17eba920852c171e942c. This changes the test to look for a directory (not a link into `$DEVENV_STATE`) named `.venv` in `$DEVENV_ROOT`.