### PR TITLE
fix: removed use of deprecated lib functions

### DIFF
--- a/src/modules/integrations/aws-vault.nix
+++ b/src/modules/integrations/aws-vault.nix
@@ -16,7 +16,7 @@ in
 
     profile = lib.mkOption {
       type = lib.types.str;
-      description = lib.mdDoc ''
+      description = ''
         The profile name passed to `aws-vault exec`.
       '';
     };

--- a/src/modules/integrations/devcontainer.nix
+++ b/src/modules/integrations/devcontainer.nix
@@ -16,7 +16,7 @@ in
         options.image = lib.mkOption {
           type = lib.types.str;
           default = "ghcr.io/cachix/devenv:latest";
-          description = lib.mdDoc ''
+          description = ''
             The name of an image in a container registry.
           '';
         };
@@ -24,7 +24,7 @@ in
         options.overrideCommand = lib.mkOption {
           type = lib.types.anything;
           default = false;
-          description = lib.mdDoc ''
+          description = ''
             Override the default command.
           '';
         };
@@ -32,7 +32,7 @@ in
         options.updateContentCommand = lib.mkOption {
           type = lib.types.anything;
           default = "devenv test";
-          description = lib.mdDoc ''
+          description = ''
             Command to run after container creation.
           '';
         };
@@ -40,7 +40,7 @@ in
         options.customizations.vscode.extensions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ "mkhl.direnv" ];
-          description = lib.mdDoc ''
+          description = ''
             List of preinstalled VSCode extensions.
           '';
         };
@@ -48,7 +48,7 @@ in
 
       default = { };
 
-      description = lib.mdDoc ''
+      description = ''
         Devcontainer settings.
       '';
     };

--- a/src/modules/services/couchdb.nix
+++ b/src/modules/services/couchdb.nix
@@ -95,7 +95,7 @@ in
         options.chttpd.bind_address = lib.mkOption {
           type = lib.types.str;
           default = "127.0.0.1";
-          description = lib.mdDoc ''
+          description = ''
             Defines the IP address by which CouchDB will be accessible.
           '';
         };
@@ -103,7 +103,7 @@ in
         options.chttpd.port = lib.mkOption {
           type = lib.types.port;
           default = 5984;
-          description = lib.mdDoc ''
+          description = ''
             Defined the port number to listen.
           '';
         };

--- a/src/modules/services/nginx.nix
+++ b/src/modules/services/nginx.nix
@@ -41,7 +41,7 @@ in
       default = "${pkgs.mailcap}/etc/nginx/mime.types";
       defaultText = lib.literalExpression "\${pkgs.mailcap}/etc/nginx/mime.types";
       example = lib.literalExpression "\${pkgs.nginx}/conf/mime.types";
-      description = lib.mdDoc ''
+      description = ''
         Default MIME types for NGINX, as MIME types definitions from NGINX are very incomplete,
         we use by default the ones bundled in the mailcap package, used by most of the other
         Linux distributions.

--- a/src/modules/services/opensearch.nix
+++ b/src/modules/services/opensearch.nix
@@ -58,9 +58,9 @@ let
 in
 {
   options.services.opensearch = {
-    enable = mkEnableOption (lib.mdDoc "OpenSearch");
+    enable = mkEnableOption "OpenSearch";
 
-    package = lib.mkPackageOptionMD pkgs "OpenSearch" {
+    package = lib.mkPackageOption pkgs "OpenSearch" {
       default = [ "opensearch" ];
     };
 
@@ -71,7 +71,7 @@ in
         options."network.host" = lib.mkOption {
           type = lib.types.str;
           default = "127.0.0.1";
-          description = lib.mdDoc ''
+          description = ''
             Which port this service should listen on.
           '';
         };
@@ -79,7 +79,7 @@ in
         options."cluster.name" = lib.mkOption {
           type = lib.types.str;
           default = "opensearch";
-          description = lib.mdDoc ''
+          description = ''
             The name of the cluster.
           '';
         };
@@ -87,7 +87,7 @@ in
         options."discovery.type" = lib.mkOption {
           type = lib.types.str;
           default = "single-node";
-          description = lib.mdDoc ''
+          description = ''
             The type of discovery to use.
           '';
         };
@@ -95,7 +95,7 @@ in
         options."http.port" = lib.mkOption {
           type = lib.types.port;
           default = 9200;
-          description = lib.mdDoc ''
+          description = ''
             The port to listen on for HTTP traffic.
           '';
         };
@@ -103,7 +103,7 @@ in
         options."transport.port" = lib.mkOption {
           type = lib.types.port;
           default = 9300;
-          description = lib.mdDoc ''
+          description = ''
             The port to listen on for transport traffic.
           '';
         };
@@ -111,13 +111,13 @@ in
 
       default = { };
 
-      description = lib.mdDoc ''
+      description = ''
         OpenSearch configuration.
       '';
     };
 
     logging = lib.mkOption {
-      description = lib.mdDoc "OpenSearch logging configuration.";
+      description = "OpenSearch logging configuration.";
 
       default = ''
         logger.action.name = org.opensearch.action

--- a/src/modules/services/varnish.nix
+++ b/src/modules/services/varnish.nix
@@ -47,7 +47,7 @@ in
       type = types.listOf types.package;
       default = [ ];
       example = literalExpression "[ pkgs.varnish73Packages.modules ]";
-      description = lib.mdDoc ''
+      description = ''
         Varnish modules (except 'std').
       '';
     };


### PR DESCRIPTION
Removes the uses of deprecated functions, that is no longer used/removed aliases.
Hopefully this should be fine? I'm not 100% sure that devenv does not follow some older nixpkgs version.