### PR TITLE
docs: update home page

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -25,6 +25,7 @@
   languages.python.venv.requirements = ./requirements.txt;
   languages.javascript.enable = true;
   languages.javascript.npm.enable = true;
+  languages.javascript.npm.install.enable = true;
 
   devcontainer.enable = true;
   devcontainer.settings.customizations.vscode.extensions = [ "jnoortheen.nix-ide" ];

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -25,3 +25,10 @@ body {
 .md-main__inner {
     padding-bottom: 1rem;
 }
+
+@layer components {
+    .language-shell::before {
+        content: attr(data-shell-prefix);
+        @apply me-2 text-blue-300;
+    }
+}

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,6 +1,6 @@
-@import 'tailwindcss/base';
-@import 'tailwindcss/components';
-@import 'tailwindcss/utilities';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 body {
     /* Override the mkdocs default of 0.5rem */

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -2,6 +2,11 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+body {
+    /* Override the mkdocs default of 0.5rem */
+    font-size: 0.8rem; /* 16px */
+}
+
 /* hide site name */
 .md-header__topic {
     visibility: hidden;

--- a/docs/assets/output.css
+++ b/docs/assets/output.css
@@ -592,87 +592,16 @@ html {
   }
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-.pointer-events-none {
-  pointer-events: none;
-}
-
-.visible {
-  visibility: visible;
-}
-
-.collapse {
-  visibility: collapse;
-}
-
 .static {
   position: static;
-}
-
-.absolute {
-  position: absolute;
 }
 
 .relative {
   position: relative;
 }
 
-.inset-0 {
-  inset: 0px;
-}
-
-.-inset-y-px {
-  top: -1px;
-  bottom: -1px;
-}
-
-.inset-x-0 {
-  left: 0px;
-  right: 0px;
-}
-
-.-left-3 {
-  left: -0.6rem;
-}
-
-.-top-40 {
-  top: -8rem;
-}
-
-.-top-80 {
-  top: -16rem;
-}
-
-.left-1 {
-  left: 0.2rem;
-}
-
-.top-1 {
-  top: 0.2rem;
-}
-
 .isolate {
   isolation: isolate;
-}
-
-.-z-10 {
-  z-index: -10;
-}
-
-.mx-0 {
-  margin-left: 0px;
-  margin-right: 0px;
 }
 
 .mx-auto {
@@ -680,28 +609,8 @@ html {
   margin-right: auto;
 }
 
-.-mb-px {
-  margin-bottom: -1px;
-}
-
-.mb-4 {
-  margin-bottom: 0.8rem;
-}
-
 .mb-6 {
   margin-bottom: 1.2rem;
-}
-
-.mb-8 {
-  margin-bottom: 1.6rem;
-}
-
-.ms-2 {
-  margin-inline-start: 0.4rem;
-}
-
-.mt-1 {
-  margin-top: 0.2rem;
 }
 
 .mt-10 {
@@ -732,48 +641,12 @@ html {
   display: flex;
 }
 
-.table {
-  display: table;
-}
-
 .grid {
   display: grid;
 }
 
-.contents {
-  display: contents;
-}
-
-.hidden {
-  display: none;
-}
-
-.h-2 {
-  height: 0.4rem;
-}
-
-.h-5 {
-  height: 1rem;
-}
-
 .h-8 {
   height: 1.6rem;
-}
-
-.h-full {
-  height: 100%;
-}
-
-.w-5 {
-  width: 1rem;
-}
-
-.w-full {
-  width: 100%;
-}
-
-.w-screen {
-  width: 100vw;
 }
 
 .max-w-2xl {
@@ -784,65 +657,16 @@ html {
   max-width: 38.4rem;
 }
 
-.max-w-4xl {
-  max-width: 44.8rem;
-}
-
-.max-w-5xl {
-  max-width: 51.2rem;
-}
-
 .max-w-7xl {
   max-width: 64rem;
-}
-
-.max-w-lg {
-  max-width: 25.6rem;
-}
-
-.max-w-none {
-  max-width: none;
 }
 
 .max-w-xl {
   max-width: 28.8rem;
 }
 
-.border-collapse {
-  border-collapse: collapse;
-}
-
-.origin-bottom-left {
-  transform-origin: bottom left;
-}
-
-.-translate-x-1 {
-  --tw-translate-x: -0.2rem;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.transform {
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.transform-gpu {
-  transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.resize {
-  resize: both;
-}
-
 .grid-cols-1 {
   grid-template-columns: repeat(1, minmax(0, 1fr));
-}
-
-.grid-cols-2 {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.items-start {
-  align-items: flex-start;
 }
 
 .items-center {
@@ -867,10 +691,6 @@ html {
   row-gap: 3.2rem;
 }
 
-.gap-y-20 {
-  row-gap: 4rem;
-}
-
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
   margin-top: calc(1.6rem * calc(1 - var(--tw-space-y-reverse)));
@@ -881,43 +701,19 @@ html {
   overflow: hidden;
 }
 
-.overflow-x-auto {
-  overflow-x: auto;
-}
-
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.rounded-3xl {
-  border-radius: 1.2rem;
-}
-
-.rounded-full {
-  border-radius: 9999px;
-}
-
 .rounded-md {
   border-radius: 0.3rem;
-}
-
-.rounded-xl {
-  border-radius: 0.6rem;
 }
 
 .rounded-b-xl {
   border-bottom-right-radius: 0.6rem;
   border-bottom-left-radius: 0.6rem;
-}
-
-.rounded-tl-xl {
-  border-top-left-radius: 0.6rem;
-}
-
-.border {
-  border-width: 1px;
 }
 
 .border-b {
@@ -932,46 +728,12 @@ html {
   border-top-width: 1px;
 }
 
-.border-t-2 {
-  border-top-width: 2px;
-}
-
-.border-gray-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
-}
-
-.border-gray-600 {
-  --tw-border-opacity: 1;
-  border-color: rgb(75 85 99 / var(--tw-border-opacity));
-}
-
-.border-white {
-  --tw-border-opacity: 1;
-  border-color: rgb(255 255 255 / var(--tw-border-opacity));
-}
-
-.border-b-white {
-  --tw-border-opacity: 1;
-  border-bottom-color: rgb(255 255 255 / var(--tw-border-opacity));
-}
-
 .border-b-white\/20 {
   border-bottom-color: rgb(255 255 255 / 0.2);
 }
 
-.border-r-white {
-  --tw-border-opacity: 1;
-  border-right-color: rgb(255 255 255 / var(--tw-border-opacity));
-}
-
 .border-r-white\/10 {
   border-right-color: rgb(255 255 255 / 0.1);
-}
-
-.border-t-white {
-  --tw-border-opacity: 1;
-  border-top-color: rgb(255 255 255 / var(--tw-border-opacity));
 }
 
 .border-t-white\/20 {
@@ -988,21 +750,6 @@ html {
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
 
-.bg-gray-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(229 231 235 / var(--tw-bg-opacity));
-}
-
-.bg-gray-400 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(156 163 175 / var(--tw-bg-opacity));
-}
-
-.bg-gray-800 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(31 41 55 / var(--tw-bg-opacity));
-}
-
 .bg-gray-800\/40 {
   background-color: rgb(31 41 55 / 0.4);
 }
@@ -1010,16 +757,6 @@ html {
 .bg-gray-900 {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity));
-}
-
-.bg-indigo-100 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(224 231 255 / var(--tw-bg-opacity));
-}
-
-.bg-indigo-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(99 102 241 / var(--tw-bg-opacity));
 }
 
 .bg-white {
@@ -1031,35 +768,8 @@ html {
   background-color: rgb(255 255 255 / 0.05);
 }
 
-.bg-gradient-to-tr {
-  background-image: linear-gradient(to top right, var(--tw-gradient-stops));
-}
-
-.object-cover {
-  -o-object-fit: cover;
-     object-fit: cover;
-}
-
 .p-1 {
   padding: 0.2rem;
-}
-
-.p-2 {
-  padding: 0.4rem;
-}
-
-.p-3 {
-  padding: 0.6rem;
-}
-
-.px-0 {
-  padding-left: 0px;
-  padding-right: 0px;
-}
-
-.px-1 {
-  padding-left: 0.2rem;
-  padding-right: 0.2rem;
 }
 
 .px-2 {
@@ -1082,34 +792,9 @@ html {
   padding-right: 0.8rem;
 }
 
-.px-6 {
-  padding-left: 1.2rem;
-  padding-right: 1.2rem;
-}
-
-.px-8 {
-  padding-left: 1.6rem;
-  padding-right: 1.6rem;
-}
-
-.py-0 {
-  padding-top: 0px;
-  padding-bottom: 0px;
-}
-
-.py-1 {
-  padding-top: 0.2rem;
-  padding-bottom: 0.2rem;
-}
-
 .py-14 {
   padding-top: 2.8rem;
   padding-bottom: 2.8rem;
-}
-
-.py-16 {
-  padding-top: 3.2rem;
-  padding-bottom: 3.2rem;
 }
 
 .py-2 {
@@ -1122,77 +807,13 @@ html {
   padding-bottom: 0.5rem;
 }
 
-.py-24 {
-  padding-top: 4.8rem;
-  padding-bottom: 4.8rem;
-}
-
-.py-32 {
-  padding-top: 6.4rem;
-  padding-bottom: 6.4rem;
-}
-
-.py-48 {
-  padding-top: 9.6rem;
-  padding-bottom: 9.6rem;
-}
-
-.py-56 {
-  padding-top: 11.2rem;
-  padding-bottom: 11.2rem;
-}
-
 .py-8 {
   padding-top: 1.6rem;
   padding-bottom: 1.6rem;
 }
 
-.pb-14 {
-  padding-bottom: 2.8rem;
-}
-
-.pl-16 {
-  padding-left: 3.2rem;
-}
-
-.pl-3 {
-  padding-left: 0.6rem;
-}
-
-.pl-9 {
-  padding-left: 1.8rem;
-}
-
-.pr-0 {
-  padding-right: 0px;
-}
-
-.pr-4 {
-  padding-right: 0.8rem;
-}
-
 .pt-14 {
   padding-top: 2.8rem;
-}
-
-.pt-16 {
-  padding-top: 3.2rem;
-}
-
-.pt-3 {
-  padding-top: 0.6rem;
-}
-
-.pt-4 {
-  padding-top: 0.8rem;
-}
-
-.pt-6 {
-  padding-top: 1.2rem;
-}
-
-.pt-8 {
-  padding-top: 1.6rem;
 }
 
 .text-center {
@@ -1207,16 +828,6 @@ html {
 .text-3xl {
   font-size: 1.5rem;
   line-height: 1.8rem;
-}
-
-.text-4xl {
-  font-size: 1.8rem;
-  line-height: 2rem;
-}
-
-.text-6xl {
-  font-size: 3rem;
-  line-height: 1;
 }
 
 .text-base {
@@ -1237,11 +848,6 @@ html {
 .text-xl {
   font-size: 1rem;
   line-height: 1.4rem;
-}
-
-.text-xs {
-  font-size: 0.6rem;
-  line-height: 0.8rem;
 }
 
 .font-bold {
@@ -1287,16 +893,6 @@ html {
   color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
-.text-gray-300 {
-  --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
-}
-
-.text-gray-400 {
-  --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity));
-}
-
 .text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
@@ -1312,28 +908,9 @@ html {
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
-.text-indigo-600 {
-  --tw-text-opacity: 1;
-  color: rgb(79 70 229 / var(--tw-text-opacity));
-}
-
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.underline {
-  text-decoration-line: underline;
-}
-
-.opacity-20 {
-  opacity: 0.2;
-}
-
-.shadow {
-  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-sm {
@@ -1342,50 +919,8 @@ html {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.outline {
-  outline-style: solid;
-}
-
-.ring-1 {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-}
-
-.ring-inset {
-  --tw-ring-inset: inset;
-}
-
-.ring-black {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(0 0 0 / var(--tw-ring-opacity));
-}
-
-.ring-white {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(255 255 255 / var(--tw-ring-opacity));
-}
-
-.blur {
-  --tw-blur: blur(8px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.blur-3xl {
-  --tw-blur: blur(64px);
-  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
 .filter {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.transition {
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
-  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
 }
 
 body {

--- a/docs/assets/output.css
+++ b/docs/assets/output.css
@@ -592,6 +592,13 @@ html {
   }
 }
 
+.language-shell::before {
+  content: attr(data-shell-prefix);
+  margin-inline-end: 0.4rem;
+  --tw-text-opacity: 1;
+  color: rgb(147 197 253 / var(--tw-text-opacity));
+}
+
 .static {
   position: static;
 }

--- a/docs/assets/output.css
+++ b/docs/assets/output.css
@@ -446,6 +446,10 @@ video {
   display: none;
 }
 
+html {
+  font-size: 20px;
+}
+
 *, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -588,6 +592,18 @@ video {
   }
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
 .pointer-events-none {
   pointer-events: none;
 }
@@ -627,23 +643,23 @@ video {
 }
 
 .-left-3 {
-  left: -0.75rem;
+  left: -0.6rem;
 }
 
 .-top-40 {
-  top: -10rem;
+  top: -8rem;
 }
 
 .-top-80 {
-  top: -20rem;
+  top: -16rem;
 }
 
 .left-1 {
-  left: 0.25rem;
+  left: 0.2rem;
 }
 
 .top-1 {
-  top: 0.25rem;
+  top: 0.2rem;
 }
 
 .isolate {
@@ -669,31 +685,39 @@ video {
 }
 
 .mb-4 {
-  margin-bottom: 1rem;
+  margin-bottom: 0.8rem;
 }
 
 .mb-6 {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.2rem;
 }
 
 .mb-8 {
-  margin-bottom: 2rem;
+  margin-bottom: 1.6rem;
+}
+
+.ms-2 {
+  margin-inline-start: 0.4rem;
+}
+
+.mt-1 {
+  margin-top: 0.2rem;
 }
 
 .mt-10 {
-  margin-top: 2.5rem;
+  margin-top: 2rem;
 }
 
 .mt-2 {
-  margin-top: 0.5rem;
+  margin-top: 0.4rem;
 }
 
 .mt-4 {
-  margin-top: 1rem;
+  margin-top: 0.8rem;
 }
 
 .mt-6 {
-  margin-top: 1.5rem;
+  margin-top: 1.2rem;
 }
 
 .block {
@@ -725,15 +749,15 @@ video {
 }
 
 .h-2 {
-  height: 0.5rem;
+  height: 0.4rem;
 }
 
 .h-5 {
-  height: 1.25rem;
+  height: 1rem;
 }
 
 .h-8 {
-  height: 2rem;
+  height: 1.6rem;
 }
 
 .h-full {
@@ -741,7 +765,7 @@ video {
 }
 
 .w-5 {
-  width: 1.25rem;
+  width: 1rem;
 }
 
 .w-full {
@@ -753,23 +777,27 @@ video {
 }
 
 .max-w-2xl {
-  max-width: 42rem;
+  max-width: 33.6rem;
+}
+
+.max-w-3xl {
+  max-width: 38.4rem;
 }
 
 .max-w-4xl {
-  max-width: 56rem;
+  max-width: 44.8rem;
 }
 
 .max-w-5xl {
-  max-width: 64rem;
+  max-width: 51.2rem;
 }
 
 .max-w-7xl {
-  max-width: 80rem;
+  max-width: 64rem;
 }
 
 .max-w-lg {
-  max-width: 32rem;
+  max-width: 25.6rem;
 }
 
 .max-w-none {
@@ -777,7 +805,7 @@ video {
 }
 
 .max-w-xl {
-  max-width: 36rem;
+  max-width: 28.8rem;
 }
 
 .border-collapse {
@@ -789,7 +817,7 @@ video {
 }
 
 .-translate-x-1 {
-  --tw-translate-x: -0.25rem;
+  --tw-translate-x: -0.2rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -826,27 +854,27 @@ video {
 }
 
 .gap-x-6 {
-  -moz-column-gap: 1.5rem;
-       column-gap: 1.5rem;
+  -moz-column-gap: 1.2rem;
+       column-gap: 1.2rem;
 }
 
 .gap-x-8 {
-  -moz-column-gap: 2rem;
-       column-gap: 2rem;
+  -moz-column-gap: 1.6rem;
+       column-gap: 1.6rem;
 }
 
 .gap-y-16 {
-  row-gap: 4rem;
+  row-gap: 3.2rem;
 }
 
 .gap-y-20 {
-  row-gap: 5rem;
+  row-gap: 4rem;
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-y-reverse: 0;
-  margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+  margin-top: calc(1.6rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(1.6rem * var(--tw-space-y-reverse));
 }
 
 .overflow-hidden {
@@ -864,7 +892,7 @@ video {
 }
 
 .rounded-3xl {
-  border-radius: 1.5rem;
+  border-radius: 1.2rem;
 }
 
 .rounded-full {
@@ -872,20 +900,20 @@ video {
 }
 
 .rounded-md {
-  border-radius: 0.375rem;
+  border-radius: 0.3rem;
 }
 
 .rounded-xl {
-  border-radius: 0.75rem;
+  border-radius: 0.6rem;
 }
 
 .rounded-b-xl {
-  border-bottom-right-radius: 0.75rem;
-  border-bottom-left-radius: 0.75rem;
+  border-bottom-right-radius: 0.6rem;
+  border-bottom-left-radius: 0.6rem;
 }
 
 .rounded-tl-xl {
-  border-top-left-radius: 0.75rem;
+  border-top-left-radius: 0.6rem;
 }
 
 .border {
@@ -1013,15 +1041,15 @@ video {
 }
 
 .p-1 {
-  padding: 0.25rem;
+  padding: 0.2rem;
 }
 
 .p-2 {
-  padding: 0.5rem;
+  padding: 0.4rem;
 }
 
 .p-3 {
-  padding: 0.75rem;
+  padding: 0.6rem;
 }
 
 .px-0 {
@@ -1030,104 +1058,109 @@ video {
 }
 
 .px-1 {
-  padding-left: 0.25rem;
-  padding-right: 0.25rem;
+  padding-left: 0.2rem;
+  padding-right: 0.2rem;
 }
 
 .px-2 {
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+  padding-left: 0.4rem;
+  padding-right: 0.4rem;
 }
 
 .px-3 {
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
 }
 
 .px-3\.5 {
-  padding-left: 0.875rem;
-  padding-right: 0.875rem;
+  padding-left: 0.7rem;
+  padding-right: 0.7rem;
 }
 
 .px-4 {
-  padding-left: 1rem;
-  padding-right: 1rem;
+  padding-left: 0.8rem;
+  padding-right: 0.8rem;
 }
 
 .px-6 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
+  padding-left: 1.2rem;
+  padding-right: 1.2rem;
 }
 
 .px-8 {
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: 1.6rem;
+  padding-right: 1.6rem;
+}
+
+.py-0 {
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 
 .py-1 {
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
 }
 
 .py-14 {
-  padding-top: 3.5rem;
-  padding-bottom: 3.5rem;
+  padding-top: 2.8rem;
+  padding-bottom: 2.8rem;
 }
 
 .py-16 {
-  padding-top: 4rem;
-  padding-bottom: 4rem;
+  padding-top: 3.2rem;
+  padding-bottom: 3.2rem;
 }
 
 .py-2 {
+  padding-top: 0.4rem;
+  padding-bottom: 0.4rem;
+}
+
+.py-2\.5 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
 
-.py-2\.5 {
-  padding-top: 0.625rem;
-  padding-bottom: 0.625rem;
-}
-
 .py-24 {
-  padding-top: 6rem;
-  padding-bottom: 6rem;
+  padding-top: 4.8rem;
+  padding-bottom: 4.8rem;
 }
 
 .py-32 {
-  padding-top: 8rem;
-  padding-bottom: 8rem;
+  padding-top: 6.4rem;
+  padding-bottom: 6.4rem;
 }
 
 .py-48 {
-  padding-top: 12rem;
-  padding-bottom: 12rem;
+  padding-top: 9.6rem;
+  padding-bottom: 9.6rem;
 }
 
 .py-56 {
-  padding-top: 14rem;
-  padding-bottom: 14rem;
+  padding-top: 11.2rem;
+  padding-bottom: 11.2rem;
 }
 
 .py-8 {
-  padding-top: 2rem;
-  padding-bottom: 2rem;
+  padding-top: 1.6rem;
+  padding-bottom: 1.6rem;
 }
 
 .pb-14 {
-  padding-bottom: 3.5rem;
+  padding-bottom: 2.8rem;
 }
 
 .pl-16 {
-  padding-left: 4rem;
+  padding-left: 3.2rem;
 }
 
 .pl-3 {
-  padding-left: 0.75rem;
+  padding-left: 0.6rem;
 }
 
 .pl-9 {
-  padding-left: 2.25rem;
+  padding-left: 1.8rem;
 }
 
 .pr-0 {
@@ -1135,31 +1168,31 @@ video {
 }
 
 .pr-4 {
-  padding-right: 1rem;
+  padding-right: 0.8rem;
 }
 
 .pt-14 {
-  padding-top: 3.5rem;
+  padding-top: 2.8rem;
 }
 
 .pt-16 {
-  padding-top: 4rem;
+  padding-top: 3.2rem;
 }
 
 .pt-3 {
-  padding-top: 0.75rem;
+  padding-top: 0.6rem;
 }
 
 .pt-4 {
-  padding-top: 1rem;
+  padding-top: 0.8rem;
 }
 
 .pt-6 {
-  padding-top: 1.5rem;
+  padding-top: 1.2rem;
 }
 
 .pt-8 {
-  padding-top: 2rem;
+  padding-top: 1.6rem;
 }
 
 .text-center {
@@ -1167,48 +1200,48 @@ video {
 }
 
 .text-2xl {
-  font-size: 1.5rem;
-  line-height: 2rem;
+  font-size: 1.2rem;
+  line-height: 1.6rem;
 }
 
 .text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
+  font-size: 1.5rem;
+  line-height: 1.8rem;
 }
 
 .text-4xl {
-  font-size: 2.25rem;
-  line-height: 2.5rem;
+  font-size: 1.8rem;
+  line-height: 2rem;
 }
 
 .text-6xl {
-  font-size: 3.75rem;
+  font-size: 3rem;
   line-height: 1;
 }
 
 .text-base {
-  font-size: 1rem;
-  line-height: 1.5rem;
+  font-size: 0.8rem;
+  line-height: 1.2rem;
 }
 
 .text-lg {
-  font-size: 1.125rem;
-  line-height: 1.75rem;
+  font-size: 0.9rem;
+  line-height: 1.4rem;
 }
 
 .text-sm {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: 0.7rem;
+  line-height: 1rem;
 }
 
 .text-xl {
-  font-size: 1.25rem;
-  line-height: 1.75rem;
+  font-size: 1rem;
+  line-height: 1.4rem;
 }
 
 .text-xs {
-  font-size: 0.75rem;
-  line-height: 1rem;
+  font-size: 0.6rem;
+  line-height: 0.8rem;
 }
 
 .font-bold {
@@ -1224,15 +1257,15 @@ video {
 }
 
 .leading-6 {
-  line-height: 1.5rem;
+  line-height: 1.2rem;
 }
 
 .leading-7 {
-  line-height: 1.75rem;
+  line-height: 1.4rem;
 }
 
 .leading-8 {
-  line-height: 2rem;
+  line-height: 1.6rem;
 }
 
 .tracking-tight {
@@ -1355,6 +1388,12 @@ video {
   transition-duration: 150ms;
 }
 
+body {
+  /* Override the mkdocs default of 0.5rem */
+  font-size: 0.8rem;
+  /* 16px */
+}
+
 /* hide site name */
 
 .md-header__topic {
@@ -1411,7 +1450,7 @@ video {
   }
 
   .sm\:max-w-2xl {
-    max-width: 42rem;
+    max-width: 33.6rem;
   }
 
   .sm\:max-w-none {
@@ -1419,19 +1458,19 @@ video {
   }
 
   .sm\:gap-y-20 {
-    row-gap: 5rem;
+    row-gap: 4rem;
   }
 
   .sm\:text-4xl {
-    font-size: 2.25rem;
-    line-height: 2.5rem;
+    font-size: 1.8rem;
+    line-height: 2rem;
   }
 }
 
 @media (min-width: 768px) {
   .md\:px-6 {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: 1.2rem;
+    padding-right: 1.2rem;
   }
 }
 
@@ -1442,7 +1481,7 @@ video {
   }
 
   .lg\:max-w-lg {
-    max-width: 32rem;
+    max-width: 25.6rem;
   }
 
   .lg\:max-w-none {
@@ -1463,11 +1502,11 @@ video {
   }
 
   .lg\:px-8 {
-    padding-left: 2rem;
-    padding-right: 2rem;
+    padding-left: 1.6rem;
+    padding-right: 1.6rem;
   }
 
   .lg\:pl-3 {
-    padding-left: 0.75rem;
+    padding-left: 0.6rem;
   }
 }

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -651,7 +651,7 @@ $ devenv container run processes
               <div class="flex bg-gray-800/40">
                 <div class="flex items-center text-sm font-medium leading-6 border-b border-r border-b-white/20 border-r-white/10 bg-white/5 h-8">
                   <div class="px-4 text-gray-200">
-                    devenv.nix</div>
+                    devenv.yaml</div>
                 </div>
               </div>
               <pre class="text-white text-sm"><code class="language-yaml">inputs:

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -119,7 +119,7 @@
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv shell
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv shell
 hello determinism
 ncdu 2.3
 
@@ -165,7 +165,7 @@ ncdu 2.3
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv shell build
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv shell build
 ...
           </code></pre>
           </div>
@@ -229,7 +229,7 @@ ncdu 2.3
       <div class="px-4 lg:px-0">
         <div class="mt-4 relative isolate overflow-hidden rounded-md sm:mx-auto sm:max-w-2xl lg:mx-0 lg:max-w-none">
           <div class="bg-gray-900">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv search devenv
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv search devenv
 +--------------+---------------+------------------------------------------------------------------------+
 | Package      | Version       | Description                                                            |
 +--------------+---------------+------------------------------------------------------------------------+
@@ -368,7 +368,7 @@ ncdu 2.3
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv up
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv up
 • Building processes ...
 • Starting processes ...
 ...
@@ -480,7 +480,7 @@ ncdu 2.3
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv up
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv up
 ...
             </code></pre>
           </div>
@@ -523,7 +523,7 @@ ncdu 2.3
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv test
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv test
 ...
             </code></pre>
           </div>
@@ -624,7 +624,7 @@ ncdu 2.3
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-nix">$ devenv container build processes
+            <pre class="text-white text-sm"><code class="language-shell">$ devenv container build processes
 ...
 
 $ devenv container copy processes

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,13 +1,20 @@
 {% extends "main.html" %}
 
+{% block scripts %}
+  {{ super() }}
+  <link rel="stylesheet" href="/assets/github-dark.min.css">
+  <script src="/assets/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+{% endblock %}
+
 <!-- Render hero under tabs -->
 {% block tabs %}
-{{ super() }}
+{% endblock %}
 
-<link rel="stylesheet" href="/assets/github-dark.min.css">
-<script src="/assets/highlight.min.js"></script>
-<script>hljs.highlightAll();</script>
+{% block site_nav %}
+{% endblock %}
 
+{% block hero %}
 
 <div class="relative isolate overflow-hidden pt-14">
   <div class="mx-auto max-w-3xl py-8 px-4">
@@ -702,7 +709,7 @@ imports:
 
 {% endblock %}
 
-<!-- Content -->
+<!-- Override content -->
 {% block content %}
 {% endblock %}
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -175,7 +175,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Scripts and Git hooks</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             Define <a href="/scripts/" class="text-[#425C82] font-semibold">scripts</a> and
             <a href="/pre-commit-hooks/" class="text-[#425C82] font-semibold">git hooks</a>
             to automate your development workflow.
@@ -219,7 +219,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Search packages and options</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             Explore <a href="/packages/" class="text-[#425C82] font-semibold">packages</a> and <a
               href="/reference/options/" class="text-[#425C82] font-semibold">options</a> to customize your
             environment.
@@ -259,7 +259,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Languages</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             Supports over 50 <a href="/languages/" class="text-[#425C82] font-semibold">programming languages</a>.
           <dl class="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
             <div class="relative lg:pl-3">
@@ -380,7 +380,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Run processes</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             Define your <a class="text-[#425C82] font-semibold" href="/processes/">processes in a declarative way</a>
             and start them with <code class="bg-gray-100 p-1">devenv up</code>.
           <dl class="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
@@ -417,7 +417,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Run services</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             <a class="text-[#425C82] font-semibold" href="/services">Pick from a number of community maintained
               services</a> like <strong>PostgreSQL, Redis, MySQL,
               RabbitMQ, WireMock, MinIO, Caddy, ElasticSearch</strong>, and <a class="text-[#425C82] font-semibold"
@@ -533,7 +533,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Run tests</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             Running <a class="text-[#425C82] font-semibold" href="/tests">a script inside your development environment
               with all processes running</a> should be as simple as <code class="bg-gray-100 p-1">devenv test</code>.
           <dl class="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
@@ -560,7 +560,7 @@ ncdu 2.3
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Container interoperability</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             <a href="/containers/" class="text-[#425C82] font-semibold">Generate containers</a> from your development
             environment and build/copy/run them.
           <dl class="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">
@@ -670,7 +670,7 @@ imports:
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
           <p class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">Poly/Mono repo composability</p>
-          <p class="mt-6 text-lg leading-8 text-gray-600">
+          <p class="mt-6 text-xl font-medium leading-8 text-gray-600">
             <a class="text-[#425C82] font-semibold" href="/composing-using-imports/">Compose multiple environments</a>
             into a single environment.
           <dl class="mt-10 max-w-xl space-y-8 text-base leading-7 text-gray-600 lg:max-w-none">

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -10,7 +10,7 @@
 
 
 <div class="relative isolate overflow-hidden pt-14">
-  <div class="mx-auto max-w-2xl py-8 px-4">
+  <div class="mx-auto max-w-3xl py-8 px-4">
     <div class="text-center">
       <h1 class="text-2xl font-bold tracking-tight text-black sm:text-4xl">Fast, Declarative, Reproducible and Composable
         Developer Environments using Nix</h1>
@@ -27,7 +27,7 @@
       </p>
       <div class="mt-10 flex items-center justify-center gap-x-6">
         <a href="/getting-started/"
-          class="rounded-md bg-black px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:to-[#425C82] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">Get
+          class="rounded-md bg-black px-3.5 py-2.5 font-semibold text-white shadow-sm hover:to-[#425C82] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">Get
           started</a>
       </div>
     </div>
@@ -36,7 +36,7 @@
 
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
@@ -126,7 +126,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4 lg:px-0">
         <div class="relative isolate overflow-hidden rounded-md sm:mx-auto sm:max-w-2xl lg:mx-0 lg:max-w-none">
@@ -207,7 +207,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 lg:items-start">
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
@@ -247,7 +247,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
@@ -332,7 +332,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
 
       <div class="px-4 lg:px-0">
@@ -405,7 +405,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8" f>
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
@@ -484,7 +484,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4 lg:px-0">
         <div class="relative isolate overflow-hidden rounded-md sm:mx-auto sm:max-w-2xl lg:mx-0 lg:max-w-none">
@@ -548,7 +548,7 @@ ncdu 2.3
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4">
         <div class="mx-auto max-w-2xl lg:mx-0 lg:max-w-lg">
@@ -634,7 +634,7 @@ $ devenv container run processes
 </div>
 
 <div class="overflow-hidden bg-white py-14">
-  <div class="mx-auto max-w-5xl md:px-6 lg:px-8">
+  <div class="mx-auto max-w-7xl md:px-6 lg:px-8">
     <div class="grid grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:grid-cols-2 lg:items-start">
       <div class="px-4 lg:px-0">
         <div class="relative isolate overflow-hidden rounded-md sm:mx-auto sm:max-w-2xl lg:mx-0 lg:max-w-none">
@@ -695,7 +695,7 @@ imports:
   </div>
 </div>
 
-<div class="mx-auto text-center max-w-5xl md:px-6 lg:px-8">
+<div class="mx-auto text-center max-w-7xl md:px-6 lg:px-8">
   <h2 class="text-2xl mb-6">Built by</h2>
   <a href="https://cachix.org"><img src="/assets/images/cachix.webp" width="250px" /></a>
 </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -103,7 +103,7 @@
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, config, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, config, ... }: {
   env.GREET = "determinism";
 
   packages = [ 
@@ -115,17 +115,16 @@
     ncdu --version
   '';
 }
-                </code></pre>
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv shell
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv shell
 hello determinism
 ncdu 2.3
-
-(devenv) $
-            </code></pre>
+</code><code class="language-shell" data-shell-prefix="(devenv) $">
+</code></pre>
           </div>
         </div>
       </div>
@@ -147,7 +146,7 @@ ncdu 2.3
                   </div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
   scripts.build.exec = "parcel build";
 
   # Runs on git commit and CI
@@ -161,14 +160,15 @@ ncdu 2.3
     };
   };
 }
-            </code></pre>
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv shell build
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv shell build
 ...
-          </code></pre>
+
+</code></pre>
           </div>
         </div>
       </div>
@@ -230,7 +230,7 @@ ncdu 2.3
       <div class="px-4 lg:px-0">
         <div class="mt-4 relative isolate overflow-hidden rounded-md sm:mx-auto sm:max-w-2xl lg:mx-0 lg:max-w-none">
           <div class="bg-gray-900">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv search devenv
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv search devenv
 +--------------+---------------+------------------------------------------------------------------------+
 | Package      | Version       | Description                                                            |
 +--------------+---------------+------------------------------------------------------------------------+
@@ -246,7 +246,7 @@ ncdu 2.3
 | devenv.latestVersion     | string  | "1.0.3"   | The latest version of devenv.                              |
 +--------------------------+---------+-----------+------------------------------------------------------------+
 • Found 1 package and 3 options for 'devenv'.
-            </code></pre>
+</code></pre>
           </div>
         </div>
       </div>
@@ -300,7 +300,7 @@ ncdu 2.3
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, config, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, config, ... }: {
   languages.python = {
     enable = true;
     version = "3.11";
@@ -330,7 +330,7 @@ ncdu 2.3
     };
   };
 }
-              </code></pre>
+</code></pre>
             </div>
           </div>
         </div>
@@ -353,7 +353,7 @@ ncdu 2.3
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
   packages = [ 
     pkgs.mkdocs
     pkgs.watchexec
@@ -364,16 +364,17 @@ ncdu 2.3
     tailwind.exec = "watchexec -e html,css,js npx tailwindcss build extra.css -o output.css";
   };
 }
-              </code></pre>
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv up
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv up
 • Building processes ...
 • Starting processes ...
 ...
-            </code></pre>
+
+</code></pre>
           </div>
         </div>
       </div>
@@ -463,7 +464,7 @@ ncdu 2.3
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
   services.postgres = {
     enable = true;
     package = pkgs.postgresql_15;
@@ -476,14 +477,15 @@ ncdu 2.3
     initialScript = "CREATE EXTENSION IF NOT EXISTS timescaledb;";
   };
 }
-              </code></pre>
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv up
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv up
 ...
-            </code></pre>
+
+</code></pre>
           </div>
         </div>
       </div>
@@ -504,7 +506,7 @@ ncdu 2.3
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
   packages = [ 
     pkgs.mkdocs
     pkgs.curl
@@ -519,14 +521,16 @@ ncdu 2.3
     curl http://localhost:8000 | grep "Hello, world!"
   '';
 }
-              </code></pre>
+
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv test
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv test
 ...
-            </code></pre>
+
+</code></pre>
           </div>
         </div>
       </div>
@@ -610,7 +614,7 @@ ncdu 2.3
                     devenv.nix</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
+<pre class="text-white text-sm"><code class="language-nix">{ pkgs, ... }: {
   packages = [ 
     pkgs.mkdocs
     pkgs.curl
@@ -620,20 +624,20 @@ ncdu 2.3
     docs.exec = "mkdocs serve";
   };
 }
-              </code></pre>
+
+</code></pre>
             </div>
           </div>
 
           <div class="overflow-hidden bg-gray-900 border-t border-t-white/20">
-            <pre class="text-white text-sm"><code class="language-shell">$ devenv container build processes
+<pre class="text-white text-sm"><code class="language-shell" data-shell-prefix="$">devenv container build processes
+...
+</code><code class="language-shell" data-shell-prefix="$">devenv container copy processes
+...
+</code><code class="language-shell" data-shell-prefix="$"> devenv container run processes
 ...
 
-$ devenv container copy processes
-...
-
-$ devenv container run processes
-...
-            </code></pre>
+</code></pre>
           </div>
         </div>
       </div>
@@ -654,7 +658,7 @@ $ devenv container run processes
                     devenv.yaml</div>
                 </div>
               </div>
-              <pre class="text-white text-sm"><code class="language-yaml">inputs:
+<pre class="text-white text-sm"><code class="language-yaml">inputs:
   myorg-devenv:
     url: github:myorg/myorg-devenv
 imports:
@@ -662,7 +666,7 @@ imports:
   - ./backend
   - myorg-devenv/service1
   - myorg-devenv/service2
-              </code></pre>
+</code></pre>
             </div>
           </div>
         </div>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,16 +1,17 @@
 {% extends "main.html" %}
 
+{% block styles %}
+{{ super () }}
+<link rel="stylesheet" href="/assets/github-dark.min.css">
+{% endblock %}
+
 {% block scripts %}
-  {{ super() }}
-  <link rel="stylesheet" href="/assets/github-dark.min.css">
-  <script src="/assets/highlight.min.js"></script>
-  <script>hljs.highlightAll();</script>
+{{ super() }}
+<script src="/assets/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
 {% endblock %}
 
-<!-- Render hero under tabs -->
-{% block tabs %}
-{% endblock %}
-
+<!-- Disable site nav on the home page -->
 {% block site_nav %}
 {% endblock %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "dependencies": {
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.38",
-        "tailwindcss": "^3.4.3"
+        "tailwindcss": "^3.4.3",
+        "tailwindcss-base-font-size": "^1.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1237,6 +1238,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-base-font-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss-base-font-size/-/tailwindcss-base-font-size-1.0.1.tgz",
+      "integrity": "sha512-elrT3W0hM3l08cFl1p0g4hOLlXlSjXCCFeBfTMsWV+LRLOLZ0v7ILQPGg5q7hDGK45YB7E10UWkfyl0SazjWmg==",
+      "peerDependencies": {
+        "tailwindcss": ">=3.3.2"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.3"
+    "tailwindcss": "^3.4.3",
+    "tailwindcss-base-font-size": "^1.0.1"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  plugins: [require('tailwindcss'), require('autoprefixer')]
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './docs/**/*.{js,css,html}'
+    './docs/**/*.{js,html}'
   ],
   theme: {
     extend: {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,17 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./docs/**/*.{js,css,html}"
+    './docs/**/*.{js,css,html}'
   ],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require('tailwindcss-base-font-size')({
+      // mkdocs uses 20px as the base font size.
+      // Rescale tailwind to match this.
+      baseFontSize: 20,
+    }),
+  ],
 }
 


### PR DESCRIPTION
- Rescaled the Tailwind classes to work with mkdocs' 20px base font-size. `text-base` is now 16px (as it should be) instead of 20px.
- Fixed the random "Home" element at the end of the home page.
- Switch to console/shell highlighting for console output.
- Added a shell prefix to the console examples.
- Moved homepage scripts to the scripts block.
- Moved homepage css to the styles block.
- Updated the tailwind setup to fix an issue where unused styles were not being removed.