### PR TITLE
Revert "Add `ncurses` if process-compose's TUI is enabled"

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -96,7 +96,7 @@ in
         up "$@" &
     '';
 
-    packages = [ cfg.package ] ++ lib.optional cfg.tui.enable pkgs.ncurses;
+    packages = [ cfg.package ];
 
     process.managers.process-compose = {
       configFile = lib.mkDefault (settingsFormat.generate "process-compose.yaml" cfg.settings);


### PR DESCRIPTION
Reverts cachix/devenv#1465

Mitigates #1569.

The `ncurses` derivation creates recursive symlinks in `includes` that can trip up aggressive file watchers that decide to venture into `.devenv/profile`. Reverting for now until we better understand the process-compose requirements.