### PR TITLE
Fix flake-parts template

### DIFF
--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -30,9 +30,6 @@
         # module parameters provide easy access to attributes of the same
         # system.
 
-        # needed for devenv up
-        packages.devenv-up = self'.devShells.default.config.procfileScript;
-
         # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
         packages.default = pkgs.hello;
 
@@ -57,6 +54,8 @@
           enterShell = ''
             hello
           '';
+
+          processes.hello.exec = "hello";
         };
 
       };

--- a/templates/simple/flake.nix
+++ b/templates/simple/flake.nix
@@ -37,7 +37,7 @@
                     hello
                   '';
 
-                  processes.run.exec = "hello";
+                  processes.hello.exec = "hello";
                 }
               ];
             };


### PR DESCRIPTION
Fixes #1027.
Fixes half of #1153.

~Also, updated all the templates to use `devenv/latest`, instead of `main`.~