### PR TITLE
Streamline .envrc used in templates

### DIFF
--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -1,11 +1,1 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
-fi
-
-nix_direnv_watch_file devenv.nix
-nix_direnv_watch_file devenv.lock
-nix_direnv_watch_file devenv.yaml
-if ! use flake . --impure
-then
-  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
-fi
+use flake . --impure

--- a/templates/simple/.envrc
+++ b/templates/simple/.envrc
@@ -1,10 +1,1 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
-fi
-
-nix_direnv_watch_file flake.nix
-nix_direnv_watch_file flake.lock
-if ! use flake . --impure
-then
-  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
-fi
+use flake . --impure

--- a/templates/terraform/.envrc
+++ b/templates/terraform/.envrc
@@ -1,11 +1,1 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
-fi
-
-nix_direnv_watch_file devenv.nix
-nix_direnv_watch_file devenv.lock
-nix_direnv_watch_file devenv.yaml
-if ! use flake . --impure
-then
-  echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
-fi
+use flake . --impure


### PR DESCRIPTION
As per ```nix-direnv```'s Readme, there is no need to explicitly watch ```flake.nix``` or ```flake.lock``` beacause it already does that.

Also, ```nix_direnv_watch_file``` has been deprecated.