### PR TITLE
fix 1.0.4 regression: python venv always recreated

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -68,6 +68,7 @@ let
           ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
         ''
       }
+      echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"
     fi
 
     source "$VENV_PATH"/bin/activate


### PR DESCRIPTION
Fix regression introduced by https://github.com/cachix/devenv/commit/6ff0c3a81ccbf79f00b5f3289f77df21114bd87e where Python venv will always be recreated unconditionally even if there is no reason to do so.