### PR TITLE
doc: implement meta.doc

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -123,6 +123,13 @@
       ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
       \`\`\`
     EOF
+
+    mkdir -p docs/languages
+    docs='${builtins.toJSON (builtins.map (lang: { name = lib.removeSuffix ".nix" (builtins.baseNameOf lang.file); doc = lang.value; }) config.meta.doc)}'
+    echo $docs | jq -r '.[]|[.name, .doc] | @tsv' |
+      while IFS=$'\t' read -r name doc; do
+        echo $doc > "docs/languages/$name.md"
+      done
   '';
 
   pre-commit.hooks = {

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -62,6 +62,7 @@
             specialArgs = inputs // { inherit inputs pkgs; };
             modules = [
               (inputs.devenv.modules + /top-level.nix)
+              (inputs.devenv.modules + /doc.nix)
               {
                 devenv.cliVersion = version;
                 devenv.root = devenv_root;

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           eval = pkgs.lib.evalModules {
             modules = [
               ./src/modules/top-level.nix
+              ./src/modules/doc.nix
               { devenv.warnOnNewVersion = false; }
             ];
             specialArgs = { inherit pre-commit-hooks pkgs inputs; };
@@ -147,6 +148,7 @@
               };
               modules = [
                 (self.modules + /top-level.nix)
+                ./src/modules/doc.nix
                 ({ config, ... }: {
                   packages = [
                     (mkDevShellPackage config pkgs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ nav:
     - Guides:
       - Using With Flakes: guides/using-with-flakes.md
       - Using With flake.parts: guides/using-with-flake-parts.md
+    - Languages:
+      - languages/elm.md
     - Integrations:
       - .env: integrations/dotenv.md
       - GitHub Actions: integrations/github-actions.md

--- a/src/modules/doc.nix
+++ b/src/modules/doc.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+
+let
+  docType = lib.types.str // {
+    merge = loc: defs: defs;
+  };
+in
+{
+  options = {
+    meta = {
+      doc = lib.mkOption {
+        type = docType;
+        internal = true;
+        default = "";
+        description = ''
+          Module documentation in markdown format.
+        '';
+      };
+    };
+  };
+}

--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -1,10 +1,18 @@
-{ pkgs, config, lib, ... }:
+{ pkgs, config, options, lib, ... }:
 
 let
   cfg = config.languages.elm;
 in
 {
-  meta.doc = "Hello from Elm!";
+  meta.doc = ''
+    ### Elm
+
+    Hello from Elm!
+
+    ### Options
+
+    ${lib.strings.concatStringsSep "\n" (lib.attrNames options.languages.elm)}
+  '';
 
   options.languages.elm = {
     enable = lib.mkEnableOption "tools for Elm development";

--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -4,6 +4,8 @@ let
   cfg = config.languages.elm;
 in
 {
+  meta.doc = "Hello from Elm!";
+
   options.languages.elm = {
     enable = lib.mkEnableOption "tools for Elm development";
   };


### PR DESCRIPTION
@k3yss 

This is basically what NixOS does. The `meta` attribute is allowed by the module system, but not defined by default, so we can hijack it for our needs. Every module now has a `meta.doc` field that can be populated.

I tried doing a submodule for languages, but there's some sort of error about nested options that needs investigating. 
```nix
languages = lib.mkOption {
  type = types.attrsOf (types.submodule ({...}: {
    freeformType = types.attrsOf (types.submodule ({...}: {
      imports = [ ./doc.nix ];
    }));
  }));
};
```

The tricky bit is that we define the nav manually in `mkdocs.yml`. I'm not sure how to tell it to pick up all files within a directory. We might need to write a small plugin.
