### PR TITLE
Nix language support improvements, including smaller Cachix

### DIFF
--- a/src/modules/cachix.nix
+++ b/src/modules/cachix.nix
@@ -1,4 +1,4 @@
-{ lib, config, ... }:
+{ pkgs, lib, config, ... }:
 let
   cfg = config.cachix;
 in
@@ -19,6 +19,11 @@ in
       type = lib.types.nullOr lib.types.str;
       description = "What cache to push to. Automatically also adds it to the list of caches to pull from.";
       default = null;
+    };
+
+    package = lib.mkPackageOption pkgs "Cachix" {
+      default = "cachix";
+      example = lib.literalExpression "inputs.devenv.inputs.cachix.packages.\${pkgs.stdenv.system}.cachix";
     };
   };
 

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -2,6 +2,7 @@
 
 let
   cfg = config.languages.nix;
+  cachix = "${lib.getBin config.cachix.package}";
 in
 {
   options.languages.nix = {
@@ -16,11 +17,10 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
-      cachix
       statix
       vulnix
       deadnix
       cfg.lsp.package
-    ];
+    ] ++ (lib.optional config.cachix.enable cachix);
   };
 }

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -3,6 +3,13 @@
 let
   cfg = config.languages.nix;
   cachix = "${lib.getBin config.cachix.package}";
+
+  # a bit of indirection to prevent mkShell from overriding the installed Nix
+  vulnix = pkgs.buildEnv {
+    name = "vulnix";
+    paths = [ pkgs.vulnix ];
+    pathsToLink = [ "/bin" ];
+  };
 in
 {
   options.languages.nix = {
@@ -18,9 +25,10 @@ in
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       statix
-      vulnix
       deadnix
       cfg.lsp.package
-    ] ++ (lib.optional config.cachix.enable cachix);
+    ] ++ (lib.optional config.cachix.enable cachix) ++ [
+      vulnix
+    ];
   };
 }


### PR DESCRIPTION
**This fix saves 7 GB** in the closure size of my devenv projects which have Nix language support enabled.

Background: Currently, with `languages.nix.enable = true;`, all outputs of the `cachix` package in Nixpkgs get installed. Unlike the Cachix package provided by the [cachix/cachix](https://github.com/cachix/cachix) flake, this is a massive multi-output derivation that includes a huge Haskell runtime with libs in `.out` and more than a gigabyte of library documentation in `.doc`.

The original issue here raises some questions for me about how devenv profiles are constructed and whether they do or should honor `meta.outputsToInstall`-- maybe there's something to think about there, too. (The Cachix package in nixpkgs has only `"bin"` in `meta.outputsToInstall`.)

Anyway, this fix works now and is a huge quality of life improvement for me!