### PR TITLE
Add Delta support (a syntax-highlighting pager for git)

### DIFF
--- a/docs/integrations/delta.md
+++ b/docs/integrations/delta.md
@@ -1,0 +1,9 @@
+To get started using [Delta, a syntax-highlighting pager for git, diff, and grep output](https://dandavison.github.io/delta/), flip a toggle:
+
+```nix title="devenv.nix"
+{ pkgs, ... }:
+
+{
+    delta.enable = true;
+}
+```

--- a/docs/integrations/difftastic.md
+++ b/docs/integrations/difftastic.md
@@ -1,4 +1,4 @@
-To get started using [Difftastic, a structural diff that understands syntax for over 30 langauges](https://difftastic.wilfred.me.uk/), flip a toggle:
+To get started using [Difftastic, a structural diff that understands syntax for over 30 languages](https://difftastic.wilfred.me.uk/), flip a toggle:
 
 
 ```nix title="devenv.nix"

--- a/src/modules/integrations/delta.nix
+++ b/src/modules/integrations/delta.nix
@@ -1,0 +1,15 @@
+{ pkgs, lib, config, ... }:
+
+{
+  options.delta.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Integrate delta into git: https://dandavison.github.io/delta/.";
+  };
+
+  config = lib.mkIf config.delta.enable {
+    packages = [ pkgs.delta ];
+
+    env.GIT_PAGER = "delta";
+  };
+}


### PR DESCRIPTION
Hello,

I noticed there was support for difftastic but not delta.  
Delta is an awesome git pager: https://dandavison.github.io/delta/features.html

I actually enjoy it more than difftastic, so I was wondering if it could be a nice addition.