### PR TITLE
Fix Typst fontPaths example

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -42240,7 +42240,7 @@ list of string
 
 
 *Example:*
-` [ "${pkgs.roboto}/share/fonts/truetype "] ] `
+` [ "${pkgs.roboto}/share/fonts/truetype" ] `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/typst.nix)

--- a/docs/supported-languages/typst.md
+++ b/docs/supported-languages/typst.md
@@ -61,4 +61,4 @@ list of string
 
 
 *Example:*
-` [ "${pkgs.roboto}/share/fonts/truetype "] ] `
+` [ "${pkgs.roboto}/share/fonts/truetype" ] `

--- a/src/modules/languages/typst.nix
+++ b/src/modules/languages/typst.nix
@@ -19,7 +19,7 @@ in
       description = "Directories to be searched for fonts.";
       default = [ ];
       defaultText = lib.literalExpression "[]";
-      example = lib.literalExpression ''[ "''${pkgs.roboto}/share/fonts/truetype "] ]'';
+      example = lib.literalExpression ''[ "''${pkgs.roboto}/share/fonts/truetype" ]'';
     };
   };
 


### PR DESCRIPTION
This is a follow-up to #1791. I hadn't noticed but there is an extra bracket and a misplaced space in the example

```
[ "${pkgs.roboto}/share/fonts/truetype "] ]
```

This changes it to

```
[ "${pkgs.roboto}/share/fonts/truetype" ]
```