### PR TITLE
python-rewrite: remove cachix error

### DIFF
--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -61,19 +61,13 @@ CACHIX_KNOWN_PUBKEYS = DEVENV_HOME / "cachix_pubkeys.json"
 SYSTEM = os.uname().machine.lower().replace("arm", "aarch") + "-" + os.uname().sysname.lower()
 
 def run_nix(command: str,
-            replace_shell=False,
-            use_cachix=False,
-            logging=True,
-            dont_exit=False) -> str:
+            **kwargs) -> str:
     ctx = click.get_current_context()
     nix_flags = ctx.obj['nix_flags']
     flags = " ".join(NIX_FLAGS) + " " + " ".join(nix_flags)
     command_flags = " ".join(ctx.obj['command_flags'])
     return run_command(f"nix {flags} {command} {command_flags}",
-                       replace_shell=replace_shell,
-                       use_cachix=use_cachix,
-                       logging=logging,
-                       dont_exit=dont_exit)
+                       **kwargs)
 
 def run_command(command: str, 
                 disable_stderr=False,

--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -114,8 +114,9 @@ def run_command(command: str,
                 stderr=None if not disable_stderr else subprocess.DEVNULL,
                 universal_newlines=True).stdout.strip()
     except subprocess.CalledProcessError as e:
-        click.echo("\n", err=True)
-        log(f"Following command exited with code {e.returncode}:\n\n  {e.cmd}", level="error")
+        if logging:
+            click.echo("\n", err=True)
+            log(f"Following command exited with code {e.returncode}:\n\n  {e.cmd}", level="error")
         if dont_exit:
             raise e
         else:

--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -724,10 +724,8 @@ def get_cachix_caches(logging=True):
     This is cached because it's expensive to run.
     """
     try:
-        caches_raw = run_nix("eval .#devenv.cachix --json", dont_exit=True)
+        caches_raw = run_nix("eval .#devenv.cachix --json", dont_exit=True, disable_stderr=True, logging=False)
     except subprocess.CalledProcessError as e:
-        log_warning("Failed to evaluate .#devenv.cachix")
-        log_warning("Maybe you need to upgrade to devenv 1.0: https://devenv.sh/getting-started/")
         return {"pull": [], "push": None}, {}
 
     caches = json.loads(caches_raw)


### PR DESCRIPTION
Currently whenever the python-rewrite of devenv is used on a <1.0 version project it shows the following output:

```
direnv: loading ~/tmp/devenv-experiment/.envrc
direnv: loading https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc (sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0=)
direnv: using devenv
direnv: .envrc changed, reloading
error:
       error: flake 'git+file:///home/bob.vanderlinden/tmp/devenv-experiment' does not provide attribute 'packages.x86_64-linux.devenv.cachix', 'legacyPackages.x86_64-linux.devenv.cachix' or 'devenv.cachix'


✖ Following command exited with code 1:

  /nix/store/bnbhch04awczibxch0qg4lbc3aksrcvw-nix-devenv-2.18.0/bin/nix --show-trace --extra-experimental-features nix-command --extra-experimental-features flakes --option warn-dirty false --option eval-cache false --system x86_64-linux eval .#devenv.cachix --json 
• Failed to evaluate .#devenv.cachix
• Maybe you need to upgrade to devenv 1.0: https://devenv.sh/getting-started/
[2/5 built, 1/30/31 copied (58.4/93.8 MiB), 10.7/15.5 MiB DL] fetching perl-5.38.0 from https://cache.nixdirenv: ([/nix/store/f84679kq9qvfmhzb2la8m4yqqkba95vl-direnv-2.32.3/bin/direnv export fish]) is taking a while to execute. Use CTRL-C to give up.
direnv: updated devenv shell cache
✨ devenv 1.0 is newer than devenv input in devenv.lock. Run `devenv update` to sync.
direnv: export +C_INCLUDE_PATH +DEVENV_DOTFILE +DEVENV_PROFILE +DEVENV_ROOT +DEVENV_STATE +IN_NIX_SHELL +LD_LIBRARY_PATH +LIBRARY_PATH +PKG_CONFIG_PATH +name ~PATH ~XDG_CONFIG_DIRS ~XDG_DATA_DIRS
```

This includes a confusing error about cachix. This error is not a problem and may be ignored, but it would confuse the user.

After this PR the output looks like:

```
$ devenv shell
• Building shell ...
✔ Building shell in 1.0s.
• Entering shell
✨ devenv 1.0 is newer than devenv input in devenv.lock. Run `devenv update` to sync.
```