### PR TITLE
processes: add documentation url to processes help output

### DIFF
--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -186,7 +186,7 @@ enum Commands {
 }
 
 #[derive(Subcommand, Clone)]
-#[clap(about = "Start or stop processes.")]
+#[clap(about = "Start or stop processes. https://devenv.sh/processes/")]
 enum ProcessesCommand {
     #[command(alias = "start")]
     Up {


### PR DESCRIPTION
Add missing documenatation URL to `devenv processes` command help output.
