### PR TITLE
feat(services): make "postgres" process the top-level process within process-compose

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -314,7 +314,7 @@ in
     };
 
     processes.postgres = {
-      exec = "${startScript}/bin/start-postgres";
+      exec = "exec ${startScript}/bin/start-postgres";
 
       process-compose = {
         # SIGINT (= 2) for faster shutdown: https://www.postgresql.org/docs/current/server-shutdown.html


### PR DESCRIPTION
process-compose has functionality to show open ports of the processes it manages:

https://github.com/F1bonacc1/process-compose/blob/2540374e305b0ac683ad88e06c637fe2fa7c0e5c/src/app/process.go#L736-L751

This doesn't work if the networked process is the child of the implicit `bash` used by process-compose.

By running prepending `exec` we replace the implicit bash script with the start-postgres script, which calls `exec postgres` internally.

This pattern should be enforced across the modules.