### PR TITLE
Fix defaultCopyArgs always getting ignored

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -332,16 +332,16 @@ impl Devenv {
             let copy_script = &copy_script[0];
             let copy_script_string = &copy_script.to_string_lossy();
 
-            let copy_args = [
-                spec,
-                registry.unwrap_or("false").to_string(),
-                copy_args.join(" "),
-            ];
+            let base_args = [spec, registry.unwrap_or("false").to_string()];
+            let command_args: Vec<String> = base_args
+                .into_iter()
+                .chain(copy_args.iter().map(|s| s.to_string()))
+                .collect();
 
-            info!("Running {copy_script_string} {}", copy_args.join(" "));
+            info!("Running {copy_script_string} {}", command_args.join(" "));
 
             let status = std::process::Command::new(copy_script)
-                .args(copy_args)
+                .args(command_args)
                 .stdout(std::process::Stdio::inherit())
                 .stderr(std::process::Stdio::inherit())
                 .status()

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -182,7 +182,7 @@ let
     echo "Copying container $container to $dest"
     echo
 
-    ${nix2container.skopeo-nix2container}/bin/skopeo --insecure-policy copy "nix:$container" "$dest" ''${args[@]}
+    ${nix2container.skopeo-nix2container}/bin/skopeo --insecure-policy copy "nix:$container" "$dest" "''${args[@]}"
   '';
   containerOptions = types.submodule ({ name, config, ... }: {
     options = {


### PR DESCRIPTION
I was looking to deploy a container built by devenv to fly.io, and found that configuring registry auth through `defaultCopyArgs` like in the docs or example didn't work. I had to specify it through `--copy-args` on the command line.

https://github.com/cachix/devenv/blob/4b8677f62022e6a235cc4e93a6bbc3d57b77817f/docs/containers.md?plain=1#L143-L149

### Why this was happening:

The `copy-container` script determines whether to use `defaultCopyArgs` by looking at the remaining number of script arguments after consuming the first and second arguments:

https://github.com/cachix/devenv/blob/4b8677f62022e6a235cc4e93a6bbc3d57b77817f/src/modules/containers.nix#L175-L179

However, the `copy` command always invokes the script with three arguments:

https://github.com/cachix/devenv/blob/4b8677f62022e6a235cc4e93a6bbc3d57b77817f/devenv/src/devenv.rs#L335-L339

Even if `copy_args` is empty, it gets passed in as an empty string.

### In lieu of a test case:

With a `devenv.nix` like

```nix
{ pkgs, lib, config, inputs, ... }:
{
  # This is a subset of my devenv.nix
  containers."processes".registry = "docker://registry.fly.io/";
  containers."processes".defaultCopyArgs = [
    "--dest-creds"
    # Wanted to switch to `tokens create` as `auth token` emitted a warning when invoked
    "x:\"$(${pkgs.flyctl}/bin/flyctl tokens create org -x 10m | sed 's/ /\\ /g')\""
  ];
}
```

And `copy-container` script in Nix store modified (or with a custom devenv source) with this debug log:

```sh
function join_by { local IFS="$1"; shift; echo "$*"; }

echo Script args: $(join_by '|' "$@")
```

Before this patch:

```
$ devenv container copy processes
...
Script args: /nix/store/xxxxxx.json|false|
...
```

Note the final `|` that shows that there's a third, empty argument.

```sh
$ devenv container --copy-args 'abc def' --copy-args 'ghi' copy processes
...
Script args: /nix/store/xxxxxx.json|false|abc def ghi
...
```

All `--copy-args` arguments get passed in as a single argument, which will get interpreted by skopeo as three arguments as `copy-container` doesn't put quotes around them when invoking skopeo. This works as long as none of them contains whitespace, but incidentally, fly.io's newer `flyctl tokens create` command returns a token with a whitespace.

With this patch:

```sh
$ devenv container copy processes
...
• Copying processes container ...
Running /nix/store/3cmbig1kz2rbirr92cl668692sscg18p-copy-container /nix/store/xxxxxx.json false
Script args: /nix/store/xxxxxx.json|false
                                           
Copying container /nix/store/xxxxxx.json to docker://registry.fly.io/yyyyyy:latest
                                           
Getting image source signatures
Copying blob 3202cb314bf5 done   |                                                                                                                                            
Copying blob 254750567eda done   | 
Copying config 3f695b96ee done   |                                                     
Writing manifest to image destination
✔ Copying processes container in 58.3s
```

```sh
$ devenv container --copy-args 'abc def' --copy-args 'ghi' copy processes
...
Script args: /nix/store/xxxxxx.json|false|abc def|ghi
...
```

