### PR TITLE
pre-commit: run only on changed files instead of all the files

### DIFF
--- a/src/modules/integrations/pre-commit.nix
+++ b/src/modules/integrations/pre-commit.nix
@@ -21,7 +21,7 @@
   config = lib.mkIf ((lib.filterAttrs (id: value: value.enable) config.pre-commit.hooks) != { }) {
     ci = [ config.pre-commit.run ];
     enterTest = ''
-      pre-commit run -a
+      pre-commit run
     '';
     # Add the packages for any enabled hooks at the end to avoid overriding the language-defined packages.
     packages = lib.mkAfter ([ config.pre-commit.package ] ++ (config.pre-commit.enabledPackages or [ ]));


### PR DESCRIPTION
According to https://pre-commit.com , by default, the pre-commit hooks should only run on the edited files instead of all files. This PR addresses this and changes the default to the former.

Another thing we can provide is an option in devenv.nix to set the desired behavior.