### PR TITLE
tasks: use `lib.getExe` to fetch the package binary by default

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -83325,17 +83325,17 @@ list of string
 
 
 
-Override the binary name if it doesn’t match package name
+Override the binary name from the default ` package.meta.mainProgram `.
 
 
 
 *Type:*
-string
+null or string
 
 
 
 *Default:*
-` config.package.pname `
+` null `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/tasks.nix](https://github.com/cachix/devenv/blob/main/src/modules/tasks.nix)

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -13,8 +13,14 @@ let
           if builtins.isNull command
           then null
           else
+            let
+              binary =
+                if config.binary != null
+                then "${pkgs.lib.getBin config.package}/bin/${config.binary}"
+                else pkgs.lib.getExe config.package;
+            in
             pkgs.writeScript name ''
-              #!${pkgs.lib.getBin config.package}/bin/${config.binary}
+              #!${binary}
               ${lib.optionalString (!isStatus) "set -e"}
               ${command}
               ${lib.optionalString (config.exports != [] && !isStatus) "${devenv}/bin/devenv-tasks export ${lib.concatStringsSep " " config.exports}"}
@@ -28,10 +34,9 @@ let
             description = "Command to execute the task.";
           };
           binary = lib.mkOption {
-            type = types.str;
-            description = "Override the binary name if it doesn't match package name";
-            default = config.package.pname;
-            defaultText = lib.literalExpression "config.package.pname";
+            type = types.nullOr types.str;
+            description = "Override the binary name if it differs from from the output of `lib.getExe`.";
+            default = null;
           };
           package = lib.mkOption {
             type = types.package;

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -35,7 +35,7 @@ let
           };
           binary = lib.mkOption {
             type = types.nullOr types.str;
-            description = "Override the binary name if it differs from from the output of `lib.getExe`.";
+            description = "Override the binary name from the default `package.meta.mainProgram`.";
             default = null;
           };
           package = lib.mkOption {
@@ -123,8 +123,8 @@ in
 
     assertions = [
       {
-        assertion = lib.all (task: lib.hasPrefix "bash" task.binary || task.exports == [ ]) (lib.attrValues config.tasks);
-        message = "The 'exports' option for a task can only be set when 'binary' is set to 'bash' or 'bash-interactive'.";
+        assertion = lib.all (task: task.package.meta.mainProgram == "bash" || task.binary == "bash" || task.exports == [ ]) (lib.attrValues config.tasks);
+        message = "The 'exports' option for a task can only be set when 'package' is a bash package.";
       }
     ];
 


### PR DESCRIPTION
`tasks.<name>.binary` is now an optional override, in case `lib.getExe` (i.e. `meta.mainProgram`) returns something that doesn't work.

This fixes an upcoming issue in nixpkgs/master where the pname for `bash` is changing to `bash-interactive` by default. Using the `pname` as the name of the binary will break tasks.