### PR TITLE
Remove darwinFlags in rust module

### DIFF
--- a/examples/rust-wasm-cross/devenv.nix
+++ b/examples/rust-wasm-cross/devenv.nix
@@ -27,9 +27,4 @@
   ] ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk; [
     frameworks.Security
   ]);
-
-  # macOS workaround:
-  # The linker on macOS doesn't like the frameworks option when compiling to wasm32.
-  # See https://github.com/rust-lang/rust/issues/122333
-  env.RUSTFLAGS = lib.mkIf pkgs.stdenv.isDarwin (lib.mkForce "");
 }

--- a/examples/rust/.test.sh
+++ b/examples/rust/.test.sh
@@ -3,12 +3,6 @@ set -ex
 cargo --version
 rustc --version
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  echo "$RUSTFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
-  echo "$RUSTDOCFLAGS" | grep -- "-L framework=$DEVENV_PROFILE/Library/Frameworks"
-  echo "$CFLAGS" | grep -- "-iframework $DEVENV_PROFILE/Library/Frameworks"
-fi
-
 [[ "$CARGO_INSTALL_ROOT" == "$DEVENV_STATE/cargo-install" ]]
 echo "$PATH" | grep -- "$CARGO_INSTALL_ROOT/bin"
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -127,7 +127,6 @@ in
 
         env =
           let
-            darwinFlags = lib.optionalString pkgs.stdenv.isDarwin "-L framework=${config.devenv.profile}/Library/Frameworks";
             moldFlags = lib.optionalString cfg.mold.enable "-C link-arg=-fuse-ld=mold";
           in
           {
@@ -137,8 +136,8 @@ in
               if cfg.toolchain ? rust-src
               then "${cfg.toolchain.rust-src}/lib/rustlib/src/rust/library"
               else pkgs.rustPlatform.rustLibSrc;
-            RUSTFLAGS = "${darwinFlags} ${moldFlags} ${cfg.rustflags}";
-            RUSTDOCFLAGS = "${darwinFlags} ${moldFlags}";
+            RUSTFLAGS = "${moldFlags} ${cfg.rustflags}";
+            RUSTDOCFLAGS = "${moldFlags}";
             CFLAGS = lib.optionalString pkgs.stdenv.isDarwin "-iframework ${config.devenv.profile}/Library/Frameworks";
           };
 


### PR DESCRIPTION
Remove `darwinFlags` to fix linking error when compiling no_std crate. Closing #1355 

Only tested with Developer Frameworks already installed in the system.

I am not sure if this change will break those who only rely on Developer Frameworks in Nixpkgs and don't have Developer Frameworks installed outside Nix.