### PR TITLE
feat: correct mysqlx socket location

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -245,6 +245,7 @@ in
       {
         MYSQL_HOME = config.env.DEVENV_STATE + "/mysql";
         MYSQL_UNIX_PORT = config.env.DEVENV_STATE + "/mysql.sock";
+        MYSQLX_UNIX_PORT = config.env.DEVENV_STATE + "/mysqlx.sock";
       }
       // (optionalAttrs (hasAttrByPath [ "mysqld" "port" ] cfg.settings) {
         MYSQL_TCP_PORT = toString cfg.settings.mysqld.port;


### PR DESCRIPTION
Corrects the error: Plugin mysqlx reported: 'Setup of socket: '/run/mysqld/mysqlx.sock' failed, can't create lock file /run/mysqld/mysqlx.sock.lock'

With the fix the console only shows the success message: X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /path/to/devenv/project/.devenv/state/mysqlx.sock

Tested with mysql80 and mariadb default package