### PR TITLE
Update restart Nix command for macOS to include -k flag

### DIFF
--- a/devenv/src/command.rs
+++ b/devenv/src/command.rs
@@ -298,7 +298,7 @@ impl App {
                     let restart_command = if cfg!(target_os = "linux") {
                         "sudo systemctl restart nix-daemon"
                     } else {
-                        "sudo launchctl kickstart system/org.nixos.nix-daemon"
+                        "sudo launchctl kickstart -k system/org.nixos.nix-daemon"
                     };
                     if trusted == Some(0) {
                         self.logger.error(&indoc::formatdoc!(


### PR DESCRIPTION
This PR adds a recommendation to use the `-k` flag when invoking `launchctl kickstart` to ensure that the Nix daemon is launched even if it is already running.

For context: while bootstrapping a new machine running MacOS today I ran into a small issue when setting up Nix + devenv. Specifically I installed Nix using the Determinate Systems installer then ran into an error when first running devenv since my user was not in the `trusted-users` list. When I used the suggested command I kept getting the same error since the Nix daemon had not actually been restarted which led me to try with the additional `-k` flag. I'm fairly new to MacOS, but from what I can tell on the launchctl docs this additional flag is required to actually restart the service.


