### PR TITLE
fix: Root user password assignment in MySQL and MariaDB

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -114,7 +114,12 @@ with lib; let
     ${concatMapStrings (user: ''
         echo "Adding user: ${user.name}"
         ${optionalString (user.password != null) "password='${user.password}'"}
-        ( echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
+        (
+          if [ "${user.name}" = "root" ]; then
+            echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';"
+          else
+            echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
+          fi
           ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
             echo 'GRANT ${permission} ON ${database} TO `${user.name}`@`localhost`;'
           '')

--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -115,7 +115,7 @@ with lib; let
         echo "Adding user: ${user.name}"
         ${optionalString (user.password != null) "password='${user.password}'"}
         (
-          if [ "${user.name}" = "root" ]; then
+          if [ "${user.name}" = "root" ] && [ -n ${user.password} ]; then
             echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';"
           else
             echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${optionalString (user.password != null) "IDENTIFIED BY '$password'"};"


### PR DESCRIPTION
This PR addresses an issue in `MySQL` or `MariaDB` where attempts to assign a password to the root user are unsuccessful, resulting in the default `blank` password being used.

Fixes #1251 