### PR TITLE
[BUG] Fix postgres .test.sh

### DIFF
--- a/examples/postgres/.test.sh
+++ b/examples/postgres/.test.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 set -ex
-devenv up&
-timeout 20 bash -c 'until psql -c "SELECT 1" mydb; do sleep 0.5; done'
+
+devenv up &
+
+timeout 20 bash -c 'until psql -h /tmp -c "SELECT 1" mydb 2>/dev/null; do sleep 0.5; done'

--- a/examples/postgres/devenv.nix
+++ b/examples/postgres/devenv.nix
@@ -1,11 +1,16 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
+  packages = [ pkgs.coreutils ];
   services.postgres = {
     enable = true;
     extensions = extensions: [ extensions.postgis ];
 
     initialDatabases = [{ name = "mydb"; }];
+
+    settings = {
+      unix_socket_directories = "/tmp";
+    };
 
     initialScript = ''
       CREATE EXTENSION IF NOT EXISTS postgis;


### PR DESCRIPTION
There are two issues here:
1. There is no `timeout` command unless you use `coreutils`
2. The default path for the self-hosted runners is 104 characters
   * `psql` has a limit of 103 characters for unix socket names :-/

This change adds `coreutils` to the `packages` and forces the `unix_socket_directories` to be `/tmp` so that `psql` is appeased.