### PR TITLE
normalize paths when root is /

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -194,8 +194,9 @@ in
         '';
       }
     ];
-    devenv.dotfile = config.devenv.root + "/.devenv";
-    devenv.state = config.devenv.dotfile + "/state";
+    # use builtins.toPath to normalize path if root is "/" (container)
+    devenv.dotfile = builtins.toPath (config.devenv.root + "/.devenv");
+    devenv.state = builtins.toPath (config.devenv.dotfile + "/state");
     devenv.profile = profile;
 
     env.DEVENV_PROFILE = config.devenv.profile;


### PR DESCRIPTION
When devenv.root is "/", devenv.state becomes "//.devenv/state," and similar with devenv.dotfile.  Avoid this by normalizing using builtins.toPath to normalize the path (it strips extra slashes).

This is a fork of the python-rewrite branch, for better or worse.