### PR TITLE
docs: make the services postgres example a valid example

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -18,7 +18,14 @@ Here's an example starting PostgreSQL with a few extensions:
       extensions.timescaledb
     ];
     settings.shared_preload_libraries = "timescaledb";
-    initialScript = "CREATE EXTENSION IF NOT EXISTS timescaledb;";
+    initialScript = ''
+      CREATE CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+      CREATE DATABASE postgres;
+      CREATE USER postgres WITH ENCRYPTED PASSWORD 'postgres';
+      GRANT ALL PRIVILEGES ON DATABASE postgres TO postgres;
+    '';
+    listen_addresses = "127.0.0.1";
   };
 }
 ```

--- a/docs/services.md
+++ b/docs/services.md
@@ -19,7 +19,7 @@ Here's an example starting PostgreSQL with a few extensions:
     ];
     settings.shared_preload_libraries = "timescaledb";
     initialScript = ''
-      CREATE CREATE EXTENSION IF NOT EXISTS timescaledb;
+      CREATE EXTENSION IF NOT EXISTS timescaledb;
 
       CREATE DATABASE postgres;
       CREATE USER postgres WITH ENCRYPTED PASSWORD 'postgres';


### PR DESCRIPTION
The existing postgres services example gives an error of "role "postgres" does not exist" . this took me a while to figure out until i got the correct config in discord discussion. and It would be good if the example just worked out of the box.