### PR TITLE
rust-wasm-cross: fix darwin and aarch64-linux builds

### DIFF
--- a/examples/rust-wasm-cross/.test.sh
+++ b/examples/rust-wasm-cross/.test.sh
@@ -4,7 +4,8 @@ cargo --version
 rustc --version
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  echo "$RUSTFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
+  # See env.RUSTFLAGS in devenv.nix
+  # echo "$RUSTFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
   echo "$RUSTDOCFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
   echo "$CFLAGS" | grep -- "-iframework $DEVENV_PROFILE/Library/Frameworks"
 fi

--- a/examples/rust-wasm-cross/.test.sh
+++ b/examples/rust-wasm-cross/.test.sh
@@ -3,13 +3,6 @@ set -ex
 cargo --version
 rustc --version
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  # See env.RUSTFLAGS in devenv.nix
-  # echo "$RUSTFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
-  echo "$RUSTDOCFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
-  echo "$CFLAGS" | grep -- "-iframework $DEVENV_PROFILE/Library/Frameworks"
-fi
-
 [[ "$CARGO_INSTALL_ROOT" == "$DEVENV_STATE/cargo-install" ]]
 echo "$PATH" | grep -- "$CARGO_INSTALL_ROOT/bin"
 

--- a/examples/rust-wasm-cross/devenv.nix
+++ b/examples/rust-wasm-cross/devenv.nix
@@ -11,16 +11,21 @@
     components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" "rust-std" ];
   };
 
-  # These break us
-  # pre-commit.hooks = {
-  #  rustfmt.enable = true;
-  #  clippy.enable = true;
-  # };
+  pre-commit.hooks = {
+    clippy.enable = true;
+    rustfmt.enable = true;
+  };
 
   packages = [
     pkgs.wasm-pack
+    pkgs.binaryen # use a newer version of wasm-opt
     pkgs.nodejs
   ] ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
     frameworks.Security
   ]);
+
+  # macOS workaround:
+  # The linker on macOS doesn't like the frameworks option when compiling to wasm32.
+  # See https://github.com/rust-lang/rust/issues/122333
+  env.RUSTFLAGS = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce "");
 }


### PR DESCRIPTION
- Fix the linker issue on macOS. Link to upstream issue.
- Fix the build on `aarch64-linux`, where `wasm-pack` complains that it can't load a build of `wasm-opt`.