### PR TITLE
package: use binary wrapper and preset locale archive

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -29,14 +29,13 @@ pkgs.rustPlatform.buildRustPackage {
   };
 
   nativeBuildInputs = [
-    pkgs.makeWrapper
-    pkgs.pkg-config
     pkgs.installShellFiles
+    pkgs.makeBinaryWrapper
+    pkgs.pkg-config
   ] ++ pkgs.lib.optional (!build_tasks) pkgs.sqlx-cli;
 
-  buildInputs = [ pkgs.openssl ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-  ];
+  buildInputs = [ pkgs.openssl ]
+    ++ pkgs.lib.optional pkgs.stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
 
   # Force sqlx to use the prepared queries
   SQLX_OFFLINE = true;

--- a/package.nix
+++ b/package.nix
@@ -50,11 +50,17 @@ pkgs.rustPlatform.buildRustPackage {
   postInstall = pkgs.lib.optionalString (!build_tasks) ''
     wrapProgram $out/bin/devenv \
       --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} \
+      ${pkgs.lib.optionalString (pkgs.stdenv.isLinux && (pkgs.glibcLocalesUtf8 != null)) ''
+        --set-default LOCALE_ARCHIVE ${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive \
+      ''}
       --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
 
     # TODO: problematic for our library...
     wrapProgram $out/bin/devenv-run-tests \
       --set DEVENV_NIX ${inputs.nix.packages.${pkgs.stdenv.system}.nix} \
+      ${pkgs.lib.optionalString (pkgs.stdenv.isLinux && (pkgs.glibcLocalesUtf8 != null)) ''
+        --set-default LOCALE_ARCHIVE ${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive \
+      ''}
       --prefix PATH ":" "$out/bin:${inputs.cachix.packages.${pkgs.stdenv.system}.cachix}/bin"
 
     # Generate manpages


### PR DESCRIPTION
On non-NixOS Linux systems, any call to bash will print out a warning about failing to set locale vars. This can be triggered for the entire code path, from launching devenv until `enterShell`.

The fix is to set `LOCALE_ARCHIVE` globally. This should be done right after installing Nix, but is not a very obvious thing.

The issue with devenv is that our first entry-point is `wrapProgram`, which calls bash. This PR switches to `makeBinaryWrapper` to avoid calls to bash and sets `LOCALE_ARCHIVE` if missing.