### PR TITLE
Remove PATH from devenv:python:uv task exports.

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -470,7 +470,7 @@ in
       "devenv:python:uv" = lib.mkIf cfg.uv.sync.enable {
         description = "Initialize uv sync";
         exec = initUvScript;
-        exports = [ "PATH" "VIRTUAL_ENV" ];
+        exports = [ "VIRTUAL_ENV" ];
       };
 
       "devenv:enterShell".after = lib.optional cfg.venv.enable "devenv:python:virtualenv"


### PR DESCRIPTION
Removes PATH from the exports of the `devenv:python:uv` task. PATH is not modified in initUvScript and will conflict with `devenv:python:virtualenv` PATH export which leads to virtual environments randomly not activating on enterShell

Fixes #1502