### PR TITLE
up: add missing new line to log message

### DIFF
--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -945,7 +945,7 @@ impl App {
         }
 
         {
-            let _logprogress = log::LogProgress::new("Starting processes", false);
+            let _logprogress = log::LogProgress::new("Starting processes", true);
 
             let process = process.unwrap_or("");
 


### PR DESCRIPTION
Add missing new line to `devenv up` log output.

Original output:

```
• Building processes ...
• Using Cachix: devenv
✔ Building processes in 1.1s.
• Starting processes ...• Building shell ...
✔ Building shell in 0.7s.
```

New output:
```
• Building processes ...
• Using Cachix: devenv
✔ Building processes in 1.1s.
• Starting processes ...
• Building shell ...
✔ Building shell in 0.7s.
```
