### PR TITLE
feat: add a `--quiet` flag to disable logging

### DIFF
--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -23,7 +23,13 @@ pub struct GlobalOptions {
     #[arg(short, long, global = true, help = "Enable debug log level.")]
     pub verbose: bool,
 
-    #[arg(short, long, global = true, help = "Disable all logs")]
+    #[arg(
+        short,
+        long,
+        global = true,
+        conflicts_with = "verbose",
+        help = "Disable all logs"
+    )]
     pub quiet: bool,
 
     #[arg(short = 'j', long,

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -23,6 +23,9 @@ pub struct GlobalOptions {
     #[arg(short, long, global = true, help = "Enable debug log level.")]
     pub verbose: bool,
 
+    #[arg(short, long, global = true, help = "Disable all logs")]
+    pub quiet: bool,
+
     #[arg(short = 'j', long,
         global = true, help = "Maximum number of Nix builds at any time.",
         default_value_t = max_jobs())]
@@ -96,6 +99,7 @@ impl Default for GlobalOptions {
     fn default() -> Self {
         Self {
             verbose: false,
+            quiet: false,
             max_jobs: max_jobs(),
             cores: 2,
             system: default_system(),

--- a/devenv/src/log.rs
+++ b/devenv/src/log.rs
@@ -2,6 +2,29 @@ use ansiterm::Colour::{Blue, DarkGray, Green, Red, Yellow};
 use std::io::Write;
 use std::time::Instant;
 
+pub enum LogProgressCreator {
+    Silent,
+    Logging,
+}
+
+impl LogProgressCreator {
+    pub fn with_newline(&self, message: &str) -> Option<LogProgress> {
+        use LogProgressCreator::*;
+        match self {
+            Silent => None,
+            Logging => Some(LogProgress::new(message, true)),
+        }
+    }
+
+    pub fn without_newline(&self, message: &str) -> Option<LogProgress> {
+        use LogProgressCreator::*;
+        match self {
+            Silent => None,
+            Logging => Some(LogProgress::new(message, false)),
+        }
+    }
+}
+
 pub struct LogProgress {
     message: String,
     start: Option<Instant>,
@@ -43,6 +66,7 @@ impl Drop for LogProgress {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub enum Level {
+    Silent,
     Error,
     Warn,
     Info,
@@ -96,6 +120,7 @@ impl Logger {
                 let prefix = DarkGray.paint("•");
                 eprintln!("{} {}", prefix, message);
             }
+            Level::Silent => {}
         }
     }
 }

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -14,6 +14,8 @@ fn main() -> Result<()> {
 
     let level = if cli.global_options.verbose {
         log::Level::Debug
+    } else if cli.global_options.quiet {
+        log::Level::Silent
     } else {
         log::Level::Info
     };


### PR DESCRIPTION
Fixes #435 

This is useful for people who don't want to clutter their terminal with logs. This will also be useful in CI environments for people who want a cleaner log. For example a user can enter a shell without seeing any logs using the following commad.
```sh
devenv -q shell
```