### PR TITLE
fix: add missing task option descriptions

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -41497,7 +41497,7 @@ package
 
 
 
-This option has no description.
+A set of tasks.
 
 
 

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -61,6 +61,7 @@ let
               command = config.command;
               input = config.input;
             };
+            description = "Internal configuration for the task.";
           };
           exports = lib.mkOption {
             type = types.listOf types.str;
@@ -92,13 +93,17 @@ let
   tasksJSON = (lib.mapAttrsToList (name: value: { inherit name; } // value.config) config.tasks);
 in
 {
-  options.tasks = lib.mkOption {
-    type = types.attrsOf taskType;
-  };
+  options = {
+    tasks = lib.mkOption {
+      type = types.attrsOf taskType;
+      description = "A set of tasks.";
+    };
 
-  options.task.config = lib.mkOption {
-    type = types.package;
-    internal = true;
+    task.config = lib.mkOption {
+      type = types.package;
+      internal = true;
+      description = "The generated tasks.json file.";
+    };
   };
 
   config = {


### PR DESCRIPTION
Fixes `devenv search`.