### PR TITLE
eval-cache: bust the cache when using input overrides

### DIFF
--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -385,6 +385,7 @@ impl Nix {
 
             cached_cmd.watch_path(self.devenv_root.join("devenv.yaml"));
             cached_cmd.watch_path(self.devenv_root.join("devenv.lock"));
+            cached_cmd.watch_path(self.devenv_dotfile.join("flake.json"));
 
             // Ignore anything in .devenv.
             cached_cmd.unwatch_path(&self.devenv_dotfile);


### PR DESCRIPTION
Overrides go through flake.json, instead of the nix commands. This made them invisible to the caching system.