### PR TITLE
fix: `Env` should not be escaped

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -141,7 +141,7 @@ let
       WorkingDir = "${homeDir}";
       Env = lib.mapAttrsToList
         (name: value:
-          "${name}=${lib.escapeShellArg (toString value)}"
+          "${name}=${toString value}"
         )
         config.env ++ [ "HOME=${homeDir}" "USER=${user}" ];
       Cmd = [ cfg.startupCommand ];


### PR DESCRIPTION
According to https://github.com/opencontainers/image-spec/blob/main/config.md:

> Entries are in the format of `VARNAME=VARVALUE`. These values act as defaults and are merged with any specified when creating a container.

The `VARVALUE` part does not understand shell escape or quotes.