### PR TITLE
docs: package reference common patterns

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -4,27 +4,27 @@ By default, devenv [uses a fork of nixpkgs](https://devenv.sh/blog/2024/03/20/de
 
 1. Add `nixpkgs-unstable` input to `devenv.yaml`:
 
-```yaml
-inputs:
-  nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
-  nixpkgs-unstable:
-    url: github:nixos/nixpkgs/nixpkgs-unstable
-```
+   ```yaml
+   inputs:
+     nixpkgs:
+       url: github:cachix/devenv-nixpkgs/rolling
+     nixpkgs-unstable:
+       url: github:nixos/nixpkgs/nixpkgs-unstable
+   ```
 
-2. Use the package in your `devenv.nix`:
+1. Use the package in your `devenv.nix`:
 
-```nix
-{ pkgs, inputs, ... }:
-let
-  pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
-in
-{
-  packages = [
-    pkgs-unstable.elmPackages.elm-test-rs
-  ];
-}
-```
+   ```nix
+   { pkgs, inputs, ... }:
+   let
+     pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+   in
+   {
+     packages = [
+       pkgs-unstable.elmPackages.elm-test-rs
+     ];
+   }
+   ```
 
 ## Nix patterns
 

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -30,6 +30,8 @@ Entering shell ...
 jq-1.6
 ```
 
+To add unstable packages see [Common patterns](common-patterns.md).
+
 ## Searching
 
 To search for available packages, use ``devenv search <NAME>``:


### PR DESCRIPTION
- Add reference on packages docs for common patterns (I lost half an hours to find it).
- Fix auto-numbering on common-patterns markdown.