### PR TITLE
flake: make it difficult to clobber the flake shim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -233,7 +233,7 @@
               modules = [
                 (self.modules + /top-level.nix)
                 ({ config, ... }: {
-                  packages = [
+                  packages = pkgs.lib.mkBefore [
                     (mkDevShellPackage config pkgs)
                   ];
                   devenv.warnOnNewVersion = false;


### PR DESCRIPTION
This makes it harder to accidentally add the regular devenv CLI to packages and make the flake integration inoperable.