### PR TITLE
Allow container startupCommand to work

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -28,7 +28,10 @@ let
 
     source ${shell.envScript}
 
-    exec "$@"
+    # expand any envvars before exec
+    cmd="`echo "$@"|${pkgs.envsubst}/bin/envsubst`"
+
+    exec $cmd
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;


### PR DESCRIPTION
Container startup commands did not work due to quoting of args; we now also evaluate any shell variables in the startup command before executing it.

This patch is against the python-rewrite branch.