### PR TITLE
docs(phoenix): add example for elixir phoenix

### DIFF
--- a/examples/phoenix/.test.sh
+++ b/examples/phoenix/.test.sh
@@ -4,11 +4,10 @@ mix local.hex --force
 mix local.rebar --force
 echo Y | mix archive.install hex phx_new
 echo Y | mix phx.new hello
-awk -i inplace '{
-  gsub(/username: "postgres",/, "username: \"" ENVIRON["USER"] "\",")
-  gsub(/password: "postgres",/, "password: \"\",")
-  print
-}' 'hello/config/dev.exs'
+sed -i.bak \
+    -e "s/username: \"postgres\",/username: \"$USER\",/" \
+    -e "s/password: \"postgres\",/password: \"\",/" \
+    ./hello/config/dev.exs && rm ./hello/config/dev.exs.bak
 devenv up&
 timeout 20 bash -c 'until echo > /dev/tcp/localhost/4000; do sleep 0.5; done'
 curl -s http://localhost:4000/ | grep "Phoenix Framework"

--- a/examples/phoenix/.test.sh
+++ b/examples/phoenix/.test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -ex
 mix local.hex --force
+mix local.rebar --force
 echo Y | mix archive.install hex phx_new
 echo Y | mix phx.new hello
 awk -i inplace '{

--- a/examples/phoenix/.test.sh
+++ b/examples/phoenix/.test.sh
@@ -4,9 +4,7 @@ mix local.hex --force
 mix local.rebar --force
 echo Y | mix archive.install hex phx_new
 echo Y | mix phx.new hello
-sed -i.bak \
-    -e "s/username: \"postgres\",/username: \"$USER\",/" \
-    -e "s/password: \"postgres\",/password: \"\",/" \
+sed -i.bak -e "s/username: \"postgres\",/socket_dir: System.get_env(\"PGDATA\"),/" \
     ./hello/config/dev.exs && rm ./hello/config/dev.exs.bak
 devenv up&
 timeout 20 bash -c 'until echo > /dev/tcp/localhost/4000; do sleep 0.5; done'

--- a/examples/phoenix/.test.sh
+++ b/examples/phoenix/.test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+mix local.hex --force
+echo Y | mix archive.install hex phx_new
+echo Y | mix phx.new hello
+awk -i inplace '{
+  gsub(/username: "postgres",/, "username: \"" ENVIRON["USER"] "\",")
+  gsub(/password: "postgres",/, "password: \"\",")
+  print
+}' 'hello/config/dev.exs'
+devenv up&
+timeout 20 bash -c 'until echo > /dev/tcp/localhost/4000; do sleep 0.5; done'
+curl -s http://localhost:4000/ | grep "Phoenix Framework"

--- a/examples/phoenix/README.md
+++ b/examples/phoenix/README.md
@@ -1,0 +1,14 @@
+Based on [the official tutorial](https://hexdocs.pm/phoenix/installation.html).
+
+```shell-session
+$ devenv shell
+$ mix local.hex --force
+$ mix archive.install hex phx_new
+$ mix phx.new hello
+$ awk -i inplace '{
+    gsub(/username: "postgres",/, "username: \"" ENVIRON["USER"] "\",")
+    gsub(/password: "postgres",/, "password: \"\",")
+    print
+  }' 'hello/config/dev.exs'
+$ devenv up
+```

--- a/examples/phoenix/README.md
+++ b/examples/phoenix/README.md
@@ -6,10 +6,9 @@ $ mix local.hex --force
 $ mix local.rebar --force
 $ mix archive.install hex phx_new
 $ mix phx.new hello
-$ awk -i inplace '{
-    gsub(/username: "postgres",/, "username: \"" ENVIRON["USER"] "\",")
-    gsub(/password: "postgres",/, "password: \"\",")
-    print
-  }' 'hello/config/dev.exs'
+$ sed -i.bak \
+    -e "s/username: \"postgres\",/username: \"$USER\",/" \
+    -e "s/password: \"postgres\",/password: \"\",/" \
+    ./hello/config/dev.exs && rm ./hello/config/dev.exs.bak
 $ devenv up
 ```

--- a/examples/phoenix/README.md
+++ b/examples/phoenix/README.md
@@ -6,9 +6,7 @@ $ mix local.hex --force
 $ mix local.rebar --force
 $ mix archive.install hex phx_new
 $ mix phx.new hello
-$ sed -i.bak \
-    -e "s/username: \"postgres\",/username: \"$USER\",/" \
-    -e "s/password: \"postgres\",/password: \"\",/" \
+$ sed -i.bak -e "s/username: \"postgres\",/socket_dir: System.get_env(\"PGDATA\"),/" \
     ./hello/config/dev.exs && rm ./hello/config/dev.exs.bak
 $ devenv up
 ```

--- a/examples/phoenix/README.md
+++ b/examples/phoenix/README.md
@@ -3,6 +3,7 @@ Based on [the official tutorial](https://hexdocs.pm/phoenix/installation.html).
 ```shell-session
 $ devenv shell
 $ mix local.hex --force
+$ mix local.rebar --force
 $ mix archive.install hex phx_new
 $ mix phx.new hello
 $ awk -i inplace '{

--- a/examples/phoenix/devenv.nix
+++ b/examples/phoenix/devenv.nix
@@ -1,9 +1,7 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
-  packages = with pkgs;
-  [ inotify-tools
-  ];
+  packages = lib.optionals pkgs.stdenv.isLinux [ pkgs.inotify-tools ];
 
   languages.elixir.enable = true;
 

--- a/examples/phoenix/devenv.nix
+++ b/examples/phoenix/devenv.nix
@@ -1,0 +1,16 @@
+{ pkgs, ... }:
+
+{
+  packages = with pkgs;
+  [ inotify-tools
+  ];
+
+  languages.elixir.enable = true;
+
+  services.postgres = {
+    enable = true;
+    listen_addresses = "127.0.0.1";
+  };
+
+  processes.phoenix.exec = "cd hello && mix ecto.create && mix phx.server";
+}

--- a/examples/phoenix/devenv.nix
+++ b/examples/phoenix/devenv.nix
@@ -5,10 +5,7 @@
 
   languages.elixir.enable = true;
 
-  services.postgres = {
-    enable = true;
-    listen_addresses = "127.0.0.1";
-  };
+  services.postgres.enable = true;
 
   processes.phoenix.exec = "cd hello && mix ecto.create && mix phx.server";
 }

--- a/examples/phoenix/devenv.yaml
+++ b/examples/phoenix/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable


### PR DESCRIPTION
This is my attempt for an elixir phoenix example.

Based on the ruby on rails example: https://github.com/cachix/devenv/commit/8d246b0c01721c546cdef6786560e5bd1ffae689 

Some differences I noted were:
- Rails uses unix domain socket by default [and also defaults to username: "$USER" and password: ""](https://stackoverflow.com/a/24039062), while phoenix has a default `username: "postgres" and password: "postgres"`.
  So what I did was to make postgres listen to `127.0.0.1`, then modify the config/dev.exs to use `username: "$USER" and password: ""`
- There's no project/bin in the phoenix project.
  As a workaround, I made `processes.phoenix.exec` cd into the project first before running the create database and start server commands
