### PR TITLE
flake-parts: add `devenv test` support

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -57,6 +57,7 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
               devenv.containers
             ) // {
               "${shellPrefix shellName}devenv-up" = devenv.procfileScript;
+              "${shellPrefix shellName}devenv-test" = devenv.test;
             }
           )
           config.devenv.shells;


### PR DESCRIPTION
Adds support for `devenv test` in `flake-parts`. Continuation of https://github.com/cachix/devenv/pull/1524.