### PR TITLE
Fix `devenv info` and process-compose config containing entire startup scripts

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -56,7 +56,7 @@ in
           (name: value: "${name}=${toString value}")
           config.env;
         processes = lib.mapAttrs
-          (name: value: { command = value.exec; } // value.process-compose)
+          (name: value: { command = "exec ${pkgs.writeShellScript name value.exec}"; } // value.process-compose)
           config.processes;
       };
     };

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -153,6 +153,6 @@ in
 
     ci = [ config.procfileScript ];
 
-    infoSections."processes" = lib.mapAttrsToList (name: process: "${name}: ${process.exec}") config.processes;
+    infoSections."processes" = lib.mapAttrsToList (name: process: "${name}: exec ${pkgs.writeShellScript name process.exec}") config.processes;
   };
 }


### PR DESCRIPTION
I ran into an issue where process-compose failed to initialize minio properly (on macOS). I noticed we were putting the entire minio `startScript` in the process-compose config. Wrapping it in `writeShellScript` (like other process managers do) seems to fix it. I suspect process-compose was running the script using a different shell, perhaps the old bash 3.x on macOS.

This also updates the `devenv info` output, which was also dumping the startup script.