### PR TITLE
fix: don't delete runtime dir on process down

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -146,7 +146,6 @@ in
         wait $backgroundPID
         ${config.process.after}
         echo "Processes stopped."
-        rm -rf ${config.devenv.runtime}
       }
 
       trap down SIGINT SIGTERM


### PR DESCRIPTION
Fixes #1270.

@domenkozar, should we be deleting the runtime dir when taking down processes? Any good reason to do this?

There are a few issues with this line:

1. It relies on trapping a signal. In the case of process-compose, I think the reason it's immune from this failure is because the trap is never triggered. We need to rethink how we run post-process actions.
2. We create the runtime dir in the CLI, but try to delete it in the shell script. This sounds like a bug magnet to me.
3. There was an issue a while back where redis would crash on shutdown because of a race condition here.

