### PR TITLE
docs: Fix undefined variable in minimal flake-parts example

### DIFF
--- a/docs/guides/using-with-flake-parts.md
+++ b/docs/guides/using-with-flake-parts.md
@@ -35,7 +35,7 @@ Here's an example of a minimal `flake.nix` file that includes `devenv`:
     devenv.url = "github:cachix/devenv";
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs = inputs@{ flake-parts, nixpkgs, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.devenv.flakeModule


### PR DESCRIPTION
Fixes a non working example in the docs