### PR TITLE
Pin releases on cachix

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -26,13 +26,18 @@ jobs:
         name: devenv
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: |
-        nix profile remove '.*' 
-        nix profile install --accept-flake-config . 
+        nix profile remove '.*'
+        nix profile install --accept-flake-config .
     - name: Run tests
       run: |
         devenv ci
         devenv shell devenv-run-tests
         devenv search ncdu | grep "pkgs\.ncdu"
+  pin:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/pin.yml
+    secrets: inherit
   generate-examples:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pin.yml
+++ b/.github/workflows/pin.yml
@@ -1,0 +1,39 @@
+name: "Pin release on Cachix"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to build and pin"
+        type: "string"
+        required: true
+
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+
+jobs:
+  pin:
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [[ubuntu-latest], [macos-latest], [self-hosted, macOS], [nscloud-arm64]]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v23
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - uses: cachix/cachix-action@v12
+      with:
+        name: devenv
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+    - name: Pin release
+      run: cachix pin devenv ${{ github.ref_name }} $(nix build --accept-flake-config --print-out-paths)


### PR DESCRIPTION
Can be triggered manually or via another workflow, i.e. after the build succeeds.

Related #536.