### PR TITLE
fix/robustify wait_for_port function

### DIFF
--- a/src/modules/tests.nix
+++ b/src/modules/tests.nix
@@ -34,7 +34,7 @@
         local port=$1
         local timeout=''${2:-15}
 
-        timeout $timeout bash -c "until echo > /dev/tcp/localhost/$port; do sleep 0.5; done"
+        timeout $timeout bash -c "until ${pkgs.libressl.nc}/bin/nc -z localhost $port 2>/dev/null; do sleep 0.5; done"
       }
 
       export -f wait_for_port


### PR DESCRIPTION
This happened (posted to discord yesterday):

```
I'm now since a few months using devenv again, and get a strange error for `wait_for_port 34000` => `bash: line 1: /dev/tcp/localhost/34000: Connection refused`??? (Executed within `enterTest`) This confuses me, when I contributed to `devenv`'s `postgres` service a few months ago `wait_for_port` trivially worked?
```

This seems to be a bug (see e.g. https://unix.stackexchange.com/questions/777846/stdin-redirection-from-dev-tcp-localhost-port for a bit more insight), or at least the method used for port checking is not robust and not portable; this PR aims to fix this.