### PR TITLE
containers: add `usr/bin/env` to the root layer

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -107,8 +107,9 @@ let
           pkgs.bashInteractive
           pkgs.su
           pkgs.sudo
+          pkgs.dockerTools.usrBinEnv
         ];
-        pathsToLink = "/bin";
+        pathsToLink = [ "/bin" "/usr/bin" ];
       })
       mkEtc
       mkTmp


### PR DESCRIPTION
Fixes #1579.