### PR TITLE
container: override tmpdir and runtime dir

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -296,6 +296,8 @@ in
       containers.${envContainerName}.isBuilding = true;
     })
     (lib.mkIf config.container.isBuilding {
+      devenv.tmpdir = lib.mkOverride (lib.modules.defaultOverridePriority - 1) "/tmp";
+      devenv.runtime = lib.mkOverride (lib.modules.defaultOverridePriority - 1) "${config.devenv.tmpdir}/devenv";
       devenv.root = lib.mkForce "${homeDir}";
       devenv.dotfile = lib.mkOverride 49 "${homeDir}/.devenv";
     })


### PR DESCRIPTION
We shouldn't inherit them from the current shell.

IMHO when/if we move away from flakes, we should do this on the rust side.

Fixes #1182.