### PR TITLE
Allow setting rabbitMQ nodeName

### DIFF
--- a/examples/rabbitmq/.test.sh
+++ b/examples/rabbitmq/.test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -ex
+
+devenv up &
+DEVENV_PID=$!
+export DEVENV_PID
+
+devenv_stop() {
+    pkill -P "$DEVENV_PID"
+}
+
+trap devenv_stop EXIT
+
+timeout 20 bash -c 'until rabbitmqctl -q status 2>/dev/null; do sleep 0.5; done'

--- a/examples/rabbitmq/devenv.nix
+++ b/examples/rabbitmq/devenv.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  services.rabbitmq = {
+    enable = true;
+    managementPlugin = { enable = true; };
+  };
+}

--- a/examples/rabbitmq/devenv.yaml
+++ b/examples/rabbitmq/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -64,6 +64,19 @@ in
       type = types.port;
     };
 
+    nodeName = mkOption {
+      default = "rabbit@localhost";
+      type = types.str;
+      description = ''
+        The name of the RabbitMQ node.  This is used to identify
+        the node in a cluster.  If you are running multiple
+        RabbitMQ nodes on the same machine, you must give each
+        node a unique name.  The name must be of the form
+        `name@host`, where `name` is an arbitrary name and
+        `host` is the domain name of the host.
+      '';
+    };
+
     cookie = mkOption {
       default = "";
       type = types.str;
@@ -142,7 +155,7 @@ in
     env.RABBITMQ_CONFIG_FILE = config_file;
     env.RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
     env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
-    env.RABBITMQ_NODENAME = "rabbit@localhost";
+    env.RABBITMQ_NODENAME = cfg.nodeName;
     env.RABBITMQ_HOST = cfg.listenAddress;
     env.ERL_EPMD_ADDRESS = cfg.listenAddress;
 

--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -14,10 +14,13 @@ let
     [ ${concatStringsSep "," cfg.plugins} ].
   '';
 in
-
 {
   imports = [
-    (lib.mkRenamedOptionModule [ "rabbitmq" "enable" ] [ "services" "rabbitmq" "enable" ])
+    (lib.mkRenamedOptionModule [ "rabbitmq" "enable" ] [
+      "services"
+      "rabbitmq"
+      "enable"
+    ])
   ];
 
   options.services.rabbitmq = {
@@ -146,7 +149,8 @@ in
       "management.tcp.ip" = cfg.listenAddress;
     };
 
-    services.rabbitmq.plugins = optional cfg.managementPlugin.enable "rabbitmq_management";
+    services.rabbitmq.plugins =
+      optional cfg.managementPlugin.enable "rabbitmq_management";
 
     env.RABBITMQ_DATA_DIR = config.env.DEVENV_STATE + "/rabbitmq";
     env.RABBITMQ_MNESIA_BASE = config.env.RABBITMQ_DATA_DIR + "/mnesia";


### PR DESCRIPTION
Adds the ability to set a custom node name for rabbitMQ.
This then allows having more than one instance of rabbitMQ running simultaneously in different projects.