### PR TITLE
Allow follows in top-level inputs and validate flake inputs

### DIFF
--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -37,8 +37,13 @@ impl Input {
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct FlakeInput {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub follows: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
     pub inputs: HashMap<String, Input>,
+    #[serde(skip_serializing_if = "is_true", default = "true_default")]
     pub flake: bool,
 }
 

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -1078,7 +1078,16 @@ impl App {
 
         let mut flake_inputs = HashMap::new();
         for (input, attrs) in self.config.inputs.iter() {
-            flake_inputs.insert(input.clone(), config::FlakeInput::from(attrs));
+            match config::FlakeInput::try_from(attrs) {
+                Ok(flake_input) => {
+                    flake_inputs.insert(input.clone(), flake_input);
+                }
+                Err(e) => {
+                    self.logger
+                        .error(&format!("Failed to parse input {}: {}", input, e));
+                    bail!("Failed to parse inputs");
+                }
+            }
         }
         fs::write(
             self.devenv_dotfile.join("flake.json"),


### PR DESCRIPTION
Fixes #1049.

There are two commits to this:
1. Removing null attributes when serializing the flake input struct. This fixes #1049.
2. Validating that only one of `url` and `follows` are set.

2 is a little controversial because Nix actually allows setting both `url` and `follows` at the same time. The following example will not trigger an error in Nix:
```nix
{
  nixpkgs = {
    url = "...";
    follows = "other-input/nixpkgs";
  };
}
```
Nix seems to implicitly prioritise `follows` over `url`, which could be quite confusing. Our choice is whether to do better than Nix in this situation and throw a descriptive error, or allow it through and let Nix decide what's best.