### PR TITLE
Fix `container build` command failing due to insufficient config option specification for `perms`

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -289,9 +289,10 @@ let
                             description = "A store path.";
                           };
                           regex = lib.mkOption {
-                            type = types.str;
+                            type = types.nullOr types.str;
                             description = "A regex pattern to select files or directories to apply the ``mode`` to.";
                             example = ".*";
+                            default = null;
                           };
                           mode = lib.mkOption {
                             type = types.str;

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -290,29 +290,33 @@ let
                           };
                           regex = lib.mkOption {
                             type = types.nullOr types.str;
-                            description = "A regex pattern to select files or directories to apply the ``mode`` to.";
+                            description = "A regex pattern to select files or directories to apply the permissions, owner, and group info to.";
                             example = ".*";
                             default = null;
                           };
                           mode = lib.mkOption {
                             type = types.str;
-                            description = "The numeric permissions mode to apply to all of the files matched by the ``regex``.";
+                            description = "File permissions to apply in octal representation.";
                             example = "644";
                           };
                           uid = lib.mkOption {
                             type = types.int;
+                            description = "Numeric ID of the owner to apply.";
                             default = lib.toInt uid;
                           };
                           gid = lib.mkOption {
                             type = types.int;
+                            description = "Numeric ID of the group to apply.";
                             default = lib.toInt gid;
                           };
                           uname = lib.mkOption {
                             type = types.str;
+                            description = "String representation of the owner to apply.";
                             default = user;
                           };
                           gname = lib.mkOption {
                             type = types.str;
+                            description = "String representation of the group to apply.";
                             default = group;
                           };
                         };

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -298,6 +298,22 @@ let
                             description = "The numeric permissions mode to apply to all of the files matched by the ``regex``.";
                             example = "644";
                           };
+                          uid = lib.mkOption {
+                            type = types.int;
+                            default = lib.toInt uid;
+                          };
+                          gid = lib.mkOption {
+                            type = types.int;
+                            default = lib.toInt gid;
+                          };
+                          uname = lib.mkOption {
+                            type = types.str;
+                            default = user;
+                          };
+                          gname = lib.mkOption {
+                            type = types.str;
+                            default = group;
+                          };
                         };
                       }
                     ];

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -1,6 +1,7 @@
 set -xe
 
 rm devenv.yaml || true
+devenv inputs add devenv "path:../../?dir=src/modules"
 devenv build languages.python.package
 devenv shell ls -- -la | grep ".test.sh"
 devenv shell ls ../ | grep "cli"


### PR DESCRIPTION
Trying to build a shell container against a minimal devenv.nix fails right now:

```sh
$ devenv container build shell
[...]
error: The option `containers.shell.layers."[definition 1-entry 1]".perms."[definition 1-entry 1]".gid' does not exist. Definition values:
- In `/nix/store/virtual0000000000000000000000007-source/src/modules/containers.nix': 1000
```

devenv version: devenv 1.0.8 (x86_64-linux)

devenv.nix:

```nix
{ pkgs, lib, config, inputs, ... }:

{}
```

<details><summary>devenv.yaml</summary>
<p>

```yaml
inputs:
  devenv:
    # fails
    url: github:cachix/devenv/58f2ff7b7cbb6f2325f5ddae6858a6e0c2d66cbd?dir=src/modules
    # ok
    #url: github:cachix/devenv/d1e690595ed39a15426cfa503bb44383cfa03ae7?dir=src/modules
  mk-shell-bin:
    url: github:rrbutani/nix-mk-shell-bin
  nixpkgs:
    url: github:cachix/devenv-nixpkgs/rolling
  nix2container:
    url: github:nlewo/nix2container
    inputs:
      nixpkgs:
        follows: nixpkgs
```

</p>
</details> 

<details><summary>devenv.lock</summary>
<p>

```json
{
  "nodes": {
    "devenv": {
      "locked": {
        "dir": "src/modules",
        "lastModified": 1725552963,
        "owner": "cachix",
        "repo": "devenv",
        "rev": "58f2ff7b7cbb6f2325f5ddae6858a6e0c2d66cbd",
        "treeHash": "1cd0d97307e87b086e3c47b723d3f0037dc4d865",
        "type": "github"
      },
      "original": {
        "dir": "src/modules",
        "owner": "cachix",
        "repo": "devenv",
        "rev": "58f2ff7b7cbb6f2325f5ddae6858a6e0c2d66cbd",
        "type": "github"
      }
    },
    "flake-compat": {
      "flake": false,
      "locked": {
        "lastModified": 1696426674,
        "owner": "edolstra",
        "repo": "flake-compat",
        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
        "type": "github"
      },
      "original": {
        "owner": "edolstra",
        "repo": "flake-compat",
        "type": "github"
      }
    },
    "flake-utils": {
      "inputs": {
        "systems": "systems"
      },
      "locked": {
        "lastModified": 1710146030,
        "owner": "numtide",
        "repo": "flake-utils",
        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
        "type": "github"
      },
      "original": {
        "owner": "numtide",
        "repo": "flake-utils",
        "type": "github"
      }
    },
    "gitignore": {
      "inputs": {
        "nixpkgs": [
          "pre-commit-hooks",
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1709087332,
        "owner": "hercules-ci",
        "repo": "gitignore.nix",
        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
        "type": "github"
      },
      "original": {
        "owner": "hercules-ci",
        "repo": "gitignore.nix",
        "type": "github"
      }
    },
    "mk-shell-bin": {
      "locked": {
        "lastModified": 1677004959,
        "owner": "rrbutani",
        "repo": "nix-mk-shell-bin",
        "rev": "ff5d8bd4d68a347be5042e2f16caee391cd75887",
        "treeHash": "496327dabdc787353a29987f492dd4939151baad",
        "type": "github"
      },
      "original": {
        "owner": "rrbutani",
        "repo": "nix-mk-shell-bin",
        "type": "github"
      }
    },
    "nix2container": {
      "inputs": {
        "flake-utils": "flake-utils",
        "nixpkgs": [
          "nixpkgs"
        ]
      },
      "locked": {
        "lastModified": 1724996935,
        "owner": "nlewo",
        "repo": "nix2container",
        "rev": "fa6bb0a1159f55d071ba99331355955ae30b3401",
        "treeHash": "a934d246fadcf8b36d28f3577fad413f5ab3f7d3",
        "type": "github"
      },
      "original": {
        "owner": "nlewo",
        "repo": "nix2container",
        "type": "github"
      }
    },
    "nixpkgs": {
      "locked": {
        "lastModified": 1716977621,
        "owner": "cachix",
        "repo": "devenv-nixpkgs",
        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "ref": "rolling",
        "repo": "devenv-nixpkgs",
        "type": "github"
      }
    },
    "nixpkgs-stable": {
      "locked": {
        "lastModified": 1725407940,
        "owner": "NixOS",
        "repo": "nixpkgs",
        "rev": "6f6c45b5134a8ee2e465164811e451dcb5ad86e3",
        "treeHash": "f65d5344b23cfbe3695140b602bc463349b26638",
        "type": "github"
      },
      "original": {
        "owner": "NixOS",
        "ref": "nixos-24.05",
        "repo": "nixpkgs",
        "type": "github"
      }
    },
    "pre-commit-hooks": {
      "inputs": {
        "flake-compat": "flake-compat",
        "gitignore": "gitignore",
        "nixpkgs": [
          "nixpkgs"
        ],
        "nixpkgs-stable": "nixpkgs-stable"
      },
      "locked": {
        "lastModified": 1725513492,
        "owner": "cachix",
        "repo": "pre-commit-hooks.nix",
        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
        "treeHash": "4b46d77870afecd8f642541cb4f4927326343b59",
        "type": "github"
      },
      "original": {
        "owner": "cachix",
        "repo": "pre-commit-hooks.nix",
        "type": "github"
      }
    },
    "root": {
      "inputs": {
        "devenv": "devenv",
        "mk-shell-bin": "mk-shell-bin",
        "nix2container": "nix2container",
        "nixpkgs": "nixpkgs",
        "pre-commit-hooks": "pre-commit-hooks"
      }
    },
    "systems": {
      "locked": {
        "lastModified": 1681028828,
        "owner": "nix-systems",
        "repo": "default",
        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
        "type": "github"
      },
      "original": {
        "owner": "nix-systems",
        "repo": "default",
        "type": "github"
      }
    }
  },
  "root": "root",
  "version": 7
}
```

</p>
</details> 

It appears to be that this started happening since 58f2ff7b7cbb6f2325f5ddae6858a6e0c2d66cbd, and from what I can tell, the config option it added for `perms` is missing a few attributes.

Once I added them, the build command started giving this error instead:

```
error: The option `containers.shell.layers."[definition 1-entry 1]".perms."[definition 1-entry 1]".regex' is used but not defined.
```

Allowing `regex` to be null addressed this error.