### PR TITLE
devenv: don't create local project directories on `devenv init`

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -107,7 +107,6 @@ impl Devenv {
             .expect("Failed to create DEVENV_HOME directory");
         std::fs::create_dir_all(&devenv_home_gc)
             .expect("Failed to create DEVENV_HOME_GC directory");
-        std::fs::create_dir_all(&devenv_dot_gc).expect("Failed to create .devenv/gc directory");
 
         let nix = cnix::Nix::new(
             options.config.clone(),

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<()> {
         Commands::Search { name } => devenv.search(&name).await,
         Commands::Gc {} => devenv.gc(),
         Commands::Info {} => devenv.info().await,
-        Commands::Repl {} => devenv.repl(),
+        Commands::Repl {} => devenv.repl().await,
         Commands::Build { attributes } => devenv.build(&attributes).await,
         Commands::Update { name } => devenv.update(&name).await,
         Commands::Up { process, detach } => devenv.up(process.as_deref(), &detach, &detach).await,
@@ -170,7 +170,7 @@ async fn main() -> Result<()> {
         },
 
         // hidden
-        Commands::Assemble => devenv.assemble(false),
+        Commands::Assemble => devenv.assemble(false).await,
         Commands::PrintDevEnv { json } => devenv.print_dev_env(json).await,
         Commands::GenerateJSONSchema => {
             config::write_json_schema();


### PR DESCRIPTION
Fixes #1769.

Removes an extraneous call to create `.devenv/gc` when creating the devenv lib and modifies to cnix to optionally initialise the database later.

In theory, init should only be in the CLI binary. It doesn't even need the library to work.

We should merge https://github.com/cachix/devenv/pull/1721 first to resolve conflicts.