### PR TITLE
Add rnix-lsp to nix tools

### DIFF
--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -15,6 +15,7 @@ in
       vulnix
       deadnix
       nil
+      rnix-lsp
     ];
   };
 }


### PR DESCRIPTION
`rnix-lsp` can be used in VS Code extension [jnoortheen.nix-ide](https://marketplace.visualstudio.com/items?itemName=jnoortheen.nix-ide)