### PR TITLE
devenv: deterministically sort flake inputs to aid caching layer

### DIFF
--- a/devenv-eval-cache/src/command.rs
+++ b/devenv-eval-cache/src/command.rs
@@ -464,8 +464,10 @@ async fn query_cached_output(
             debug!(
                 old_hash = cmd.input_hash,
                 new_hash = new_input_hash,
-                "Input hashes do not match, refreshing command",
+                "Input hashes don't match. The inputs have been modified since the command was cached. Refreshing command."
             );
+            trace!(inputs = ?inputs, "Inputs");
+
             should_refresh = true;
         }
 

--- a/devenv-eval-cache/src/command.rs
+++ b/devenv-eval-cache/src/command.rs
@@ -255,10 +255,12 @@ impl Input {
     }
 
     pub fn compute_input_hash(inputs: &[Self]) -> String {
-        inputs
-            .iter()
-            .filter_map(Input::content_hash)
-            .collect::<String>()
+        hash::digest(
+            inputs
+                .iter()
+                .filter_map(Input::content_hash)
+                .collect::<String>(),
+        )
     }
 
     pub fn partition_refs(inputs: &[Self]) -> (Vec<&FileInputDesc>, Vec<&EnvInputDesc>) {

--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -4,7 +4,7 @@ use nix_conf_parser::NixConf;
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::cell::{Ref, RefCell};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::os::unix::fs::symlink;
@@ -686,7 +686,7 @@ impl Nix {
                 .use_preconfigured_tls(http_client_tls::tls_config())
                 .build()
                 .expect("Failed to create reqwest client");
-            let mut new_known_keys: HashMap<String, String> = HashMap::new();
+            let mut new_known_keys: BTreeMap<String, String> = BTreeMap::new();
             for name in caches.caches.pull.iter() {
                 if !caches.known_keys.contains_key(name) {
                     let mut request =
@@ -916,7 +916,7 @@ pub struct Cachix {
 #[derive(Deserialize, Default, Clone)]
 pub struct CachixCaches {
     caches: Cachix,
-    known_keys: HashMap<String, String>,
+    known_keys: BTreeMap<String, String>,
 }
 
 #[derive(Deserialize, Clone)]

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -2,7 +2,7 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use schemars::{schema_for, JsonSchema};
 use schematic::ConfigLoader;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt, path::Path};
+use std::{collections::BTreeMap, fmt, path::Path};
 
 const YAML_CONFIG: &str = "devenv.yaml";
 
@@ -17,8 +17,8 @@ pub struct Input {
     pub flake: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub follows: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub inputs: HashMap<String, Input>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub inputs: BTreeMap<String, Input>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub overlays: Vec<String>,
 }
@@ -29,8 +29,8 @@ pub struct FlakeInput {
     pub url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub follows: Option<String>,
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
-    pub inputs: HashMap<String, Input>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub inputs: BTreeMap<String, Input>,
     #[serde(skip_serializing_if = "is_true", default = "true_default")]
     pub flake: bool,
 }
@@ -93,9 +93,9 @@ pub struct Clean {
 #[config(rename_all = "camelCase", allow_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
-    #[serde(skip_serializing_if = "HashMap::is_empty", default)]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     #[setting(nested)]
-    pub inputs: HashMap<String, Input>,
+    pub inputs: BTreeMap<String, Input>,
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     pub allow_unfree: bool,
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
@@ -153,7 +153,7 @@ impl Config {
     /// Add a new input, overwriting any existing input with the same name.
     pub fn add_input(&mut self, name: &str, url: &str, follows: &[String]) -> Result<()> {
         // A set of inputs built from the follows list.
-        let mut inputs = HashMap::new();
+        let mut inputs = BTreeMap::new();
 
         // Resolve the follows to top-level inputs.
         // We assume that nixpkgs is always available.
@@ -277,7 +277,7 @@ mod tests {
     #[test]
     fn preserve_options_on_override_input_url() {
         let mut config = Config {
-            inputs: HashMap::from_iter(vec![(
+            inputs: BTreeMap::from_iter(vec![(
                 "non-flake".to_string(),
                 Input {
                     url: Some("path:some-path".to_string()),

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -290,7 +290,7 @@ mod tests {
         config
             .override_input_url("non-flake", "path:some-other-path")
             .expect("Failed to override input URL");
-        assert_eq!(config.inputs["non-flake"].flake, false);
+        assert!(!config.inputs["non-flake"].flake);
         assert_eq!(
             config.inputs["non-flake"].url,
             Some("path:some-other-path".to_string())

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -34,7 +34,7 @@ pub static DIRENVRC_VERSION: Lazy<u8> = Lazy::new(|| {
     DIRENVRC
         .lines()
         .find(|line| line.contains("export DEVENV_DIRENVRC_VERSION"))
-        .and_then(|line| line.split('=').last())
+        .and_then(|line| line.split('=').next_back())
         .map(|version| version.trim())
         .and_then(|version| version.parse().ok())
         .unwrap_or(0)
@@ -301,8 +301,7 @@ impl Devenv {
                 None => &config_clean.keep,
             };
 
-            let filtered_env: HashMap<String, String> =
-                std::env::vars().filter(|(k, _)| keep.contains(k)).collect();
+            let filtered_env = std::env::vars().filter(|(k, _)| keep.contains(k));
 
             shell_cmd.envs(filtered_env);
             shell_cmd.arg("--norc").arg("--noprofile");

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use sha2::Digest;
 use similar::{ChangeTag, TextDiff};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 use std::os::unix::{fs::PermissionsExt, process::CommandExt};
 use std::{
@@ -855,7 +855,7 @@ impl Devenv {
         // Initialise any Nix state
         self.nix.assemble().await?;
 
-        let mut flake_inputs = HashMap::new();
+        let mut flake_inputs = BTreeMap::new();
         for (input, attrs) in self.config.inputs.iter() {
             match config::FlakeInput::try_from(attrs) {
                 Ok(flake_input) => {

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use sha2::Digest;
 use similar::{ChangeTag, TextDiff};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::os::unix::{fs::PermissionsExt, process::CommandExt};
 use std::{
@@ -997,7 +997,7 @@ pub struct DevEnv {
 }
 
 #[derive(Deserialize)]
-struct PackageResults(HashMap<String, PackageResult>);
+struct PackageResults(BTreeMap<String, PackageResult>);
 
 #[derive(Deserialize)]
 struct PackageResult {
@@ -1006,7 +1006,7 @@ struct PackageResult {
 }
 
 #[derive(Deserialize)]
-struct OptionResults(HashMap<String, OptionResult>);
+struct OptionResults(BTreeMap<String, OptionResult>);
 
 #[derive(Deserialize)]
 struct OptionResult {

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -4,12 +4,14 @@ devenvFlake: { flake-parts-lib, lib, inputs, ... }: {
     let
       devenvType = (devenvFlake.lib.mkEval {
         inherit inputs pkgs;
-        modules = [({ config, ... }: {
-          config = {
-            _module.args.pkgs = pkgs.appendOverlays config.overlays;
-            # Add flake-parts-specific config here if necessary
-          };
-        })] ++ config.devenv.modules;
+        modules = [
+          ({ config, ... }: {
+            config = {
+              _module.args.pkgs = pkgs.appendOverlays config.overlays;
+              # Add flake-parts-specific config here if necessary
+            };
+          })
+        ] ++ config.devenv.modules;
       }).type;
 
       shellPrefix = shellName: if shellName == "default" then "" else "${shellName}-";


### PR DESCRIPTION
- Sort the flake inputs (flake.json) deterministically to prevent random cache misses.
- Switch to BTreeMap for all sorts of inputs where we'd prefer to have a deterministic order.
- Re-hash the input hash to prevent it from growing O(n) with inputs.
