### PR TITLE
Add options to Python language module

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -116,7 +116,7 @@
     cat > docs/languages-all.md <<EOF
       \`\`\`nix
       ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
-      \`\`\`   
+      \`\`\`
     EOF
   '';
 

--- a/examples/python-directory/.gitignore
+++ b/examples/python-directory/.gitignore
@@ -1,0 +1,5 @@
+
+# Devenv
+.devenv*
+devenv.local.nix
+

--- a/examples/python-directory/.test.sh
+++ b/examples/python-directory/.test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -exu
+POETRY_VENV="$PWD/directory/.venv"
+[ -d "$POETRY_VENV" ]
+[ "$(poetry env info --path)" = "$POETRY_VENV" ]
+[ "$(command -v python)" = "$POETRY_VENV/bin/python" ]
+python --version
+poetry --version
+poetry run python -c 'import requests'
+python -c 'import requests'

--- a/examples/python-directory/devenv.nix
+++ b/examples/python-directory/devenv.nix
@@ -1,0 +1,13 @@
+{ pkgs, config, ... }:
+
+{
+  languages.python = {
+    enable = true;
+    directory = "./directory";
+    poetry = {
+      enable = true;
+      install.enable = true;
+      activate.enable = true;
+    };
+  };
+}

--- a/examples/python-directory/devenv.yaml
+++ b/examples/python-directory/devenv.yaml
@@ -1,0 +1,7 @@
+---
+
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python

--- a/examples/python-directory/devenv.yaml
+++ b/examples/python-directory/devenv.yaml
@@ -1,5 +1,3 @@
----
-
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/examples/python-directory/directory/pyproject.toml
+++ b/examples/python-directory/directory/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "python-directory"
+version = "0.1.0"
+description = ""
+authors = [
+    "Bob van der Linden <bobvanderlinden@gmail.com>",
+    "Matthias Thym <git@thym.at>"
+]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+requests = "^2.30"

--- a/examples/python-poetry/devenv.nix
+++ b/examples/python-poetry/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, ... }:
+{ pkgs, config, ... }:
 
 {
   packages = [
@@ -15,6 +15,23 @@
 
   languages.python = {
     enable = true;
-    poetry.enable = true;
+    poetry = {
+      enable = true;
+      install = {
+        enable = true;
+        installRootPackage = false;
+        onlyInstallRootPackage = false;
+        compile = false;
+        quiet = false;
+        groups = [ ];
+        ignoredGroups = [ ];
+        onlyGroups = [ ];
+        extras = [ ];
+        allExtras = false;
+        verbosity = "no";
+      };
+      activate.enable = true;
+      package = pkgs.poetry;
+    };
   };
 }

--- a/examples/python-poetry/devenv.yaml
+++ b/examples/python-poetry/devenv.yaml
@@ -1,0 +1,7 @@
+---
+
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python

--- a/examples/python-poetry/devenv.yaml
+++ b/examples/python-poetry/devenv.yaml
@@ -1,5 +1,3 @@
----
-
 inputs:
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable

--- a/examples/python-poetry/pyproject.toml
+++ b/examples/python-poetry/pyproject.toml
@@ -1,15 +1,17 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "python-poetry"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
-authors = ["Bob van der Linden <bobvanderlinden@gmail.com>"]
+authors = [
+    "Bob van der Linden <bobvanderlinden@gmail.com>",
+    "Matthias Thym <git@thym.at>"
+]
 readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
 numpy = "^1.24.1"
-
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -173,6 +173,17 @@ in
       example = "3.11 or 3.11.2";
     };
 
+    directory = lib.mkOption {
+      type = lib.types.str;
+      default = config.devenv.root;
+      defaultText = lib.literalExpression "config.devenv.root";
+      description = ''
+        The Python project's root directory. Defaults to the root of the devenv project.
+        Can be an absolute path or one relative to the root of the devenv project.
+      '';
+      example = "./directory";
+    };
+
     venv.enable = lib.mkEnableOption "Python virtual environment";
 
     venv.requirements = lib.mkOption {
@@ -188,14 +199,6 @@ in
       type = lib.types.bool;
       default = false;
       description = "Whether `pip install` should avoid outputting messages during devenv initialisation.";
-    };
-
-    directory = lib.mkOption {
-      type = lib.types.str;
-      default = config.devenv.root;
-      description = ''
-        The Python project's root directory. Defaults to the root of the devenv project.
-      '';
     };
 
     poetry = {

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -39,7 +39,7 @@ let
   };
 
   initVenvScript = pkgs.writeShellScript "init-venv.sh" ''
-    # Make sure any tools are not attempting to use the python interpreter from any
+    # Make sure any tools are not attempting to use the Python interpreter from any
     # existing virtual environment. For instance if devenv was started within an venv.
     unset VIRTUAL_ENV
 
@@ -82,11 +82,11 @@ let
   initPoetryScript = pkgs.writeShellScript "init-poetry.sh" ''
     function _devenv_init_poetry_venv
     {
-      # Make sure any tools are not attempting to use the python interpreter from any
+      # Make sure any tools are not attempting to use the Python interpreter from any
       # existing virtual environment. For instance if devenv was started within an venv.
       unset VIRTUAL_ENV
 
-      # Make sure poetry's venv uses the configured python executable.
+      # Make sure poetry's venv uses the configured Python executable.
       ${cfg.poetry.package}/bin/poetry env use --no-interaction --quiet ${package.interpreter}
     }
 
@@ -94,7 +94,7 @@ let
     {
       local POETRY_INSTALL_COMMAND=(${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments} ${lib.optionalString (cfg.directory != ".") ''--directory=${cfg.directory}''})
       # Avoid running "poetry install" for every shell.
-      # Only run it when the "poetry.lock" file or python interpreter has changed.
+      # Only run it when the "poetry.lock" file or Python interpreter has changed.
       # We do this by storing the interpreter path and a hash of "poetry.lock" in venv.
       local ACTUAL_POETRY_CHECKSUM="${package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}pyproject.toml):$(${pkgs.nix}/bin/nix-hash --type sha256 "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}poetry.lock):''${POETRY_INSTALL_COMMAND[@]}"
       local POETRY_CHECKSUM_FILE="$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}.venv/poetry.lock.checksum
@@ -245,7 +245,7 @@ in
           description = "Whether to install all extras. See `--all-extras`.";
         };
       };
-      activate.enable = lib.mkEnableOption "activate the poetry virtual environment automatically";
+      activate.enable = lib.mkOption "Whether to activate the poetry virtual environment automatically.";
 
       package = lib.mkOption {
         type = lib.types.package;

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -222,7 +222,17 @@ in
         groups = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
-          description = "Which dependency-groups to install. See `--with`.";
+          description = "Which dependency groups to install. See `--with`.";
+        };
+        ignoredGroups = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Which dependency groups to ignore. See `--without`.";
+        };
+        onlyGroups = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Which dependency groups to exclusively install. See `--only`.";
         };
         extras = lib.mkOption {
           type = lib.types.listOf lib.types.str;
@@ -252,6 +262,8 @@ in
       lib.optional (!cfg.poetry.install.installRootPackage) "--no-root" ++
       lib.optional cfg.poetry.install.quiet "--quiet" ++
       lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" ''"${lib.concatStringsSep "," cfg.poetry.install.groups}"'' ] ++
+      lib.optionals (cfg.poetry.install.ignoredGroups != [ ]) [ "--without" ''"${lib.concatStringsSep "," cfg.poetry.install.ignoredGroups}"'' ] ++
+      lib.optionals (cfg.poetry.install.onlyGroups != [ ]) [ "--only" ''"${lib.concatStringsSep " " cfg.poetry.install.onlyGroups}"'' ] ++
       lib.optionals (cfg.poetry.install.extras != [ ]) [ "--extras" ''"${lib.concatStringsSep " " cfg.poetry.install.extras}"'' ] ++
       lib.optional cfg.poetry.install.allExtras "--all-extras";
 

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -43,7 +43,7 @@ let
     # existing virtual environment. For instance if devenv was started within an venv.
     unset VIRTUAL_ENV
 
-    VENV_PATH="${config.env.DEVENV_STATE}/venv"
+    VENV_PATH="${config.env.DEVENV_STATE}/${lib.optionalString (cfg.directory != ".") ''"${cfg.directory}/"''}venv"
 
     profile_python="$(${readlink} ${package.interpreter})"
     devenv_interpreter_path="$(${pkgs.coreutils}/bin/cat "$VENV_PATH/.devenv_interpreter" 2> /dev/null || echo false )"
@@ -92,12 +92,12 @@ let
 
     function _devenv_poetry_install
     {
-      local POETRY_INSTALL_COMMAND=(${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments})
+      local POETRY_INSTALL_COMMAND=(${cfg.poetry.package}/bin/poetry install --no-interaction ${lib.concatStringsSep " " cfg.poetry.install.arguments} ${lib.optionalString (cfg.directory != ".") ''--directory=${cfg.directory}''})
       # Avoid running "poetry install" for every shell.
       # Only run it when the "poetry.lock" file or python interpreter has changed.
       # We do this by storing the interpreter path and a hash of "poetry.lock" in venv.
-      local ACTUAL_POETRY_CHECKSUM="${package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 pyproject.toml):$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock):''${POETRY_INSTALL_COMMAND[@]}"
-      local POETRY_CHECKSUM_FILE="$DEVENV_ROOT"/.venv/poetry.lock.checksum
+      local ACTUAL_POETRY_CHECKSUM="${package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}pyproject.toml):$(${pkgs.nix}/bin/nix-hash --type sha256 "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}poetry.lock):''${POETRY_INSTALL_COMMAND[@]}"
+      local POETRY_CHECKSUM_FILE="$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}.venv/poetry.lock.checksum
       if [ -f "$POETRY_CHECKSUM_FILE" ]
       then
         read -r EXPECTED_POETRY_CHECKSUM < "$POETRY_CHECKSUM_FILE"
@@ -116,7 +116,7 @@ let
       fi
     }
 
-    if [ ! -f pyproject.toml ]
+    if [ ! -f "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}pyproject.toml ]
     then
       echo "No pyproject.toml found. Run 'poetry init' to create one." >&2
     else
@@ -125,7 +125,7 @@ let
         _devenv_poetry_install
       ''}
       ${lib.optionalString cfg.poetry.activate.enable ''
-        source "$DEVENV_ROOT"/.venv/bin/activate
+        source "$DEVENV_ROOT"/${lib.optionalString (cfg.directory != ".") ''${cfg.directory}/''}.venv/bin/activate
       ''}
     fi
   '';
@@ -188,6 +188,15 @@ in
       type = lib.types.bool;
       default = false;
       description = "Whether `pip install` should avoid outputting messages during devenv initialisation.";
+    };
+
+
+    directory = lib.mkOption {
+      type = lib.types.str;
+      default = ".";
+      description = ''
+        The Python project's root directory. Defaults to the root of the devenv project.
+      '';
     };
 
     poetry = {


### PR DESCRIPTION
Recently I continued using devenv for various different projects at work, so the need to have it also manage multi-language development environments got bigger.

For a lot of projects, the structure looks similar to the following.

```
project
├── backend
├── devenv.lock
├── devenv.nix
├── devenv.yaml
└── frontend
```

In this example `backend` would for example be the subdirectory of some Python/Django component and then there would be the `frontend` subdirectory e.g. some JavaScript/Node.js component.

For that reason I would like to specify a subdirectory for the individual components.

In this PR I made the necessary changes to be able to specify a working directory via `languages.python.directory`.
While it is already possible to pass paths of requirements files to install dependencies from, it is currently not possible to specify the location of the virtual environment or to change the working directory of the poetry command.

This makes it impossible to have the `pyproject.toml` file anywhere other than at the devenv root.

I also added some more missing options to `languages.python.poetry.install`.