### PR TITLE
git-hooks: prevent pre-commit from leaking build inputs into env

### DIFF
--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -1,10 +1,22 @@
 { pkgs, self, lib, config, inputs, ... }:
 
 let
+  cfg = config.git-hooks;
+
   git-hooks-module =
     inputs.git-hooks
       or inputs.pre-commit-hooks
       or (throw "git-hooks or pre-commit-hooks input required");
+
+  # `propagatedBuildInputs` in Python apps are leaked into the environment.
+  # This normally leaks the Python interpreter and its site-packages, causing collision errors.
+  # This affects all packages built with `buildPythonApplication` or `toPythonApplication`.
+  # pre-commit is particularly annoying as it is difficult for end-users to track down.
+  # Tracking: https://github.com/NixOS/nixpkgs/issues/302376
+  packageBin = pkgs.runCommandLocal "pre-commit-bin" { } ''
+    mkdir -p $out/bin
+    ln -s ${cfg.package}/bin/pre-commit $out/bin/pre-commit
+  '';
 in
 {
   imports = [
@@ -28,14 +40,14 @@ in
     description = "Integration with https://github.com/cachix/git-hooks.nix";
   };
 
-  config = lib.mkIf ((lib.filterAttrs (id: value: value.enable) config.git-hooks.hooks) != { }) {
-    ci = [ config.git-hooks.run ];
+  config = lib.mkIf ((lib.filterAttrs (id: value: value.enable) cfg.hooks) != { }) {
+    ci = [ cfg.run ];
     # Add the packages for any enabled hooks at the end to avoid overriding the language-defined packages.
-    packages = lib.mkAfter ([ config.git-hooks.package ] ++ (config.git-hooks.enabledPackages or [ ]));
+    packages = lib.mkAfter ([ packageBin ] ++ (cfg.enabledPackages or [ ]));
     tasks = {
       # TODO: split installation script into status + exec
       "devenv:git-hooks:install" = {
-        exec = config.git-hooks.installationScript;
+        exec = cfg.installationScript;
         before = [ "devenv:enterShell" ];
       };
       "devenv:git-hooks:run" = {

--- a/tests/git-hooks-no-python-leak/devenv.nix
+++ b/tests/git-hooks-no-python-leak/devenv.nix
@@ -1,0 +1,12 @@
+# Assert that the pre-commit package does not leak its dependencies into the environment.
+{
+  git-hooks.hooks.nixfmt-rfc-style.enable = true;
+
+  enterTest = ''
+    if [ -n "$PYTHONPATH" ]; then
+      echo "PYTHONPATH is non-empty: $PYTHONPATH" >&2
+      echo "The pre-commit package is leaking its dependencies into the environment." >&2
+      exit 1
+    fi
+  '';
+}


### PR DESCRIPTION
Upstream issue: https://github.com/NixOS/nixpkgs/issues/302376

Python derivations built with `buildPythonApplication` or converted from a library with `toPythonApplication` do not make the distinction between build- and run-time dependencies. When these packages are added to `packages`, their `propagatedBuildInputs` are leaked into the environment. This includes the Python interpreter and other dependencies, which may conflict with the user's configured environment.

This PR symlinks the pre-commit binary to avoid bringing along all of the Python baggage with it.

Fixes https://github.com/cachix/devenv/issues/1644.