### PR TITLE
docs: fix invalid JSON in DEVENV_TASK_OUTPUT_FILE example

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -102,7 +102,7 @@ Tasks support passing inputs and produce outputs, both as JSON objects:
     "myapp:mytask" = {
       exec = ''
         echo $DEVENV_TASK_INPUTS> $DEVENV_ROOT/input.json
-        echo '{ "output" = 1; }' > $DEVENV_TASK_OUTPUT_FILE
+        echo '{ "output": 1 }' > $DEVENV_TASK_OUTPUT_FILE
         echo $DEVENV_TASKS_OUTPUTS > $DEVENV_ROOT/outputs.json
       '';
       input = {


### PR DESCRIPTION
The example previously wrote what appears to be Nix code to the output file instead of JSON like it expects.