### PR TITLE
fix for bitrot in flake template; devenv up requires processes.run.exec

### DIFF
--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -35,6 +35,8 @@
                   enterShell = ''
                     hello
                   '';
+
+                  processes.run.exec = "hello";
                 }
               ];
             };


### PR DESCRIPTION
Without the fix, the examples in the devenv tutorial won't work.