### PR TITLE
Add "Built with Nix" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # [devenv.sh](https://devenv.sh) - Fast, Declarative, Reproducible, and Composable Developer Environments
 
-[![Join Discord](https://img.shields.io/discord/1036369714731036712?color=7389D8&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/naMgvexb6q) 
-![License: Apache 2.0](https://img.shields.io/github/license/cachix/devenv) 
-[![version](https://img.shields.io/github/v/release/cachix/devenv?color=green&label=version&sort=semver)](https://github.com/cachix/devenv/releases) 
+[![Built with Nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
+[![Discord channel](https://img.shields.io/discord/1036369714731036712?color=7389D8&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/naMgvexb6q)
+![License: Apache 2.0](https://img.shields.io/github/license/cachix/devenv)
+[![Version](https://img.shields.io/github/v/release/cachix/devenv?color=green&label=version&sort=semver)](https://github.com/cachix/devenv/releases)
 [![CI](https://github.com/cachix/devenv/actions/workflows/buildtest.yml/badge.svg)](https://github.com/cachix/devenv/actions/workflows/buildtest.yml?branch=main)
 
 ![logo](docs/assets/logo.webp)


### PR DESCRIPTION
Would you like to add the "Built with Nix" badge?

I initially tried to add the badge for the Matrix channel, but the shields.io badge somehow shows it as being inaccessible with both the room name and the alias. This is probably due to the room not being world readable (chat history visible to anyone).

![Matrix channel](https://img.shields.io/matrix/devenv%3Amatrix.org)
![Matrix channel](https://img.shields.io/matrix/!plrRoZsBTUYBWzvzIq%3Amatrix.org)