### PR TITLE
update process manager implementation examples

### DIFF
--- a/examples/hivemind/devenv.nix
+++ b/examples/hivemind/devenv.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 {
-  process.implementation = "hivemind";
+  process.manager.implementation = "hivemind";
   processes.foo.exec = "echo foo; sleep inf";
   processes.bar.exec = "echo bar; sleep inf";
 }

--- a/examples/overmind/devenv.nix
+++ b/examples/overmind/devenv.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 {
-  process.implementation = "overmind";
+  process.manager.implementation = "overmind";
   processes.foo.exec = "echo foo; sleep inf";
   processes.bar.exec = "echo bar; sleep inf";
 }


### PR DESCRIPTION
Was trying to use `overmind` using the example in the repo and got:
```
warning: The option `process.implementation' defined in `<path to my workdir>/deven
v.nix' has been renamed to `process.manager.implementation'. 
```
Fixed the `overmind` and `hivemind` example to follow this hint.