### PR TITLE
feat: support private caches

### DIFF
--- a/devenv/src/command.rs
+++ b/devenv/src/command.rs
@@ -275,13 +275,17 @@ impl App {
                 };
 
                 let mut new_known_keys: HashMap<String, String> = HashMap::new();
+                let client = reqwest::blocking::Client::new();
                 for name in caches.caches.pull.iter() {
                     if !caches.known_keys.contains_key(name) {
-                        let resp = reqwest::blocking::get(&format!(
-                            "https://cachix.org/api/v1/cache/{}",
+                        let mut request = client.get(&format!(
+                            "https://cachix.org/api/v1/cache/{}", 
                             name
-                        ))
-                        .expect("Failed to get cache");
+                        ));
+                        if let Ok(ret) = env::var("CACHIX_AUTH_TOKEN") {
+                            request = request.bearer_auth(ret);
+                        }
+                        let resp = request.send().expect("Failed to get cache");
                         if resp.status().is_client_error() {
                             self.logger.error(&format!(
                                 "Cache {} does not exist or you don't have a CACHIX_AUTH_TOKEN configured.",

--- a/devenv/src/command.rs
+++ b/devenv/src/command.rs
@@ -278,10 +278,8 @@ impl App {
                 let client = reqwest::blocking::Client::new();
                 for name in caches.caches.pull.iter() {
                     if !caches.known_keys.contains_key(name) {
-                        let mut request = client.get(&format!(
-                            "https://cachix.org/api/v1/cache/{}", 
-                            name
-                        ));
+                        let mut request =
+                            client.get(&format!("https://cachix.org/api/v1/cache/{}", name));
                         if let Ok(ret) = env::var("CACHIX_AUTH_TOKEN") {
                             request = request.bearer_auth(ret);
                         }


### PR DESCRIPTION
Fix for #1024 -- enables the usage of the cachix env var.

Note, this does *not* support the netrc, as that would seemingly be more complicated

```
$ ~/projects/devenv/result/bin/devenv test
• Overriding .devenv to .devenv.HbfeKKcHpORj
• Building tests ...
• Using Cachix: devenv, private
• Trusting private.cachix.org on first use with the public key private.cachix.org-1:blabla
✔ Building tests in 11.2s.
```