### PR TITLE
home: bump packages count

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -31,7 +31,7 @@
       <p class="mt-6 text-lg leading-8 text-gray-800">
         Develop <a href="/basics" class="text-[#425C82] font-medium">natively</a>
         • Deploy <a href="/containers" class="text-[#425C82] font-medium">containers</a>
-        • 80.000+ <a href="/packages" class="text-[#425C82] font-medium">packages</a>
+        • 100.000+ <a href="/packages" class="text-[#425C82] font-medium">packages</a>
         • Write <a href="/scripts" class="text-[#425C82] font-medium">scripts</a>
         • 50+ <a href="/languages" class="text-[#425C82] font-medium">supported languages</a>
         • Define <a href="/processes" class="text-[#425C82] font-medium">processes</a>


### PR DESCRIPTION
Noticed this while browsing the home page, bumps the count like https://github.com/NixOS/nixos-search/pull/756 does.