### PR TITLE
examples/python-poetry: use python libraries instead of packages

### DIFF
--- a/examples/python-poetry/devenv.nix
+++ b/examples/python-poetry/devenv.nix
@@ -1,7 +1,7 @@
 { pkgs, config, ... }:
 
 {
-  packages = [
+  languages.python.libraries = [
     # A native dependency of numpy
     pkgs.zlib
 


### PR DESCRIPTION
Requires https://github.com/cachix/devenv/issues/920

The `python-poetry` example is currently failing on the `python-rewrite` branch. The problem is that `LD_LIBRARY_PATH` is not supplied by `packages` anymore, but now is supplied using `languages.python.libraries`. This PR makes that change.