### PR TITLE
nixseparatedebuginfod: new module

### DIFF
--- a/src/modules/services/nixseparatedebuginfod.nix
+++ b/src/modules/services/nixseparatedebuginfod.nix
@@ -1,0 +1,39 @@
+{ pkgs, lib, config, ... }:
+
+let
+  cfg = config.services.nixseparatedebuginfod;
+  listen_address = "${cfg.host}:${toString cfg.port}";
+in
+{
+  options.services.nixseparatedebuginfod = {
+    enable = lib.mkEnableOption "nixseparatedebuginfod";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.nixseparatedebuginfod;
+      description = "nixseparatedebuginfod package to use.";
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "IP address for nixseparatedebuginfod to listen on.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 1949;
+      description = "Port for nixseparatedebuginfod to listen on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    processes.nixseparatedebuginfod.exec = ''
+      exec ${lib.getExe cfg.package} -l ${listen_address}
+    '';
+
+    enterShell = ''
+      export DEBUGINFOD_URLS="http://${listen_address}''${DEBUGINFOD_URLS:+ $DEBUGINFOD_URLS}"
+    '';
+  };
+}

--- a/tests/nixseparatedebuginfod/Makefile
+++ b/tests/nixseparatedebuginfod/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all
+all: example
+
+.PHONY: install
+install: example
+	install -Dm755 $< $(DESTDIR)/bin/$<
+
+.PHONY: clean
+clean:
+	$(RM) example

--- a/tests/nixseparatedebuginfod/devenv.nix
+++ b/tests/nixseparatedebuginfod/devenv.nix
@@ -1,0 +1,28 @@
+{ lib, pkgs, config, ... }:
+
+let
+  cfg = config.services.nixseparatedebuginfod;
+  inherit (pkgs.stdenv) hostPlatform;
+
+  # Use a locally built derivation so that the test wouldn't rely on cache.nixos.org
+  cbin = pkgs.stdenv.mkDerivation {
+    pname = "cbin";
+    version = "1.0";
+    src = ./.;
+    installFlags = [ "DESTDIR=$(out)" ];
+    separateDebugInfo = true;
+    meta.mainProgram = "example";
+  };
+in
+lib.mkIf (lib.meta.availableOn hostPlatform cfg.package) {
+  services.nixseparatedebuginfod.enable = true;
+
+  # The Nix store needs to be indexed by nixseparatedebuginfod for debug outputs from local
+  # derivations to be served. This can take a few minutes.
+  process.before = "${lib.getExe cfg.package} --index-only";
+
+  enterTest = ''
+    wait_for_port ${toString cfg.port} 120
+    ${pkgs.elfutils}/bin/debuginfod-find debuginfo ${lib.getExe cbin}
+  '';
+}

--- a/tests/nixseparatedebuginfod/example.c
+++ b/tests/nixseparatedebuginfod/example.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return 0;
+}


### PR DESCRIPTION
This creates a new module for [nixseparatedebuginfod](https://github.com/symphorien/nixseparatedebuginfod) to aid with debugging. It launches nixseparatedebuginfod and prepends the server URL to the `DEBUGINFOD_URLS` environment variable.
