### PR TITLE
Pass `--no-pure-eval` instead of `--impure`

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -62,7 +62,7 @@
         nix flake init --template ''${DEVENV_ROOT}#simple
         nix flake update \
           --override-input devenv ''${DEVENV_ROOT}
-        nix develop --accept-flake-config --impure --command echo nix-develop started succesfully |& tee ./console
+        nix develop --accept-flake-config --no-pure-eval --command echo nix-develop started succesfully |& tee ./console
         grep -F 'nix-develop started succesfully' <./console
         grep -F "$(${lib.getExe pkgs.hello})" <./console
 
@@ -105,7 +105,7 @@
     exec = ''
       set -e
       output_file=docs/reference/options.md
-      options=$(nix build --accept-flake-config --impure --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
+      options=$(nix build --accept-flake-config --no-pure-eval --extra-experimental-features 'flakes nix-command' --show-trace --print-out-paths --no-link '.#devenv-docs-options')
       echo "# devenv.nix options" > $output_file
       echo >> $output_file
       cat $options >> $output_file

--- a/devenv/src/command.rs
+++ b/devenv/src/command.rs
@@ -148,7 +148,7 @@ impl Devenv {
                         .map(|arg| arg == &"build" || arg == &"eval" || arg == &"print-dev-env")
                         .unwrap_or(false)
                 {
-                    flags.push("--impure");
+                    flags.push("--no-pure-eval");
                 }
                 // set a dummy value to overcome https://github.com/NixOS/nix/issues/10247
                 cmd.env("NIX_PATH", ":");

--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -19,7 +19,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=$(nix build '.#${shellPrefix (config._module.args.name or "default")}devenv-up' --no-link --print-out-paths --impure)
+      procfilescript=$(nix build '.#${shellPrefix (config._module.args.name or "default")}devenv-up' --no-link --print-out-paths --no-pure-eval)
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1


### PR DESCRIPTION
`--impure` means both impure evaluate and impure build, while `--no-pure-eval` means impure evaluate and pure build.  `--no-pure-eval` can be used to determine cwd. `--impure`  is more evil and unnecessary in devenv.