### PR TITLE
[BUG] Use a full path `mktemp` to not leave orphans in `$DEVENV_ROOT`

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -99,8 +99,7 @@ let
       echo "PostgreSQL is setting up the initial database."
       echo
       OLDPGHOST="$PGHOST"
-      PGHOST="$DEVENV_STATE/$(mktemp -d "pg-init-XXXXXX")"
-      mkdir -p "$PGHOST"
+      PGHOST=$(mktemp -d "$DEVENV_STATE/pg-init-XXXXXX")
 
       function remove_tmp_pg_init_sock_dir() {
         if [[ -d "$1" ]]; then


### PR DESCRIPTION
The existing implementation creates a `pg-init-XXXXXX` directory inside of `$DEVENV_ROOT` and _also_ in `$DEVENV_STATE`. This change makes it so that the one in the root directory is no longer created.