### PR TITLE
getting-started: use github url for better name inference

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,7 +57,7 @@ Recommended, speeds up the installation by providing binaries.
 === "Flake profiles"
 
     ```
-    nix profile install --accept-flake-config tarball+https://install.devenv.sh/latest
+    nix profile install --accept-flake-config github:cachix/devenv/latest
     ```
 === "Declaratively using flakes"
 


### PR DESCRIPTION
On Nix 2.20+, `nix profile` now refers to profile elements using names. These names are inferred from URLs. With the current URL it is inferred as `latest`, instead of `devenv`.

```
$ nix profile install tarball+https://install.devenv.sh/latest
$ nix profile upgrade devenv
warning: 'devenv' does not match any packages
warning: Use 'nix profile list' to see the current profile.
$ nix profile list
...
Name:               latest
```

Changing the URL would work, but for now referring to the github repo will also work:

```
$ nix profile install github:cachix/devenv/latest
$ nix profile upgrade devenv
$ nix profile list
Name:               devenv
...
```

If you'd like to look into changing the URL, you can make sure the last segment is named `devenv`. Or `devenv` is used in as the package in the flake instead of `default`. See https://github.com/NixOS/nix/blob/master/tests/unit/libexpr/flake/url-name.cc

I haven't touched the other instances of this URL, as those will likely work just fine.