### PR TITLE
add go example

### DIFF
--- a/examples/go/default.nix
+++ b/examples/go/default.nix
@@ -1,0 +1,13 @@
+{ pkgs, name, version, ... }:
+pkgs.buildGoApplication {
+  pname = name;
+  version = version;
+
+  src = builtins.path {
+    path = ./.;
+    name = "source";
+  };
+
+  ## remember to call 'gomod2nix' to generate this file
+  modules = ./gomod2nix.toml;
+}

--- a/examples/go/devenv.nix
+++ b/examples/go/devenv.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  packages = [ pkgs.git pkgs.gomod2nix ];
+
+  languages.go.enable = true;
+
+  pre-commit.hooks = {
+    govet = {
+      enable = true;
+      pass_filenames = false;
+    };
+    gotest.enable = true;
+    golangci-lint = {
+      enable = true;
+      pass_filenames = false;
+    };
+  };
+
+  outputs = let
+    name = "my-app";
+    version = "1.0.0";
+  in { app = import ./default.nix { inherit pkgs name version; }; };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/examples/go/devenv.yaml
+++ b/examples/go/devenv.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  gomod:
+    url: github:nix-community/gomod2nix
+    overlays:
+      - default
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true


### PR DESCRIPTION
This PR adds an example to build go applications.

It adds:
 -  the input for gomod2nix
 - the output with the example app
 
 feel free to update anything needed or let me know what needs to be changed.