### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@
 
 ### 2. Install [Cachix](https://cachix.org)
 
-Recommended, speeds up the installation by providing binaries.
+Speeds up the installation by providing binaries.
 
 === "Newcomers"
 


### PR DESCRIPTION
TL;DR the installation of `cachix` is required at least for Mac with Apple Silicon chip.


I'm new to all this `nix` ecosystem. And tried to follow the getting started guide.
On the second step, I followed the link for Cachix and got an impression that it's a paid product. At the same time the step saying "Recommended" suggests that it's optional.

So I though it's some sort of an advertisement of the product, and thought that I might get back to it later when I'm more comfortable with the tool and want to pay for extra superpowers 🙂 

Apparently it failed and folks in Discord suggested that the step is required and I should not worry about it, as only users who fill the cache are paying, for the rest it's free 🙌🏻 
