### PR TITLE
docs(phoenix): remove interactive prompt from devenv shell init script

### DIFF
--- a/examples/phoenix/devenv.nix
+++ b/examples/phoenix/devenv.nix
@@ -18,8 +18,8 @@
     if [ ! -d "hello" ]; then
       mix local.hex --force
       mix local.rebar --force
-      mix archive.install hex phx_new
-      mix phx.new hello
+      mix archive.install --force hex phx_new
+      mix phx.new --install hello
     fi
   '';
 }


### PR DESCRIPTION
`devenv shell` should not prompt the user for (y/n) questions.