### PR TITLE
Fix rebar3 erlang version

### DIFF
--- a/src/modules/languages/erlang.nix
+++ b/src/modules/languages/erlang.nix
@@ -2,6 +2,9 @@
 
 let
   cfg = config.languages.erlang;
+  rebar3 = pkgs.rebar3.overrideAttrs (oldAttrs: {
+    buildInputs = [ cfg.package ];
+  });
 in
 {
   options.languages.erlang = {
@@ -20,7 +23,7 @@ in
       packages = [
         cfg.package
         pkgs.erlang-ls
-        pkgs.rebar3
+        rebar3
       ];
     };
 }


### PR DESCRIPTION
There is a weird bug with rebar3 in nixpkgs right now where it is using the version of erlang in its build inputs to actually compile your code and other things. For example, without this change, if I use the following

```nix
languages.erlang.enable = true;
languages.erlang.package = pkgs.erlang_27;
```

then run `rebar3 shell` to open a repl for my application, it will open using Erlang 25, because that is the version of erlang that is used in nixpkgs to build rebar3.

With this change, we will now be using whatever version of erlang the user requests to also build rebar3, which leads to the correct version being loaded when calling the various rebar3 commands.

The reason I said at the start that this is technically a bug is because even if I compiled rebar3 with OTP 25, it should still load OTP 27 (or whatever version) if that is what I have installed. If you would rather see a proper fix upstreamed to nixpkgs, I would need a little direction on how to do that because I currently do not understand why this is happening.