### PR TITLE
Fix maven failing to build with `function 'anonymous lambda' called with unexpected argument 'jdk'`

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -2649,7 +2649,7 @@ package
 
 
 *Default:*
-` "pkgs.maven.override { jdk = cfg.jdk.package; }" `
+` "pkgs.maven.override { jdk_headless = cfg.jdk.package; }" `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/java.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/java.nix)

--- a/docs/supported-languages/java.md
+++ b/docs/supported-languages/java.md
@@ -128,4 +128,4 @@ package
 
 
 *Default:*
-` "pkgs.maven.override { jdk = cfg.jdk.package; }" `
+` "pkgs.maven.override { jdk_headless = cfg.jdk.package; }" `

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -21,7 +21,7 @@ in
       enable = mkEnableOption "maven";
       package = mkOption {
         type = types.package;
-        defaultText = "pkgs.maven.override { jdk = cfg.jdk.package; }";
+        defaultText = "pkgs.maven.override { jdk_headless = cfg.jdk.package; }";
         description = ''
           The Maven package to use.
           The Maven package by default inherits the JDK from `languages.java.jdk.package`.
@@ -42,7 +42,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    languages.java.maven.package = mkDefault (pkgs.maven.override { jdk = cfg.jdk.package; });
+    languages.java.maven.package = mkDefault (pkgs.maven.override { jdk_headless = cfg.jdk.package; });
     languages.java.gradle.package = mkDefault (pkgs.gradle.override { java = cfg.jdk.package; });
     packages = (optional cfg.enable cfg.jdk.package)
       ++ (optional cfg.maven.enable cfg.maven.package)

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -2,6 +2,13 @@
 
 let
   cfg = config.languages.java;
+  mavenArgs = builtins.functionArgs pkgs.maven.override;
+  mavenPackage =
+    if builtins.hasAttr "jdk" mavenArgs then
+    # ensure backwards compatibility when using pkgs from before this commit: https://github.com/NixOS/nixpkgs/commit/ea0bc3224593ddf7ac6c702c7acb6c89cf188f0f
+      pkgs.maven.override { jdk = cfg.jdk.package; }
+    else
+      pkgs.maven.override { jdk_headless = cfg.jdk.package; };
   inherit (lib) types mkEnableOption mkOption mkDefault mkIf optional literalExpression;
 in
 {
@@ -42,7 +49,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    languages.java.maven.package = mkDefault (pkgs.maven.override { jdk_headless = cfg.jdk.package; });
+    languages.java.maven.package = mkDefault mavenPackage;
     languages.java.gradle.package = mkDefault (pkgs.gradle.override { java = cfg.jdk.package; });
     packages = (optional cfg.enable cfg.jdk.package)
       ++ (optional cfg.maven.enable cfg.maven.package)

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -2,7 +2,7 @@
 
 let
   cfg = config.languages.java;
-  mavenArgs = builtins.functionArgs pkgs.maven.override;
+  mavenArgs = pkgs.maven.override.__functionArgs;
   mavenPackage =
     if builtins.hasAttr "jdk" mavenArgs then
     # ensure backwards compatibility when using pkgs from before this commit: https://github.com/NixOS/nixpkgs/commit/ea0bc3224593ddf7ac6c702c7acb6c89cf188f0f


### PR DESCRIPTION
On nixpkgs, the `jdk` argument has been renamed to `jdk_headless`, currently causing the devenv to fail to build maven with:
```
error: function 'anonymous lambda' called with unexpected argument 'jdk'

at /nix/store/pwwns4fq736wqpmf5xfsxds4kh4f580w-source/pkgs/by-name/ma/maven/package.nix:1:1:
```

See [this commit on nixpkgs](https://github.com/NixOS/nixpkgs/commit/ea0bc3224593ddf7ac6c702c7acb6c89cf188f0f#diff-b3af06f6694c5996094cf6cd4db45398f256ff6e2d56d9a7b1b275092badd7d9)