### PR TITLE
Nonroot containers

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -163,6 +163,21 @@ boolean
 
 
 
+## containers.\<name>.maxLayers
+
+The maximum number of layers created when the container is created.
+
+*Type:*
+int
+
+*Default:*
+` 1 `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/containers.nix](https://github.com/cachix/devenv/blob/main/src/modules/containers.nix)
+
+
+
 ## containers.\<name>.name
 
 Name of the container.

--- a/src/devenv/cli.py
+++ b/src/devenv/cli.py
@@ -681,8 +681,7 @@ def add(ctx, name, url, follows):
 )
 @click.argument("names", nargs=-1)
 @click.option("--debug", is_flag=True, help="Run tests in debug mode.")
-@click.option(
-    "--keep-going", is_flag=True, help="Continue running tests if one fails.")
+@click.option("--keep-going", is_flag=True, help="Continue running tests if one fails.")
 @click.pass_context
 def test(ctx, debug, keep_going, names):
     ctx.invoke(assemble)

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, self, devenv, ... }:
+{ pkgs, config, lib, self, ... }:
 
 let
   projectName = name:

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -21,8 +21,9 @@ let
     attribute = "containers";
   };
   shell = mk-shell-bin.lib.mkShellBin { drv = config.shell; nixpkgs = pkgs; };
+  intrbash = "${pkgs.bashInteractive}/bin/bash";
   mkEntrypoint = cfg: pkgs.writeScript "entrypoint" ''
-    #!${pkgs.bash}/bin/bash
+    #!${intrbash}
 
     export PATH=/bin
 
@@ -31,7 +32,7 @@ let
     # expand any envvars before exec
     cmd="`echo "$@"|${pkgs.envsubst}/bin/envsubst`"
 
-    bash -c "$cmd"
+    ${intrbash} -c "$cmd"
   '';
   user = "user";
   group = "user";
@@ -49,9 +50,9 @@ let
 
     mkdir -p $out/etc/pam.d
 
-    echo "root:x:0:0:System administrator:/root:/bin/bash" > \
+    echo "root:x:0:0:System administrator:/root:${intrbash}" > \
           $out/etc/passwd
-    echo "${user}:x:${uid}:${gid}::${homedir}:/bin/bash" >> \
+    echo "${user}:x:${uid}:${gid}::${homedir}:${intrbash}" >> \
           $out/etc/passwd
 
     echo "root:!x:::::::" > $out/etc/shadow
@@ -85,7 +86,6 @@ let
           pkgs.bashInteractive
           pkgs.su
           pkgs.sudo
-          devenv
         ];
         pathsToLink = "/bin";
       })
@@ -226,7 +226,7 @@ let
         type = types.package;
         internal = true;
         default = pkgs.writeScript "docker-run" ''
-          #!${pkgs.bash}/bin/bash
+          #!${intrbash}
 
           docker run -it ${config.name}:${config.version} "$@"
         '';
@@ -257,7 +257,7 @@ in
 
       containers.shell = {
         name = lib.mkDefault "shell";
-        startupCommand = lib.mkDefault "bash";
+        startupCommand = lib.mkDefault intrbash;
       };
 
       containers.processes = {

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -112,7 +112,16 @@ let
       })
       mkEtc
       mkTmp
-    ] ++ mkMultiHome (homeRoots cfg);
+    ];
+
+    maxLayers = cfg.maxLayers;
+
+    layers = [
+      (nix2container.nix2container.buildLayer {
+        perms = map mkPerm (mkMultiHome (homeRoots cfg));
+        copyToRoot = mkMultiHome (homeRoots cfg);
+      })
+    ];
 
     perms = [
       {
@@ -124,7 +133,7 @@ let
         uname = "root";
         gname = "root";
       }
-    ] ++ (map mkPerm (mkMultiHome (homeRoots cfg)));
+    ];
 
     config = {
       Entrypoint = cfg.entrypoint;
@@ -214,6 +223,12 @@ let
         type = types.nullOr types.str;
         description = "Registry to push the container to.";
         default = "docker://";
+      };
+
+      maxLayers = lib.mkOption {
+        type = types.nullOr types.int;
+        description = "Maximum number of container layers created.";
+        default = 1;
       };
 
       isBuilding = lib.mkOption {

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, self, ... }:
+{ pkgs, config, lib, self, devenv, ... }:
 
 let
   projectName = name:
@@ -31,31 +31,99 @@ let
     # expand any envvars before exec
     cmd="`echo "$@"|${pkgs.envsubst}/bin/envsubst`"
 
-    exec $cmd
+    bash -c "$cmd"
   '';
+  user = "user";
+  group = "user";
+  uid = "1000";
+  gid = "1000";
+  homedir = "/env";
+
+  mkTemp = (pkgs.runCommand "tmp" { } ''
+    mkdir -p $out/tmp
+  '');
+
+  mkUser = (pkgs.runCommand "user" { } ''
+    mkdir -p $out${homedir}
+    cp -R ${self}/* $out${homedir}/
+
+    mkdir -p $out/etc/pam.d
+
+    echo "root:x:0:0:System administrator:/root:/bin/bash" > \
+          $out/etc/passwd
+    echo "${user}:x:${uid}:${gid}::${homedir}:/bin/bash" >> \
+          $out/etc/passwd
+
+    echo "root:!x:::::::" > $out/etc/shadow
+    echo "${user}:!x:::::::" >> $out/etc/shadow
+
+    echo "root:x:0:" > $out/etc/group
+    echo "${group}:x:${gid}:" >> $out/etc/group
+
+    cat > $out/etc/pam.d/other <<EOF
+    account sufficient pam_unix.so
+    auth sufficient pam_rootok.so
+    password requisite pam_unix.so nullok sha512
+    session required pam_unix.so
+    EOF
+
+    touch $out/etc/login.defs
+  '');
+
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;
     tag = cfg.version;
+    initializeNixDatabase = true;
+    nixUid = lib.toInt uid;
+    nixGid = lib.toInt gid;
+
     copyToRoot = [
-      (pkgs.runCommand "create-paths" { } ''
-        mkdir -p $out/tmp
-      '')
       (pkgs.buildEnv {
         name = "root";
         paths = [
           pkgs.coreutils-full
-          pkgs.bash
-        ] ++ lib.optionals (cfg.copyToRoot != null)
-          (if builtins.typeOf cfg.copyToRoot == "list"
-          then cfg.copyToRoot
-          else [ cfg.copyToRoot ]);
-        pathsToLink = "/";
+          pkgs.bashInteractive
+          pkgs.su
+          pkgs.sudo
+          devenv
+        ];
+        pathsToLink = "/bin";
       })
+      mkUser
+      mkTemp
     ];
+
+    perms = [
+      {
+        path = mkUser;
+        regex = "${homedir}";
+        mode = "0744";
+        uid = lib.toInt uid;
+        gid = lib.toInt gid;
+        uname = user;
+        gname = group;
+      }
+      {
+        path = mkTemp;
+        regex = "/tmp";
+        mode = "1777";
+        uid = 0;
+        gid = 0;
+        uname = "root";
+        gname = "root";
+      }
+    ];
+
     config = {
-      Env = lib.mapAttrsToList (name: value: "${name}=${lib.escapeShellArg (toString value)}") config.env;
-      Cmd = [ cfg.startupCommand ];
       Entrypoint = cfg.entrypoint;
+      User = "${user}";
+      WorkingDir = "${homedir}";
+      Env = lib.mapAttrsToList
+        (name: value:
+          "${name}=${lib.escapeShellArg (toString value)}"
+        )
+        config.env ++ [ "HOME=${homedir}" "USER=${user}" ];
+      Cmd = [ cfg.startupCommand ];
     };
   };
 
@@ -201,7 +269,7 @@ in
       containers.${envContainerName}.isBuilding = true;
     })
     (lib.mkIf config.container.isBuilding {
-      devenv.root = lib.mkForce "/";
+      devenv.root = lib.mkForce "${homedir}";
     })
   ];
 }

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -7,7 +7,7 @@ let
     ++ (lib.optional cfg.manylinux.enable pkgs.pythonManylinuxPackages.manylinux2014Package)
     # see https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$XJ5CO4bKMevYzZq_rrNo64YycknVFJIJTy6hVCJjRlA?via=nixos.org&via=matrix.org&via=nixos.dev
     ++ [ pkgs.stdenv.cc.cc.lib ]
-    );
+  );
 
   readlink = "${pkgs.coreutils}/bin/readlink -f ";
   package = pkgs.callPackage "${pkgs.path}/pkgs/development/interpreters/python/wrapper.nix" {


### PR DESCRIPTION
- Container environments will now have a "user" user.
- The "user" user will have a home dir at `/env`.
- All devenv files (the files referenced by `containers.<name>.copyToRoot`) will now end up in `/env` and will be owned by "user".
- The /nix/store will now be owned by the `user` user.
- `/env` is now the DEVENV_ROOT when within a container.
- the shell in a container environment is now `bashInteractive`, which respects up arrow, down arrow, search, etc.
- The default user in a container environment shell is now the "user" user. 
-  The "user" user will now run all processes and services.
- The max number of layers (a `nix2container` feature) is now an option. 

I'm still a bit unsure whether the permissions of the resulting /env files are the best we can do, but I think so.  They are 744 to the user user.

It would also be nice to not have container gen take so long.  My usage of layers here was to try to speed things up after first gen, but it seems the practical max number of layers is around 100 at least if it is to be a Docker image, and that doesn't help much because it's doing a layer per derivation I think.