### PR TITLE
fix: allow caddy dataDir with spaces

### DIFF
--- a/src/modules/services/caddy.nix
+++ b/src/modules/services/caddy.nix
@@ -190,6 +190,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    processes.caddy.exec = "XDG_DATA_HOME=${cfg.dataDir}/data XDG_CONFIG_HOME=${cfg.dataDir}/config ${cfg.package}/bin/${cfg.package.meta.mainProgram} run ${optionalString cfg.resume "--resume"} --config ${configJSON}";
+    processes.caddy.exec = ''XDG_DATA_HOME="${cfg.dataDir}/data" XDG_CONFIG_HOME="${cfg.dataDir}/config" ${cfg.package}/bin/${cfg.package.meta.mainProgram} run ${optionalString cfg.resume "--resume"} --config ${configJSON}'';
   };
 }


### PR DESCRIPTION
I have a project example path of `/home/user/coding/my projects/devenv-project`.

When running `devenv up` the caddy logs show:
`/nix/store/2diacl69qsxagwr73f1ykc5j750sln0j-caddy: line 2: projects/devenv-project/.devenv/state/caddy/data: No such file or directory`

caddy tries to use `projects/devenv-project/.devenv/state/caddy` as dataDir instead of `/home/user/coding/my projects/devenv-project/.devenv/state/caddy`.

This PR quotes the `XDG_*_HOME` paths so they can also contain spaces.