### PR TITLE
flake-parts template: make flake-parts input source explicit

### DIFF
--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -6,6 +6,7 @@
       url = "file+file:///dev/null";
       flake = false;
     };
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:cachix/devenv-nixpkgs/rolling";
     devenv.url = "github:cachix/devenv";
     nix2container.url = "github:nlewo/nix2container";


### PR DESCRIPTION
Prevents https://github.com/cachix/devenv/issues/1360, which occurs with the current template if a local flake registry (global, user, whatever) sets `flake-parts` directly to a path under `/nix/store` which is later garbage collected.

That issue seems like a pretty big footgun in its non-obviousness, and it's also a mess to clean up. I think it's probably better not to have any `type: "indirect"` stuff in the default `flake.locks` produced by our flake-parts template. This fix addresses the named issue in just that way.