### PR TITLE
Add Typst fontPaths option

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -42240,7 +42240,7 @@ list of string
 
 
 *Example:*
-` [ "\/nix/store/pbcb7j89fggfmjafzplcpylvksay4v9q-roboto-2.138/share/fonts/truetype "] ] `
+` [ "${pkgs.roboto}/share/fonts/truetype "] ] `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix)

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -42221,6 +42221,37 @@ package
 
 
 
+## languages.typst.fontPaths
+
+
+
+Directories to be searched for fonts.
+
+
+
+*Type:*
+list of string
+
+
+
+*Default:*
+` [] `
+
+
+
+*Example:*
+
+```
+[
+  "\${pkgs.roboto}/share/fonts/truetype"
+]
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix)
+
+
+
 ## languages.unison.enable
 
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -42240,12 +42240,7 @@ list of string
 
 
 *Example:*
-
-```
-[
-  "\${pkgs.roboto}/share/fonts/truetype"
-]
-```
+` [ "\/nix/store/pbcb7j89fggfmjafzplcpylvksay4v9q-roboto-2.138/share/fonts/truetype "] ] `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix)

--- a/docs/supported-languages/typst.md
+++ b/docs/supported-languages/typst.md
@@ -61,9 +61,4 @@ list of string
 
 
 *Example:*
-
-```
-[
-  "\${pkgs.roboto}/share/fonts/truetype"
-]
-```
+` [ "\/nix/store/pbcb7j89fggfmjafzplcpylvksay4v9q-roboto-2.138/share/fonts/truetype "] ] `

--- a/docs/supported-languages/typst.md
+++ b/docs/supported-languages/typst.md
@@ -39,3 +39,31 @@ package
 
 *Default:*
 ` pkgs.typst `
+
+
+
+## languages\.typst\.fontPaths
+
+
+
+Directories to be searched for fonts\.
+
+
+
+*Type:*
+list of string
+
+
+
+*Default:*
+` [] `
+
+
+
+*Example:*
+
+```
+[
+  "\${pkgs.roboto}/share/fonts/truetype"
+]
+```

--- a/docs/supported-languages/typst.md
+++ b/docs/supported-languages/typst.md
@@ -61,4 +61,4 @@ list of string
 
 
 *Example:*
-` [ "\/nix/store/pbcb7j89fggfmjafzplcpylvksay4v9q-roboto-2.138/share/fonts/truetype "] ] `
+` [ "${pkgs.roboto}/share/fonts/truetype "] ] `

--- a/src/modules/languages/typst.nix
+++ b/src/modules/languages/typst.nix
@@ -19,7 +19,7 @@ in
       description = "Directories to be searched for fonts.";
       default = [ ];
       defaultText = lib.literalExpression "[]";
-      example = lib.literalExpression ''[ "\${pkgs.roboto}/share/fonts/truetype "] ]'';
+      example = lib.literalExpression ''[ "''${pkgs.roboto}/share/fonts/truetype "] ]'';
     };
   };
 

--- a/src/modules/languages/typst.nix
+++ b/src/modules/languages/typst.nix
@@ -19,7 +19,7 @@ in
       description = "Directories to be searched for fonts.";
       default = [ ];
       defaultText = lib.literalExpression "[]";
-      example = [ "\${pkgs.roboto}/share/fonts/truetype" ];
+      example = lib.literalExpression ''[ "\${pkgs.roboto}/share/fonts/truetype "] ]'';
     };
   };
 

--- a/src/modules/languages/typst.nix
+++ b/src/modules/languages/typst.nix
@@ -13,6 +13,14 @@ in
       default = pkgs.typst;
       defaultText = lib.literalExpression "pkgs.typst";
     };
+
+    fontPaths = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "Directories to be searched for fonts.";
+      default = [ ];
+      defaultText = lib.literalExpression "[]";
+      example = [ "\${pkgs.roboto}/share/fonts/truetype" ];
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -21,5 +29,7 @@ in
       pkgs.tinymist # lsp
       pkgs.typstyle # formatter
     ];
+
+    env.TYPST_FONT_PATHS = lib.concatStringsSep ":" cfg.fontPaths;
   };
 }


### PR DESCRIPTION
In order to make some fonts available to Typst, the latter supports the `TYPST_FONT_PATHS` environment variable. Sure, fonts can be made available by simply adding them to the `packages`. However, doing so results in Typst seeing them as system fonts, so you can't really know if it mistakenly chooses a font that is installed on your computer instead. Setting them via `TYPST_FONT_PATHS`, in combination with running Typst with the `--ignore-system-fonts` flag, allows for a fully reproducible build.