### PR TITLE
Update documentation for devenv upgrades tip

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,7 @@
 
 !!! Updating
 
-    Follow the instructions for an installation above. 
+    To update, refer to the specific upgrade instructions provided in the documentation for the installer you used from the options above. 
 
 ## Initial set up
 


### PR DESCRIPTION
Simply changed the current tip to be a little clearer for people who might mistake the current instruction to mean upgrade via rerunning the install instruction.

"Follow the instructions for an installation above."

to

"To update, refer to the specific upgrade instructions provided in the documentation for the installer you used from the options above. "