### PR TITLE
Fix deprecated mkdocs plugin options

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,7 @@ nav:
     - Overview:
       - Automatic Shell Activation: automatic-shell-activation.md
       - Garbage Collection: garbage-collection.md
-    - Guides: 
+    - Guides:
       - Using With Flakes: guides/using-with-flakes.md
       - Using With flake.parts: guides/using-with-flake-parts.md
     - Integrations:
@@ -68,30 +68,32 @@ nav:
   - Community:
       - Get Involved: community/get-involved.md
       - Contributing: community/contributing.md
+
 plugins:
-  search: {}
-  markdownextradata: {}
-  include-markdown: {}
-  social:
-    cards_color:
-      fill: "#FBFBFB"
-      text: "#425C82"
-  rss:
-    match_path: blog/posts/.* 
-    date_from_meta:
-      as_creation: date
-      as_update: date
+  - search
+  - markdownextradata
+  - include-markdown
+  - social:
+      cards_layout_options:
+        background_color: "#FBFBFB"
+        color: "#425C82"
+  - rss:
+      match_path: blog/posts/.*
+      date_from_meta:
+        as_creation: date
+        as_update: date
 
 extra:
   social:
-    - icon: fontawesome/brands/twitter 
+    - icon: fontawesome/brands/twitter
       link: https://twitter.com/cachix_org
-    - icon: fontawesome/brands/github 
+    - icon: fontawesome/brands/github
       link: https://github.com/cachix/devenv
-    - icon: fontawesome/brands/discord 
+    - icon: fontawesome/brands/discord
       link: https://discord.gg/naMgvexb6q
   devenv:
     version: 0.6.3
+
 markdown_extensions:
   - tables
   - admonition
@@ -102,5 +104,5 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - pymdownx.tasklist


### PR DESCRIPTION
Fixes a few yaml formatting nitpicks and the following warning:

```console
17:10:18 docs.1  | WARNING  -  Config value 'plugins': Plugin 'material/social' option 'cards_color': Deprecated, use 'cards_layout_options.background_color' and 'cards_layout_options.color' with 'default' layout
```