### PR TITLE
macos: add an option to configure the macOS SDK or remove it completely

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -602,6 +602,29 @@ string
 
 
 
+## apple.sdk
+
+
+
+The Apple SDK to use for the developer environment.
+
+If set to ` null `, the system SDK will be used.
+
+
+
+*Type:*
+null or package
+
+
+
+*Default:*
+` if pkgs.stdenv.isDarwin then pkgs.apple-sdk else null `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)
+
+
+
 ## aws-vault.enable
 
 
@@ -2299,8 +2322,6 @@ list of (one of “commit-msg”, “post-checkout”, “post-commit”, “pos
 
 ## git-hooks.excludes
 
-
-
 Exclude files that were matched by these patterns.
 
 
@@ -2319,6 +2340,8 @@ list of string
 
 
 ## git-hooks.gitPackage
+
+
 
 The ` git ` package to use.
 
@@ -5136,8 +5159,6 @@ boolean
 
 ## git-hooks.hooks.autoflake.settings.binPath
 
-
-
 Path to autoflake binary.
 
 
@@ -5160,6 +5181,8 @@ null or string
 
 
 ## git-hooks.hooks.autoflake.settings.flags
+
+
 
 Flags passed to autoflake.
 
@@ -7009,8 +7032,6 @@ null or package
 
 ## git-hooks.hooks.clippy.packageOverrides.cargo
 
-
-
 The cargo package to use
 
 
@@ -7024,6 +7045,8 @@ package
 
 
 ## git-hooks.hooks.clippy.packageOverrides.clippy
+
+
 
 The clippy package to use
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -606,9 +606,9 @@ string
 
 
 
-The Apple SDK to use for the developer environment.
+The Apple SDK to add to the developer environment on macOS.
 
-If set to ` null `, the system SDK will be used.
+If set to ` null `, the system SDK can be used if the shell allows access to external environment variables.
 
 
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -69,18 +69,21 @@ in
     stdenv = lib.mkOption {
       type = types.package;
       description = "The stdenv to use for the developer environment.";
-      default =
-        if pkgs.stdenv.isDarwin
+      default = pkgs.stdenv;
+      defaultText = lib.literalExpression "pkgs.stdenv";
+
+      # Remove the default apple-sdk on macOS.
+      # Allow users to specify an optional SDK in `apple.sdk`.
+      apply = stdenv:
+        if stdenv.isDarwin
         then
-          pkgs.stdenv.override
+          stdenv.override
             (prev: {
-              # Remove the default apple-sdk on macOS.
-              # Allow users to specify an optional SDK in `apple.sdk`.
               extraBuildInputs =
                 builtins.filter (x: !lib.hasPrefix "apple-sdk" x.pname) prev.extraBuildInputs;
             })
-        else pkgs.stdenv;
-      defaultText = lib.literalExpression "pkgs.stdenv";
+        else stdenv;
+
     };
 
     apple = {

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -336,8 +336,7 @@ in
         (pkgs.mkShell.override { stdenv = config.stdenv; }) ({
           name = "devenv-shell";
           hardeningDisable = config.hardeningDisable;
-          # inherit buildInputs nativeBuildInputs;
-          inherit (config) packages;
+          inherit buildInputs nativeBuildInputs;
           shellHook = ''
             ${lib.optionalString config.devenv.debug "set -x"}
             ${config.enterShell}

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -87,9 +87,9 @@ in
       sdk = lib.mkOption {
         type = types.nullOr types.package;
         description = ''
-          The Apple SDK to use for the developer environment.
+          The Apple SDK to add to the developer environment on macOS.
 
-          If set to `null`, the system SDK will be used.
+          If set to `null`, the system SDK can be used if the shell allows access to external environment variables.
         '';
         default = if pkgs.stdenv.isDarwin then pkgs.apple-sdk else null;
         defaultText = lib.literalExpression "if pkgs.stdenv.isDarwin then pkgs.apple-sdk else null";

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+{
+  packages = [ pkgs.apple-sdk ];
+
+  # Test that the above SDK is picked up by xcode-select.
+  enterTest = ''
+    if [ -v "$DEVELOPER_DIR" ]; then
+      echo "DEVELOPER_DIR is not set."
+      exit 1
+    fi
+
+    xcode-select -p | grep -q /nix/store
+  '';
+}

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 
 {
-  packages = [ pkgs.apple-sdk ];
+  apple.sdk = pkgs.apple-sdk;
 
   # Test that the above SDK is picked up by xcode-select.
   enterTest = ''

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -3,6 +3,10 @@
 {
   apple.sdk = pkgs.apple-sdk;
 
+  packages = [
+    pkgs.xcbuild
+  ];
+
   # Test that the above SDK is picked up by xcode-select.
   enterTest = lib.optionalString pkgs.stdenv.isDarwin ''
     if [ -v "$DEVELOPER_DIR" ]; then

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -1,10 +1,10 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
   apple.sdk = pkgs.apple-sdk;
 
   # Test that the above SDK is picked up by xcode-select.
-  enterTest = ''
+  enterTest = lib.optionalString pkgs.stdenv.isDarwin ''
     if [ -v "$DEVELOPER_DIR" ]; then
       echo "DEVELOPER_DIR is not set."
       exit 1

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 
-{
+lib.mkIf pkgs.stdenv.isDarwin {
   apple.sdk = pkgs.apple-sdk;
 
   packages = [
@@ -8,7 +8,7 @@
   ];
 
   # Test that the above SDK is picked up by xcode-select.
-  enterTest = lib.optionalString pkgs.stdenv.isDarwin ''
+  enterTest = ''
     if [ -v "$DEVELOPER_DIR" ]; then
       echo "DEVELOPER_DIR is not set."
       exit 1

--- a/tests/macos-no-default-sdk/devenv.nix
+++ b/tests/macos-no-default-sdk/devenv.nix
@@ -1,0 +1,18 @@
+{
+  # Test that there is no default SDK set on macOS.
+  enterTest = ''
+    variables_to_check=(
+      "DEVELOPER_DIR"
+      "DEVELOPER_DIR_FOR_BUILD"
+      "SDKROOT"
+      "NIX_APPLE_SDK_VERSION"
+    )
+
+    for var in "''${variables_to_check[@]}"; do
+      if [ -v "$var" ]; then
+        echo "$var is set. Expected no default Apple SDK." >&2
+        exit 1
+      fi
+    done
+  '';
+}

--- a/tests/macos-no-default-sdk/devenv.nix
+++ b/tests/macos-no-default-sdk/devenv.nix
@@ -1,4 +1,6 @@
 {
+  apple.sdk = null;
+
   # Test that there is no default SDK set on macOS.
   enterTest = ''
     variables_to_check=(

--- a/tests/macos-no-default-sdk/devenv.nix
+++ b/tests/macos-no-default-sdk/devenv.nix
@@ -1,8 +1,8 @@
-{
+{ pkgs, lib, ... }: {
   apple.sdk = null;
 
   # Test that there is no default SDK set on macOS.
-  enterTest = ''
+  enterTest = lib.optionalString pkgs.stdenv.isDarwin ''
     variables_to_check=(
       "DEVELOPER_DIR"
       "DEVELOPER_DIR_FOR_BUILD"

--- a/tests/macos-no-default-sdk/devenv.nix
+++ b/tests/macos-no-default-sdk/devenv.nix
@@ -1,8 +1,10 @@
-{ pkgs, lib, ... }: {
+{ pkgs, lib, ... }:
+
+lib.mkIf pkgs.stdenv.isDarwin {
   apple.sdk = null;
 
   # Test that there is no default SDK set on macOS.
-  enterTest = lib.optionalString pkgs.stdenv.isDarwin ''
+  enterTest = ''
     variables_to_check=(
       "DEVELOPER_DIR"
       "DEVELOPER_DIR_FOR_BUILD"


### PR DESCRIPTION
- Remove the default SDK from stdenv. This is currently not easy to do.
- Ensure users can set their own SDK if necessary via `packages`.

Fixes #1674.
Fixes #1641.