### PR TITLE
rust: replace fenix with rust-overlay allow specifying rust version

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -15296,7 +15296,7 @@ string
 
 
 
-List of extra [targets](https://github.com/nix-community/fenix\#supported-platforms-and-targets)
+List of extra [targets](https://doc.rust-lang.org/nightly/rustc/platform-support.html)
 to install. Defaults to only the native target.
 
 
@@ -15434,6 +15434,28 @@ null or package
 
 *Default:*
 ` pkgs.rustfmt `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix)
+
+
+
+## languages.rust.version
+
+
+
+Which version of rust to use, this value could be ` latest `,` 1.81.0 `, ` 2021-01-01 `.
+Only works when languages.rust.channel is NOT nixpkgs.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "latest" `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix)

--- a/docs/supported-languages/rust.md
+++ b/docs/supported-languages/rust.md
@@ -103,7 +103,7 @@ string
 
 
 
-List of extra [targets](https://github\.com/nix-community/fenix\#supported-platforms-and-targets)
+List of extra [targets](https://doc\.rust-lang\.org/nightly/rustc/platform-support\.html)
 to install\. Defaults to only the native target\.
 
 
@@ -223,3 +223,22 @@ null or package
 
 *Default:*
 ` pkgs.rustfmt `
+
+
+
+## languages\.rust\.version
+
+
+
+Which version of rust to use, this value could be ` latest `,` 1.81.0 `, ` 2021-01-01 `\.
+Only works when languages\.rust\.channel is NOT nixpkgs\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "latest" `

--- a/examples/rust-wasm-cross/devenv.yaml
+++ b/examples/rust-wasm-cross/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
-  fenix:
-    url: github:nix-community/fenix
+  rust-overlay:
+    url: github:oxalica/rust-overlay
     inputs:
       nixpkgs:
         follows: nixpkgs

--- a/examples/rust/devenv.yaml
+++ b/examples/rust/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
-  fenix:
-    url: github:nix-community/fenix
+  rust-overlay:
+    url: github:oxalica/rust-overlay
     inputs:
       nixpkgs:
         follows: nixpkgs

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -3,16 +3,44 @@
 let
   cfg = config.languages.rust;
 
-  fenix = config.lib.getInput {
-    name = "fenix";
-    url = "github:nix-community/fenix";
-    attribute = "languages.rust.version";
+  rust-overlay = config.lib.getInput {
+    name = "rust-overlay";
+    url = "github:oxalica/rust-overlay";
+    attribute = "languages.rust.input";
     follows = [ "nixpkgs" ];
   };
+
+  # https://github.com/nix-community/fenix/blob/cdfd7bf3e3edaf9e3f6d1e397d3ee601e513613c/lib/combine.nix
+  combine = name: paths:
+    pkgs.symlinkJoin {
+      inherit name paths;
+      postBuild = ''
+        for file in $(find $out/bin -xtype f -maxdepth 1); do
+          install -m755 $(realpath "$file") $out/bin
+    
+          if [[ $file =~ /rustfmt$ ]]; then
+            continue
+          fi
+    
+          ${lib.optionalString pkgs.stdenv.isLinux ''
+            if isELF "$file"; then
+              patchelf --set-rpath $out/lib "$file" || true
+            fi
+          ''}
+    
+          ${lib.optionalString pkgs.stdenv.isDarwin ''
+            install_name_tool -add_rpath $out/lib "$file" || true
+          ''}
+        done
+    
+        for file in $(find $out/lib -name "librustc_driver-*"); do
+          install $(realpath "$file") "$file"
+        done
+      '';
+    };
 in
 {
   imports = [
-    (lib.mkRenamedOptionModule [ "languages" "rust" "version" ] [ "languages" "rust" "channel" ])
     (lib.mkRenamedOptionModule [ "languages" "rust" "packages" ] [ "languages" "rust" "toolchain" ])
   ];
 
@@ -34,8 +62,8 @@ in
       default = [ ];
       defaultText = lib.literalExpression ''[ ]'';
       description = ''
-        List of extra [targets](https://github.com/nix-community/fenix#supported-platforms-and-targets)
-        to install. Defaults to only the native target.
+        List of extra [targets](https://doc.rust-lang.org/nightly/rustc/platform-support.html)
+        to install. Defaults to only the native target. 
       '';
     };
 
@@ -44,6 +72,16 @@ in
       default = "nixpkgs";
       defaultText = lib.literalExpression ''"nixpkgs"'';
       description = "The rustup toolchain to install.";
+    };
+
+    version = lib.mkOption {
+      type = lib.types.str;
+      default = "latest";
+      defaultText = lib.literalExpression ''"latest"'';
+      description = ''
+        Which version of rust to use, this value could be `latest`,`1.81.0`, `2021-01-01`.
+        Only works when languages.rust.channel is NOT nixpkgs.
+      '';
     };
 
     rustflags = lib.mkOption {
@@ -104,6 +142,17 @@ in
               languages.rust.channel = "stable";
             '';
           }
+          {
+            assertion = cfg.channel == "nixpkgs" -> (cfg.version == "latest");
+            message = ''
+              Cannot use `languages.rust.channel = "nixpkgs"` with `languages.rust.version`.
+
+              The nixpkgs channel does not contain all versions required, and is
+              therefore not supported to be used together.
+
+              languages.rust.channel = "stable";
+            '';
+          }
         ];
 
         # Set $CARGO_INSTALL_ROOT so that executables installed by `cargo install` can be found from $PATH
@@ -154,21 +203,17 @@ in
 
     (lib.mkIf (cfg.channel != "nixpkgs") (
       let
-        rustPackages = fenix.packages.${pkgs.stdenv.system};
-        fenixChannel =
-          if cfg.channel == "nightly"
-          then "latest"
-          else cfg.channel;
-        toolchain = rustPackages.${fenixChannel};
+        toolchain = (rust-overlay.lib.mkRustBin {} pkgs.buildPackages)."${cfg.channel}"."${cfg.version}";
+        filteredToolchain = (lib.filterAttrs (n: _: builtins.elem n toolchain._manifest.profiles.complete) toolchain);
       in
       {
         languages.rust.toolchain =
-          (builtins.mapAttrs (_: pkgs.lib.mkDefault) toolchain);
+          (builtins.mapAttrs (_: pkgs.lib.mkDefault) filteredToolchain);
 
         packages = [
-          (rustPackages.combine (
-            (map (c: toolchain.${c}) cfg.components) ++
-            (map (t: rustPackages.targets.${t}.${fenixChannel}.rust-std) cfg.targets)
+          (combine "rust-mixed" (
+            (map (c: cfg.toolchain.${c}) cfg.components) ++
+            (map (t: toolchain._components.${t}.rust-std) cfg.targets)
           ))
         ];
       }

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -212,7 +212,7 @@ in
 
         packages = [
           (combine "rust-mixed" (
-            (map (c: cfg.toolchain.${c}) cfg.components) ++
+            (map (c: cfg.toolchain.${c}) (cfg.components ++ [ "rust-std" ])) ++
             (map (t: toolchain._components.${t}.rust-std) cfg.targets)
           ))
         ];

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -203,7 +203,7 @@ in
 
     (lib.mkIf (cfg.channel != "nixpkgs") (
       let
-        toolchain = (rust-overlay.lib.mkRustBin {} pkgs.buildPackages)."${cfg.channel}"."${cfg.version}";
+        toolchain = (rust-overlay.lib.mkRustBin { } pkgs.buildPackages)."${cfg.channel}"."${cfg.version}";
         filteredToolchain = (lib.filterAttrs (n: _: builtins.elem n toolchain._manifest.profiles.complete) toolchain);
       in
       {


### PR DESCRIPTION
Adds basic support for specifying the version of the rust toolchain you want to use.
This change moves away from using fenix, to instead using rust-overlay.

It seems to work just fine, and is somewhat minimal invasive.
TODO:
- [ ] Not sure what to do about removing the renamed option, and then using it again.. Is there any better ways?
- [x] Make targets work, nothing compiles atm.

Example:

```nix
{
  languages.rust = {
    enable = true;

    # latest stable version
    # channel = "stable";

    # nightly version
    # channel = "nightly";
    # version = "2024-06-20";

    # specific stable version
    # channel = "stable";
    # version = "1.70.0";

  };
}
```

```yaml
inputs:
  devenv:
    url: github:eyJhb/devenv/rust-versions
```