### PR TITLE
Reuse `DEVENV_RUNTIME` to work around `nix develop` modifying `TMPDIR`

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -175,12 +175,16 @@ in
         # - free to create as an unprivileged user across OSes
         default =
           let
+            runtimeEnv = builtins.getEnv "DEVENV_RUNTIME";
+
             hashedRoot = builtins.hashString "sha256" config.devenv.state;
 
             # same length as git's abbreviated commit hashes
             shortHash = builtins.substring 0 7 hashedRoot;
           in
-          "${config.devenv.tmpdir}/devenv-${shortHash}";
+          if runtimeEnv != ""
+          then runtimeEnv
+          else "${config.devenv.tmpdir}/devenv-${shortHash}";
       };
 
       tmpdir = lib.mkOption {


### PR DESCRIPTION
Fixes #1153.

`nix develop` sets `TMPDIR` which changes the computed runtime dir between creating the shell and running `devenv up`.
`DEVENV_RUNTIME` changes from `/tmp/devenv-<hash>` to `/tmp/nix-shell.<hash>/devenv-<hash>`.

This makes the flake-based `devenv up` error out because process-compose expects the runtime dir to exists when creating the unix socket.
Non-flake `devenv up` is not affected by this, as it seems to create the new runtime dir before running the procfile.

On NixOS, this error doesn't show up because `XDG_RUNTIME_DIR` is set by default and is used as the `tmpdir`. This is not touched by `nix develop`.


