### PR TITLE
fix: let `devenv` created OCI images be compatible with `libnvidia-container`

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -49,7 +49,7 @@ let
           (if builtins.typeOf cfg.copyToRoot == "list"
           then cfg.copyToRoot
           else [ cfg.copyToRoot ]);
-        pathsToLink = "/";
+        pathsToLink = [ "/" "/lib" ];
       })
     ];
     config = {


### PR DESCRIPTION
Currently OCI images created by `devenv` contain a symlink `/lib -> /nix/store/lf0wpjrj8yx4gsmw2s3xfl58ixmqk8qa-bash-5.2-p15/lib`. The symlink conflicts with `libnvidia-container` because `libnvidia-container` tries to create a file `/lib/firmware/nvidia/525.85.12/gsp_ad10x.bin` while it specifies `O_NOFOLLOW` according to https://github.com/NVIDIA/libnvidia-container/blob/1eb5a30a6ad0415550a9df632ac8832bf7e2bbba/src/utils.c#L523

As a result, `libnvidia-container` will produce the following error when starting a container built from `devenv`
```
mount error: file creation failed: /run/containerd/io.containerd.runtime.v2.task/k8s.io/master-node/rootfs/lib/firmware/nvidia/525.85.12/gsp_ad10x.bin: file exists: unknown
```

This PR makes `/lib` a regular directory, and makes files under `/lib` symlinks, so that the OCI images created by `devenv` would be compatible with `libnvidia-container`.