### PR TITLE
devenv: replace `nix develop` with a custom shell launcher

### DIFF
--- a/devenv-run-tests/src/main.rs
+++ b/devenv-run-tests/src/main.rs
@@ -137,7 +137,7 @@ async fn run_tests_in_directory(
             if PathBuf::from(setup_script).exists() {
                 eprintln!("    Running {setup_script}");
                 devenv
-                    .shell(&Some(format!("./{setup_script}")), &[], false)
+                    .run_in_shell(format!("./{setup_script}"), &[])
                     .await?;
             }
 

--- a/devenv-run-tests/src/main.rs
+++ b/devenv-run-tests/src/main.rs
@@ -137,7 +137,7 @@ async fn run_tests_in_directory(
             if PathBuf::from(setup_script).exists() {
                 eprintln!("    Running {setup_script}");
                 devenv
-                    .run_in_shell(format!("./{setup_script}"), &[])
+                    .exec_in_shell(format!("./{setup_script}"), &[])
                     .await?;
             }
 

--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -124,23 +124,6 @@ impl Nix {
         Ok(())
     }
 
-    pub async fn develop(
-        &self,
-        args: &[&str],
-        replace_shell: bool,
-    ) -> Result<devenv_eval_cache::Output> {
-        let options = Options {
-            logging_stdout: true,
-            // Cannot cache this because we don't get the derivation back.
-            // We'd need to switch to print-dev-env and our own `nix develop`.
-            cache_output: false,
-            bail_on_error: false,
-            replace_shell,
-            ..self.options
-        };
-        self.run_nix_with_substituters("nix", args, &options).await
-    }
-
     pub async fn dev_env(
         &self,
         json: bool,

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -219,7 +219,6 @@ impl Devenv {
         cmd: &Option<String>,
         args: &[String],
     ) -> Result<std::process::Command> {
-        self.assemble(false).await?;
         let DevEnv { mut output, .. } = self.get_dev_environment(false).await?;
 
         // TODO: fetch bash from nixpkgs or from the module config
@@ -268,7 +267,9 @@ impl Devenv {
             }
         }
 
-        tokio::fs::write(&path, output).await.unwrap();
+        tokio::fs::write(&path, output)
+            .await
+            .expect("Failed to write the shell script");
 
         let default_clean = config::Clean {
             enabled: false,

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -291,11 +291,7 @@ impl Devenv {
             .await
             .expect("Failed to set permissions");
 
-        let default_clean = config::Clean {
-            enabled: false,
-            keep: vec![],
-        };
-        let config_clean = self.config.clean.as_ref().unwrap_or(&default_clean);
+        let config_clean = self.config.clean.clone().unwrap_or_default();
         if self.global_options.clean.is_some() || config_clean.enabled {
             shell_cmd.env_clear();
 

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -324,13 +324,16 @@ impl Devenv {
         Ok(())
     }
 
-    pub async fn run_in_shell(
+    pub async fn exec_in_shell(
         &mut self,
         cmd: String,
         args: &[String],
     ) -> Result<std::process::Output> {
         let mut shell_cmd = self.prepare_shell(&Some(cmd), args).await?;
-        let span = info_span!("running_shell", devenv.user_message = "Running in shell");
+        let span = info_span!(
+            "executing_in_shell",
+            devenv.user_message = "Executing in shell"
+        );
         span.in_scope(|| {
             shell_cmd
                 .stdin(std::process::Stdio::inherit())
@@ -644,7 +647,7 @@ impl Devenv {
         let span = info_span!("test", devenv.user_message = "Running tests");
         let result = async {
             debug!("Running command: {test_script}");
-            self.run_in_shell(test_script, &[]).await
+            self.exec_in_shell(test_script, &[]).await
         }
         .instrument(span)
         .await?;

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -906,6 +906,9 @@ impl Devenv {
         )
         .expect("Failed to write imports.txt");
 
+        fs::create_dir_all(&self.devenv_runtime)
+            .unwrap_or_else(|_| panic!("Failed to create {}", self.devenv_runtime.display()));
+
         // create flake.devenv.nix
         let vars = indoc::formatdoc!(
             "version = \"{}\";

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -219,6 +219,7 @@ impl Devenv {
         cmd: &Option<String>,
         args: &[String],
     ) -> Result<std::process::Command> {
+        self.assemble(false).await?;
         let DevEnv { mut output, .. } = self.get_dev_environment(false).await?;
 
         // TODO: fetch bash from nixpkgs or from the module config

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
     match command {
         Commands::Shell { cmd, ref args } => match cmd {
             Some(cmd) => {
-                devenv.run_in_shell(cmd, args).await?;
+                devenv.exec_in_shell(cmd, args).await?;
                 Ok(())
             }
             None => devenv.shell().await,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -74,7 +74,13 @@ async fn main() -> Result<()> {
     let mut devenv = Devenv::new(options).await;
 
     match command {
-        Commands::Shell { cmd, args } => devenv.shell(&cmd, &args, true).await,
+        Commands::Shell { cmd, ref args } => match cmd {
+            Some(cmd) => {
+                devenv.run_in_shell(cmd, args).await?;
+                Ok(())
+            }
+            None => devenv.shell().await,
+        },
         Commands::Test { .. } => devenv.test().await,
         Commands::Container {
             registry,


### PR DESCRIPTION
Removes `nix develop` that was used for the underlying shell and replaces it with a custom shell launcher.

We still rely on Nix to generate the rcfile script for us, but this is a good first step towards a snix shell.

As a bonus, by reducing the number of calls to the Nix CLI and making better use of our caching system, this drastically improves the time-to-shell.

For the devenv repo, the numbers are:
- Linux: 500ms -> 150ms
- macOS: 1300ms -> 300ms