### PR TITLE
Pass command line arguments to mysql scripts

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -293,11 +293,17 @@ in
         MYSQL_TCP_PORT = toString cfg.settings.mysqld.port;
       });
 
-    scripts.mysql.exec = "${mysqlWrapped}/bin/mysql";
+    scripts.mysql.exec = ''
+      ${mysqlWrapped}/bin/mysql "$@"
+    '';
 
-    scripts.mysqladmin.exec = "${mysqladminWrapped}/bin/mysqladmin";
+    scripts.mysqladmin.exec = ''
+      ${mysqladminWrapped}/bin/mysqladmin "$@"
+    '';
 
-    scripts.mysqldump.exec = "${mysqldumpWrapped}/bin/mysqldump";
+    scripts.mysqldump.exec = ''
+      ${mysqldumpWrapped}/bin/mysqldump "$@"
+    '';
 
     processes.mysql.exec = "${startScript}/bin/start-mysql";
     processes.mysql-configure.exec = "${configureScript}/bin/configure-mysql";

--- a/tests/mysql/.test.sh
+++ b/tests/mysql/.test.sh
@@ -1,6 +1,14 @@
+set -e
+
 wait_for_port 3306
+
+# Wait for configure-mysql to finish.
+sleep 5
+
 # through unix_socket
 mysql -e 'SELECT VERSION()'
 
 # through tcp/ip
-mysql -h 127.0.0.1 -udb -pdb -e 'SELECT VERSION()'
+mysql -h "127.0.0.1" -udb -pdb -e 'SELECT VERSION()'
+
+ping-mysql

--- a/tests/mysql/devenv.nix
+++ b/tests/mysql/devenv.nix
@@ -16,4 +16,8 @@
       };
     };
   };
+
+  scripts.ping-mysql.exec = ''
+    $DEVENV_PROFILE/bin/mysqladmin ping
+  '';
 }


### PR DESCRIPTION
@M-arcus and I encountered an issue when working with the mysql and mysqladmin scripts. This was caused by command line arguments not being passed to the underlying mysql binaries.

This PR therefore fixes #1007 

I also updated the mysql tests, because they didn't wait for the configure-mysql process to finish and didn't test for the issue described above.