### PR TITLE
Fix: sync nodejs versions

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -218,7 +218,7 @@ in
     ]
     ++ lib.optional cfg.npm.enable (cfg.npm.package)
     ++ lib.optional cfg.pnpm.enable (cfg.pnpm.package)
-    ++ lib.optional cfg.yarn.enable (cfg.yarn.package)
+    ++ lib.optional cfg.yarn.enable (cfg.yarn.package.override { nodejs = cfg.package; })
     ++ lib.optional cfg.bun.enable (cfg.bun.package)
     ++ lib.optional cfg.corepack.enable (pkgs.runCommand "corepack-enable" { } ''
       mkdir -p $out/bin


### PR DESCRIPTION
This fixes yarn using a different nodejs version (partially solves https://github.com/cachix/devenv/issues/637). This doesn't work if yarn pkg is a `nodePackage`. Pnpm also has the same problem since it's a `nodePackage`, not sure how to fix that, seems to use the first node version that is installed.