### PR TITLE
postgres: improve how PGHOST is computed

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -84429,7 +84429,19 @@ CREATE ROLE bar;
 
 
 
-Listen address
+A comma-separated list of TCP/IP address(es) on which the server should listen for connections.
+
+By default, the server only accepts connections over unix sockets.
+
+This option is parsed to set the ` PGHOST ` environment variable.
+
+Special values:
+
+ - '\*' to listen on all available network interfaces.
+ - '0.0.0.0' to listen on all available IPv4 network interfaces.
+ - '::' to listen on all available IPv6 network interfaces.
+ - 'localhost' to listen only on the loopback interface.
+ - '' (empty string) disables TCP/IP connections and listens only on the unix socket.
 
 
 

--- a/docs/supported-services/postgres.md
+++ b/docs/supported-services/postgres.md
@@ -362,7 +362,19 @@ CREATE ROLE bar;
 
 
 
-Listen address
+A comma-separated list of TCP/IP address(es) on which the server should listen for connections\.
+
+By default, the server only accepts connections over unix sockets\.
+
+This option is parsed to set the ` PGHOST ` environment variable\.
+
+Special values:
+
+ - '\*' to listen on all available network interfaces\.
+ - '0\.0\.0\.0' to listen on all available IPv4 network interfaces\.
+ - '::' to listen on all available IPv6 network interfaces\.
+ - 'localhost' to listen only on the loopback interface\.
+ - '' (empty string) disables TCP/IP connections and listens only on the unix socket\.
 
 
 

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -11,6 +11,31 @@ let
 
   runtimeDir = "${config.env.DEVENV_RUNTIME}/postgres";
 
+  parseListenAddresses = input:
+    let
+      convertSpecialValue = value:
+        if value == "*" || value == "0.0.0.0" then "127.0.0.1"
+        else if value == "::" then "::1"
+        else value;
+
+      # Parse a single address, handling IPv6 addresses in brackets
+      parseAddress = address:
+        let
+          trimmed = lib.trim address;
+          ipv4Match = builtins.match "\\d+\\.\\d+\\.\\d+\\.\\d+" trimmed;
+          ipv6Match = builtins.match "\\[.*\\]" trimmed;
+          match =
+            if ipv4Match != null then
+              builtins.head ipv4Match
+            else if ipv4Match != null then
+              builtins.head ipv6Match
+            else
+              trimmed;
+        in
+        convertSpecialValue match;
+    in
+    map parseAddress (lib.splitString "," input);
+
   postgresPkg =
     if cfg.extensions != null
     then
@@ -212,7 +237,20 @@ in
 
     listen_addresses = lib.mkOption {
       type = types.str;
-      description = "Listen address";
+      description = ''
+        A comma-separated list of TCP/IP address(es) on which the server should listen for connections.
+
+        By default, the server only accepts connections over unix sockets.
+
+        This option is parsed to set the `PGHOST` environment variable.
+
+        Special values:
+          - \'*\' to listen on all available network interfaces.
+          - \'0.0.0.0\' to listen on all available IPv4 network interfaces.
+          - \'::\' to listen on all available IPv6 network interfaces.
+          - \'localhost\' to listen only on the loopback interface.
+          - \'\' (empty string) disables TCP/IP connections and listens only on the unix socket.
+      '';
       default = "";
       example = "127.0.0.1";
     };
@@ -344,8 +382,18 @@ in
     packages = [ postgresPkg startScript ];
 
     env.PGDATA = config.env.DEVENV_STATE + "/postgres";
-    env.PGHOST = lib.mkDefault runtimeDir;
-    env.PGPORT = cfg.port;
+    env.PGHOST =
+      let
+        host =
+          if cfg.listen_addresses == ""
+          then runtimeDir
+          else parseListenAddresses cfg.listen_addresses;
+      in
+      lib.mkDefault host;
+    env.PGPORT =
+      if cfg.listen_addresses != ""
+      then cfg.port
+      else null;
 
     services.postgres.settings = {
       listen_addresses = cfg.listen_addresses;


### PR DESCRIPTION
- Use one of the IP addresses from `listen_addresses` if configured.
- Handles special listen addresses, like `*`, `0.0.0.0`, and `::`.
- Only set `PGPORT` if using IP addresses.
- Expand the docs for `listen_addresses` using the official postgres docs as reference.