### PR TITLE
Improve services.postgres db init

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -34784,6 +34784,8 @@ list of (submodule)
 [
   {
     name = "foodatabase";
+    user = "ufoo";
+    pass = "barpaz";
     schema = ./foodatabase.sql;
   }
   { name = "bardatabase"; }
@@ -34801,6 +34803,38 @@ list of (submodule)
 
 
 The name of the database to create.
+
+
+
+*Type:*
+string
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/postgres.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/postgres.nix)
+
+
+
+## services.postgres.initialDatabases.\*.user
+
+
+
+The user who owns the database.
+
+
+
+*Type:*
+string
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/postgres.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/postgres.nix)
+
+
+
+## services.postgres.initialDatabases.\*.pass
+
+
+
+The password of the user who owns the database.
 
 
 

--- a/tests/postgresql-customdbuser/.test.sh
+++ b/tests/postgresql-customdbuser/.test.sh
@@ -1,0 +1,30 @@
+set -e
+
+wait_for_port 2345
+pg_isready -d template1
+
+# negative check (whether error handling in the test is reliable)
+psql \
+	--set ON_ERROR_STOP=on \
+	--username=notexists \
+	--dbname=testdb \
+	--echo-all \
+	-c '\dt' && {
+	echo "Problem with error handling!!!"
+	exit 1
+}
+
+# now check whether we can connect to our db as our new user and have permission to do stuff with the DB
+psql \
+	--set ON_ERROR_STOP=on \
+	--username=testuser \
+	--dbname=testdb \
+	--echo-all \
+	--file=- <<'EOF'
+\dt
+SELECT * FROM supermasters;
+INSERT INTO 
+    supermasters (ip,nameserver,account)
+    VALUES ('10.100.9.99','dns.example.org','exampleaccount');
+SELECT * FROM supermasters;
+EOF

--- a/tests/postgresql-customdbuser/devenv.nix
+++ b/tests/postgresql-customdbuser/devenv.nix
@@ -1,0 +1,19 @@
+{
+  services.postgres = {
+    enable = true;
+    listen_addresses = "localhost";
+    port = 2345;
+    # NOTE: use default for initialScript, which is:
+    # initialScript = ''
+    #   CREATE USER postgres SUPERUSER;
+    # '';
+    initialDatabases = [
+      {
+        name = "testdb";
+        user = "testuser";
+        pass = "testuserpass";
+        schema = ./.; # *.sql in version order
+      }
+    ];
+  };
+}

--- a/tests/postgresql-customdbuser/testinitdb.sql
+++ b/tests/postgresql-customdbuser/testinitdb.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS supermasters (
+    ip INET NOT NULL,
+    nameserver VARCHAR(255) NOT NULL,
+    account VARCHAR(40) NOT NULL,
+    PRIMARY KEY (ip, nameserver)
+);


### PR DESCRIPTION
Add user/pass capability to `services.postgres.initialDatabases` because we usually like to test our services with specific DB users. The options are optional, functionality remains the same if not given.

If we now do this:

```nix
  services.postgres = {
    enable = true;
    listen_addresses = "localhost";
    port = 15432;
    initialDatabases = [
      {
        name = "pdns";
        user = "pdns";
        pass = "mypdnssecretpass1234";
        schema = ./_testdata; # *.sql in version order
      }
    ];
  };
```

the following will happen:

1. `postgres` DB is created as usual, owned by `$USER` (who is SUPERUSER) for this instance)
2. A role `pdns` with password `${pass}` is created
3. Database `${name}` is created
4. All privileges on `pdns` are granted to user `pdns`.
5. The schema seeding scripts in `${schema}` are executed as user `pdns`.