### PR TITLE
Introducing devenv Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ![License: Apache 2.0](https://img.shields.io/github/license/cachix/devenv)
 [![Version](https://img.shields.io/github/v/release/cachix/devenv?color=green&label=version&sort=semver)](https://github.com/cachix/devenv/releases)
 [![CI](https://github.com/cachix/devenv/actions/workflows/buildtest.yml/badge.svg)](https://github.com/cachix/devenv/actions/workflows/buildtest.yml?branch=main)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20devenv%20Guru-006BFF)](https://gurubase.io/g/devenv)
 
 Running ``devenv init`` generates ``devenv.nix``:
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [devenv Guru](https://gurubase.io/g/devenv) to Gurubase. devenv Guru uses the data from this repo and data from the [docs](https://devenv.sh/) to answer questions by leveraging the LLM.

In this PR, I showcased the "devenv Guru", which highlights that devenv now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable devenv Guru in Gurubase, just let me know that's totally fine.
