### PR TITLE
templates/simple: fix typo in .envrc

### DIFF
--- a/templates/simple/.envrc
+++ b/templates/simple/.envrc
@@ -2,9 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 
-nix_direnv_watch_file devenv.nix
-nix_direnv_watch_file devenv.lock
-nix_direnv_watch_file devenv.yaml
+nix_direnv_watch_file flake.nix
+nix_direnv_watch_file flake.lock
 if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2


### PR DESCRIPTION
Fix the filenames of the flake (simple) template. 