### PR TITLE
Allways creating home directory even if nothing in `copyToRoot`

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -40,8 +40,11 @@ let
   gid = "1000";
   homeDir = "/env";
 
-  mkHome = path: (pkgs.runCommand "devenv-container-home" { } ''
+  mkEnsureHomeExists = pkgs.runCommand "devenv-ensure-home" { } ''
     mkdir -p $out${homeDir}
+  '';
+
+  mkHome = path: (pkgs.runCommand "devenv-container-home" { } ''
     cp -R ${path}/. $out${homeDir}/
   '');
 
@@ -91,7 +94,6 @@ let
       gname = group;
     };
 
-
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;
     tag = cfg.version;
@@ -112,6 +114,7 @@ let
       })
       mkEtc
       mkTmp
+      mkEnsureHomeExists
     ];
 
     maxLayers = cfg.maxLayers;
@@ -133,6 +136,7 @@ let
         uname = "root";
         gname = "root";
       }
+      (mkPerm mkEnsureHomeExists)
     ];
 
     config = {


### PR DESCRIPTION
Fixes missing home directory when no `copyToRoot`.

```
{
  containers.example = {
    name = "example";
    startupCommand = "bash";
    copyToRoot = [ ];
  };
}
```

Previous error message

```
✦ ❯ docker run -it example
mkdir: cannot create directory '/env/.devenv': Permission denied
ln: failed to create symbolic link '/env/.devenv/profile': No such file or directory
ln: failed to create symbolic link '/env/.devenv/run': No such file or directory
```