### PR TITLE
examples: rename `process_ready` to `process_healthy`

### DIFF
--- a/examples/process-compose/devenv.nix
+++ b/examples/process-compose/devenv.nix
@@ -34,7 +34,7 @@
 
     process-compose = {
       depends_on.foo.condition = "process_completed_successfully";
-      depends_on.postgres.condition = "process_ready";
+      depends_on.postgres.condition = "process_healthy";
       environment = [ "BAR=BAZ" ];
     };
   };

--- a/examples/python-django/devenv.nix
+++ b/examples/python-django/devenv.nix
@@ -29,7 +29,7 @@ in
 
   processes.runserver = {
     exec = "python manage.py runserver";
-    process-compose.depends_on.postgres.condition = "process_ready";
+    process-compose.depends_on.postgres.condition = "process_healthy";
   };
 
   enterTest = ''


### PR DESCRIPTION
AFAIKT `process_ready` is not a thing. 

https://f1bonacc1.github.io/process-compose/launcher/#define-process-dependencies