### PR TITLE
[Rust] Fix: flag conversion was invalid so use string instead of array of string

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -98,9 +98,9 @@ in
       }
     ))
     (lib.mkIf (cfg.enable && pkgs.stdenv.isDarwin) {
-      env.RUSTFLAGS = [ "-L framework=${config.devenv.profile}/Library/Frameworks" ];
-      env.RUSTDOCFLAGS = [ "-L framework=${config.devenv.profile}/Library/Frameworks" ];
-      env.CFLAGS = [ "-iframework ${config.devenv.profile}/Library/Frameworks" ];
+      env.RUSTFLAGS = "-L framework=${config.devenv.profile}/Library/Frameworks";
+      env.RUSTDOCFLAGS = "-L framework=${config.devenv.profile}/Library/Frameworks";
+      env.CFLAGS = "-iframework ${config.devenv.profile}/Library/Frameworks";
     })
     (lib.mkIf (cfg.channel != "nixpkgs") (
       let


### PR DESCRIPTION
Fixes #845, I confirmed the invalid flag-conversion is fixed and the cargo example that I provided is working at macOS.

 `'[-L' 'framework=/nix/store/fpvjkq98ylmpp5gkzym4mss1w0s0ji77-devenv-profile/Library/Frameworks]'` is now `-L framework=/nix/store/fpvjkq98ylmpp5gkzym4mss1w0s0ji77-devenv-profile/Library/Frameworks`