### PR TITLE
Add express example

### DIFF
--- a/examples/express/.gitignore
+++ b/examples/express/.gitignore
@@ -1,0 +1,4 @@
+# Devenv
+.devenv*
+devenv.local.nix
+node_modules

--- a/examples/express/.test.sh
+++ b/examples/express/.test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+devenv up&
+timeout 20 bash -c 'until echo > /dev/tcp/localhost/3000; do sleep 0.5; done'
+curl -s http://localhost:3000/ | grep "hello world"
+

--- a/examples/express/app.js
+++ b/examples/express/app.js
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const app = express();
+
+app.get("/", (req, res) => {
+  res.send("hello world")
+});
+
+app.listen(3000);

--- a/examples/express/devenv.nix
+++ b/examples/express/devenv.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib, ... }:
+
+{
+  languages.javascript = {
+    enable = true;
+    npm.install.enable = true;
+  };
+
+  processes.nodejs.exec = "node app.js";
+
+}

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "javascript",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^5.0.1"
+  }
+}


### PR DESCRIPTION
As mentioned on #948, a very barebones express example, I wasn't sure if I was supposed add `devenv.yaml`, `devenv.lock` or `package-lock.json`, but the examples I referred to didn't have them. I can add them if needed.

I can build Next.js and Remix based examples based on this, once this is merged.