### PR TITLE
devenv: preserve existing options when overriding inputs

### DIFF
--- a/devenv-run-tests/src/main.rs
+++ b/devenv-run-tests/src/main.rs
@@ -69,7 +69,7 @@ async fn run_tests_in_directory(
 
             let mut config = devenv::config::Config::load_from(path)?;
             for input in args.override_input.chunks_exact(2) {
-                config.add_input(&input[0].clone(), &input[1].clone(), &[]);
+                config.override_input_url(&input[0], &input[1]);
             }
 
             // Override the input for the devenv module

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
 
     let mut config = config::Config::load()?;
     for input in cli.global_options.override_input.chunks_exact(2) {
-        config.add_input(&input[0].clone(), &input[1].clone(), &[]);
+        config.override_input_url(&input[0].clone(), &input[1].clone())
     }
 
     let mut options = devenv::DevenvOptions {


### PR DESCRIPTION
`--override-input` would previously completely overwrite the existing input. This could end up removing any existing follows and flake options.

Fixes #1801.