### PR TITLE
fix: typo in description for enabling react native support

### DIFF
--- a/src/modules/integrations/android.nix
+++ b/src/modules/integrations/android.nix
@@ -246,7 +246,7 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Whether to include the Flutter tools.
+        Whether to include the React Native tools.
       '';
     };
   };


### PR DESCRIPTION
I think this is a typo.

![image](https://github.com/user-attachments/assets/4ee8f2d6-64ed-4917-8df7-02e2cc9c019e)
