### PR TITLE
elasticmq: init

### DIFF
--- a/examples/elasticmq/.test.sh
+++ b/examples/elasticmq/.test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -ex
+
+devenv up &
+DEVENV_PID=$!
+export DEVENV_PID
+
+function stop() {
+    pkill -P "$DEVENV_PID"
+}
+
+trap stop EXIT
+
+timeout 60 bash -c 'until echo > /dev/tcp/localhost/9325; do sleep 0.5; done'
+
+QUEUE_NAME=$(curl http://localhost:9325/statistics/queues -s | jq .[].name -r)
+
+if [[ "$QUEUE_NAME" != "test-queue" ]]; then
+  echo "The queue is not created"
+  exit 1
+fi

--- a/examples/elasticmq/devenv.nix
+++ b/examples/elasticmq/devenv.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  services.elasticmq.enable = true;
+  services.elasticmq.settings = ''
+    queues {
+      test-queue {}
+    }
+  '';
+}

--- a/examples/elasticmq/devenv.yaml
+++ b/examples/elasticmq/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/services/elasticmq.nix
+++ b/src/modules/services/elasticmq.nix
@@ -1,0 +1,28 @@
+{ pkgs, lib, config, ... }:
+
+let
+  cfg = config.services.elasticmq;
+  types = lib.types;
+in
+{
+  options.services.elasticmq = {
+    enable = lib.mkEnableOption "elasticmq-server";
+
+    package = lib.mkOption {
+      type = types.package;
+      description = "Which package of elasticmq-server-bin to use";
+      default = pkgs.elasticmq-server-bin;
+      defaultText = lib.literalExpression "pkgs.elasticmq-server-bin";
+    };
+
+    settings = lib.mkOption {
+      type = types.lines;
+      default = "";
+      description = "Configuration for elasticmq-server";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    processes.elasticmq-server.exec = "JAVA_TOOL_OPTIONS=\"-Dconfig.file=${pkgs.writeText "elasticmq-server.conf" cfg.settings}\" ${cfg.package}/bin/elasticmq-server";
+  };
+}


### PR DESCRIPTION
[Amazon SQS](https://aws.amazon.com/sqs/) compatible solution was asked at the [SymfonyCon Brussels](https://live.symfony.com/2023-brussels-con/) for Devenv. So we quickly added this after the Talk this to Devenv :)

