### PR TITLE
feat: Added custom option and config

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -85,8 +85,8 @@ let
 
   configFile = pkgs.writeText "postgresql.conf" (lib.concatStringsSep "\n"
     (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") cfg.settings));
-  setupPgHbaFileScript = if cfg.customPgHbaFile != null then
-    ''cp ${cfg.customPgHbaFile} "$PGDATA/pg_hba.conf"'' else "";
+  setupPgHbaFileScript = if cfg.hbaConf != null then
+    ''cp ${cfg.hbaConf} "$PGDATA/pg_hba.conf"'' else "";
   setupScript = pkgs.writeShellScriptBin "setup-postgres" ''
     set -euo pipefail
     export PATH=${postgresPkg}/bin:${pkgs.coreutils}/bin
@@ -282,8 +282,8 @@ in
       '';
     };
 
-    customPgHbaFile = lib.mkOption {
-      type = types.nullOr types.path;
+    hbaConf = lib.mkOption {
+      type = types.nullOr types.str;
       default = null;
       description = ''
         The path to a custom pg_hba.conf file to copy into the postgres installation. This
@@ -291,7 +291,7 @@ in
         you're using flakes remember to add the file to version control!
       '';
       example = lib.literalExpression ''
-        ./my-custom/directory/to/pg_hba.conf
+        "${./my-custom/directory/to/pg_hba.conf}"
       '';
     };
   };

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -85,10 +85,12 @@ let
 
   configFile = pkgs.writeText "postgresql.conf" (lib.concatStringsSep "\n"
     (lib.mapAttrsToList (n: v: "${n} = ${toStr v}") cfg.settings));
-  setupPgHbaFileScript = 
-    if cfg.hbaConf != null then let
-      file = pkgs.writeText "pg_hba.conf" cfg.hbaConf;
-    in ''cp ${file} "$PGDATA/pg_hba.conf"''
+  setupPgHbaFileScript =
+    if cfg.hbaConf != null then
+      let
+        file = pkgs.writeText "pg_hba.conf" cfg.hbaConf;
+      in
+      ''cp ${file} "$PGDATA/pg_hba.conf"''
     else "";
   setupScript = pkgs.writeShellScriptBin "setup-postgres" ''
     set -euo pipefail


### PR DESCRIPTION
This PR resolves (https://github.com/cachix/devenv/issues/1212) by adding a configuration option that enables the user to start the PostgreSQL server with a custom pg_hba.conf file, this file is primarily used to enable or disable which IPs get to connect to the server both locally (from UNIX sockets) or from the network (using TCP/IP).

I had a "Fine I'll do it myself moment" and honestly after I saw the code it wasn't really that hard.