### PR TITLE
feat: .git/info/exclude support in init

### DIFF
--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -554,7 +554,14 @@ def version(ctx):
     short_help="Scaffold devenv.yaml, devenv.nix, and .envrc.",
 )
 @click.argument("target", default=".")
-def init(target):
+@click.option(
+    "-gl",
+    "--gitignore_local",
+    is_flag=True,
+    default=False,
+    help="write to .git/info/exclude instead of .gitignore",
+)
+def init(target, gitignore_local):
     os.makedirs(target, exist_ok=True)
 
     required_files = ["devenv.nix", "devenv.yaml", ".envrc"]
@@ -575,9 +582,12 @@ def init(target):
                 os.path.join(examples_path, example, filename), full_filename
             )
 
-    with open(".gitignore", "a+") as gitignore_file:
+    gitignore = ".gitignore"
+    if gitignore_local and Path(".git/info").exists():
+        gitignore = ".git/info/exclude"
+    with open(gitignore, "a+") as gitignore_file:
         if "devenv" not in gitignore_file.read():
-            log("Appending defaults to .gitignore", level="info")
+            log(f"Appending defaults to {gitignore}", level="info")
             gitignore_file.write("\n")
             gitignore_file.write("# Devenv\n")
             gitignore_file.write(".devenv*\n")


### PR DESCRIPTION
Adds #466 via `-gl/--gitignore_local` flag (I didn't know what else to name it).

This will only work if the current directory (as opposed to a given `target`) is a git repo, and silently fall back to `.gitignore` otherwise. I chose to do so because `devenv` currently seems to write `.gitignore` only in the current directory as well.

I'm not sure how/where to add a test, but will happily make one if someone tells me.