### PR TITLE
Add skipLibraryPathEnv config

### DIFF
--- a/src/modules/mkNakedShell.nix
+++ b/src/modules/mkNakedShell.nix
@@ -54,6 +54,7 @@ in
 , meta ? { }
 , passthru ? { }
 , debug ? false
+, skipLibraryPathEnv ? false
 }:
 let
   # simpler version of https://github.com/numtide/devshell/blob/20d50fc6adf77fd8a652fc824c6e282d7737b85d/modules/env.nix#L41
@@ -100,7 +101,11 @@ let
 
       # prepend common compilation lookup paths
       export PKG_CONFIG_PATH="$DEVENV_PROFILE/lib/pkgconfig:''${PKG_CONFIG_PATH-}"
-      export LD_LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LD_LIBRARY_PATH-}"
+      ${
+        lib.optionalString (!skipLibraryPathEnv) ''
+          export LD_LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LD_LIBRARY_PATH-}"
+        ''
+      }
       export LIBRARY_PATH="$DEVENV_PROFILE/lib:''${LIBRARY_PATH-}"
       export C_INCLUDE_PATH="$DEVENV_PROFILE/include:''${C_INCLUDE_PATH-}"
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -127,6 +127,11 @@ in
         internal = true;
       };
 
+      skipLibraryPathEnv = lib.mkOption {
+        type = types.bool;
+        default = false;
+      };
+
     };
   };
 
@@ -201,6 +206,7 @@ in
         profile = profile;
         shellHook = config.enterShell;
         debug = config.devenv.debug;
+        skipLibraryPathEnv = config.devenv.skipLibraryPathEnv;
       }
     );
 


### PR DESCRIPTION
This PR provide an option to opt out `LD_LIBRARY_PATH`, as a workaround for https://github.com/cachix/devenv/issues/555