### PR TITLE
cachix: use `cachix.enable` to disable cache setup logic

### DIFF
--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -719,9 +719,10 @@ impl<'a> Nix<'a> {
                             .map(|s| s.split_whitespace().collect::<Vec<_>>());
 
                         if let Some(trusted_public_keys) = trusted_public_keys {
-                            for (_name, key) in caches.known_keys.iter() {
-                                if !trusted_public_keys.iter().any(|p| p == key) {
-                                    missing_public_keys.push(key.clone());
+                            let mut known_keys = caches.known_keys.values();
+                            for key in trusted_public_keys.iter() {
+                                if !known_keys.any(|k| k == key) {
+                                    missing_public_keys.push(key.to_string());
                                 }
                             }
                         }

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -923,7 +923,7 @@ package
 
 
 
-What caches to pull from.
+Which Cachix caches to pull from.
 
 
 
@@ -933,7 +933,12 @@ list of string
 
 
 *Default:*
-` [ ] `
+
+```
+[
+  "devenv"
+]
+```
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/cachix.nix](https://github.com/cachix/devenv/blob/main/src/modules/cachix.nix)
@@ -944,7 +949,7 @@ list of string
 
 
 
-What cache to push to. Automatically also adds it to the list of caches to pull from.
+Which Cachix cache to push to. This cache is also added to ` cachix.pull `.
 
 
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -933,12 +933,7 @@ list of string
 
 
 *Default:*
-
-```
-[
-  "devenv"
-]
-```
+` [ "devenv" ] `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/cachix.nix](https://github.com/cachix/devenv/blob/main/src/modules/cachix.nix)

--- a/src/modules/cachix.nix
+++ b/src/modules/cachix.nix
@@ -13,7 +13,8 @@ in
     pull = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       description = "Which Cachix caches to pull from.";
-      default = [ "devenv" ];
+      default = [ ];
+      defaultText = lib.literalExpression ''[ "devenv" ]'';
     };
 
     push = lib.mkOption {
@@ -29,7 +30,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    cachix.pull = lib.optional (cfg.push != null) config.cachix.push;
+    cachix.pull = [ "devenv" ]
+      ++ (lib.optional (cfg.push != null) config.cachix.push);
 
     warnings = lib.optionals (!config.devenv.flakesIntegration && lib.versionOlder config.devenv.cliVersion "1.0") [
       ''

--- a/src/modules/cachix.nix
+++ b/src/modules/cachix.nix
@@ -12,13 +12,13 @@ in
 
     pull = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      description = "What caches to pull from.";
-      default = [ ];
+      description = "Which Cachix caches to pull from.";
+      default = [ "devenv" ];
     };
 
     push = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
-      description = "What cache to push to. Automatically also adds it to the list of caches to pull from.";
+      description = "Which Cachix cache to push to. This cache is also added to `cachix.pull`.";
       default = null;
     };
 
@@ -29,8 +29,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    cachix.pull = [ "devenv" ]
-      ++ (lib.optionals (cfg.push != null) [ config.cachix.push ]);
+    cachix.pull = lib.optional (cfg.push != null) config.cachix.push;
 
     warnings = lib.optionals (!config.devenv.flakesIntegration && lib.versionOlder config.devenv.cliVersion "1.0") [
       ''


### PR DESCRIPTION
The previous logic assumed that cache setup should be disabled if `cachix.pull` is empty, but that `devenv` is always a default cache. We now read in `cachix.enable` and use that to enable/disable setting up caches.