### PR TITLE
Update .envrc

### DIFF
--- a/templates/simple/.envrc
+++ b/templates/simple/.envrc
@@ -2,8 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 
-nix_direnv_watch_file flake.nix
-nix_direnv_watch_file flake.lock
+watch_file flake.nix
+watch_file flake.lock
 if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2


### PR DESCRIPTION
Got the following message after running `nix flake init --template github:cachix/devenv` and `direnv allow`:
```bash
direnv: `nix_direnv_watch_file` is deprecated - use `watch_file`
```
