### PR TITLE
feat: Expose devenv options for nixd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
         {
           default = self.packages.${system}.devenv;
           devenv = mkPackage pkgs;
+          devenv-module-options = evaluatedModules;
           devenv-docs-options = options.optionsCommonMark;
           devenv-docs-options-json = options.optionsJSON;
           devenv-generate-individual-docs =


### PR DESCRIPTION
This PR exposes options for modules which is required if we want to support nixd lsp natively. We would need this before https://github.com/nix-community/nixd/pull/584 is merged.