### PR TITLE
feat: add DEVENV_RUNTIME directory

### DIFF
--- a/docs/files-and-variables.md
+++ b/docs/files-and-variables.md
@@ -41,6 +41,11 @@ Points to `$DEVENV_ROOT/.devenv`.
 
 Points to `$DEVENV_DOTFILE/state`.
 
+### $DEVENV_RUNTIME
+
+Points to a temporary directory with a path that's unique to each `$DEVENV_ROOT`.
+It's similar in purpose to `/run`.
+
 ### $DEVENV_PROFILE
 
 Points to the Nix store path that has final profile of packages/scripts provided by devenv.

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -4,6 +4,10 @@ let
   cfg = config.services.postgres;
   types = lib.types;
 
+  q = lib.escapeShellArg;
+
+  runtimeDir = "${config.env.DEVENV_RUNTIME}/postgres";
+
   postgresPkg =
     if cfg.extensions != null then
       if builtins.hasAttr "withPackages" cfg.package
@@ -61,7 +65,7 @@ let
   runInitialScript =
     if cfg.initialScript != null then
       ''
-        echo ${lib.escapeShellArg cfg.initialScript} | psql --dbname postgres
+        echo ${q cfg.initialScript} | psql --dbname postgres
       ''
     else
       "";
@@ -99,21 +103,13 @@ let
       echo "PostgreSQL is setting up the initial database."
       echo
       OLDPGHOST="$PGHOST"
-      PGHOST=$(mktemp -d "$DEVENV_STATE/pg-init-XXXXXX")
+      PGHOST=${q runtimeDir}
 
-      function remove_tmp_pg_init_sock_dir() {
-        if [[ -d "$1" ]]; then
-          rm -rf "$1"
-        fi
-      }
-      trap "remove_tmp_pg_init_sock_dir '$PGHOST'" EXIT
-
-      pg_ctl -D "$PGDATA" -w start -o "-c unix_socket_directories=$PGHOST -c listen_addresses= -p ${toString cfg.port}"
+      pg_ctl -D "$PGDATA" -w start -o "-c unix_socket_directories=${runtimeDir} -c listen_addresses= -p ${toString cfg.port}"
       ${setupInitialDatabases}
 
       ${runInitialScript}
       pg_ctl -D "$PGDATA" -m fast -w stop
-      remove_tmp_pg_init_sock_dir "$PGHOST"
       PGHOST="$OLDPGHOST"
       unset OLDPGHOST
     else
@@ -125,6 +121,7 @@ let
   '';
   startScript = pkgs.writeShellScriptBin "start-postgres" ''
     set -euo pipefail
+    mkdir -p ${q runtimeDir}
     ${setupScript}/bin/setup-postgres
     exec ${postgresPkg}/bin/postgres
   '';
@@ -282,14 +279,13 @@ in
     packages = [ postgresPkg startScript ];
 
     env.PGDATA = config.env.DEVENV_STATE + "/postgres";
-    env.PGHOST = config.env.PGDATA;
+    env.PGHOST = runtimeDir;
     env.PGPORT = cfg.port;
 
     services.postgres.settings = {
       listen_addresses = cfg.listen_addresses;
       port = cfg.port;
-      # relative to PGDATA
-      unix_socket_directories = lib.mkDefault ".";
+      unix_socket_directories = lib.mkDefault runtimeDir;
     };
 
     processes.postgres = {


### PR DESCRIPTION
This PR creates a new directory, `DEVENV_RUNTIME`. Its purpose is similar to `/run` and `XDG_RUNTIME_DIR`. It's created under `/tmp` with a short path name so that Unix domain sockets can be created there without hitting path length limits.

This also changes PostgreSQL to use `DEVENV_RUNTIME` so that it can work without worrying about the path length of the project directory. It should fix the issue described in #540. For a complete fix, modules that use Unix domain sockets also need to be fixed.
