### PR TITLE
Feature/add nixd

### DIFF
--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -6,6 +6,12 @@ in
 {
   options.languages.nix = {
     enable = lib.mkEnableOption "tools for Nix development";
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.nil;
+      defaultText = lib.literalExpression "pkgs.nil";
+      description = "The LSP package to use";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -14,7 +20,6 @@ in
       statix
       vulnix
       deadnix
-      nil
-    ];
+    ] ++ cfg.package;
   };
 }

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -6,7 +6,7 @@ in
 {
   options.languages.nix = {
     enable = lib.mkEnableOption "tools for Nix development";
-    package = lib.mkOption {
+    lsp.package = lib.mkOption {
       type = lib.types.package;
       default = pkgs.nil;
       defaultText = lib.literalExpression "pkgs.nil";
@@ -20,6 +20,6 @@ in
       statix
       vulnix
       deadnix
-    ] ++ cfg.package;
+    ] ++ cfg.lsp.package;
   };
 }


### PR DESCRIPTION
Add the option to choose the Nix LSP package (default to `nil` for compatibility).