### PR TITLE
python: Add python.venv.pythonPackages option

### DIFF
--- a/examples/python-venv/.test.sh
+++ b/examples/python-venv/.test.sh
@@ -3,3 +3,8 @@ set -ex
 [ "$(command -v python)" = "$PWD/.devenv/state/venv/bin/python" ]
 [ "$VIRTUAL_ENV" = "$PWD/.devenv/state/venv" ]
 python --version
+
+# urllib3 is a propagated dependency of requests
+python -c "import urllib3;print(urllib3)"
+
+python -c "import requests;print(requests)"

--- a/examples/python-venv/devenv.nix
+++ b/examples/python-venv/devenv.nix
@@ -3,4 +3,5 @@
 {
   languages.python.enable = true;
   languages.python.venv.enable = true;
+  languages.python.venv.pythonPackages = ps: [ ps.requests ];
 }

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -11,6 +11,29 @@ let
           url: github:cachix/nixpkgs-python
   '');
 
+  libPrefix = cfg.package.libPrefix;
+
+  isPythonPackage = pkg: pkg ? pythonModule;
+
+  # List of Python package dependencies for a given derivation
+  pythonPackageDeps = pkg: builtins.filter isPythonPackage (
+    [ pkg ] ++ pkg.propagatedBuildInputs ++ pkg.propagatedNativeBuildInputs
+  );
+
+  # List of Python package derivations to include in the virtualenv
+  pythonPackages = lib.lists.unique (
+    lib.lists.concatMap pythonPackageDeps (
+      cfg.venv.pythonPackages cfg.package.pkgs
+    )
+  );
+
+  # Bash commands for creating .pth files for Python package derivations
+  pythonPackagesScript = lib.concatMapStrings
+    (pkg: ''
+      echo ${pkg}/lib/${libPrefix}/site-packages > $VENV_PATH/lib/${libPrefix}/site-packages/${pkg.pname}.pth
+    '')
+    pythonPackages;
+
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
     # Make sure any tools are not attempting to use the python interpreter from any
     # existing virtual environment. For instance if devenv was started within an venv.
@@ -32,6 +55,7 @@ let
       ${cfg.package.interpreter} -m venv "$VENV_PATH"
       ${pkgs.coreutils}/bin/ln -sf ${config.devenv.profile} "$VENV_PATH"/devenv-profile
     fi
+    ${pythonPackagesScript}
     source "$VENV_PATH"/bin/activate
     ${lib.optionalString (cfg.venv.requirements != null) ''
       "$VENV_PATH"/bin/pip install -r ${pkgs.writeText "requirements.txt" cfg.venv.requirements}
@@ -118,6 +142,15 @@ in
       description = ''
         Contents of pip requirements.txt file.
         This is passed to `pip install -r` during `devenv shell` initialisation.
+      '';
+    };
+
+    venv.pythonPackages = lib.mkOption {
+      type = lib.types.functionTo (lib.types.listOf lib.types.package);
+      default = ps: [ ];
+      example = "ps: [ps.requests]";
+      description = ''
+        Python packages packaged for Nix to install inside the virtual environment.
       '';
     };
 


### PR DESCRIPTION
This option allows the user to install Nix-native Python packages, much like `pkgs.python3.withPackages (ps: ...)`. The difference is that the packages are inserted into the user's venv as standard `.pth` files.

See the `python-venv` example.