### PR TITLE
fix: --upgrade-dep not available with python < 3.9

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -63,10 +63,14 @@ let
         echo uv venv "$VENV_PATH"
         uv venv "$VENV_PATH"
       ''
-      else ''
+      else if lib.versionAtLeast cfg.version "3.9"  then ''
           echo ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
           ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
         ''
+        else ''
+          echo ${package.interpreter} -m venv "$VENV_PATH"
+          ${package.interpreter} -m venv "$VENV_PATH"
+        '' 
       }
       echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"
     fi

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -63,14 +63,10 @@ let
         echo uv venv "$VENV_PATH"
         uv venv "$VENV_PATH"
       ''
-      else if lib.versionAtLeast cfg.version "3.9"  then ''
-          echo ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
-          ${package.interpreter} -m venv --upgrade-deps "$VENV_PATH"
+      else ''
+          echo ${package.interpreter} -m venv ${if lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
+          ${package.interpreter} -m venv ${if lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
         ''
-        else ''
-          echo ${package.interpreter} -m venv "$VENV_PATH"
-          ${package.interpreter} -m venv "$VENV_PATH"
-        '' 
       }
       echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"
     fi

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -64,8 +64,8 @@ let
         uv venv "$VENV_PATH"
       ''
       else ''
-          echo ${package.interpreter} -m venv ${if lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
-          ${package.interpreter} -m venv ${if lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
+          echo ${package.interpreter} -m venv ${if builtins.isNull cfg.version || lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
+          ${package.interpreter} -m venv ${if builtins.isNull cfg.version || lib.versionAtLeast cfg.version "3.9" then "--upgrade-deps" else ""} "$VENV_PATH"
         ''
       }
       echo "${package.interpreter}" > "$VENV_PATH/.devenv_interpreter"


### PR DESCRIPTION
The `--upgrade-dep` flag was introduced in python version `3.9`, this PR disables the flag in case of python version lower than the version `3.9`

fixes #1289 