### PR TITLE
fix: let nix not cache bash generated file

### DIFF
--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -5,7 +5,9 @@ fi
 nix_direnv_watch_file flake.nix
 nix_direnv_watch_file flake.lock
 
-if ! use flake . --override-input devenv-root --option tarball-ttl 0 "file+file://"<(printf %s "$PWD")
+DEVENV_ROOT_FILE="$(mktemp)"
+printf %s "$PWD" > "$DEVENV_ROOT_FILE"
+if ! use flake . --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi

--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -5,7 +5,7 @@ fi
 nix_direnv_watch_file flake.nix
 nix_direnv_watch_file flake.lock
 
-if ! use flake . --override-input devenv-root "file+file://"<(printf %s "$PWD")
+if ! use flake . --override-input devenv-root --option tarball-ttl 0 "file+file://"<(printf %s "$PWD")
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi


### PR DESCRIPTION
Originally, bash generates `/dev/fd/63` from `"file+file://"<(printf %s "$PWD")` and nix caches the file content with TTL 3600 seconds, as a result, if two flake-parts based devenv projects are created under different paths, they would interfere each other's cache for `/dev/fd/63`, and result in wrong `DEVENV_ROOT`.

This PR disables the nix file cache to avoid the problem.
