### PR TITLE
Updated source_url in .envrc

### DIFF
--- a/devenv/init/.envrc
+++ b/devenv/init/.envrc
@@ -1,3 +1,3 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-vQHh9/fZ+UvAS1uFqtTwXlEop31C5gx37i5t73aO15g="
 
 use devenv

--- a/examples/simple/.envrc
+++ b/examples/simple/.envrc
@@ -1,3 +1,3 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/d1f7b48e35e6dee421cfd0f51481d17f77586997/direnvrc" "sha256-YBzqskFZxmNb3kYVoKD9ZixoPXJh1C9ZvTLGFRkauZ0="
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-vQHh9/fZ+UvAS1uFqtTwXlEop31C5gx37i5t73aO15g="
 
 use devenv

--- a/examples/supported-languages/.envrc
+++ b/examples/supported-languages/.envrc
@@ -1,3 +1,3 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/af67fa52f0d0588b185069354a4c94aba0e32476/direnvrc" "sha256-sLuqWQl6hJ8eO1xaDwUETRnobEV+LL/9rhje9calUz8="
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-vQHh9/fZ+UvAS1uFqtTwXlEop31C5gx37i5t73aO15g="
 
 use devenv


### PR DESCRIPTION
The current version of `.envrc`, which is used by `devenv init`, refers to an outdated version of `direnvrc`. I did not check the differences between the versions but assumed, that the newer one should be provided for the users of the `init` command.

BTW: Very nice tool. I like it very much.