### PR TITLE
feat: add odin language support

### DIFF
--- a/src/modules/languages/odin.nix
+++ b/src/modules/languages/odin.nix
@@ -1,0 +1,33 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.odin;
+in
+{
+  options.languages.odin = {
+    enable = lib.mkEnableOption "tools for Odin Language";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.odin;
+      defaultText = lib.literalExpression "pkgs.odin";
+      description = "The odin package to use.";
+    };
+
+    debugger = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.gdb;
+      defaultText = lib.literalExpression "pkgs.gdb";
+      description = "The debugger package to use with odin.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [
+      gnumake
+      ols
+      cfg.debugger
+      cfg.package
+    ];
+  };
+}

--- a/src/modules/languages/odin.nix
+++ b/src/modules/languages/odin.nix
@@ -24,6 +24,8 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      nasm
+      clang
       gnumake
       ols
       cfg.debugger


### PR DESCRIPTION
This pull request adds support for https://odin-lang.org/, with `package` and `debugger` options. By default `gnumake` `ols`, `clang` and `nasm` packages are included.

resolves #888