### PR TITLE
Set GOTOOLCHAIN=local for languages.go

### DIFF
--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -49,6 +49,7 @@ in
 
     env.GOROOT = cfg.package + "/share/go/";
     env.GOPATH = config.env.DEVENV_STATE + "/go";
+    env.GOTOOLCHAIN = "local";
 
     enterShell = ''
       export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
Doesn't seem to make sense to have support for go from nixpkgs but then let the go compiler fetch a random toolchain so lets tell it to use the local toolchain always.