### PR TITLE
`cli` test should use local devenv module

### DIFF
--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -1,6 +1,7 @@
 set -xe
 
 rm devenv.yaml || true
+devenv inputs add devenv "path:../../?dir=src/modules"
 devenv build languages.python.package
 devenv shell ls -- -la | grep ".test.sh"
 devenv shell ls ../ | grep "cli"


### PR DESCRIPTION
One change from #1421 that wasn't part of #1427. (Both PRs addressed the same bug in `devenv container build shell`, and the latter was merged.)

While working on #1421, I noticed `tests/cli`, which runs `devenv container build shell` as part of its test script, wouldn't fail as it should've when the bug was present. I believe it's because `tests/cli/devenv.yaml` doesn't override the `devenv` input like `devenv-run-tests` or `tests/clean/devenv.yaml` does.

https://github.com/cachix/devenv/blob/9ff4999b3555936942ee84f6c11fbb103ca52b3e/devenv-run-tests/src/main.rs#L80-L85

https://github.com/cachix/devenv/blob/9ff4999b3555936942ee84f6c11fbb103ca52b3e/tests/clean/devenv.yaml#L1-L3