### PR TITLE
redis: prevent infinite recursion when port is set to an env var

### DIFF
--- a/src/modules/services/redis.nix
+++ b/src/modules/services/redis.nix
@@ -76,7 +76,8 @@ in
 
     env = {
       REDISDATA = config.env.DEVENV_STATE + "/redis";
-    } // optionalAttrs (cfg.port == 0) { inherit REDIS_UNIX_SOCKET; };
+      REDIS_UNIX_SOCKET = if cfg.port == 0 then REDIS_UNIX_SOCKET else null;
+    };
 
     processes.redis = {
       exec = "${startScript}/bin/start-redis";


### PR DESCRIPTION
Modules should take care not to conditionally set `env` using user-provided input. If the conditional is another `env` value, evaluation will fail with an infinite recursion error.

While the user can often easily break the loop on their end, knowing what to do requires considerable experience with the module system.

Fixes #1440.