### PR TITLE
services/mysql: use empty config while mysql server bootstrapping, fi…

### DIFF
--- a/tests/mysql/.test.sh
+++ b/tests/mysql/.test.sh
@@ -1,0 +1,6 @@
+wait_for_port 3306
+# through unix_socket
+mysql -e 'SELECT VERSION()'
+
+# through tcp/ip
+mysql -h 127.0.0.1 -udb -pdb -e 'SELECT VERSION()'

--- a/tests/mysql/devenv.nix
+++ b/tests/mysql/devenv.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+{
+  services.mysql = {
+    enable = true;
+    initialDatabases = [{ name = "db"; }];
+    ensureUsers = [{
+      name = "db";
+      password = "db";
+      ensurePermissions = { "*.*" = "ALL PRIVILEGES"; };
+    }];
+    settings = {
+      mysql = {
+        host = "127.0.0.1";
+        user = "db";
+        password = "db";
+      };
+    };
+  };
+}


### PR DESCRIPTION
…xes #1007


When the user configures a mysql client password, it affects also our configuration script and this blocks the bootstrap process.

I created similar wrapper as before, but with empty config file.