### PR TITLE
Update templates .envrc files

### DIFF
--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -2,8 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 
-nix_direnv_watch_file flake.nix
-nix_direnv_watch_file flake.lock
+watch_file flake.nix
+watch_file flake.lock
 
 DEVENV_ROOT_FILE="$(mktemp)"
 printf %s "$PWD" > "$DEVENV_ROOT_FILE"

--- a/templates/terraform/.envrc
+++ b/templates/terraform/.envrc
@@ -2,8 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.2.1; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.1/direnvrc" "sha256-zelF0vLbEl5uaqrfIzbgNzJWGmLzCmYAkInj/LNxvKs="
 fi
 
-nix_direnv_watch_file flake.nix
-nix_direnv_watch_file flake.lock
+watch_file flake.nix
+watch_file flake.lock
 if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2


### PR DESCRIPTION
Update templates .envrc files to use watch_file
instead of the deprecated nix_direnv_watch_file.