### PR TITLE
devenv: fixup nixos-specific cache fallback docs

### DIFF
--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -708,14 +708,20 @@ impl<'a> Nix<'a> {
                         b) Add binary caches to /etc/nix/nix.conf yourself by editing configuration.nix:
                         {{
                             nix.extraOptions = ''
-                                extra-substituters = {};
-                                extra-trusted-public-keys = {};
+                                extra-substituters = {}
+                                extra-trusted-public-keys = {}
                             '';
                         }}
 
-                        Lastly rebuild your system
+                        Disable automatic cache configuration in `devenv.nix`:
 
-                        $ sudo nixos-rebuild switch
+                        {{
+                            cachix.enable = false;
+                        }}
+
+                        Lastly, rebuild your system:
+
+                          $ sudo nixos-rebuild switch
                     ", whoami::username()
                     , caches.caches.pull.iter().map(|cache| format!("https://{}.cachix.org", cache)).collect::<Vec<String>>().join(" ")
                     , caches.known_keys.values().cloned().collect::<Vec<String>>().join(" ")


### PR DESCRIPTION
Removes semicolons from the `nix.conf` suggestion and adds back the missing instructions to set `cachix.enable = false` when using os-wide caches on nixos.