### PR TITLE
Support allowBroken

### DIFF
--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -2,6 +2,7 @@
 | Key                          | Value                                                                         |
 | ---------------------------- | ----------------------------------------------------------------------------- |
 | allowUnfree                  | Allow unfree packages. Defaults to `false`.                                   |
+| allowBroken                  | Allow packages marked as broken. Defaults to `false`.                         |
 | inputs                       | Defaults to `inputs.nixpkgs.url: github:NixOS/nixpkgs/nixpkgs-unstable`.      |
 | inputs.&lt;name&gt;          | Identifier name used when passing the input in your ``devenv.nix`` function.  |
 | inputs.&lt;name&gt;.url      | URI specification of the input, see below for possible values.                |

--- a/src/devenv-yaml.nix
+++ b/src/devenv-yaml.nix
@@ -18,6 +18,7 @@ pkgs.writers.writePython3Bin "devenv-yaml" { libraries = with pkgs.python3Packag
   schema = Map({
       Optional("inputs", default=None): inputsSchema,
       Optional("allowUnfree", default=False): Bool(),
+      Optional("allowBroken", default=False): Bool(),
       Optional("imports", default=None): Seq(Str()),
       Optional("permittedInsecurePackages", default=None): Seq(Str())
   })

--- a/src/flake.nix
+++ b/src/flake.nix
@@ -24,6 +24,7 @@
           system = "${pkgs.stdenv.system}";
           config = {
             allowUnfree = devenv.allowUnfree or false;
+            allowBroken = devenv.allowBroken or false;
             permittedInsecurePackages = devenv.permittedInsecurePackages or [];
           };
           inherit overlays;


### PR DESCRIPTION
## Motivation

Some packages are marked as broken, but can contain binaries that still work and are useful. One example of this is `ssconvert` from `pkgs.gnumeric` on Darwin. `pkgs.gnumeric` is marked as broken, but `ssconvert` works just fine, if `allowBroken = true;` is set.

## Testing

I've tested this with the aforementioned `pkgs.gnumeric` package, which is marked as broken. `allowBroken: true` in `devenv.yaml` allows to install `pkgs.gnumeric`.