### PR TITLE
feat: Add support languages.terraform.version

### DIFF
--- a/examples/terraform/.test.sh
+++ b/examples/terraform/.test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -ex
+terraform --version | grep "1.7.4"

--- a/examples/terraform/devenv.nix
+++ b/examples/terraform/devenv.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  languages.terraform = {
+    enable = true;
+    version = "1.7.4";
+  };
+}

--- a/examples/terraform/devenv.yaml
+++ b/examples/terraform/devenv.yaml
@@ -1,0 +1,6 @@
+allowUnfree: true
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  nixpkgs-terraform:
+    url: github:stackbuilders/nixpkgs-terraform

--- a/examples/terraform/devenv.yaml
+++ b/examples/terraform/devenv.yaml
@@ -1,6 +1,4 @@
 allowUnfree: true
 inputs:
-  nixpkgs:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable
   nixpkgs-terraform:
     url: github:stackbuilders/nixpkgs-terraform

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -35,7 +35,7 @@ in
 
   config = lib.mkIf cfg.enable {
     languages.terraform.package = lib.mkMerge [
-      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform#available-versions")))
+      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform for more details.")))
     ];
 
     packages = with pkgs; [

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -1,15 +1,13 @@
-{ pkgs, config, lib, inputs, ... }:
+{ pkgs, config, lib, ... }:
 
 let
   cfg = config.languages.terraform;
 
-  nixpkgs-terraform = inputs.nixpkgs-terraform or (throw ''
-    To use languages.terraform.version, you need to add the following to your devenv.yaml:
-
-      inputs:
-        nixpkgs-terraform:
-          url: github:stackbuilders/nixpkgs-terraform
-  '');
+  nixpkgs-terraform = config.lib.getInput {
+    name = "nixpkgs-terraform";
+    url = "github:stackbuilders/nixpkgs-terraform";
+    attribute = "languages.terraform.version";
+  };
 in
 {
   options.languages.terraform = {

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -35,7 +35,7 @@ in
 
   config = lib.mkIf cfg.enable {
     languages.terraform.package = lib.mkMerge [
-      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform for more details.")))
+      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")))
     ];
 
     packages = with pkgs; [

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -35,7 +35,7 @@ in
 
   config = lib.mkIf cfg.enable {
     languages.terraform.package = lib.mkMerge [
-      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")))
+      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, update the nixpkgs-terraform input or go to https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")))
     ];
 
     packages = with pkgs; [

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -1,7 +1,15 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, lib, inputs, ... }:
 
 let
   cfg = config.languages.terraform;
+
+  nixpkgs-terraform = inputs.nixpkgs-terraform or (throw ''
+    To use languages.terraform.version, you need to add the following to your devenv.yaml:
+
+      inputs:
+        nixpkgs-terraform:
+          url: github:stackbuilders/nixpkgs-terraform
+  '');
 in
 {
   options.languages.terraform = {
@@ -13,9 +21,23 @@ in
       defaultText = lib.literalExpression "pkgs.terraform";
       description = "The Terraform package to use.";
     };
+
+    version = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        The Terraform version to use.
+        This automatically sets the `languages.terraform.package` using [nixpkgs-terraform](https://github.com/stackbuilders/nixpkgs-terraform).
+      '';
+      example = "1.5.0 or 1.6.2";
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    languages.terraform.package = lib.mkMerge [
+      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, see https://github.com/stackbuilders/nixpkgs-terraform#available-versions")))
+    ];
+
     packages = with pkgs; [
       cfg.package
       terraform-ls


### PR DESCRIPTION
This PR follows the pattern of `languages.python` to allow for easy version selection in the Terraform language module using [stackbuilders/nixpkgs-terraform](https://github.com/stackbuilders/nixpkgs-terraform).