### PR TITLE
Add support for `uv` project management

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -41,7 +41,7 @@ let
 
   initVenvScript =
     let
-      USE_UV_SYNC = cfg.uv.sync.enable && builtins.compareVersions pkgs.uv.version "0.4.4" >= 0;
+      USE_UV_SYNC = cfg.uv.sync.enable && builtins.compareVersions cfg.uv.package.version "0.4.4" >= 0;
     in
     pkgs.writeShellScript "init-venv.sh" ''
       pushd "${cfg.directory}"
@@ -94,7 +94,7 @@ let
               echo "${requirements}" > "$VENV_PATH/.devenv_requirements"
               ${if cfg.uv.enable then ''
                 echo "Requirements changed, running uv pip install -r ${requirements}..."
-                uv pip install -r ${requirements}
+                ${cfg.uv.package}/bin/uv pip install -r ${requirements}
               ''
               else ''
                   echo "Requirements changed, running pip install -r ${requirements}..."
@@ -115,7 +115,7 @@ let
     function check_uv_version {
       RED='\033[0;31m'
       NC='\033[0m' # No Color
-      local UV_VERSION=$(uv --version | cut -d ' ' -f 2)
+      local UV_VERSION=$(${cfg.uv.package}/bin/uv --version | cut -d ' ' -f 2)
       if [ $(${pkgs.nix}/bin/nix-instantiate --eval --expr "builtins.compareVersions \"$UV_VERSION\" \"0.4.4\"") -lt 0 ]; then
         echo -e "''${RED}Warning: uv version $UV_VERSION is less than 0.4.4. uv sync requires version >= 0.4.4.''${NC}" >&2
         return 1
@@ -129,7 +129,7 @@ let
         return 1
       fi
 
-      local UV_SYNC_COMMAND=(uv sync ${lib.escapeShellArgs cfg.uv.sync.arguments})
+      local UV_SYNC_COMMAND=(${cfg.uv.package}/bin/uv sync ${lib.escapeShellArgs cfg.uv.sync.arguments})
 
       # Add extras if specified
       ${lib.concatMapStrings (extra: ''

--- a/tests/python-uv-sync/.gitignore
+++ b/tests/python-uv-sync/.gitignore
@@ -1,0 +1,5 @@
+
+# Devenv
+.devenv*
+devenv.local.nix
+

--- a/tests/python-uv-sync/.test.sh
+++ b/tests/python-uv-sync/.test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -exu
+python --version
+uv --version
+python -c 'import requests'

--- a/tests/python-uv-sync/devenv.nix
+++ b/tests/python-uv-sync/devenv.nix
@@ -1,0 +1,14 @@
+{ pkgs, config, ... }:
+: let
+pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+in {
+languages.python = {
+enable = true;
+directory = "./directory";
+uv = {
+enable = true;
+package = pkgs-unstable.uv;
+sync.enable = true;
+};
+};
+}

--- a/tests/python-uv-sync/devenv.yaml
+++ b/tests/python-uv-sync/devenv.yaml
@@ -1,0 +1,5 @@
+inputs:
+  nixpkgs-unstable:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python

--- a/tests/python-uv-sync/directory/pyproject.toml
+++ b/tests/python-uv-sync/directory/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-uv-sync"
+version = "0.1.0"
+description = ""
+authors = [{ name = "Alex Launi", email = "dev@launi.me" }]
+dependencies = ["requests"]


### PR DESCRIPTION
Adds support to python.nix to use `uv sync` when enabled and `uv` >= 0.4.4
`uv` 0.4.4 is the first version to respect `UV_PROJECT_ENVIRONMENT` which
allows `uv` to play nicely with the venv created by devenv (not `.venv`)
