### PR TITLE
Create the devenv_core package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "ansiterm",
  "clap 4.5.1",
  "cli-table",
+ "devenv_core",
  "dotlock",
  "fs2",
  "hex",
@@ -444,7 +445,12 @@ name = "devenv-run-tests"
 version = "0.1.0"
 dependencies = [
  "clap 3.2.25",
+ "devenv_core",
 ]
+
+[[package]]
+name = "devenv_core"
+version = "0.1.0"
 
 [[package]]
 name = "digest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
     "devenv",
     "devenv-run-tests",
+    "devenv_core",
 ]

--- a/devenv-run-tests/Cargo.toml
+++ b/devenv-run-tests/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2018"
 
 [dependencies]
 clap = { version = "3", features = ["derive"] }
+
+devenv_core = { path = "../devenv_core" }

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -27,3 +27,5 @@ tracing = "0.1.40"
 which = "6.0.0"
 whoami = "1.5.1"
 xdg = "2.5.2"
+
+devenv_core = { path = "../devenv_core" }

--- a/devenv_core/Cargo.toml
+++ b/devenv_core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "devenv_core"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/devenv_core/src/lib.rs
+++ b/devenv_core/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
This will be filled out in another PR to move some functionality from the devenv package so that it can be used in devenv-test-all.