### PR TITLE
Fix infinite symlinks in runtime dir

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -270,12 +270,12 @@ in
       mkdir -p "$DEVENV_STATE"
       if [ ! -L "$DEVENV_DOTFILE/profile" ] || [ "$(${pkgs.coreutils}/bin/readlink $DEVENV_DOTFILE/profile)" != "${profile}" ]
       then
-        ln -nsf ${profile} "$DEVENV_DOTFILE/profile"
+        ln -snf ${profile} "$DEVENV_DOTFILE/profile"
       fi
       unset ${lib.concatStringsSep " " config.unsetEnvVars}
 
       mkdir -p ${lib.escapeShellArg config.devenv.runtime}
-      ln -fs ${lib.escapeShellArg config.devenv.runtime} ${lib.escapeShellArg config.devenv.dotfile}/run
+      ln -snf ${lib.escapeShellArg config.devenv.runtime} ${lib.escapeShellArg config.devenv.dotfile}/run
     '';
 
     shell = performAssertions (


### PR DESCRIPTION
Use the `no-dereference` option to stop `ln` from following the existing `.devenv/run` symlink and creating a recursive symlink inside the runtime dir to itself.

Fixes #1115.