### PR TITLE
feat: Add option to select jdk with clojure

### DIFF
--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -6,26 +6,17 @@ in
 {
   options.languages.clojure = {
     enable = lib.mkEnableOption "tools for Clojure development";
-    jdk.package = lib.mkOption {
-      type = lib.types.package;
-      example = lib.literalExpression "pkgs.jdk8";
-      default = pkgs.jdk;
-      defaultText = lib.literalExpression "pkgs.jdk";
-      description = ''
-        The JDK package to use.
-        This will also become available as `JAVA_HOME`.
-      '';
-    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       (clojure.override {
-        jdk = cfg.jdk.package;
+        jdk = config.languages.java.jdk.package;
       })
       clojure-lsp
     ];
+    languages.java.enable = true;
 
-    env.JAVA_HOME = cfg.jdk.package.home;
+    env.JAVA_HOME = config.languages.java.jdk.package.home;
   };
 }

--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -6,12 +6,26 @@ in
 {
   options.languages.clojure = {
     enable = lib.mkEnableOption "tools for Clojure development";
+    jdk.package = lib.mkOption {
+      type = lib.types.package;
+      example = lib.literalExpression "pkgs.jdk8";
+      default = pkgs.jdk;
+      defaultText = lib.literalExpression "pkgs.jdk";
+      description = ''
+        The JDK package to use.
+        This will also become available as `JAVA_HOME`.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      clojure
+      (clojure.override {
+        jdk = cfg.jdk.package;
+      })
       clojure-lsp
     ];
+
+    env.JAVA_HOME = cfg.jdk.package.home;
   };
 }

--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -16,7 +16,5 @@ in
       clojure-lsp
     ];
     languages.java.enable = true;
-
-    env.JAVA_HOME = config.languages.java.jdk.package.home;
   };
 }


### PR DESCRIPTION
This PR adds the functionality of selecting the `jdk` version for `clojure` programming language using overrides.

Fixes #1341 