### PR TITLE
fix: Disable gdb for aarch64-linux

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -10,7 +10,7 @@ in
     debugger = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
       default =
-        if lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.gdb
+        if !(pkgs.stdenv.isAarch64 && pkgs.stdenv.isLinux) && lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.gdb
         then pkgs.gdb
         else null;
       defaultText = lib.literalExpression "pkgs.gdb";


### PR DESCRIPTION
Disable `gdb` for `aarch64-linux`.

cc https://github.com/cachix/devenv/pull/1216