### PR TITLE
Yarn must the same package as language definition.

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -184,7 +184,7 @@ in
         type = lib.types.package;
         default = pkgs.nodePackages.pnpm.override {
           nodejs = cfg.package;
-        }
+        };
         defaultText = lib.literalExpression "pkgs.nodePackages.pnpm";
         description = "The pnpm package to use.";
       };

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -158,8 +158,8 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.nodejs;
-      defaultText = lib.literalExpression "pkgs.nodejs";
+      default = pkgs.nodejs-slim;
+      defaultText = lib.literalExpression "pkgs.nodejs-slim";
       description = "The Node.js package to use.";
     };
 

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -158,8 +158,8 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.nodejs-slim;
-      defaultText = lib.literalExpression "pkgs.nodejs-slim";
+      default = pkgs.nodejs;
+      defaultText = lib.literalExpression "pkgs.nodejs";
       description = "The Node.js package to use.";
     };
 
@@ -171,8 +171,8 @@ in
       enable = lib.mkEnableOption "install npm";
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.nodejs;
-        defaultText = lib.literalExpression "pkgs.nodejs";
+        default = cfg.package;
+        defaultText = lib.literalExpression "languages.javascript.package";
         description = "The Node.js package to use.";
       };
       install.enable = lib.mkEnableOption "npm install during devenv initialisation";
@@ -182,7 +182,9 @@ in
       enable = lib.mkEnableOption "install pnpm";
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.nodePackages.pnpm;
+        default = pkgs.nodePackages.pnpm.override {
+          nodejs = cfg.package;
+        }
         defaultText = lib.literalExpression "pkgs.nodePackages.pnpm";
         description = "The pnpm package to use.";
       };
@@ -194,7 +196,7 @@ in
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.yarn.override {
-          nodejs = package;
+          nodejs = cfg.package;
         };
         defaultText = lib.literalExpression "pkgs.yarn";
         description = "The yarn package to use.";
@@ -243,7 +245,3 @@ in
     );
   };
 }
-
-
-
-

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -193,7 +193,9 @@ in
       enable = lib.mkEnableOption "install yarn";
       package = lib.mkOption {
         type = lib.types.package;
-        default = pkgs.yarn;
+        default = pkgs.yarn.override {
+          nodejs = package;
+        };
         defaultText = lib.literalExpression "pkgs.yarn";
         description = "The yarn package to use.";
       };


### PR DESCRIPTION
Inherit a package, so that we do not end up with different versions of Node.js as default is whatever is marked as stable in Nixpkgs.