### PR TITLE
fix: Prevent Redis from remaining running in the background

### DIFF
--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -22,7 +22,7 @@ let
       mkdir -p "$REDISDATA"
     fi
 
-    exec ${cfg.package}/bin/redis-server ${redisConfig} --dir "$REDISDATA"
+    exec ${cfg.package}/bin/redis-server ${redisConfig} --daemonize no --dir "$REDISDATA"
   '';
 
   tcpPing = "${cfg.package}/bin/redis-cli -p ${toString cfg.port} ping";


### PR DESCRIPTION
This fixes the issue where Redis would ignore termination signals from process-compose, as it assumes it is running under systemd and similar PID 0 managers.