### PR TITLE
Add defaultMimeTypes to Nginx

### DIFF
--- a/src/modules/services/nginx.nix
+++ b/src/modules/services/nginx.nix
@@ -19,6 +19,8 @@ let
       scgi_temp_path ${config.env.DEVENV_STATE}/nginx/;
       uwsgi_temp_path ${config.env.DEVENV_STATE}/nginx/;
 
+      include ${cfg.defaultMimeTypes};
+
       ${cfg.httpConfig}
     }
   '';
@@ -32,6 +34,18 @@ in
       default = pkgs.nginx;
       defaultText = "pkgs.nginx";
       description = "The nginx package to use.";
+    };
+
+    defaultMimeTypes = lib.mkOption {
+      type = lib.types.path;
+      default = "${pkgs.mailcap}/etc/nginx/mime.types";
+      defaultText = lib.literalExpression "$''{pkgs.mailcap}/etc/nginx/mime.types";
+      example = lib.literalExpression "$''{pkgs.nginx}/conf/mime.types";
+      description = lib.mdDoc ''
+        Default MIME types for NGINX, as MIME types definitions from NGINX are very incomplete,
+        we use by default the ones bundled in the mailcap package, used by most of the other
+        Linux distributions.
+      '';
     };
 
     httpConfig = lib.mkOption {


### PR DESCRIPTION
This adds support for MIME types to Nginx.
Without it the static files don't work because they are all of type "text/plain".

Closes: #876 

I basically copied it from here: https://github.com/NixOS/nixpkgs/blob/nixos-23.05/nixos/modules/services/web-servers/nginx/default.nix#L571
Is there maybe a better way to use configs from NixOS?
This way we just duplicate a lot of the code and I don't really know what else might be useful.
I just noticed the MIME types because my project was broken without them.