### PR TITLE
Update solidity.package documentation

### DIFF
--- a/src/modules/languages/solidity.nix
+++ b/src/modules/languages/solidity.nix
@@ -18,7 +18,7 @@ in
       type = lib.types.package;
       description = "Which compiler of Solidity to use.";
       default = pkgs.solc;
-      defaultText = lib.literalExpression "pkgs.elixir";
+      defaultText = lib.literalExpression "pkgs.solc";
     };
 
     foundry = {


### PR DESCRIPTION
It looks to me like the defaultText should be `pkgs.solc`.