### PR TITLE
docs: commit docs in CI and make doc generation idempotent

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,5 @@
 name: "Generate docs/examples"
+
 on:
   push:
     branches:
@@ -6,8 +7,9 @@ on:
     tags:
       - v*
   pull_request:
+
 jobs:
-  build:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -19,25 +21,32 @@ jobs:
       with:
         name: devenv
     - run: nix profile install .
+
     - name: Generate doc options
       run: devenv shell devenv-generate-doc-options
-    # https://github.com/NixOS/nixpkgs/issues/224661
-    - run: sed -i 's/\\\././g' docs/reference/options.md
     - uses: EndBug/add-and-commit@v9
       if: ${{ github.event_name == 'push' }}
       with:
         default_author: github_actions
         add: docs/reference/options.md
         message: 'Auto generate docs/reference/options.md'
-    - name: Generate supported-languages example
-      run: devenv shell devenv-generate-languages-example
-    - name: Generate docs
-      run: devenv shell devenv-generate-docs
+
+    - name: Generate docs and supported-languages example
+      run: |
+        devenv shell devenv-generate-docs
+        devenv shell devenv-generate-languages-example
+    - uses: EndBug/add-and-commit@v9
+      if: ${{ github.event_name == 'push' }}
+      with:
+        default_author: github_actions
+        add: docs examples/supported-languages/devenv.nix
+        message: 'Auto generate docs and examples'
+
     - name: Generate JSON schema
       run: devenv generate-json-schema
     - uses: EndBug/add-and-commit@v9
       if: ${{ github.event_name == 'push' }}
       with:
         default_author: github_actions
-        add: examples/supported-languages/devenv.nix
-        message: 'Auto generate examples/supported-languages/devenv.nix'
+        add: docs/devenv.schema.json
+        message: 'Auto generate docs/devenv.schema.json'

--- a/devenv.nix
+++ b/devenv.nix
@@ -96,10 +96,13 @@
   '';
   scripts."devenv-generate-doc-options".exec = ''
     set -e
+    output_file=docs/reference/options.md
     options=$(nix build --impure --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
-    echo "# devenv.nix options" > docs/reference/options.md
-    echo >> docs/reference/options.md
-    cat $options >> docs/reference/options.md
+    echo "# devenv.nix options" > $output_file
+    echo >> $output_file
+    cat $options >> $output_file
+    # https://github.com/NixOS/nixpkgs/issues/224661
+    sed -i 's/\\\././g' $output_file
   '';
   scripts."devenv-generate-languages-example".exec = ''
     cat > examples/supported-languages/devenv.nix <<EOF

--- a/src/modules/integrations/hostctl.nix
+++ b/src/modules/integrations/hostctl.nix
@@ -20,6 +20,7 @@ in
     hostsProfileName = lib.mkOption {
       type = lib.types.str;
       default = "devenv-${builtins.hashString "sha256" config.env.DEVENV_ROOT}";
+      defaultText = "devenv-<hash>";
       description = "Profile name to use.";
     };
 

--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -74,7 +74,7 @@ let
 
             This option is read-only and managed by NixOS.
           '';
-          example = "${runtimeDir}/<name>.sock";
+          example = literalExpression ''config.env.DEVENV_STATE + "/php-fpm/<name>.sock"'';
         };
 
         listen = mkOption {
@@ -236,16 +236,21 @@ in
         default = {
           error_log = config.env.DEVENV_STATE + "/php-fpm/php-fpm.log";
         };
+        defaultText = literalExpression ''
+          {
+            error_log = config.env.DEVENV_STATE + "/php-fpm/php-fpm.log";
+          }
+        '';
         description = ''
           PHP-FPM global directives. 
-          
+
           Refer to the "List of global php-fpm.conf directives" section of
           <https://www.php.net/manual/en/install.fpm.configuration.php>
           for details. 
-          
+
           Note that settings names must be enclosed in
           quotes (e.g. `"pm.max_children"` instead of `pm.max_children`). 
-          
+
           You need not specify the options `error_log` or `daemonize` here, since
           they are already set.
         '';

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -171,6 +171,9 @@ in
     libraries = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ "${config.devenv.dotfile}/profile" ];
+      defaultText = lib.literalExpression ''
+        [ "''${config.devenv.dotfile}/profile" ]
+      '';
       description = ''
         Additional libraries to make available to the Python interpreter.
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -55,7 +55,13 @@ in
     mold.enable = lib.mkOption {
       type = lib.types.bool;
       default = pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && cfg.targets == [ ];
-      description = "Enable mold as the linker.";
+      defaultText =
+        lib.literalExpression "pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && languages.rust.targets == [ ]";
+      description = ''
+        Enable mold as the linker.
+
+        Enabled by default on x86_64 Linux machines when no cross-compilation targets are specified.
+      '';
     };
 
     toolchain = lib.mkOption {

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -68,6 +68,13 @@ in
           unix-socket = "${config.devenv.runtime}/pc.sock";
           tui = true;
         };
+        defaultText = lib.literalExpression ''
+          {
+            version = "0.5";
+            unix-socket = "''${config.devenv.runtime}/pc.sock";
+            tui = true;
+          }
+        '';
         example = {
           version = "0.5";
           log_location = "/path/to/combined/output/logfile.log";

--- a/src/modules/services/caddy.nix
+++ b/src/modules/services/caddy.nix
@@ -158,6 +158,7 @@ in
 
     dataDir = mkOption {
       default = "${config.env.DEVENV_STATE}/caddy";
+      defaultText = literalExpression ''"${config.env.DEVENV_STATE}/caddy"'';
       type = types.path;
       description = ''
         The data directory, for storing certificates. Before 17.09, this


### PR DESCRIPTION
- Commit missing generated docs and schema in CI
- Make doc generation idempotent to the environment where it runs. This means removing any reference to local directories and hashes from the defaults and examples.
- Added a read-only `baseDir` to couchdb to make it easier to reference the location of its state when overriding settings.