### PR TITLE
process-compose: add a migration for `process.process-compose.port`

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -45,6 +45,7 @@ in
   imports =
     (map (name: lib.mkRenamedOptionModule [ "process" name ] [ "process" "manager" name ]) [ "after" "before" "implementation" ])
     ++ [
+      (lib.mkRenamedOptionModule [ "process" "process-compose" "port" ] [ "process" "managers" "process-compose" "port" ])
       (lib.mkRenamedOptionModule [ "process" "process-compose" "tui" ] [ "process" "managers" "process-compose" "tui" "enable" ])
       (lib.mkRenamedOptionModule [ "process" "process-compose" "unix-socket" ] [ "process" "managers" "process-compose" "unixSocket" "path" ])
       (lib.mkRenamedOptionModule [ "processManagerCommand" ] [ "process" "manager" "command" ])


### PR DESCRIPTION
This undocumented attr option was removed https://github.com/cachix/devenv/pull/1147. Now that `process.process-compose` itself is gone, people might start running into errors (see https://github.com/cachix/devenv/issues/1497#issuecomment-2397438790) . This adds a migration to the new `process.managers.process-compose.port`.