### PR TITLE
Put user libraries first on LD_LIBRARY_PATH

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -2,11 +2,11 @@
 
 let
   cfg = config.languages.python;
-  libraries = lib.makeLibraryPath
-    ((lib.optional cfg.manylinux.enable pkgs.pythonManylinuxPackages.manylinux2014Package)
-      # see https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$XJ5CO4bKMevYzZq_rrNo64YycknVFJIJTy6hVCJjRlA?via=nixos.org&via=matrix.org&via=nixos.dev
-      ++ [ pkgs.stdenv.cc.cc.lib ]
-      ++ cfg.libraries
+  libraries = lib.makeLibraryPath (
+    cfg.libraries
+    ++ (lib.optional cfg.manylinux.enable pkgs.pythonManylinuxPackages.manylinux2014Package)
+    # see https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$XJ5CO4bKMevYzZq_rrNo64YycknVFJIJTy6hVCJjRlA?via=nixos.org&via=matrix.org&via=nixos.dev
+    ++ [ pkgs.stdenv.cc.cc.lib ]
     );
 
   readlink = "${pkgs.coreutils}/bin/readlink -f ";


### PR DESCRIPTION
On python-rewrite branch, put user-defined libraries first on LD_LIBRARY_PATH, so manylinux versions do not block them if the user knows what he's doing.