### PR TITLE
javascript: add node_modules/.bin to PATH

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -243,7 +243,11 @@ in
       '') ++
       (lib.optional cfg.bun.install.enable ''
         source ${initBunScript}
-      '')
+      '') ++ [
+        ''
+        export PATH="${nodeModulesPath}/.bin:$PATH"
+        ''
+      ]
     );
   };
 }


### PR DESCRIPTION
Currently whenever a javascript tool is installed with npm, yarn, pnpm, it is not possible to directly use it:

```
$ npm install vite
$ vite
vite: command not found
$ npx vite
```

This is because `node_modules/.bin` is missing from `PATH`, which this PR adds. I've opted to add it regardless of which package manager of javascript is used nor regardless of whether `node_modules` exists.