### PR TITLE
devenv: skip the cache warning if the requested substituters are already configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,12 +974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1135,12 +1141,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -1359,6 +1365,14 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix-conf-parser"
+version = "0.0.1"
+dependencies = [
+ "indexmap",
+ "thiserror",
 ]
 
 [[package]]
@@ -2211,7 +2225,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hashlink",
  "hex",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "indoc",
  "miette",
  "nix",
+ "nix-conf-parser",
  "petgraph",
  "regex",
  "reqwest",
@@ -1372,6 +1373,7 @@ name = "nix-conf-parser"
 version = "0.0.1"
 dependencies = [
  "indexmap",
+ "miette",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ devenv = { path = "devenv" }
 devenv-eval-cache = { path = "devenv-eval-cache" }
 devenv-run-tests = { path = "devenv-run-tests" }
 devenv-tasks = { path = "devenv-tasks" }
+nix-conf-parser = { path = "nix-conf-parser" }
 xtask = { path = "xtask" }
 
 ansiterm = "0.12.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["devenv", "devenv-eval-cache", "devenv-run-tests", "devenv-tasks", "xtask"]
+members = ["devenv", "devenv-eval-cache", "devenv-run-tests", "devenv-tasks", "nix-conf-parser", "xtask"]
 
 [workspace.package]
 edition = "2021"
@@ -24,6 +24,7 @@ dotlock = "0.5.0"
 futures = "0.3.30"
 hex = "0.4.3"
 include_dir = "0.7.3"
+indexmap = "2.6.0"
 indoc = "2.0.4"
 lazy_static = "1.5.0"
 miette = { version = "7.1.0", features = ["fancy"] }

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -12,6 +12,7 @@ default-run = "devenv"
 [dependencies]
 devenv-eval-cache.workspace = true
 devenv-tasks.workspace = true
+nix-conf-parser.workspace = true
 
 clap.workspace = true
 cli-table.workspace = true

--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -646,7 +646,7 @@ impl<'a> Nix<'a> {
                     .trusted;
                 if trusted.is_none() {
                     self.logger.warn(
-                    "You're using very old version of Nix, please upgrade and restart nix-daemon.",
+                    "You're using an outdated version of Nix. Please upgrade and restart the nix-daemon.",
                 );
                 }
                 let restart_command = if cfg!(target_os = "linux") {
@@ -676,64 +676,78 @@ impl<'a> Nix<'a> {
                 if trusted == Some(0) {
                     if !Path::new("/etc/NIXOS").exists() {
                         self.logger.error(&indoc::formatdoc!(
-                        "You're not a trusted user of the Nix store. You have the following options:
+                        "Failed to set up binary caches.
 
-                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf for devenv to manage caches for you.
+                        devenv is configured to automatically manage binary caches with `cachix.enable = true`, but cannot do so because you are not a trusted user of the Nix store.
 
-                        trusted-users = root {}
+                        You have two options:
 
-                        Restart nix-daemon with:
+                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf to allow devenv to set up the caches for you:
 
-                          $ {restart_command}
+                               trusted-users = root {}
 
-                        b) Add binary caches to /etc/nix/nix.conf yourself:
+                           Then restart the nix-daemon:
 
-                        extra-substituters = {}
-                        extra-trusted-public-keys = {}
+                               $ {restart_command}
 
-                        And disable automatic cache configuration in `devenv.nix`:
+                        b) Add the binary caches to /etc/nix/nix.conf yourself:
 
-                        {{
-                            cachix.enable = false;
-                        }}
+                             extra-substituters = {}
+                             extra-trusted-public-keys = {}
+
+                           Then disable automatic cache configuration in `devenv.nix`:
+
+                           {{
+                               cachix.enable = false;
+                           }}
                     ", whoami::username()
                     , caches.caches.pull.iter().map(|cache| format!("https://{}.cachix.org", cache)).collect::<Vec<String>>().join(" ")
                     , caches.known_keys.values().cloned().collect::<Vec<String>>().join(" ")
                     ));
                     } else {
                         self.logger.error(&indoc::formatdoc!(
-                        "You're not a trusted user of the Nix store. You have the following options:
+                        "Failed to set up binary caches.
 
-                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf by editing configuration.nix for devenv to manage caches for you.
+                        devenv is configured to automatically manage binary caches with `cachix.enable = true`, but cannot do so because you are not a trusted user of the Nix store.
 
-                        {{
-                            nix.extraOptions = ''
-                                trusted-users = root {}
-                            '';
-                        }}
+                        You have two options:
 
-                        b) Add binary caches to /etc/nix/nix.conf yourself by editing configuration.nix:
-                        {{
-                            nix.extraOptions = ''
-                                extra-substituters = {}
-                                extra-trusted-public-keys = {}
-                            '';
-                        }}
+                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf by editing configuration.nix to let devenv set up the caches for you:
 
-                        Disable automatic cache configuration in `devenv.nix`:
+                           {{
+                               nix.extraOptions = ''
+                                   trusted-users = root {}
+                               '';
+                           }}
 
-                        {{
-                            cachix.enable = false;
-                        }}
+                           Rebuild your system:
 
-                        Lastly, rebuild your system:
+                               $ sudo nixos-rebuild switch
 
-                          $ sudo nixos-rebuild switch
+                        b) Add the binary caches to /etc/nix/nix.conf yourself by editing configuration.nix:
+
+                           {{
+                               nix.extraOptions = ''
+                                   extra-substituters = {}
+                                   extra-trusted-public-keys = {}
+                               '';
+                           }}
+
+                           Disable automatic cache configuration in `devenv.nix`:
+
+                           {{
+                               cachix.enable = false;
+                           }}
+
+                           Rebuild your system:
+
+                               $ sudo nixos-rebuild switch
                     ", whoami::username()
                     , caches.caches.pull.iter().map(|cache| format!("https://{}.cachix.org", cache)).collect::<Vec<String>>().join(" ")
                     , caches.known_keys.values().cloned().collect::<Vec<String>>().join(" ")
                     ));
                     }
+
                     bail!("You're not a trusted user of the Nix store.")
                 }
             }

--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -721,73 +721,79 @@ impl<'a> Nix<'a> {
                     if !missing_caches.is_empty() || !missing_public_keys.is_empty() {
                         if !Path::new("/etc/NIXOS").exists() {
                             self.logger.error(&indoc::formatdoc!(
-                        "Failed to set up binary caches.
+                        "Failed to set up binary caches:
+
+                           {}
 
                         devenv is configured to automatically manage binary caches with `cachix.enable = true`, but cannot do so because you are not a trusted user of the Nix store.
 
-                        You have two options:
+                        You have several options:
 
-                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf to allow devenv to set up the caches for you:
+                        a) To let devenv set up the caches for you, add yourself to the trusted-users list in /etc/nix/nix.conf:
 
-                               trusted-users = root {}
+                             trusted-users = root {}
 
                            Then restart the nix-daemon:
 
-                               $ {restart_command}
+                             $ {restart_command}
 
-                        b) Add the binary caches to /etc/nix/nix.conf yourself:
+                        b) Add the missing binary caches to /etc/nix/nix.conf yourself:
 
                              extra-substituters = {}
                              extra-trusted-public-keys = {}
 
-                           Then disable automatic cache configuration in `devenv.nix`:
+                        c) Disable automatic cache management in your devenv configuration:
 
-                           {{
+                             {{
                                cachix.enable = false;
-                           }}
-                    ", whoami::username()
+                             }}
+                    "
+                    , missing_caches.join(" ")
+                    , whoami::username()
                     , missing_caches.join(" ")
                     , missing_public_keys.join(" ")
                     ));
                         } else {
                             self.logger.error(&indoc::formatdoc!(
-                        "Failed to set up binary caches.
+                        "Failed to set up binary caches:
+
+                           {}
 
                         devenv is configured to automatically manage binary caches with `cachix.enable = true`, but cannot do so because you are not a trusted user of the Nix store.
 
-                        You have two options:
+                        You have several options:
 
-                        a) Add yourself to the trusted-users list in /etc/nix/nix.conf by editing configuration.nix to let devenv set up the caches for you:
+                        a) To let devenv set up the caches for you, add yourself to the trusted-users list in /etc/nix/nix.conf by editing configuration.nix.
 
-                           {{
-                               nix.extraOptions = ''
-                                   trusted-users = root {}
-                               '';
-                           }}
+                             {{
+                               nix.settings.trusted-users = [ \"root\" \"{}\" ];
+                             }}
 
                            Rebuild your system:
 
-                               $ sudo nixos-rebuild switch
+                             $ sudo nixos-rebuild switch
 
-                        b) Add the binary caches to /etc/nix/nix.conf yourself by editing configuration.nix:
+                        b) Add the missing binary caches to /etc/nix/nix.conf yourself by editing configuration.nix:
 
-                           {{
+                             {{
                                nix.extraOptions = ''
-                                   extra-substituters = {}
-                                   extra-trusted-public-keys = {}
+                                 extra-substituters = {}
+                                 extra-trusted-public-keys = {}
                                '';
-                           }}
+                             }}
 
-                           Disable automatic cache configuration in `devenv.nix`:
+                           Rebuild your system:
 
-                           {{
+                             $ sudo nixos-rebuild switch
+
+                        c) Disable automatic cache management in your devenv configuration:
+
+                             {{
                                cachix.enable = false;
-                           }}
-
-                           Rebuild your system:
-
-                               $ sudo nixos-rebuild switch
-                    ", whoami::username()
+                             }}
+                    "
+                    , missing_caches.join(" ")
+                    , whoami::username()
                     , missing_caches.join(" ")
                     , missing_public_keys.join(" ")
                     ));

--- a/nix-conf-parser/Cargo.toml
+++ b/nix-conf-parser/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "nix-conf-parser"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+indexmap.workspace = true
+thiserror.workspace = true

--- a/nix-conf-parser/Cargo.toml
+++ b/nix-conf-parser/Cargo.toml
@@ -6,4 +6,5 @@ license.workspace = true
 
 [dependencies]
 indexmap.workspace = true
+miette.workspace = true
 thiserror.workspace = true

--- a/nix-conf-parser/src/lib.rs
+++ b/nix-conf-parser/src/lib.rs
@@ -1,0 +1,97 @@
+use indexmap::IndexMap;
+use thiserror::Error;
+
+#[derive(Debug)]
+pub struct NixConf {
+    settings: IndexMap<String, String>,
+}
+
+impl NixConf {
+    /// Parse a string into an ordered map of key-value string pairs.
+    ///
+    /// Closely follows the upstream implementation:
+    /// https://github.com/NixOS/nix/blob/acb60fc3594edcc54dae9a10d2a0dc3f3b3be0da/src/libutil/config.cc#L104-L161
+    ///
+    /// Only intended to work on the output of `nix config show`.
+    /// Therefore, this intentionally leaves out:
+    ///   - includes and !includes
+    ///   - comments
+    ///   - formatting
+    pub fn parse(input: &str) -> Result<Self, ParseError> {
+        let mut settings = IndexMap::new();
+
+        for mut line in input.lines() {
+            // Trim comments
+            if let Some(pos) = line.find('#') {
+                line = &line[..pos];
+            }
+
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let mut tokens = line.split_whitespace().collect::<Vec<_>>();
+            tokens.retain(|t| !t.is_empty());
+
+            if tokens.is_empty() {
+                continue;
+            }
+
+            if tokens.len() < 2 {
+                return Err(ParseError::IllegalConfiguration(line.to_string()));
+            }
+
+            // Skip includes if they make it into the input
+            match tokens[0] {
+                "include" | "!include" => continue,
+                _ => {}
+            }
+
+            if tokens[1] != "=" {
+                return Err(ParseError::IllegalConfiguration(line.to_string()));
+            }
+
+            let name = tokens[0];
+            let value = tokens[2..].join(" ");
+
+            settings.insert(name.to_string(), value);
+        }
+
+        Ok(Self { settings })
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.settings.get(key)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("illegal configuration line '{0}'")]
+    IllegalConfiguration(String),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let input = r#"
+            # This is a comment
+            include /etc/nixos/hardware-configuration.nix
+            !include /etc/nixos/hardware-configuration.nix
+            single = foo
+            space  =  foo   bar 
+            list = foo bar baz
+            comment = foo # comment
+            tab =	 foo 
+        "#;
+        let nix_conf = NixConf::parse(input).unwrap();
+        assert_eq!(nix_conf.get("single"), Some(&"foo".into()));
+        assert_eq!(nix_conf.get("space"), Some(&"foo bar".into()));
+        assert_eq!(nix_conf.get("list"), Some(&"foo bar baz".into()));
+        assert_eq!(nix_conf.get("comment"), Some(&"foo".into()));
+        assert_eq!(nix_conf.get("tab"), Some(&"foo".into()));
+    }
+}

--- a/package.nix
+++ b/package.nix
@@ -14,6 +14,7 @@ pkgs.rustPlatform.buildRustPackage {
     ".*devenv-eval-cache(/.*)?"
     ".*devenv-run-tests(/.*)?"
     ".*devenv-tasks(/.*)?"
+    ".*nix-conf-parser(/.*)?"
     ".*xtask(/.*)?"
   ];
 


### PR DESCRIPTION
If devenv cannot configure the requested caches, it displays instructions to either become a trusted user or to set up the caches globally. However, it never checks if the caches are actually configured, so the only solution is to set `cachix.enable = false;`, which can get tedious across many projects.

This PR queries Nix to figure out which caches and keys are missing. If the user is not trusted, but all the caches are already configured, no warning is shown.