### PR TITLE
postgres: fix case in user message

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -118,7 +118,7 @@ let
       unset OLDPGHOST
     else
       echo
-      echo "PostgreSQL Database directory appears to contain a database; Skipping initialization"
+      echo "PostgreSQL database directory appears to contain a database; Skipping initialization"
       echo
     fi
     unset POSTGRES_RUN_INITIAL_SCRIPT


### PR DESCRIPTION
Fix case in user message printed when DB is already initialized