### PR TITLE
mysql: make settings attrs lazy

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -116,7 +116,7 @@ in
     };
 
     settings = mkOption {
-      type = format.type;
+      type = types.lazyAttrsOf (types.lazyAttrsOf types.anything);
       default = { };
       description = ''
         MySQL configuration.


### PR DESCRIPTION
Discussion: https://discord.com/channels/1036369714731036712/1150168934767673505

Currently the following will fail with an infinite recursion:

```
services.mysql.settings.mysqld.port = "${config.env.MY_PORT}";
env.MY_PORT = "1234";
```

This is because `settings` is fully evaluated in order to determine whether to set `MYSQL_TCP_PORT`. It should merely evaluate whether `services.mysql.settings.mysqld.port` exists without evaluating its value.

It is likely that the INI-settings type uses attrsOf instead of lazyAttrsOf.

I'm not fully aware of the consequences of using `lazyAttrsOf` compared to `attrsOf`. Should `lazyAttrsOf` be more common-place for these kinds of settings in general?