### PR TITLE
pre-commit: don't let hook packages override language ones

### DIFF
--- a/src/modules/integrations/pre-commit.nix
+++ b/src/modules/integrations/pre-commit.nix
@@ -23,7 +23,8 @@
     enterTest = ''
       pre-commit run -a
     '';
-    packages = [ config.pre-commit.package ] ++ (config.pre-commit.enabledPackages or [ ]);
+    # Add the packages for any enabled hooks at the end to avoid overriding the language-defined packages.
+    packages = lib.mkAfter ([ config.pre-commit.package ] ++ (config.pre-commit.enabledPackages or [ ]));
     enterShell = config.pre-commit.installationScript;
   };
 }


### PR DESCRIPTION
The packages defined by languages should take priority over the ones loaded by pre-commit. This pushes any `enabledPackages` to the end of PATH.

Language modules should still manually override the pre-commit packages to keep things in sync.

Fixes #1103.