### PR TITLE
Add OpenTofu and use as default for aws-vault

### DIFF
--- a/examples/aws-vault/devenv.nix
+++ b/examples/aws-vault/devenv.nix
@@ -1,10 +1,14 @@
-{ pkgs, ... }: {
-  languages.terraform.enable = true;
+{ pkgs, ... }:
+
+{
+  # Since Terraform adopted a non-free license (BSL 1.1) in August 2023,
+  # using terraform instead of opentofu now requires adding `allowUnfree: true` to `devenv.yaml`
+  languages.opentofu.enable = true;
 
   aws-vault = {
     enable = true;
     profile = "aws-profile";
     awscliWrapper.enable = true;
-    terraformWrapper.enable = true;
+    opentofuWrapper.enable = true;
   };
 }

--- a/src/modules/languages/opentofu.nix
+++ b/src/modules/languages/opentofu.nix
@@ -1,0 +1,23 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.opentofu;
+in
+{
+  options.languages.opentofu = {
+    enable = lib.mkEnableOption "tools for OpenTofu development";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.opentofu;
+      defaultText = lib.literalExpression "pkgs.opentofu";
+      description = "The OpenTofu package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      cfg.package
+    ];
+  };
+}


### PR DESCRIPTION
aws-vault integration is failing on CI, and probably has been since https://github.com/NixOS/nixpkgs/commit/6608f1624a8dd9d001de8fc24baa9a2d929b0e82 got merged (Terraform changed its license to the unfree BSL 1.1).

I added a comment on how to get aws-vault to work with terraform by adding `allowUnfree: true` to `devenv.yaml`, but also added the Open Source fork [OpenTofu](https://github.com/opentofu/opentofu) and a wrapper for it in aws-vault, in case people want to switch to it.