### PR TITLE
feat: adds support for multiple IP configurations for one hostname in `hostctl.nix`

### DIFF
--- a/examples/mkcert/devenv.nix
+++ b/examples/mkcert/devenv.nix
@@ -3,10 +3,12 @@
 {
   certificates = [
     "example.com"
+    "another-example.com"
   ];
 
   hosts = {
     "example.com" = "127.0.0.1";
+    "another-example.com" = [ "127.0.0.1" "::1" ];
   };
 
   services.caddy.enable = true;
@@ -14,7 +16,14 @@
     extraConfig = ''
       tls ${config.env.DEVENV_STATE}/mkcert/example.com.pem ${config.env.DEVENV_STATE}/mkcert/example.com-key.pem
 
-      respond "Hello, world!"
+      respond "Hello, world from example.com!"
+    '';
+  };
+  services.caddy.virtualHosts."another-example.com" = {
+    extraConfig = ''
+      tls ${config.env.DEVENV_STATE}/mkcert/another-example.com.pem ${config.env.DEVENV_STATE}/mkcert/another-example.com-key.pem
+
+      respond "Hello, world from another-example.com!"
     '';
   };
 }

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -1,8 +1,11 @@
 { pkgs, lib, config, ... }:
 
 let
+  reducerFn = (prev: curr: prev ++ (if builtins.typeOf curr.ip == "string" then [curr] else builtins.map (ip: { inherit ip; hostname = curr.hostname; }) curr.ip));
+  reducer = lib.lists.foldl reducerFn [];
   entries = lib.mapAttrsToList (hostname: ip: { inherit hostname ip; }) config.hosts;
-  entriesByIp = builtins.groupBy ({ ip, ... }: ip) entries;
+  separateEntriesWithIps = reducer entries;
+  entriesByIp = builtins.groupBy ({ ip, ... }: ip) separateEntriesWithIps;
   hostnamesByIp = builtins.mapAttrs (hostname: entries: builtins.map ({ hostname, ... }: hostname) entries) entriesByIp;
   lines = lib.mapAttrsToList (ip: hostnames: "${ip} ${lib.concatStringsSep " " hostnames}") hostnamesByIp;
   hostContent = lib.concatStringsSep "\n" lines;
@@ -21,11 +24,12 @@ in
     };
 
     hosts = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
+      type = lib.types.attrsOf (lib.types.either lib.types.str (lib.types.listOf lib.types.str));
       default = { };
       description = "List of hosts entries.";
       example = {
         "example.com" = "127.0.0.1";
+        "another-example.com" = [ "::1" "127.0.0.1" ];
       };
     };
   };

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -1,8 +1,8 @@
 { pkgs, lib, config, ... }:
 
 let
-  reducerFn = (prev: curr: prev ++ (if builtins.typeOf curr.ip == "string" then [curr] else builtins.map (ip: { inherit ip; hostname = curr.hostname; }) curr.ip));
-  reducer = lib.lists.foldl reducerFn [];
+  reducerFn = (prev: curr: prev ++ (if builtins.typeOf curr.ip == "string" then [ curr ] else builtins.map (ip: { inherit ip; hostname = curr.hostname; }) curr.ip));
+  reducer = lib.lists.foldl reducerFn [ ];
   entries = lib.mapAttrsToList (hostname: ip: { inherit hostname ip; }) config.hosts;
   separateEntriesWithIps = reducer entries;
   entriesByIp = builtins.groupBy ({ ip, ... }: ip) separateEntriesWithIps;


### PR DESCRIPTION
## What does this PR do

* Adds support for multiple IPs to be configured for one hostname. This is specially important if you want to configure both `127.0.0.1` and `::1` to be the resolution for the same hostname (e.g `example.com`).

I'd highlight that this PR adds support for multiple IPs (as a list of strings) but it also supports the original approach of having just a string.

In OSes like MacOS, where local dns resolution requires both configurations (otherwise you get a 10s delay on it), this is quite important for performance.

It's my first time coding in Nix language so, please bear with my poor coding skills on it. 😄 

Thank you for your time reviewing my PR and for allowing me to learn with your expertise.

Closes #857 