### PR TITLE
go: added iferr to go language module to support vim-go

### DIFF
--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -39,6 +39,9 @@ in
       (buildWithSpecificGo pkgs.go-tools)
       (buildWithSpecificGo pkgs.gopls)
       (buildWithSpecificGo pkgs.gotests)
+
+      # Required by vim-go
+      (buildWithSpecificGo pkgs.iferr)
     ];
 
     hardeningDisable = lib.optional (cfg.enableHardeningWorkaround) "fortify";


### PR DESCRIPTION
Added iferr to the list of base packages installed for go language support.