### PR TITLE
fix: better pure devenv-root handling in flakes

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -21,7 +21,9 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
           Extra modules to import into every shell.
           Allows flakeModules to add options to devenv for example.
         '';
-        default = [ ];
+        default = [
+          devenvFlake.flakeModules.readDevenvRoot
+        ];
       };
       options.devenv.shells = lib.mkOption {
         type = lib.types.lazyAttrsOf devenvType;

--- a/flake.nix
+++ b/flake.nix
@@ -220,7 +220,22 @@
           default = simple;
         };
 
-      flakeModule = import ./flake-module.nix self;
+      flakeModule = self.flakeModules.default; # Backwards compatibility
+      flakeModules = {
+        default = import ./flake-module.nix self;
+        readDevenvRoot = {inputs, lib, ...}: {
+          config =
+            let
+              devenvRootFileContent =
+                if inputs ? devenv-root
+                then builtins.readFile inputs.devenv-root.outPath
+                else "";
+            in
+            lib.mkIf (devenvRootFileContent != "") {
+              devenv.root = devenvRootFileContent;
+            };
+        };
+      };
 
       lib = {
         mkConfig = args@{ pkgs, inputs, modules }:

--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -5,7 +5,8 @@ fi
 watch_file flake.nix
 watch_file flake.lock
 
-DEVENV_ROOT_FILE="$(mktemp)"
+mkdir -p "$PWD/.devenv"
+DEVENV_ROOT_FILE="$PWD/.devenv/root"
 printf %s "$PWD" > "$DEVENV_ROOT_FILE"
 if ! use flake . --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"
 then

--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -35,12 +35,6 @@
         packages.default = pkgs.hello;
 
         devenv.shells.default = {
-          devenv.root =
-            let
-              devenvRootFileContent = builtins.readFile devenv-root.outPath;
-            in
-            pkgs.lib.mkIf (devenvRootFileContent != "") devenvRootFileContent;
-
           name = "my-project";
 
           imports = [


### PR DESCRIPTION
- Avoid creating a temporary file in each direnv evaluation.
- Provide a `flakeModules.readDevenvRoot` output for simpler handling of pure devenv.root in flakes.
- Use that module by default.

Smoother workaround for https://github.com/cachix/devenv/issues/1764

@moduon MT-1075