### PR TITLE
fix: ensure append is on newline with existing `.gitattributes`

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -181,6 +181,7 @@ impl Devenv {
                 std::fs::OpenOptions::new()
                     .append(true)
                     .open(&target_path)
+                    .and_then(|mut file| file.write("\n"))
                     .and_then(|mut file| file.write_all(path.contents()))
                     .expect("Failed to append to existing file");
             } else {


### PR DESCRIPTION
Currently, when running `devenv init` in a folder that already contains a `.gitignore` file the first line of the additions is written at the end of the last line of the existing file. If the existing file does not end with a newline, the `# Devenv` comment is appened at the end of the line.

Example:

An existing `.gitignore`
```.gitignore
dist
```
(no newline at EOF)
will result in:
```.gitignore
dist# Devenv
.devenv*
devenv.local.nix

# direnv
.direnv

# pre-commit
.pre-commit-config.yaml

```
