### PR TITLE
fix: redis startup on WSL2

### DIFF
--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -57,7 +57,7 @@ in
 
     extraConfig = mkOption {
       type = types.lines;
-      default = "";
+      default = "locale-collate C";
       description = "Additional text to be appended to `redis.conf`.";
     };
   };


### PR DESCRIPTION
On WSL, the locale is not set properly, therefore, newer Redis versions don't start. 
I would set it the locale to C, to make it same on any platform and not depend on local locales.

If someone wants something different, they can still configure it