### PR TITLE
tasks: pickup outgoing task dependencies

### DIFF
--- a/devenv-tasks/src/lib.rs
+++ b/devenv-tasks/src/lib.rs
@@ -1215,7 +1215,7 @@ mod test {
                     },
                     {
                         "name": "myapp:task_3",
-                         "after": ["myapp:task_1"],
+                        "after": ["myapp:task_1"],
                         "command": script3.to_str().unwrap()
                     },
                     {

--- a/devenv-tasks/src/lib.rs
+++ b/devenv-tasks/src/lib.rs
@@ -1145,15 +1145,9 @@ mod test {
 
     #[tokio::test]
     async fn test_before_tasks() -> Result<(), Error> {
-        let script1 = create_script(
-            "#!/bin/sh\necho 'Task 1 is running' && sleep 0.5 && echo 'Task 1 completed'",
-        )?;
-        let script2 = create_script(
-            "#!/bin/sh\necho 'Task 2 is running' && sleep 0.5 && echo 'Task 2 completed'",
-        )?;
-        let script3 = create_script(
-            "#!/bin/sh\necho 'Task 3 is running' && sleep 0.5 && echo 'Task 3 completed'",
-        )?;
+        let script1 = create_basic_script("1")?;
+        let script2 = create_basic_script("2")?;
+        let script3 = create_basic_script("3")?;
 
         let tasks = Tasks::new(
             Config::try_from(json!({
@@ -1162,7 +1156,7 @@ mod test {
                     {
                         "name": "myapp:task_1",
                         "command": script1.to_str().unwrap(),
-                        "after": ["myapp:task_3"]
+                        "before": ["myapp:task_2", "myapp:task_3"]
                     },
                     {
                         "name": "myapp:task_2",
@@ -1188,22 +1182,60 @@ mod test {
                 (name1, TaskStatus::Completed(TaskCompleted::Success(_, _))),
                 (name2, TaskStatus::Completed(TaskCompleted::Success(_, _))),
                 (name3, TaskStatus::Completed(TaskCompleted::Success(_, _)))
-            ] if name1 == "myapp:task_2" && name2 == "myapp:task_3" && name3 == "myapp:task_1"
+            ] if name1 == "myapp:task_1" && name2 == "myapp:task_2" && name3 == "myapp:task_3"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_after_tasks() -> Result<(), Error> {
+        let script1 = create_basic_script("1")?;
+        let script2 = create_basic_script("2")?;
+        let script3 = create_basic_script("3")?;
+
+        let tasks = Tasks::new(
+            Config::try_from(json!({
+                "roots": ["myapp:task_1"],
+                "tasks": [
+                    {
+                        "name": "myapp:task_1",
+                        "command": script1.to_str().unwrap(),
+                        "after": ["myapp:task_3", "myapp:task_2"]
+                    },
+                    {
+                        "name": "myapp:task_2",
+                        "after": ["myapp:task_3"],
+                        "command": script2.to_str().unwrap()
+                    },
+                    {
+                        "name": "myapp:task_3",
+                        "command": script3.to_str().unwrap()
+                    }
+                ]
+            }))
+            .unwrap(),
+        )
+        .await?;
+        tasks.run().await;
+
+        let task_statuses = inspect_tasks(&tasks).await;
+        let task_statuses = task_statuses.as_slice();
+        assert_matches!(
+            task_statuses,
+            [
+                (name1, TaskStatus::Completed(TaskCompleted::Success(_, _))),
+                (name2, TaskStatus::Completed(TaskCompleted::Success(_, _))),
+                (name3, TaskStatus::Completed(TaskCompleted::Success(_, _)))
+            ] if name1 == "myapp:task_3" && name2 == "myapp:task_2" && name3 == "myapp:task_1"
         );
         Ok(())
     }
 
     #[tokio::test]
     async fn test_before_and_after_tasks() -> Result<(), Error> {
-        let script1 = create_script(
-            "#!/bin/sh\necho 'Task 1 is running' && sleep 0.5 && echo 'Task 1 completed'",
-        )?;
-        let script2 = create_script(
-            "#!/bin/sh\necho 'Task 2 is running' && sleep 0.5 && echo 'Task 2 completed'",
-        )?;
-        let script3 = create_script(
-            "#!/bin/sh\necho 'Task 3 is running' && sleep 0.5 && echo 'Task 3 completed'",
-        )?;
+        let script1 = create_basic_script("1")?;
+        let script2 = create_basic_script("2")?;
+        let script3 = create_basic_script("3")?;
 
         let tasks = Tasks::new(
             Config::try_from(json!({
@@ -1223,6 +1255,51 @@ mod test {
                         "before": ["myapp:task_3"],
                         "after": ["myapp:task_1"],
                         "command": script2.to_str().unwrap()
+                    },
+                ]
+            }))
+            .unwrap(),
+        )
+        .await?;
+        tasks.run().await;
+
+        let task_statuses = inspect_tasks(&tasks).await;
+        let task_statuses = task_statuses.as_slice();
+        assert_matches!(
+            task_statuses,
+            [
+                (name1, TaskStatus::Completed(TaskCompleted::Success(_, _))),
+                (name2, TaskStatus::Completed(TaskCompleted::Success(_, _))),
+                (name3, TaskStatus::Completed(TaskCompleted::Success(_, _)))
+            ] if name1 == "myapp:task_1" && name2 == "myapp:task_2" && name3 == "myapp:task_3"
+        );
+        Ok(())
+    }
+
+    // Test that tasks indirectly linked to the root are picked up and run.
+    #[tokio::test]
+    async fn test_transitive_dependencies() -> Result<(), Error> {
+        let script1 = create_basic_script("1")?;
+        let script2 = create_basic_script("2")?;
+        let script3 = create_basic_script("3")?;
+
+        let tasks = Tasks::new(
+            Config::try_from(json!({
+                "roots": ["myapp:task_3"],
+                "tasks": [
+                    {
+                        "name": "myapp:task_1",
+                        "command": script1.to_str().unwrap(),
+                    },
+                    {
+                        "name": "myapp:task_2",
+                        "after": ["myapp:task_1"],
+                        "command": script2.to_str().unwrap()
+                    },
+                    {
+                        "name": "myapp:task_3",
+                        "after": ["myapp:task_2"],
+                        "command": script3.to_str().unwrap()
                     },
                 ]
             }))
@@ -1405,7 +1482,6 @@ fi
         Ok(())
     }
 
-    #[cfg(test)]
     async fn inspect_tasks(tasks: &Tasks) -> Vec<(String, TaskStatus)> {
         let mut result = Vec::new();
         for index in &tasks.tasks_order {
@@ -1415,7 +1491,6 @@ fi
         result
     }
 
-    #[cfg(test)]
     fn create_script(script: &str) -> std::io::Result<tempfile::TempPath> {
         let mut temp_file = tempfile::Builder::new()
             .prefix("script")
@@ -1426,5 +1501,11 @@ fi
             .as_file_mut()
             .set_permissions(fs::Permissions::from_mode(0o755))?;
         Ok(temp_file.into_temp_path())
+    }
+
+    fn create_basic_script(tag: &str) -> std::io::Result<tempfile::TempPath> {
+        create_script(&format!(
+            "#!/bin/sh\necho 'Task {tag} is running' && sleep 0.1 && echo 'Task {tag} completed'"
+        ))
     }
 }

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -492,7 +492,7 @@ list of string
 
 
 
-Whether to include the Flutter tools.
+Whether to include the React Native tools.
 
 
 

--- a/package.nix
+++ b/package.nix
@@ -22,7 +22,7 @@ pkgs.rustPlatform.buildRustPackage {
     then [ "-p devenv-tasks" ]
     else [ "-p devenv -p devenv-run-tests" ];
 
-  doCheck = false; #!build_tasks;
+  doCheck = !build_tasks;
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/package.nix
+++ b/package.nix
@@ -22,7 +22,7 @@ pkgs.rustPlatform.buildRustPackage {
     then [ "-p devenv-tasks" ]
     else [ "-p devenv -p devenv-run-tests" ];
 
-  doCheck = !build_tasks;
+  doCheck = false; #!build_tasks;
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -34,10 +34,14 @@ in
     packages = lib.mkAfter ([ config.git-hooks.package ] ++ (config.git-hooks.enabledPackages or [ ]));
     tasks = {
       # TODO: split installation script into status + exec
-      "devenv:git-hooks:install".exec = config.git-hooks.installationScript;
-      "devenv:git-hooks:run".exec = "pre-commit run -a";
-      "devenv:enterShell".after = [ "devenv:git-hooks:install" ];
-      "devenv:enterTest".after = [ "devenv:git-hooks:run" ];
+      "devenv:git-hooks:install" = {
+        exec = config.git-hooks.installationScript;
+        before = [ "devenv:enterShell" ];
+      };
+      "devenv:git-hooks:run" = {
+        exec = "pre-commit run -a";
+        before = [ "devenv:enterShell" ];
+      };
     };
   };
 }

--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -40,7 +40,7 @@ in
       };
       "devenv:git-hooks:run" = {
         exec = "pre-commit run -a";
-        before = [ "devenv:enterShell" ];
+        before = [ "devenv:enterTest" ];
       };
     };
   };

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -459,25 +459,24 @@ in
         description = "Initialize Python virtual environment";
         exec = initVenvScript;
         exports = [ "PATH" "VIRTUAL_ENV" ];
+        after = [ "devenv:enterShell" ];
       };
 
       "devenv:python:poetry" = lib.mkIf cfg.poetry.install.enable {
         description = "Initialize Poetry";
         exec = initPoetryScript;
         exports = [ "PATH" ] ++ lib.optional cfg.poetry.activate.enable "VIRTUAL_ENV";
-        after = lib.optional cfg.venv.enable "devenv:python:virtualenv";
+        after = [ "devenv:enterShell" ];
+        before = lib.optional cfg.venv.enable "devenv:python:virtualenv";
       };
 
       "devenv:python:uv" = lib.mkIf cfg.uv.sync.enable {
         description = "Initialize uv sync";
         exec = initUvScript;
         exports = [ "PATH" ];
-        after = lib.optional cfg.venv.enable "devenv:python:virtualenv";
+        after = [ "devenv:enterShell" ];
+        before = lib.optional cfg.venv.enable "devenv:python:virtualenv";
       };
-
-      "devenv:enterShell".after = lib.optional cfg.venv.enable "devenv:python:virtualenv"
-        ++ lib.optional cfg.poetry.install.enable "devenv:python:poetry"
-        ++ lib.optional cfg.uv.sync.enable "devenv:python:uv";
     };
 
     enterShell = ''

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -459,23 +459,23 @@ in
         description = "Initialize Python virtual environment";
         exec = initVenvScript;
         exports = [ "PATH" "VIRTUAL_ENV" ];
-        after = [ "devenv:enterShell" ];
+        before = [ "devenv:enterShell" ];
       };
 
       "devenv:python:poetry" = lib.mkIf cfg.poetry.install.enable {
         description = "Initialize Poetry";
         exec = initPoetryScript;
         exports = [ "PATH" ] ++ lib.optional cfg.poetry.activate.enable "VIRTUAL_ENV";
-        after = [ "devenv:enterShell" ];
-        before = lib.optional cfg.venv.enable "devenv:python:virtualenv";
+        before = [ "devenv:enterShell" ]
+          ++ lib.optional cfg.venv.enable "devenv:python:virtualenv";
       };
 
       "devenv:python:uv" = lib.mkIf cfg.uv.sync.enable {
         description = "Initialize uv sync";
         exec = initUvScript;
         exports = [ "PATH" ];
-        after = [ "devenv:enterShell" ];
-        before = lib.optional cfg.venv.enable "devenv:python:virtualenv";
+        before = [ "devenv:enterShell" ]
+          ++ lib.optional cfg.venv.enable "devenv:python:virtualenv";
       };
     };
 

--- a/tests/tasks/devenv.nix
+++ b/tests/tasks/devenv.nix
@@ -1,9 +1,16 @@
 {
   tasks = {
-    "myapp:shell".exec = "touch shell";
-    "devenv:enterShell".after = [ "myapp:shell" ];
-    "myapp:test".exec = "touch test";
+    "myapp:shell" = {
+      exec = "touch shell";
+      before = [ "devenv:enterShell" ];
+    };
+
+    "myapp:test" = {
+      exec = "touch test";
+    };
+    # Test specifying "after"
     "devenv:enterTest".after = [ "myapp:test" ];
+
     "example:statusIgnored" = {
       before = [ "devenv:enterTest" ];
       exec = "touch ./should-not-exist";


### PR DESCRIPTION
~I think we're running the tasks in reverse order after the toposort. The following tasks are speced to run _after_ `enterShell`, but they instead run before.~

This PR lets the graph traversal visit both incoming _and_ outgoing edges.
Traversing all the edges of a node allows picking up tasks that are only specified to run _after_ the current node. For example:

```nix
tasks."my-app:after-venv" = {
  exec = "echo hello";
  after = [ "devenv:python:virtualenv" ];
};
```

Previously, the only way to do this was to also use `before` to add this dependency to the graph, usually via `devenv:enterShell`. This change also allows running tasks after `devenv:enterShell`.

Fixes #1557.

##### TODO

While this change makes setting up tasks more predictable, we'll need to make this behavior configurable to support one-off tasks. You might want to run _just_ the specified task, or all the tasks _up_ to the specified task.

This also opens up the question of different types of constraints, e.g. _ordering_ vs _dependency_. systemd has `After` and `Requires`.

- [x] Update existing tests