### PR TITLE
fix(postgres-service): add quotes to resource names

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -52,13 +52,13 @@ let
               psql --dbname postgres <<'EOF'
               DO $$
                   BEGIN
-                      CREATE ROLE ${database.user} WITH LOGIN PASSWORD '${database.pass}';
+                      CREATE ROLE "${database.user}" WITH LOGIN PASSWORD '${database.pass}';
                       EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
                   END
               $$;
-              GRANT ALL PRIVILEGES ON DATABASE ${database.name} TO ${database.user};
+              GRANT ALL PRIVILEGES ON DATABASE "${database.name}" TO "${database.user}";
               \c ${database.name}
-              GRANT ALL PRIVILEGES ON SCHEMA public TO ${database.user};
+              GRANT ALL PRIVILEGES ON SCHEMA public TO "${database.user}";
               EOF
             ''}
               ${lib.optionalString (database.schema != null) ''


### PR DESCRIPTION
I had some trouble creating a database and user which contains a dash "-" in its name.
The name was "unit-tests" both, which causes some syntax errors during the creation of the database and during the grant process.
These changes fixes it for me.

![image](https://github.com/user-attachments/assets/5b1cdfce-3666-4f2c-87f7-45fe897a84e4)
```nix
      initialDatabases = [{
        name = "unit-tests";
        schema = ./tests/fixtures/db.sql;
        user = "unit-tests";
        pass = "unit-tests";
      }];

```