### PR TITLE
scripts: use lib.getExe to fetch the package binary by default

### DIFF
--- a/src/modules/scripts.nix
+++ b/src/modules/scripts.nix
@@ -21,10 +21,9 @@ let
           defaultText = lib.literalExpression "pkgs.bash";
         };
         binary = lib.mkOption {
-          type = types.str;
-          description = "Override the binary name if it doesn't match package name";
-          default = config.package.pname;
-          defaultText = lib.literalExpression "config.package.pname";
+          type = types.nullOr types.str;
+          description = "Override the binary name from the default `package.meta.mainProgram`";
+          default = null;
         };
         description = lib.mkOption {
           type = types.str;
@@ -37,10 +36,15 @@ let
         };
       };
 
-      config.scriptPackage =
+      config.scriptPackage = let
+        binary =
+          if config.binary != null
+          then "${pkgs.lib.getBin config.package}/bin/${config.binary}"
+          else pkgs.lib.getExe config.package;
+      in
         lib.hiPrioSet (
           pkgs.writeScriptBin name ''
-            #!${pkgs.lib.getBin config.package}/bin/${config.binary}
+            #!${binary}
             ${config.exec}
           ''
         );


### PR DESCRIPTION
Similar to #1745 but for scripts now.