### PR TITLE
feat(nim): switch to official lsp

### DIFF
--- a/src/modules/languages/nim.nix
+++ b/src/modules/languages/nim.nix
@@ -18,7 +18,7 @@ in
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.nimlsp
+      pkgs.nimlangserver
     ];
   };
 }


### PR DESCRIPTION
Currently set [nimlsp](https://github.com/PMunch/nimlsp) package does not seem to be actively maintained.
The official [Nim Language Server](https://github.com/nim-lang/langserver) seems the defacto standard as now (this what I have been using) (experienced Nim users please comment).