### PR TITLE
Allow caching

### DIFF
--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -47,6 +47,9 @@ pub struct GlobalOptions {
     )]
     pub impure: bool,
 
+    #[arg(long, global = true, help = "Use flake cache for evaluation results.")]
+    pub eval_cache: bool,
+
     #[arg(
         long,
         global = true,
@@ -97,6 +100,7 @@ impl Default for GlobalOptions {
             cores: 2,
             system: default_system(),
             impure: false,
+            eval_cache: false,
             offline: false,
             clean: None,
             nix_debugger: false,

--- a/devenv/src/command.rs
+++ b/devenv/src/command.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::os::unix::process::CommandExt;
 use std::path::Path;
 
-const NIX_FLAGS: [&str; 12] = [
+const NIX_FLAGS: [&str; 9] = [
     "--show-trace",
     "--extra-experimental-features",
     "nix-command",
@@ -15,10 +15,6 @@ const NIX_FLAGS: [&str; 12] = [
     // remove unnecessary warnings
     "--option",
     "warn-dirty",
-    "false",
-    // flake caching is too aggressive
-    "--option",
-    "eval-cache",
     "false",
     // always build all dependencies and report errors at the end
     "--keep-going",
@@ -111,6 +107,11 @@ impl Devenv {
             flags.push("--max-jobs");
             let max_jobs = self.global_options.max_jobs.to_string();
             flags.push(&max_jobs);
+
+            flags.push("--option");
+            flags.push("eval-cache");
+            let eval_cache = self.global_options.eval_cache.to_string();
+            flags.push(&eval_cache);
 
             // handle --nix-option key value
             for chunk in self.global_options.nix_option.chunks_exact(2) {


### PR DESCRIPTION
I was using devenv as flake library but later switched to cli, only noticing that is magnitude slower. What is the main reason for disabling caching? 

Without caching:
```
time devenv shell exit
• Building shell ...
✔ Building shell in 5.1s.
0.76s user 0.18s system 13% cpu 7.154 total
```

With caching:
```
time devenv --eval-cache shell exit
• Building shell ...
✔ Building shell in 1.5s.
0.06s user 0.03s system 5% cpu 1.645 total
```
