### PR TITLE
examples: fix nur example

### DIFF
--- a/examples/nur/devenv.nix
+++ b/examples/nur/devenv.nix
@@ -1,10 +1,8 @@
 { pkgs, inputs, config, ... }:
 
 {
-  imports = [ inputs.nur.nixosModules.nur ];
-
   # see the list of repos at https://nur.nix-community.org/documentation/
   packages = [
-    config.nur.repos.mic92.hello-nur
+    pkgs.nur.repos.mic92.hello-nur
   ];
 }

--- a/examples/nur/devenv.yaml
+++ b/examples/nur/devenv.yaml
@@ -1,3 +1,8 @@
 inputs:
   nur:
     url: github:nix-community/NUR
+    inputs:
+      nixpkgs:
+        follows: "nixpkgs"
+    overlays:
+      - "default"


### PR DESCRIPTION
Module support was recently dropped.
AFAIK the only way to use NUR now is through an overlay.