### PR TITLE
dotenv: support export declarations in .env files

### DIFF
--- a/src/modules/integrations/dotenv.nix
+++ b/src/modules/integrations/dotenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, self, ... }:
+{ config, lib, self, ... }:
 
 let
   cfg = config.dotenv;
@@ -9,12 +9,11 @@ let
 
   parseLine = line:
     let
-      parts = builtins.match "([^[:space:]=#]+)[[:space:]]*=[[:space:]]*(.*)" line;
+      parts = builtins.match "([[:space:]]*export[[:space:]]+)?([^[:space:]=#]+)[[:space:]]*=[[:space:]]*(.*)" line;
     in
-    if (!builtins.isNull parts) && (builtins.length parts) == 2 then
-      { name = builtins.elemAt parts 0; value = builtins.elemAt parts 1; }
-    else
-      null;
+    if parts != null && builtins.length parts == 3
+    then { name = builtins.elemAt parts 1; value = builtins.elemAt parts 2; }
+    else null;
 
   parseEnvFile = content: builtins.listToAttrs (lib.filter (x: !builtins.isNull x) (map parseLine (lib.splitString "\n" content)));
 

--- a/tests/dotenv/.setup.sh
+++ b/tests/dotenv/.setup.sh
@@ -1,3 +1,8 @@
-echo "{ env.LOCAL = \"1\";}" > devenv.local.nix
-echo "FOO=1\nBAR=2\nBAZ=3" > .env
-echo "BAZ=5" > .env.bar
+echo '{ env.LOCAL = "1";}' > devenv.local.nix
+cat <<EOF > .env
+FOO=1
+BAR=2
+BAZ=3
+export CHAZ=4
+EOF
+echo 'BAZ=5' > .env.bar

--- a/tests/dotenv/.test.sh
+++ b/tests/dotenv/.test.sh
@@ -2,4 +2,5 @@
 set -ex
 env | grep FOO=1
 env | grep BAR=1
+env | grep CHAZ=4
 env | grep BAZ=5


### PR DESCRIPTION
For example, `export FOO=1`.

Fixes #1207.

We can't use non-capturing groups, so this is the best I could come up with.

I couldn't find a spec for the .env format. But some of the parsers support multiline strings, escape quotes, and what not. That's going to be rough to do inside Nix...