### PR TITLE
test: postgres PGHOST and listen_address test

### DIFF
--- a/tests/postgres-pghost/.test.sh
+++ b/tests/postgres-pghost/.test.sh
@@ -1,0 +1,11 @@
+wait_for_port 2345
+psql postgres -c '\q' &> /dev/null
+
+# Check the exit status of the psql command
+if [ $? -eq 0 ]; then
+    echo "listen_address and PGHOST is valid, connection successful"
+    exit 0
+else
+    echo "listen_address and PGHOST is invalid, connection failed"
+    exit 1
+fi

--- a/tests/postgres-pghost/devenv.nix
+++ b/tests/postgres-pghost/devenv.nix
@@ -1,0 +1,10 @@
+{
+  services.postgres = {
+    enable = true;
+    listen_addresses = "*";
+    port = 2345;
+    initialScript = ''
+      CREATE USER postgres SUPERUSER;
+    '';
+  };
+}


### PR DESCRIPTION
This PR adds a test for examining the anomalies when we set the `listen_address/PGHOST` value to "*". The expected result is this test failing on macos based systems as described in this [this](https://www.postgresql.org/message-id/1860173.1719520971@sss.pgh.pa.us) forum

ref  #1298 