### PR TITLE
fix "devenv processes stop"

### DIFF
--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -363,7 +363,7 @@ def up(ctx, process, detach):
             f.write(
                 f"""#!/usr/bin/env bash
 {env}
-{procfilescript} {process or ""}
+exec {procfilescript} {process or ""}
             """
             )
         os.chmod(processes_script, 0o755)


### PR DESCRIPTION
On the python-rewrite branch.

To allow 'devenv processes stop' to stop processes we need to exec the procfilescript rather than run it as a subprocess.

Without this, no processes will stop.