### PR TITLE
devenv: make overlay changes backwards compatible with older modules

### DIFF
--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -60,8 +60,11 @@
               then devenvdefaultpath
               else throw (devenvdefaultpath + " file does not exist for input ${name}.");
           project = pkgs.lib.evalModules {
-            specialArgs = inputs // { inherit inputs; bootstrapPkgs = pkgs; };
+            specialArgs = inputs // { inherit inputs; };
             modules = [
+              ({ config, ... }: {
+                _module.args.pkgs = pkgs.appendOverlays (config.overlays or [ ]);
+              })
               (inputs.devenv.modules + /top-level.nix)
               {
                 devenv.cliVersion = version;

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -371,8 +371,6 @@ in
     infoSections."env" = lib.mapAttrsToList (name: value: "${name}: ${toString value}") config.env;
     infoSections."packages" = builtins.map (package: package.name) (builtins.filter (package: !(builtins.elem package.name (builtins.attrNames config.scripts))) config.packages);
 
-    _module.args.pkgs = bootstrapPkgs.appendOverlays config.overlays;
-
     ci = [ config.shell ];
     ciDerivation = pkgs.runCommand "ci" { } "echo ${toString config.ci} > $out";
   };


### PR DESCRIPTION
Since overlays require CLI-level changes to module eval, all of the changes should be shipped with the CLI. Othewise, newer CLI versions will not work with older modules.

Continuation of #1768.