### PR TITLE
Better (but not completely fixed) treatment of venv

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,10 +28,6 @@ let
 
     source ${shell.envScript}
 
-    # strip off leading slash
-    cmd="$@"
-    cmd="''${cmd:1}"
-
     exec $cmd
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,7 +28,10 @@ let
 
     source ${shell.envScript}
 
-    exec $@
+    # expand any envvars before exec
+    cmd=$(eval "echo $@")
+
+    exec $cmd
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,7 +28,11 @@ let
 
     source ${shell.envScript}
 
-    exec $@
+    # strip off leading slash
+    cmd="$@"
+    cmd="''${cmd:1}"
+
+    exec $cmd
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,7 +28,7 @@ let
 
     source ${shell.envScript}
 
-    exec "$@"
+    exec $@
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,7 +28,7 @@ let
 
     source ${shell.envScript}
 
-    exec $cmd
+    exec $@
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,8 +45,9 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    profile_python="$(${readlink} "${package.python}/bin/python")"
-    venv_python="$(${readlink} "$VENV_PATH/bin/python")"
+    profile_python="$(${readlink} "${package.interpreter}")"
+    devenv_interpreter_path = $(cat "$VENV_PATH/.devenv_interpreter") || ""
+    venv_python="$(${readlink} $devenv_interpreter_path"
 
     echo $profile_python
     echo $venv_python
@@ -60,6 +61,7 @@ let
       ''}
       echo ${package.interpreter} -m venv "$VENV_PATH"
       ${package.interpreter} -m venv "$VENV_PATH"
+      echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"
     fi
     source "$VENV_PATH"/bin/activate
     ${lib.optionalString (cfg.venv.requirements != null) ''

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -46,8 +46,8 @@ let
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
     profile_python="$(${readlink} ${package.interpreter})"
-    devenv_interpreter_path = "$(cat "$VENV_PATH/.devenv_interpreter")" || ""
-    venv_python="$(${readlink} $devenv_interpreter_path)"
+    devenv_interpreter_path = "$(cat "$VENV_PATH/.devenv_interpreter" || "" )"
+    venv_python="$(${readlink} "$devenv_interpreter_path")"
 
     echo $profile_python
     echo $venv_python

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -53,11 +53,8 @@ let
 
     if [ $profile_python != $venv_python ]
     then
-      if [ -d "$VENV_PATH" ]
-      then
-        echo "Python interpreter changed, rebuilding Python venv..."
-        ${pkgs.coreutils}/bin/rm -rf "$VENV_PATH"
-      fi
+      echo "Python interpreter changed, rebuilding Python venv..."
+      ${pkgs.coreutils}/bin/rm -rf "$VENV_PATH"
       ${lib.optionalString cfg.poetry.enable ''
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -51,7 +51,7 @@ let
     echo $profile_python
     echo $venv_python
 
-    if [ $profile_python != $venv_python ]
+    if [ -z $venv_python || $profile_python != $venv_python ]
     then
       echo "Python interpreter changed, rebuilding Python venv..."
       ${pkgs.coreutils}/bin/rm -rf "$VENV_PATH"

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,10 +45,10 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    echo ${readlink} "${package.interpreter}/bin/python"
-    echo ${readlink} "$VENV_PATH"/bin/python
+    echo $(${readlink} "${package.interpreter}/bin/python")
+    echo $(${readlink} "$VENV_PATH/bin/python")
 
-    if [ "$(${readlink} "$VENV_PATH"/bin/python)" != "$(${readlink} ${package.interpreter}/bin/python)" ]
+    if [ "$(${readlink} "$VENV_PATH/bin/python")" != "$(${readlink} ${package.interpreter}/bin/python)" ]
     then
       if [ -d "$VENV_PATH" ]
       then

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -56,8 +56,8 @@ let
       ${lib.optionalString cfg.poetry.enable ''
         [ -f "${config.env.DEVENV_STATE}/poetry.lock.checksum" ] && rm ${config.env.DEVENV_STATE}/poetry.lock.checksum
       ''}
-      echo ${package.interpreter} -m venv "$VENV_PATH"
-      ${package.interpreter} -m venv "$VENV_PATH"
+      echo ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
+      ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
       echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"
     fi
     source "$VENV_PATH"/bin/activate

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,7 +45,7 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    echo $(${readlink} "${package.interpreter}")
+    echo $(${readlink} "${package.python}")
     echo $(${readlink} "$VENV_PATH/bin/python")
 
     if [ "$(${readlink} "$VENV_PATH/bin/python")" != "$(${readlink} ${package.interpreter})" ]

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,10 +45,13 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    echo $(${readlink} "${package.python}")
-    echo $(${readlink} "$VENV_PATH/bin/python")
+    nix_python = $(${readlink} "${package.python}/bin/python")
+    venv_python = $(${readlink} "$VENV_PATH/bin/python")
 
-    if [ "$(${readlink} "$VENV_PATH/bin/python")" != "$(${readlink} ${package.interpreter})" ]
+    echo $nix_python
+    echo $venv_python
+
+    if [ $nix_python != $venv_python ]
     then
       if [ -d "$VENV_PATH" ]
       then

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,8 +45,8 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    profile_python = $(${readlink} "${package.python}/bin/python")
-    venv_python = $(${readlink} "$VENV_PATH/bin/python")
+    profile_python=$(${readlink} "${package.python}/bin/python")
+    venv_python=$(${readlink} "$VENV_PATH/bin/python")
 
     echo $profile_python
     echo $venv_python

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -51,7 +51,7 @@ let
     echo $profile_python
     echo $venv_python
 
-    if [ -z $venv_python || $profile_python != $venv_python ]
+    if [ -z $venv_python ] || [ $profile_python != $venv_python ]
     then
       echo "Python interpreter changed, rebuilding Python venv..."
       ${pkgs.coreutils}/bin/rm -rf "$VENV_PATH"

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -49,9 +49,6 @@ let
     devenv_interpreter_path="$(${pkgs.coreutils}/bin/cat "$VENV_PATH/.devenv_interpreter" 2> /dev/null|| false )"
     venv_python="$(${readlink} "$devenv_interpreter_path")"
 
-    echo $profile_python
-    echo $venv_python
-
     if [ -z $venv_python ] || [ $profile_python != $venv_python ]
     then
       echo "Python interpreter changed, rebuilding Python venv..."

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,6 +45,9 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
+    echo ${readlink} "${package.interpreter}/bin/python"
+    echo ${readlink} "$VENV_PATH"/bin/python
+
     if [ "$(${readlink} "$VENV_PATH"/bin/python)" != "$(${readlink} ${package.interpreter}/bin/python)" ]
     then
       if [ -d "$VENV_PATH" ]

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,8 +45,8 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    profile_python=$(${readlink} "${package.python}/bin/python")
-    venv_python=$(${readlink} "$VENV_PATH/bin/python")
+    profile_python="$(${readlink} "${package.python}/bin/python")"
+    venv_python="$(${readlink} "$VENV_PATH/bin/python")"
 
     echo $profile_python
     echo $venv_python

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,9 +45,9 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    profile_python="$(${readlink} "${package.interpreter}")"
-    devenv_interpreter_path = $(cat "$VENV_PATH/.devenv_interpreter") || ""
-    venv_python="$(${readlink} $devenv_interpreter_path"
+    profile_python="$(${readlink} ${package.interpreter})"
+    devenv_interpreter_path = "$(cat "$VENV_PATH/.devenv_interpreter")" || ""
+    venv_python="$(${readlink} $devenv_interpreter_path)"
 
     echo $profile_python
     echo $venv_python

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,12 +45,11 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    if [ "$(${readlink} "$VENV_PATH"/bin/python)" != "$(${readlink} ${package.interpreter}/bin/python)" ] \
-    || [ "$(${readlink} "$VENV_PATH"/requirements.txt)" != "$(${readlink} ${if requirements != null then requirements else "$VENV_PATH/requirements.txt"})" ]
+    if [ "$(${readlink} "$VENV_PATH"/bin/python)" != "$(${readlink} ${package.interpreter}/bin/python)" ]
     then
       if [ -d "$VENV_PATH" ]
       then
-        echo "Python interpreter/requirements changed, rebuilding Python venv..."
+        echo "Python interpreter changed, rebuilding Python venv..."
         ${pkgs.coreutils}/bin/rm -rf "$VENV_PATH"
       fi
       ${lib.optionalString cfg.poetry.enable ''

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -46,7 +46,7 @@ let
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
     profile_python="$(${readlink} ${package.interpreter})"
-    devenv_interpreter_path = "$(cat "$VENV_PATH/.devenv_interpreter" || "" )"
+    devenv_interpreter_path="$(${pkgs.coreutils}/bin/cat "$VENV_PATH/.devenv_interpreter" 2> /dev/null|| false )"
     venv_python="$(${readlink} "$devenv_interpreter_path")"
 
     echo $profile_python

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,10 +45,10 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    echo $(${readlink} "${package.interpreter}/bin/python")
+    echo $(${readlink} "${package.interpreter}")
     echo $(${readlink} "$VENV_PATH/bin/python")
 
-    if [ "$(${readlink} "$VENV_PATH/bin/python")" != "$(${readlink} ${package.interpreter}/bin/python)" ]
+    if [ "$(${readlink} "$VENV_PATH/bin/python")" != "$(${readlink} ${package.interpreter})" ]
     then
       if [ -d "$VENV_PATH" ]
       then

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -45,13 +45,13 @@ let
 
     VENV_PATH="${config.env.DEVENV_STATE}/venv"
 
-    nix_python = $(${readlink} "${package.python}/bin/python")
+    profile_python = $(${readlink} "${package.python}/bin/python")
     venv_python = $(${readlink} "$VENV_PATH/bin/python")
 
-    echo $nix_python
+    echo $profile_python
     echo $venv_python
 
-    if [ $nix_python != $venv_python ]
+    if [ $profile_python != $venv_python ]
     then
       if [ -d "$VENV_PATH" ]
       then

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -194,8 +194,9 @@ in
         '';
       }
     ];
-    devenv.dotfile = config.devenv.root + "/.devenv";
-    devenv.state = config.devenv.dotfile + "/state";
+    # use builtins.toPath to normalize path if root is "/" (container)
+    devenv.dotfile = builtins.toPath (config.devenv.root + "/.devenv");
+    devenv.state = builtins.toPath (config.devenv.dotfile + "/state");
     devenv.profile = profile;
 
     env.DEVENV_PROFILE = config.devenv.profile;


### PR DESCRIPTION
    - get rid of requirements check for recreation
    
    - store .devenv_interpreter because the venv
      python binary resolves to the origin
      python of the wrapper, not the wrapper
      python
    
    In practice, merging this commit will mean that
    
    a) the invocation of pip install -r will
    need to take care of any changed requirements.
    
    b) the venv, once created, will never be recreated
    unless the Python wrapper changes.  The Python
    wrapper doesn't seem to change when you add
    Python packages to your packages = list, I'm
    not sure what the other circumstances might be.
    
    In reality, this fix sucks because the venv is
    not actually based on the wrapper.  The wrapper,
    in fact, seems to never get used.  That will
    need to be addressed in some other commit, though.
