### PR TITLE
feat: add `modules` option to allow flakeModules to add options to every devshell

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,13 +8,21 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
           config = {
             # Add flake-parts-specific config here if necessary
           };
-        }];
+        }] ++ config.devenv.modules;
       }).type;
 
       shellPrefix = shellName: if shellName == "default" then "" else "${shellName}-";
     in
 
     {
+      options.devenv.modules = lib.mkOption {
+        type = lib.types.listOf lib.types.deferredModule;
+        description = ''
+          Extra modules to import into every shell.
+          Allows flakeModules to add options to devenv for example.
+        '';
+        default = [];
+      };
       options.devenv.shells = lib.mkOption {
         type = lib.types.lazyAttrsOf devenvType;
         description = ''


### PR DESCRIPTION
This PR adds an option `devenv.modules` which takes an array of module types (paths, functions and attrsets) and forwards them into all shells.

That makes it way easier for flake modules (when using flake-parts) to add custom options for shells.
For example, it would allow my [nix-devtools](https://gitlab.com/TECHNOFAB/nix-devtools) to easily add task and teller integration without the user having to add `imports` into every shell. (see `feat/flakeModule` for example)