### PR TITLE
feat: Exclude node_modules from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ examples/rust/app/target
 
 # Rust
 target
+
+# Node Modules
+node_modules


### PR DESCRIPTION
This MR excludes the `node_module` folder from the git tree which is generated when working with the `devenv.sh` website.