### PR TITLE
add: solidity and foundry support

### DIFF
--- a/docs/languages-all.md
+++ b/docs/languages-all.md
@@ -41,6 +41,7 @@
   languages.rust.enable = true;
   languages.scala.enable = true;
   languages.shell.enable = true;
+  languages.solidity.enable = true;
   languages.standardml.enable = true;
   languages.swift.enable = true;
   languages.terraform.enable = true;

--- a/examples/solidity/.test.sh
+++ b/examples/solidity/.test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+solc --version
+forge --version
+chisel --version
+anvil --version

--- a/examples/solidity/devenv.nix
+++ b/examples/solidity/devenv.nix
@@ -1,0 +1,7 @@
+{ pkgs, lib, ... }:
+{
+  languages.solidity = {
+    enable = true;
+    foundry.enable = true;
+  };
+}

--- a/examples/solidity/devenv.yaml
+++ b/examples/solidity/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  foundry:
+    url: github:shazow/foundry.nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/src/modules/languages/solidity.nix
+++ b/src/modules/languages/solidity.nix
@@ -7,6 +7,7 @@ let
     name = "foundry";
     url = "github:shazow/foundry.nix";
     attribute = "languages.solidity.foundry.package";
+    follows = [ "nixpkgs" ];
   };
 in {
   options.languages.solidity = {

--- a/src/modules/languages/solidity.nix
+++ b/src/modules/languages/solidity.nix
@@ -7,7 +7,6 @@ let
     name = "foundry";
     url = "github:shazow/foundry.nix";
     attribute = "languages.solidity.foundry.package";
-    follows = [ "nixpkgs" ];
   };
 in {
   options.languages.solidity = {

--- a/src/modules/languages/solidity.nix
+++ b/src/modules/languages/solidity.nix
@@ -1,0 +1,38 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.languages.solidity;
+
+  foundry = config.lib.getInput {
+    name = "foundry";
+    url = "github:shazow/foundry.nix";
+    attribute = "languages.solidity.foundry.package";
+    follows = [ "nixpkgs" ];
+  };
+in {
+  options.languages.solidity = {
+    enable = lib.mkEnableOption "tools for Solidity development";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Which compiler of Solidity to use.";
+      default = pkgs.solc;
+      defaultText = lib.literalExpression "pkgs.elixir";
+    };
+
+    foundry = {
+      enable = lib.mkEnableOption "install Foundry";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = "Which Foundry package to use.";
+        default = foundry.defaultPackage.${pkgs.stdenv.system};
+        defaultText = lib.literalExpression "foundry.defaultPackage.$${pkgs.stdenv.system}";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = [ cfg.package ] ++ lib.optional cfg.foundry.enable (cfg.foundry.package);
+  };
+}

--- a/src/modules/languages/solidity.nix
+++ b/src/modules/languages/solidity.nix
@@ -9,7 +9,8 @@ let
     attribute = "languages.solidity.foundry.package";
     follows = [ "nixpkgs" ];
   };
-in {
+in
+{
   options.languages.solidity = {
     enable = lib.mkEnableOption "tools for Solidity development";
 


### PR DESCRIPTION
This PR:
- adds support for Solidity (`languages.solidity`, https://soliditylang.org/) with `package` option. Default `package` is `pkgs.solc` from `nixpkgs`.
- adds support for Foundry (`languages.solidity.foundry`, https://book.getfoundry.sh/) with `package` option. Default `package` is `foundry-bin` from [foundry.nix](https://github.com/shazow/foundry.nix).

## Trying out
If you want to try this out, you will need to change your `devenv.yaml`:
```yaml
inputs:
  devenv:
    url: github:gabr1sr/devenv/new/modules/solidity?dir=src/modules
  foundry:
    url: github:shazow/foundry.nix
    inputs:
      nixpkgs:
        follows: nixpkgs
```

And change your `devenv.nix`:
```nix
{ ... }:
{
  languages.solidity = {
    enable = true;
    foundry.enable = true;
  };
}
```

Related to shazow/foundry.nix#34