### PR TITLE
fix: changed copy script so that 'skopeo' copy functions on nixos

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -182,7 +182,7 @@ let
     echo "Copying container $container to $dest"
     echo
 
-    ${nix2container.skopeo-nix2container}/bin/skopeo --insecure-policy copy "nix:$container" "$dest" "''${args[@]}"
+    ${nix2container.skopeo-nix2container}/bin/skopeo --insecure-policy copy "nix:$container" "$dest" ''${args[@]}
   '';
   containerOptions = types.submodule ({ name, config, ... }: {
     options = {


### PR DESCRIPTION
Hi, I was recently trying to use the **container sub command** and noticed it would fail to build with something like the following output every time it would run:

```
INFO[0000] Image has been written to /nix/store/5ciiy94r2g6x4vp3ci9g3j62pf9v7yds-image-shell.json
/nix/store/5ciiy94r2g6x4vp3ci9g3j62pf9v7yds-image-shell.json
✔ Building shell container in 22.0s.
• Copying shell container ...• Running /nix/store/knb9p6bnp6a9csa3w3c9h1ykm4lkyk4c-copy-container /nix/store/5ciiy94r2g6x4vp3ci9g3j62pf9v7yds-image-shell.json docker-daemon:

Copying container /nix/store/5ciiy94r2g6x4vp3ci9g3j62pf9v7yds-image-shell.json to docker-daemon:shell:latest

Container "IMAGE-NAME" uses a "transport":"details" format.

Supported transports:
containers-storage, dir, docker, docker-archive, docker-daemon, nix, oci, oci-archive, ostree, sif, tarball

See skopeo(1) section "IMAGE NAMES" for the expected format

Usage:
skopeo copy [command options] SOURCE-IMAGE DESTINATION-IMAGE

Examples:
skopeo copy docker://quay.io/skopeo/stable:latest docker://registry.example.com/skopeo:latest

Flags:
      --additional-tag strings                additional tags (supports docker-archive)
  -a, --all                                   Copy all images if SOURCE-IMAGE is a list
      --authfile string                       path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
      --decryption-key strings                *Experimental* key needed to decrypt the image
      --dest-authfile string                  path of the authentication file. Default is ${XDG_RUNTIME_DIR}/containers/auth.json
      --dest-cert-dir PATH                    use certificates at PATH (*.crt, *.cert, *.key) to connect to the registry or daemon
```

After a bit of research I found this is a recurring issue that was previously solved in a thread on your discord called `Container error`. I then looked for commits on that day and found [this commit](https://github.com/cachix/devenv/commit/47569d938553debe95ddafc4633d6237b8c9b7a3), which had fixed the error. However, it seems that at some point in a refactor or otherwise since, this was reverted, breaking the skopeo command once again, hence I re-applied the changes and verified it works with `devenv container run shell`.