### PR TITLE
texlive: switch to the new `withPackages` API

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -6312,7 +6312,7 @@ unspecified value
 
 
 *Default:*
-` pkgs.texlive `
+` pkgs.texliveSmall `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/texlive.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/texlive.nix)

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -6276,20 +6276,26 @@ boolean
 
 
 
-Packages available to TeX Live
+Extra packages to add to the base TeX Live set
 
 
 
 *Type:*
-non-empty (list of string)
+list of string
 
 
 
 *Default:*
+` [ ] `
+
+
+
+*Example:*
 
 ```
 [
-  "collection-basic"
+  "algorithms"
+  "latexmk"
 ]
 ```
 
@@ -6313,6 +6319,11 @@ unspecified value
 
 *Default:*
 ` pkgs.texliveSmall `
+
+
+
+*Example:*
+` pkgs.texliveBasic `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/texlive.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/texlive.nix)

--- a/docs/supported-languages/texlive.md
+++ b/docs/supported-languages/texlive.md
@@ -30,20 +30,26 @@ boolean
 
 
 
-Packages available to TeX Live
+Extra packages to add to the base TeX Live set
 
 
 
 *Type:*
-non-empty (list of string)
+list of string
 
 
 
 *Default:*
+` [ ] `
+
+
+
+*Example:*
 
 ```
 [
-  "collection-basic"
+  "algorithms"
+  "latexmk"
 ]
 ```
 
@@ -62,3 +68,8 @@ unspecified value
 
 *Default:*
 ` pkgs.texliveSmall `
+
+
+
+*Example:*
+` pkgs.texliveBasic `

--- a/docs/supported-languages/texlive.md
+++ b/docs/supported-languages/texlive.md
@@ -61,4 +61,4 @@ unspecified value
 
 
 *Default:*
-` pkgs.texlive `
+` pkgs.texliveSmall `

--- a/examples/texlive/.test.sh
+++ b/examples/texlive/.test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -ex
+
+which latexmk

--- a/examples/texlive/devenv.nix
+++ b/examples/texlive/devenv.nix
@@ -1,8 +1,14 @@
-{ ... }:
+{ pkgs, ... }:
 
 {
+  # https://nixos.org/manual/nixpkgs/stable/#sec-language-texlive
   languages.texlive = {
     enable = true;
-    packages = [ "scheme-small" "biblatex" "latexmk" ];
+
+    # Choose a base package set.
+    base = pkgs.texliveSmall;
+
+    # Add extra packages to the base set.
+    packages = [ "latexmk" ];
   };
 }

--- a/examples/texlive/devenv.nix
+++ b/examples/texlive/devenv.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 
 {
   languages.texlive = {

--- a/src/modules/languages/texlive.nix
+++ b/src/modules/languages/texlive.nix
@@ -2,16 +2,15 @@
 let
   cfg = config.languages.texlive;
 
-  base = cfg.base;
-  packages = lib.genAttrs cfg.packages (name: base.${name} or (throw "No such texlive package ${name}"));
-  package = base.combine packages;
+  getPackage = ps: name: ps.${name} or (throw "No such texlive package ${name}");
+  package = cfg.base.withPackages (ps: builtins.map (getPackage ps) cfg.packages);
 in
 {
   options.languages.texlive = {
     enable = lib.mkEnableOption "TeX Live";
     base = lib.mkOption {
-      default = pkgs.texlive;
-      defaultText = lib.literalExpression "pkgs.texlive";
+      default = pkgs.texliveSmall;
+      defaultText = lib.literalExpression "pkgs.texliveSmall";
       description = "TeX Live package set to use";
     };
     packages = lib.mkOption {

--- a/src/modules/languages/texlive.nix
+++ b/src/modules/languages/texlive.nix
@@ -11,12 +11,14 @@ in
     base = lib.mkOption {
       default = pkgs.texliveSmall;
       defaultText = lib.literalExpression "pkgs.texliveSmall";
+      example = lib.literalExpression "pkgs.texliveBasic";
       description = "TeX Live package set to use";
     };
     packages = lib.mkOption {
-      type = lib.types.nonEmptyListOf lib.types.str;
-      default = [ "collection-basic" ];
-      description = "Packages available to TeX Live";
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "algorithms" "latexmk" ];
+      description = "Extra packages to add to the base TeX Live set";
     };
   };
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
Docs on the new API: https://nixos.org/manual/nixpkgs/stable/#sec-language-texlive-user-guide-experimental

Though labeled "experimental", it's  been available for a year (since 23.11) and is backwards-compatible with the old `combine` API. Might as well switch over.

Also:
- The default for `base` is now `texliveSmall`. Could use `texliveBase`, but `Small` seems like reasonable default.
- `"collection-basic"` removed from `packages`. The base package set is handled by `base` now. This option can also now be empty if you don't need extra packages.

Fixes #1521.