### PR TITLE
make flake-parts .envrc match .nix and .lock files

### DIFF
--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -2,9 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 
-nix_direnv_watch_file devenv.nix
-nix_direnv_watch_file devenv.lock
-nix_direnv_watch_file devenv.yaml
+nix_direnv_watch_file flake.nix
+nix_direnv_watch_file flake.lock
 
 if ! use flake . --override-input devenv-root "file+file://"<(printf %s "$PWD")
 then


### PR DESCRIPTION
The flake-parts template's `.envrc` erroneously refers to files (`devenv.nix`, `devenv.lock`, `devenv.yaml`that are not present for that kind of setup. It should point to the ones that are really there