### PR TITLE
c: fix an issue where the wrong c/cpp compiler could be set up

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -12,9 +12,7 @@ in
     packages = with pkgs; [
       stdenv
       gnumake
-      clang
       ccls
-      gcc
       pkg-config
     ];
   };


### PR DESCRIPTION
We already add `stdenv`, which contains all the compilers and sets up the `CC` and `CXX` env variables for each platform. Adding `clang` or `gcc` on top can result in the wrong compilers being set up for the current platform, e.g. gcc on macOS. We saw this happen when building native extensions in ruby.

I imagine this broke once we switched back to `nix develop`.
Also, this might fix the macos ruby tests 👀

Fixes #966.
Fixes #965.