### PR TITLE
 allow builtins (like set and if) within container exec commands

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -31,7 +31,7 @@ let
     # expand any envvars before exec
     cmd="`echo "$@"|${pkgs.envsubst}/bin/envsubst`"
 
-    exec $cmd
+    ${pkgs.bash}/bin/bash -c "$cmd"
   '';
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;


### PR DESCRIPTION
We need to execute the cmd with bash in order to allow "if" and other bash builtins. `exec` replaces bash entirely and these commands aren't on the path.