### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@
 === "macOS"
 
     ```
-    curl -L https://github.com/NixOS/experimental-nix-installer/releases/latest/download/nix-installer.sh | bash -s install
+    curl -L https://github.com/NixOS/experimental-nix-installer/releases/download/0.27.0/nix-installer.sh | sh -s -- install
     ```
 
     !!! note "Experimental installer"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@
 === "macOS"
 
     ```
-    curl -L https://raw.githubusercontent.com/NixOS/experimental-nix-installer/main/nix-installer.sh | sh -s install
+    curl -L https://github.com/NixOS/experimental-nix-installer/releases/latest/download/nix-installer.sh | bash -s install
     ```
 
     !!! note "Experimental installer"


### PR DESCRIPTION
The install script was reworked in a following commit: https://github.com/NixOS/experimental-nix-installer/commit/d0286602ace4db04f491a5b8a8c553aa50ccfc3e

The previous command now fails with: `sh: line 28: assemble_installer_templated_version: unbound variable`