### PR TITLE
Add documentation on how to enable compilation of binary dependencies.

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -221,3 +221,23 @@ in {
   ];
 }
 ```
+
+### Compile x86 dependencies on ARM Macs via Rosetta
+
+If you want to also compile dependencies for x86, you can add dependencies to `packages`:
+
+```nix
+packages = with rosettaPkgs; [
+    freetds
+    krb5
+    openssl
+];
+```
+
+And switch the compiler to x86:
+
+```nix
+stdenv = rosettaPkgs.stdenv;
+```
+
+Then, in the generated shell, you can compile software for x86, like `pymssql` or `ibm_db`.


### PR DESCRIPTION
This feels more complicated than it should be. Especially setting the `export DYLD_FALLBACK_LIBRARY_PATH="${rosettaPkgs.lib.makeLibraryPath [ rosettaPkgs.gcc14.cc] }:$DYLD_FALLBACK_LIBRARY_PATH"` feels like it should just go into either `languages.python.libraries` or into `packages`. I didn't get that to work however.

This would fix #1603 