### PR TITLE
Add debugger tools to C language pack 

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -10,6 +10,8 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      valgrind
+      gdb
       stdenv
       gnumake
       ccls

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -28,6 +28,6 @@ in
       ccls
       pkg-config
     ] ++ lib.optional (cfg.debugger != null) cfg.debugger
-    ++ lib.optional (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.valgrind) pkgs.valgrind;
+    ++ lib.optional (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.valgrind && !pkgs.valgrind.meta.broken) pkgs.valgrind;
   };
 }

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -6,16 +6,28 @@ in
 {
   options.languages.c = {
     enable = lib.mkEnableOption "tools for C development";
+
+    debugger = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default =
+        if lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.gdb
+        then pkgs.gdb
+        else null;
+      defaultText = lib.literalExpression "pkgs.gdb";
+      description = ''
+        An optional debugger package to use with c.
+        The default is `gdb`, if supported on the current system.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      valgrind
-      gdb
       stdenv
       gnumake
       ccls
       pkg-config
-    ];
+    ] ++ lib.optional (cfg.debugger != null) cfg.debugger
+    ++ lib.optional (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.valgrind) pkgs.valgrind;
   };
 }


### PR DESCRIPTION
This PR adds `gdb` and `valgrind` to the list of default packages, which are important tools for developing with C.