### PR TITLE
feat(ocaml): add extra packages for opam

### DIFF
--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -14,6 +14,13 @@ in
         default = pkgs.ocaml-ng.ocamlPackages;
         defaultText = lib.literalExpression "pkgs.ocaml-ng.ocamlPackages_4_12";
       };
+
+    extraPackages = lib.mkOption
+      {
+        type = lib.types.listOf lib.types.package;
+        description = "Extra OCaml packages to use";
+        default = [ ];
+      };
   };
 
   config = lib.mkIf cfg.enable {
@@ -27,6 +34,6 @@ in
       cfg.packages.ocp-indent
       cfg.packages.findlib
       pkgs.ocamlformat
-    ];
+    ] ++ cfg.extraPackages;
   };
 }


### PR DESCRIPTION
This introduces a `extraPackages` option for OCaml module. This addition allows users to specify additional OCaml packages they want to include in their environment. The primary use case for this feature is to enable users to easily add extra OCaml-specific packages, such as `base` or others.

## Feedback

I would like feedback on the following points:
+ Naming convention: Should the option name `extraPackages` be more specific, such as `extraOcamlPackages`, to clarify its purpose? If the latter is the case, should we force `pkgs.ocamlPackages` for less verbosity?
+ General usability: Does this approach align with user expectations and other modules?

## Use

This is how I am using this new option:
```nix
{ ... }:
{
  imports = [ inputs.devenv.flakeModule ];
  perSystem =
    { ... }:
    {
      devenv.shells.default = {
        languages = {
          nix.enable = true;
          ocaml = {
            enable = true;
            extraPackages = with pkgs.ocamlPackages; [ base ];
          };
        };

        packages = with pkgs; [ ... ];
      };
    };
}
```