### PR TITLE
devenv: generate and ship manpages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ result
 .direnv*
 /.cache
 /.pre-commit-config.yaml
+man
 
 # examples
 examples/rust/app/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50dde5bc0c853d6248de457e5eb6e5a674a54b93810a34ded88d882ca1fe2de"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "cli-table"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,12 +886,13 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "miette"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baed61d13cc3723ee6dbed730a82bfacedc60a85d81da2d77e9c3e8ebc0b504a"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
  "backtrace",
  "backtrace-ext",
+ "cfg-if",
  "miette-derive",
  "owo-colors",
  "supports-color",
@@ -895,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301c3f54f98abc6c212ee722f5e5c62e472a334415840669e356f04850051ec"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1207,6 +1218,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustc-demangle"
@@ -2119,3 +2136,13 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_mangen",
+ "devenv",
+ "miette",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "devenv",
     "devenv-run-tests",
+    "xtask",
 ]
 
 [workspace.package]

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -18,6 +18,7 @@ miette.workspace = true
 nix.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+schemars.workspace = true
 schematic.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -28,5 +29,3 @@ tracing.workspace = true
 which.workspace = true
 whoami.workspace = true
 xdg.workspace = true
-
-schemars.workspace = true

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(
+    name = "devenv",
     color = clap::ColorChoice::Auto,
     // for --clean to work with subcommands
     subcommand_precedence_over_arg = true,

--- a/package.nix
+++ b/package.nix
@@ -5,25 +5,42 @@ pkgs.rustPlatform.buildRustPackage {
   version = "1.0.7";
 
   src = pkgs.lib.sourceByRegex ./. [
-    "Cargo.toml"
-    "Cargo.lock"
-    "devenv(/\.*)?"
-    "devenv-run-tests(/\.*)?"
+    "^\.cargo(/.*)?$"
+    "Cargo\.toml"
+    "Cargo\.lock"
+    "devenv(/.*)?"
+    "devenv-run-tests(/.*)?"
+    "xtask(/.*)?"
   ];
+
+  cargoBuildFlags = [ "-p devenv -p devenv-run-tests" ];
 
   cargoLock = {
     lockFile = ./Cargo.lock;
   };
 
-  nativeBuildInputs = [ pkgs.makeWrapper pkgs.pkg-config ];
+  nativeBuildInputs = [
+    pkgs.makeWrapper
+    pkgs.pkg-config
+    pkgs.installShellFiles
+  ];
 
   buildInputs = [ pkgs.openssl ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
     pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
   ];
 
   postInstall = ''
-    wrapProgram $out/bin/devenv --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
+    wrapProgram $out/bin/devenv \
+      --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} \
+      --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
+
     # TODO: problematic for our library...
-    wrapProgram $out/bin/devenv-run-tests --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
+    wrapProgram $out/bin/devenv-run-tests \
+      --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} \
+      --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
+
+    # Generate manpages
+    cargo xtask generate-manpages --out-dir man
+    installManPage man/*
   '';
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+clap.workspace = true
+clap_mangen = "0.2.22"
+devenv = { path = "../devenv" }
+miette.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+use miette::Result;
+
+mod manpage;
+
+#[derive(clap::Parser)]
+struct Cli {
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(clap::Subcommand)]
+enum Command {
+    GenerateManpages {
+        #[clap(
+            long,
+            value_parser,
+            value_hint = clap::ValueHint::DirPath,
+            default_value_os_t = manpage::default_out_dir()
+        )]
+        out_dir: std::path::PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::GenerateManpages { out_dir } => manpage::generate_manpages(out_dir),
+    }
+}

--- a/xtask/src/manpage.rs
+++ b/xtask/src/manpage.rs
@@ -1,0 +1,19 @@
+use clap::CommandFactory;
+use miette::{IntoDiagnostic, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+mod cli {
+    include!("../../devenv/src/cli.rs");
+}
+
+pub fn generate_manpages(out_dir: impl AsRef<Path>) -> Result<()> {
+    fs::create_dir_all(&out_dir).into_diagnostic()?;
+    clap_mangen::generate_to(cli::Cli::command(), &out_dir).into_diagnostic()?;
+    println!("Generated man pages to {}", out_dir.as_ref().display());
+    Ok(())
+}
+
+pub fn default_out_dir() -> PathBuf {
+    std::env::current_dir().unwrap().join("man")
+}


### PR DESCRIPTION
Usage:
```shell
cargo xtask generate-manpages --out-dir OPTIONAL_PATH
```