### PR TITLE
build multiplatform devcontainer image on release tag

### DIFF
--- a/.github/workflows/deploy-devcontainer-image.yml
+++ b/.github/workflows/deploy-devcontainer-image.yml
@@ -1,0 +1,59 @@
+# https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
+name: Publish Dev Container
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64,linux/arm64
+          context: ./devcontainer
+          file: ./devcontainer/Dockerfile
+          push: true
+          provenance: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.sha }}

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -9,6 +9,8 @@ RUN sudo apt-get update && sudo apt install -y xz-utils acl
 
 RUN wget -O install.sh https://nixos.org/nix/install \
   && chmod +x install.sh \
+  && mkdir -m 0755 /etc/nix \
+  && printf 'sandbox = false \nfilter-syscalls = false' > /etc/nix/nix.conf \
   && addgroup --gid 30000 --system nixbld \
   && for i in $(seq 1 30); do adduser --system --no-create-home --home /var/empty --uid $((30000 + i)) nixbld$i && adduser nixbld$i nixbld ; done \
   && USER=root sh ./install.sh --daemon --no-channel-add --nix-extra-conf-file /nix.conf \


### PR DESCRIPTION
This should solve a bunch of issues:

solves https://github.com/cachix/devenv/issues/865 (on a new tag the corresponding devcontainer will be created both tagging the tag version and `latest` i.e. `ghcr.io/cachix/devenv:v.X.X.X` and `ghcr.io/cachix/devenv:latest`)
solves https://github.com/cachix/devenv/issues/680 (this is a multiplatform docker image build for amd and arm)
partially solves https://github.com/cachix/devenv/issues/430 (building and using devcontainer on MacOs especially arm processor now works without issue)

----

I assume we'll also need to retroactively at least generate a devcontainer image for v0.6.3:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic
following the instructions to generate your CR_PART Token
then login with
```
echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin
```

https://docs.docker.com/build/building/multi-platform/

```
cd devcontainer
docker buildx create --name mybuilder --bootstrap --use
docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=v0.6.3 -t ghcr.io/cachix/devenv:v0.6.3 -t ghcr.io/cachix/devenv:latest --push .
```
