### PR TITLE
process-compose: fix an error when disabling the tui

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -40,7 +40,7 @@ in
     processManagerCommand = ''
       ${cfg.package}/bin/process-compose --config ${cfg.configFile} \
         --unix-socket ''${PC_SOCKET_PATH:-${toString config.process.process-compose.unix-socket}} \
-        --tui=''${PC_TUI_ENABLED:-${toString config.process.process-compose.tui}} \
+        --tui=''${PC_TUI_ENABLED:-${lib.boolToString config.process.process-compose.tui}} \
         -U up "$@" &
     '';
 


### PR DESCRIPTION
Serialize the tui boolean to "true" and "false", instead of "1" and "".