### PR TITLE
examples/rubyonrails: make test pass

### DIFF
--- a/examples/rubyonrails/devenv.nix
+++ b/examples/rubyonrails/devenv.nix
@@ -15,12 +15,12 @@
 
   enterShell = ''
     if [ ! -d "blog" ]; then
-      gem install rails
-      rails new blog --database=postgresql --force
+      gem install rails || exit 1
+      rails new blog --database=postgresql --force || exit 1
     fi
     export PATH="$DEVENV_ROOT/blog/bin:$PATH"
     pushd blog
-      bundle
+      bundle || exit 1
     popd
   '';
 }

--- a/examples/rubyonrails/devenv.nix
+++ b/examples/rubyonrails/devenv.nix
@@ -7,6 +7,8 @@
   packages = [
     pkgs.openssl
     pkgs.libyaml
+    pkgs.git
+    pkgs.curl
   ];
 
   services.postgres.enable = true;


### PR DESCRIPTION
The tests now seem to run inside a pure environment and tests were failing with strange errors.

Initially I worked through the `gem install rails` failures by installing the failing gems individually. This worked, but lead me to a failure from `railties` which [required `git` to be available](https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/railties/lib/rails/generators/app_base.rb#L733). After adding `git`, it seemed that installing the individual gems wasn't needed anymore, so I removed those statements. Let's :crossed_fingers: something in my environment hasn't made the test succeed by accident.

Lastly, the test itself uses curl to fetch the version from rails, so this package is also added.

I tested this using:

```
git clean -xdf examples/ && nix build && PATH=$PWD/result/bin:$PATH ./result/bin/devenv-run-tests 
--only rubyonrails examples
```

Just a side-note: I'm still somewhat unsure about the process-manager that runs inside the test. It exists _after_ `devenv-run-tests` exits. Left-over processes might potentially influence other things.