### PR TITLE
dotenv: Redirect informative messages to `stderr`

### DIFF
--- a/src/modules/integrations/dotenv.nix
+++ b/src/modules/integrations/dotenv.nix
@@ -25,13 +25,13 @@ let
       filename = builtins.baseNameOf (toString file);
     in
     lib.optionalString (!lib.pathExists file) ''
-      echo "💡 The dotenv file '${filename}' was not found."
+      echo "💡 The dotenv file '${filename}' was not found." >&2
       ${lib.optionalString exampleExists ''
-        echo
-        echo "   To create this file, you can copy the example file:"
-        echo
-        echo "   $ cp ${filename}.example ${filename}"
-        echo
+        echo >&2
+        echo "   To create this file, you can copy the example file:" >&2
+        echo >&2
+        echo "   $ cp ${filename}.example ${filename}" >&2
+        echo >&2
       ''}
     '';
 in
@@ -73,12 +73,12 @@ in
           dotenvFound = lib.any lib.pathExists dotenvPaths;
         in
         lib.optionalString dotenvFound ''
-          echo "💡 A dotenv file was found, while dotenv integration is currently not enabled."
-          echo
-          echo "   To enable it, add \`dotenv.enable = true;\` to your devenv.nix file.";
-          echo "   To disable this hint, add \`dotenv.disableHint = true;\` to your devenv.nix file.";
-          echo
-          echo "See https://devenv.sh/integrations/dotenv/ for more information.";
+          echo "💡 A dotenv file was found, while dotenv integration is currently not enabled." >&2
+          echo >&2
+          echo "   To enable it, add \`dotenv.enable = true;\` to your devenv.nix file." >&2;
+          echo "   To disable this hint, add \`dotenv.disableHint = true;\` to your devenv.nix file." >&2;
+          echo >&2
+          echo "See https://devenv.sh/integrations/dotenv/ for more information." >&2;
         '';
     })
   ];


### PR DESCRIPTION
The `dotenv` module prints informative messages on the `stdout`, which causes a problem on the CI because, in some cases, the output of a command is required for another step. 

```sh
data=$(devenv shell -- <command>)
echo "------------------------"
echo "$data"
echo "------------------------"
echo "data=$data" >> "$GITHUB_OUTPUT" 
```

When GH actions parse the output from the previous code snippet, the following error occurs:

```
------------------------
💡 The dotenv file '.env' was not found.

   To create this file, you can copy the example file:

   $ cp .env.example .env
<command output>
------------------------
Error: Unable to process file command 'output' successfully.
Error: Invalid format '   To create this file, you can copy the example file:'
```

Other modules like `update-check` already redirect the output to `stderr`:


https://github.com/cachix/devenv/blob/main/src/modules/update-check.nix#L45-L56


Here is a complete example of a GH action run that failed because of the previously described issue:

Source: https://github.com/stackbuilders/nixpkgs-terraform/actions/runs/13997414523/job/39195863295

\cc @oscar-izval 