### PR TITLE
feat: Add a default overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,5 +152,9 @@
             inherit config;
           };
       };
+
+      overlays.default = final: prev: {
+        devenv = self.packages.${prev.system}.default;
+      };
     };
 }


### PR DESCRIPTION
Add a default overlay for `devenv`.

**Use Cases**

Adding an overlay to `nixpkgs`:

```nix
import nixpkgs {
  ...
  overlays = [ devenv.overlays.default ];
};
```

Override packages in `home-manager`:

```nix
nixpkgs.overlays = [ devenv.overlays.default ];
```