### PR TITLE
info: print the script description and path in `devenv info`

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -40,93 +40,105 @@
     tailwind.exec = "watchexec -e html,css,js npx tailwindcss build docs/assets/extra.css -o docs/assets/output.css";
   };
 
-  scripts.devenv-test-cli.exec = ''
-    set -xe
-    set -o pipefail
+  scripts.devenv-test-cli = {
+    description = "Test devenv CLI.";
+    exec = ''
+      set -xe
+      set -o pipefail
 
-    pushd examples/simple
-      # this should fail since files already exist
-      devenv init && exit 1
-    popd
+      pushd examples/simple
+        # this should fail since files already exist
+        devenv init && exit 1
+      popd
 
-    tmp="$(mktemp -d)"
-    devenv init "$tmp"
-    pushd "$tmp"
-      devenv version
-      devenv --override-input devenv path:${config.devenv.root}?dir=src/modules test
-    popd
-    rm -rf "$tmp"
+      tmp="$(mktemp -d)"
+      devenv init "$tmp"
+      pushd "$tmp"
+        devenv version
+        devenv --override-input devenv path:${config.devenv.root}?dir=src/modules test
+      popd
+      rm -rf "$tmp"
 
-    # Test devenv integrated into bare Nix flake
-    tmp="$(mktemp -d)"
-    pushd "$tmp"
-      nix flake init --template ''${DEVENV_ROOT}#simple
-      nix flake update \
-        --override-input devenv ''${DEVENV_ROOT}
-      nix develop --accept-flake-config --impure --command echo nix-develop started succesfully |& tee ./console
-      grep -F 'nix-develop started succesfully' <./console
-      grep -F "$(${lib.getExe pkgs.hello})" <./console
+      # Test devenv integrated into bare Nix flake
+      tmp="$(mktemp -d)"
+      pushd "$tmp"
+        nix flake init --template ''${DEVENV_ROOT}#simple
+        nix flake update \
+          --override-input devenv ''${DEVENV_ROOT}
+        nix develop --accept-flake-config --impure --command echo nix-develop started succesfully |& tee ./console
+        grep -F 'nix-develop started succesfully' <./console
+        grep -F "$(${lib.getExe pkgs.hello})" <./console
 
-      # Assert that nix-develop fails in pure mode.
-      if nix develop --command echo nix-develop started in pure mode |& tee ./console
-      then
-        echo "nix-develop was able to start in pure mode. This is explicitly not supported at the moment."
-        exit 1
-      fi
-      grep -F 'devenv was not able to determine the current directory.' <./console
-    popd
-    rm -rf "$tmp"
+        # Assert that nix-develop fails in pure mode.
+        if nix develop --command echo nix-develop started in pure mode |& tee ./console
+        then
+          echo "nix-develop was able to start in pure mode. This is explicitly not supported at the moment."
+          exit 1
+        fi
+        grep -F 'devenv was not able to determine the current directory.' <./console
+      popd
+      rm -rf "$tmp"
 
-    # Test devenv integrated into flake-parts Nix flake
-    tmp="$(mktemp -d)"
-    pushd "$tmp"
-      nix flake init --template ''${DEVENV_ROOT}#flake-parts
-      nix flake update \
-        --override-input devenv ''${DEVENV_ROOT}
-      nix develop --accept-flake-config --override-input devenv-root "file+file://"<(printf %s "$PWD") --command echo nix-develop started succesfully |& tee ./console
-      grep -F 'nix-develop started succesfully' <./console
-      grep -F "$(${lib.getExe pkgs.hello})" <./console
-      # Test that a container can be built
-      if $(uname) == "Linux"
-      then
-        nix build --override-input devenv-root "file+file://"<(printf %s "$PWD") --accept-flake-config --show-trace .#container-processes
-      fi
-    popd
-    rm -rf "$tmp"
-  '';
-  scripts."devenv-generate-doc-options".exec = ''
-    set -e
-    output_file=docs/reference/options.md
-    options=$(nix build --impure --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
-    echo "# devenv.nix options" > $output_file
-    echo >> $output_file
-    cat $options >> $output_file
-    # https://github.com/NixOS/nixpkgs/issues/224661
-    sed -i 's/\\\././g' $output_file
-  '';
-  scripts."devenv-generate-languages-example".exec = ''
-    cat > examples/supported-languages/devenv.nix <<EOF
-    { pkgs, ... }: {
+      # Test devenv integrated into flake-parts Nix flake
+      tmp="$(mktemp -d)"
+      pushd "$tmp"
+        nix flake init --template ''${DEVENV_ROOT}#flake-parts
+        nix flake update \
+          --override-input devenv ''${DEVENV_ROOT}
+        nix develop --accept-flake-config --override-input devenv-root "file+file://"<(printf %s "$PWD") --command echo nix-develop started succesfully |& tee ./console
+        grep -F 'nix-develop started succesfully' <./console
+        grep -F "$(${lib.getExe pkgs.hello})" <./console
+        # Test that a container can be built
+        if $(uname) == "Linux"
+        then
+          nix build --override-input devenv-root "file+file://"<(printf %s "$PWD") --accept-flake-config --show-trace .#container-processes
+        fi
+      popd
+      rm -rf "$tmp"
+    '';
+  };
+  scripts."devenv-generate-doc-options" = {
+    description = "Generate option docs.";
+    exec = ''
+      set -e
+      output_file=docs/reference/options.md
+      options=$(nix build --impure --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
+      echo "# devenv.nix options" > $output_file
+      echo >> $output_file
+      cat $options >> $output_file
+      # https://github.com/NixOS/nixpkgs/issues/224661
+      sed -i 's/\\\././g' $output_file
+    '';
+  };
+  scripts."devenv-generate-languages-example" = {
+    description = "Generate an example enabling every supported language.";
+    exec = ''
+      cat > examples/supported-languages/devenv.nix <<EOF
+      { pkgs, ... }: {
 
-      # Enable all languages tooling!
-      ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
+        # Enable all languages tooling!
+        ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
 
-      # If you're missing a language, please contribute it by following examples of other languages <3
-    }
-    EOF
-  '';
-  scripts."devenv-generate-docs".exec = ''
-    cat > docs/services-all.md <<EOF
-      \`\`\`nix
-      ${lib.concatStringsSep "\n  " (map (lang: "services.${lang}.enable = true;") (builtins.attrNames config.services))}
-      \`\`\`
-    EOF
-    cat > docs/languages-all.md <<EOF
-      \`\`\`nix
-      ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
-      \`\`\`
-    EOF
-  '';
+        # If you're missing a language, please contribute it by following examples of other languages <3
+      }
+      EOF
+    '';
+  };
+  scripts."devenv-generate-docs" = {
+    description = "Generate lists of all languages and services.";
+    exec = ''
+      cat > docs/services-all.md <<EOF
+        \`\`\`nix
+        ${lib.concatStringsSep "\n  " (map (lang: "services.${lang}.enable = true;") (builtins.attrNames config.services))}
+        \`\`\`
+      EOF
+      cat > docs/languages-all.md <<EOF
+        \`\`\`nix
+        ${lib.concatStringsSep "\n  " (map (lang: "languages.${lang}.enable = true;") (builtins.attrNames config.languages))}
+        \`\`\`
+      EOF
+    '';
+  };
 
   pre-commit.hooks = {
     nixpkgs-fmt.enable = true;


### PR DESCRIPTION
Adds the script's description and its path to the output of `devenv info`.
Preview for devenv:

```shell
# processes
- docs: exec /nix/store/1vi1k0wy7a86g8i5imypw1p2g1g2bjl9-docs
- tailwind: exec /nix/store/ln9gvm1gkmii8bxr51n4r54c8j1w3991-tailwind

# scripts
- devenv-generate-doc-options: Generate option docs.
  /nix/store/f3kp77kfxl08nqlpzdmkykqnf1cwnfhc-devenv-generate-doc-options

- devenv-generate-docs: Generate lists of all languages and services.
  /nix/store/ycwim9lpm0azqkh77sysr3j2kw17m5fc-devenv-generate-docs

- devenv-generate-languages-example: Generate an example enabling every supported language.
  /nix/store/17x10g90jicnadi2ixm5as2gd9ch6vi6-devenv-generate-languages-example

- devenv-test-cli: Test devenv CLI.
  /nix/store/jiyllnk1sm3bamhrkbh38lhhh5svhqij-devenv-test-cli

```

Suggested by @karfau on discord.