### PR TITLE
Move cwd for yarn to start of args to support newer versions

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -90,7 +90,7 @@ let
 
       if [ "$ACTUAL_YARN_CHECKSUM" != "$EXPECTED_YARN_CHECKSUM" ]
       then
-        if ${cfg.yarn.package}/bin/yarn install ${lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"}
+        if ${cfg.yarn.package}/bin/yarn "--cwd ${cfg.directory}" install ${lib.optionalString (cfg.directory != config.devenv.root)}
         then
           echo "$ACTUAL_YARN_CHECKSUM" > "$YARN_CHECKSUM_FILE"
         else


### PR DESCRIPTION
If the installed version of yarn is newer than v2 (currently v4.6), the —cwd option needs to be specified as the first argument. This modification is backward compatible.

Example error:

Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path

$ yarn install [--json] [--immutable] [--immutable-cache] [--refresh-lockfile] [--check-cache] [--check-resolutions] [--inline-builds] [--mode #0] Install failed. Run 'yarn install' manually.