### PR TITLE
scala: add support for mill (build tool)

### DIFF
--- a/src/modules/languages/scala.nix
+++ b/src/modules/languages/scala.nix
@@ -1,8 +1,9 @@
 { pkgs, config, lib, ... }:
-
 let
   cfg = config.languages.scala;
   java = config.languages.java;
+  sbt = cfg.sbt.package;
+  mill = cfg.mill.package;
 in
 {
   options.languages.scala = {
@@ -16,19 +17,38 @@ in
         The Scala package to use.
       '';
     };
+
+    sbt = with lib; {
+      enable = mkEnableOption "sbt, the standard build tool for Scala";
+      package = mkPackageOption pkgs "sbt" {
+        default = "sbt";
+        example = "sbt-with-scala-native";
+      };
+    };
+
+    mill = with lib; {
+      enable = mkEnableOption "mill, a simplified, fast build tool for Scala";
+      package = mkPackageOption pkgs "mill" {
+        default = "mill";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       (cfg.package.override
         { jre = java.jdk.package; })
-      (sbt.override
-        { jre = java.jdk.package; })
       (metals.override
         { jre = java.jdk.package; })
       (coursier.override
         { jre = java.jdk.package; })
       (scalafmt.override
+        { jre = java.jdk.package; })
+    ] ++ lib.optionals cfg.sbt.enable [
+      (sbt.override
+        { jre = java.jdk.package; })
+    ] ++ lib.optionals cfg.mill.enable [
+      (mill.override
         { jre = java.jdk.package; })
     ] ++ lib.optionals (lib.versionAtLeast java.jdk.package.version "17") [
       (scala-cli.override


### PR DESCRIPTION
This change makes the choice of Scala build tools configurable.

This is a minimal change that's in line with the existing functionality in the Scala module.