### PR TITLE
Add Default for $RUBYLIB and $GEM_PATH

### DIFF
--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -108,8 +108,8 @@ in
       let libdir = cfg.package.version.libDir;
       in
       ''
-        export RUBYLIB="$DEVENV_PROFILE/${libdir}:$DEVENV_PROFILE/lib/ruby/site_ruby:$DEVENV_PROFILE/lib/ruby/site_ruby/${libdir}:$DEVENV_PROFILE/lib/ruby/site_ruby/${libdir}/${pkgs.stdenv.system}:$RUBYLIB"
-        export GEM_PATH="$GEM_HOME/gems:$GEM_PATH"
+        export RUBYLIB="$DEVENV_PROFILE/${libdir}:$DEVENV_PROFILE/lib/ruby/site_ruby:$DEVENV_PROFILE/lib/ruby/site_ruby/${libdir}:$DEVENV_PROFILE/lib/ruby/site_ruby/${libdir}/${pkgs.stdenv.system}:''${RUBYLIB:-}"
+        export GEM_PATH="$GEM_HOME/gems:''${GEM_PATH:-}"
         export PATH="$GEM_HOME/bin:$PATH"
       '';
   };


### PR DESCRIPTION
Without this, bash throws up its hands if these vars are not set. I'm using the flake integration and `nix-direnv`, which I think is potentially relevant because I'm betting `nix-direnv` (or `direnv`) is doing `set -u`. Using `nix develop .# --impure` does not have the issue.

Truncated output, with `devenv.debug = true;`:
```console
# ...
++++ PGHOST=/Users/eric/code/notarize-api/.devenv/state/postgres
++++ export PGPORT=5432
++++ PGPORT=5432
++++ export REDISDATA=/Users/eric/code/notarize-api/.devenv/state/redis
++++ REDISDATA=/Users/eric/code/notarize-api/.devenv/state/redis
++++ export STATSD_ADDR=
++++ STATSD_ADDR=
++++ export STATSD_ENV=
++++ STATSD_ENV=
++++ export name=api-devshell
++++ name=api-devshell
/nix/store/6zm9g2n21l74gywp85vfn1qjvkq7krkb-nix-direnv-3.0.4/share/nix-direnv/direnvrc:329: RUBYLIB: unbound variable
+++++ __dump_at_exit
+++++ local ret=1
+++++ /nix/store/7dacgcmg51sh67kv4v6ilrsyn7ignsdh-direnv-2.33.0/bin/direnv dump json ''
+++++ trap - EXIT
+++++ exit 1
```