### PR TITLE
Add ocaml's findlib

### DIFF
--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -25,6 +25,7 @@ in
       cfg.packages.utop
       cfg.packages.odoc
       cfg.packages.ocp-indent
+      cfg.packages.findlib
       pkgs.ocamlformat
     ];
   };


### PR DESCRIPTION
findlib is required in order for dune to find the different ocaml packages that are installed. Unfortunately opam (ocaml's package manager) does not work on NixOS. So we need to specify all of the ocaml packages that we want to use in our nix files as well.

---

On a somewhat related note, I should update/add the ocaml example to include [nix-ocaml/nix-overlays](https://github.com/nix-ocaml/nix-overlays) because apparently nixpkgs upstream is somewhat outdated for packages.