### PR TITLE
feat: add `containers.<name>.maxLayers` option

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -169,7 +169,7 @@ let
       maxLayers = lib.mkOption {
         type = types.int;
         description = "the maximum number of layers to create.";
-        defaultText = lib.literalExpression 1;
+        defaultText = lib.literalExpression "1";
         default = 1;
       };
     };

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -33,6 +33,7 @@ let
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;
     tag = cfg.version;
+    maxLayers = cfg.maxLayers;
     copyToRoot = [
       (pkgs.runCommand "create-paths" { } ''
         mkdir -p $out/tmp
@@ -163,6 +164,13 @@ let
 
           docker run -it ${config.name}:${config.version} "$@"
         '';
+      };
+
+      maxLayers = lib.mkOption {
+        type = types.int;
+        description = "the maximum number of layers to create.";
+        defaultText = lib.literalExpression 1;
+        default = 1;
       };
     };
   });


### PR DESCRIPTION
This PR allows multi-layered Docker images described at https://github.com/nlewo/nix2container/tree/9d7f33ef0058f4df4c0912025f43c758a3289d76#:~:text=maxLayers%20(defaults%20to%201)%3A%20the%20maximum%20number%20of%20layers%20to%20create.%20This%20is%20based%20on%20the%20store%20path%20%22popularity%22%20as%20described%20in%20this%20blog%20post.%20Note%20this%20is%20applied%20on%20the%20image%20layers%20and%20not%20on%20layers%20added%20with%20the%20buildImage.layers%20attribute.