### PR TITLE
feat: add `devenv.flakeArgs` to avoid `--no-pure-eval`

### DIFF
--- a/src/devenv-devShell.nix
+++ b/src/devenv-devShell.nix
@@ -19,7 +19,7 @@ pkgs.writeScriptBin "devenv" ''
 
   case $command in
     up)
-      procfilescript=$(nix build '.#${shellPrefix (config._module.args.name or "default")}devenv-up' --no-link --print-out-paths --no-pure-eval)
+      procfilescript=$(nix build '.#${shellPrefix (config._module.args.name or "default")}devenv-up' --no-link --print-out-paths ${lib.escapeShellArgs config.devenv.flakeArgs})
       if [ "$(cat $procfilescript|tail -n +2)" = "" ]; then
         echo "No 'processes' option defined: https://devenv.sh/processes/"
         exit 1

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -155,6 +155,12 @@ in
         default = builtins.getEnv "PWD";
       };
 
+      flakeArgs = lib.mkOption {
+        type = types.listOf types.str;
+        internal = true;
+        default = [ "--override-input" "devenv-root" "path:.devenv/state/pwd" ];
+      };
+
       dotfile = lib.mkOption {
         type = types.str;
         internal = true;
@@ -272,6 +278,7 @@ in
       fi
 
       mkdir -p "$DEVENV_STATE"
+      printf %s "$DEVENV_ROOT" > "$DEVENV_STATE/pwd"
       if [ ! -L "$DEVENV_DOTFILE/profile" ] || [ "$(${pkgs.coreutils}/bin/readlink $DEVENV_DOTFILE/profile)" != "${profile}" ]
       then
         ln -snf ${profile} "$DEVENV_DOTFILE/profile"

--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -5,9 +5,10 @@ fi
 nix_direnv_watch_file flake.nix
 nix_direnv_watch_file flake.lock
 
-DEVENV_ROOT_FILE="$(mktemp)"
-printf %s "$PWD" > "$DEVENV_ROOT_FILE"
-if ! use flake . --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"
+mkdir -p .devenv/state/
+printf %s "$PWD" > .devenv/state/pwd
+
+if ! use flake . --override-input devenv-root path:.devenv/state/pwd
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi


### PR DESCRIPTION
This PR avoids `--no-pure-eval` in `devenv-devShell.nix`, in favor of `"--override-input" "devenv-root" "path:.devenv/state/pwd"`.
