### PR TITLE
[FEAT] Conditionally link devenv profile

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -190,8 +190,10 @@ in
       fi
 
       mkdir -p .devenv
-      rm -f .devenv/profile
-      ln -s ${profile} .devenv/profile
+      if [ ! -L .devenv/profile ] || [ "$(${pkgs.coreutils}/bin/readlink .devenv/profile)" != "${profile}" ]
+      then
+        ln -nsf ${profile} .devenv/profile
+      fi
     '';
 
     shell = performAssertions (


### PR DESCRIPTION
When loading a shell, devenv checks .devenv/profile is

1. not a link
2. `readlink` reports someplace other than `${profile}`

Then will remove whatever is `.devenv/profile` and re-`ln` to the current active profile. When running a single command at a time, this is usually not a problem, but if you attempt to run two commands at the same time, then the race condition of one process removing a link while another is creating the link will emit warnings to stderr.

I tested this by pointing an example to the local repo and then on `enterShell = "set -x";` to see the checks working. The resulting shell created the link on the first attempt and then skipped the `rm`/`ln` on the subsequent invocations.