### PR TITLE
Add `ncurses` if process-compose's TUI is enabled

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -44,7 +44,7 @@ in
         -U up "$@" &
     '';
 
-    packages = [ cfg.package ];
+    packages = [ cfg.package ] ++ lib.optionals config.process.process-compose.tui pkgs.ncurses;
 
     process-managers.process-compose = {
       configFile = settingsFormat.generate "process-compose.yaml" cfg.settings;


### PR DESCRIPTION
process-compose's TUI depends on ncurses