### PR TITLE
feat: Add fortran language support

### DIFF
--- a/src/modules/languages/fortran.nix
+++ b/src/modules/languages/fortran.nix
@@ -1,0 +1,24 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.fortran;
+in
+{
+  options.languages.fortran = {
+    enable = lib.mkEnableOption "tools for Fortran Development.";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.gfortran;
+      defaultText = lib.literalExpression "pkgs.gfortran";
+      description = "The Fortran package to use.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      fortran-fpm
+      fortran-language-server
+    ];
+  };
+}


### PR DESCRIPTION
This PR adds support for fortran language in devenv project:

The following language features are added:
1. A default fortran compiler `gfortran` with an option to use your own version from nix repository
2. `fortran-fpm` a popular fortran package manager
3.  `fortran-language-server` LSP support for fortran.