### PR TITLE
Fix egression in yarn cwd path

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -90,7 +90,7 @@ let
 
       if [ "$ACTUAL_YARN_CHECKSUM" != "$EXPECTED_YARN_CHECKSUM" ]
       then
-        if ${cfg.yarn.package}/bin/yarn "--cwd ${cfg.directory}" install ${lib.optionalString (cfg.directory != config.devenv.root)}
+        if ${cfg.yarn.package}/bin/yarn ${lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"} install
         then
           echo "$ACTUAL_YARN_CHECKSUM" > "$YARN_CHECKSUM_FILE"
         else


### PR DESCRIPTION
in #1755 the cwd was moved but the lib.optionalString that chooses it didn't follow, this PR moves the lib.optionalString to the correct location