### PR TITLE
Add devenv-up into the shell environment

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -47,9 +47,7 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
                 { "${shellPrefix shellName}container-${containerName}" = container.derivation; }
               )
               devenv.containers
-            ) // {
-              "${shellPrefix shellName}devenv-up" = devenv.procfileScript;
-            }
+            )
           )
           config.devenv.shells;
     });

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -10,8 +10,6 @@ pkgs.writeScriptBin "devenv" ''
   # we want subshells to fail the program
   set -e
 
-  NIX_FLAGS="--show-trace --extra-experimental-features nix-command --extra-experimental-features flakes"
-
   command=$1
   if [[ ! -z $command ]]; then
     shift
@@ -19,13 +17,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=$(nix build '.#${shellPrefix (config._module.args.name or "default")}devenv-up' --no-link --print-out-paths --impure)
-      if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
-        echo "No 'processes' option defined: https://devenv.sh/processes/"
-        exit 1
-      else
-        exec $procfilescript "$@"
-      fi
+      exec devenv-up "$@"
       ;;
     version)
       echo "devenv: ${version}"

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -108,10 +108,16 @@ in
       type = types.package;
     };
 
+    procfileBin = lib.mkOption {
+      type = types.package;
+      internal = true;
+      default = pkgs.writeScriptBin "devenv-up" "echo No processes to run. Exiting.";
+    };
+
     procfileScript = lib.mkOption {
       type = types.package;
       internal = true;
-      default = pkgs.writeShellScript "no-processes" "";
+      default = "${config.procfileBin}/bin/devenv-up";
     };
   };
 
@@ -126,7 +132,7 @@ in
     procfileEnv =
       pkgs.writeText "procfile-env" (lib.concatStringsSep "\n" envList);
 
-    procfileScript = pkgs.writeShellScript "devenv-up" ''
+    procfileBin = pkgs.writeScriptBin "devenv-up" ''
       ${config.process.before}
 
       ${config.processManagerCommand}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -281,7 +281,7 @@ in
     shell = performAssertions (
       (pkgs.mkShell.override { stdenv = config.stdenv; }) ({
         name = "devenv-shell";
-        packages = config.packages;
+        packages = config.packages ++ [config.procfileBin];
         shellHook = ''
           ${lib.optionalString config.devenv.debug "set -x"}
           ${config.enterShell}


### PR DESCRIPTION
This brings devenv-up as a package which is brought into the shell environment. `devenv-up` is now present in the $PATH and runs it immediately and `devenv up` execs.

The main motivation here is when using a Flake directly. Previously `devenv up` would run `nix build` on demand which is (1) fragile since it makes assumptions around what the flake is actually called and (2) doesn't register it as root.

By bringing the devenv-up into shell we solve both of these problems. Be aware that we're not able to bring it into the _profile_ since this leads to a infinite recursion: The devenv-up script is designed to run "outside" of the devenv environment (since the process-compose.yaml file sets the environment variables for you).

This commit doesn't change behavior in the Rust implementation, but I believe we could now also tweak this to invoke `devenv-up` directly instead of adding it as a root.