### PR TITLE
Update languages example to use rust channel.

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -10,8 +10,8 @@ What if you could have the tooling for any programming language by flipping a to
   languages.python.version = "3.11.3";
 
   languages.rust.enable = true;
-  # https://devenv.sh/reference/options/#languagesrustversion
-  languages.rust.version = "latest";
+  # https://devenv.sh/reference/options/#languagesrustchannel
+  languages.rust.channel = "stable";
 }
 ```
 


### PR DESCRIPTION
On my first attempt to use devshell, the languages example broke for me. It seems like the way to specify versions might have changed?