### PR TITLE
fix: ensure .devenv directory exists for devenv:enterShell task

### DIFF
--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -127,6 +127,7 @@ in
       "devenv:enterShell" = {
         description = "Runs when entering the shell";
         exec = ''
+          mkdir -p "$DEVENV_DOTFILE"
           echo "$DEVENV_TASK_ENV" > "$DEVENV_DOTFILE/load-exports"
           chmod +x "$DEVENV_DOTFILE/load-exports"
         '';


### PR DESCRIPTION
Fixes #1475 