### PR TITLE
Bug/tailwindcss - Update devenv.nix to Use Tailwind Nix Package

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -35,7 +35,7 @@
 
   processes = {
     docs.exec = "mkdocs serve";
-    tailwind.exec = "watchexec -e html,css,js npx tailwindcss build docs/assets/extra.css -o docs/assets/output.css";
+    tailwind.exec = "watchexec -e html,css,js ${lib.getExe pkgs.tailwindcss} build docs/assets/extra.css -o docs/assets/output.css";
   };
 
   scripts.devenv-test-cli = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,6 +1,4 @@
-{ inputs, pkgs, lib, config, ... }:
-
-{
+{ inputs, pkgs, lib, config, ... }: {
   env.DEVENV_NIX = inputs.nix.packages.${pkgs.stdenv.system}.nix;
 
   packages = [
@@ -156,7 +154,7 @@
     generate-css = {
       enable = true;
       name = "generate-css";
-      entry = "npx tailwindcss build docs/assets/extra.css -o docs/assets/output.css";
+      entry = "${lib.getExe pkgs.tailwindcss} build docs/assets/extra.css -o docs/assets/output.css";
     };
   };
 }


### PR DESCRIPTION
The base `devenv.nix` configuration relied on NPX to execute Tailwind CSS commands. However, for users without Node.js installed locally, these commands would fail. This update replaces NPX with the Tailwind package from Nix, ensuring compatibility regardless of local Node.js installations.