### PR TITLE
docs: nix-darwin linux-builder module link

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -4,7 +4,9 @@
 
     To be able to generate containers on macOS, you will need to use a remote Linux builder.
 
-    The easiest way is to [set the remote builder up using Nix](https://nixos.org/manual/nixpkgs/unstable/#sec-darwin-builder).
+    The easiest ways to do so are:
+    - [Set the remote builder up using Nix](https://nixos.org/manual/nixpkgs/unstable/#sec-darwin-builder).
+    - [Use the nix-darwin linux-builder module](https://github.com/LnL7/nix-darwin/blob/master/modules/nix/linux-builder.nix).
 
 Use `devenv container build <name>` to generate an [OCI container](https://opencontainers.org/) from your development environment.
 


### PR DESCRIPTION
Just a small documentation addition for setting up linux builders on Darwin that hopefully some will find useful if they don't already know about it.

The Darwin module allows for easy linux-builder setup with a 1 line enable through:
    `nix.linux-builder.enable = true;`