### PR TITLE
direnv: fix excessive reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "devenv-tasks",
  "dialoguer",
  "dotlock",
+ "fd-lock",
  "hex",
  "http-client-tls",
  "include_dir",
@@ -986,6 +987,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.0.5",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "filetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [workspace]
 resolver = "2"
 members = [
-    "devenv",
-    "devenv-generate",
-    "devenv-eval-cache",
-    "devenv-run-tests",
-    "devenv-tasks",
-    "http-client-tls",
-    "nix-conf-parser",
-    "xtask",
+  "devenv",
+  "devenv-generate",
+  "devenv-eval-cache",
+  "devenv-run-tests",
+  "devenv-tasks",
+  "http-client-tls",
+  "nix-conf-parser",
+  "xtask",
 ]
 
 [workspace.package]
@@ -35,6 +35,7 @@ cli-table = "0.4.9"
 console = "0.15.8"
 dotlock = "0.5.0"
 dialoguer = "0.11.0"
+fd-lock = "4"
 futures = "0.3.30"
 hex = "0.4.3"
 include_dir = "0.7.3"
@@ -51,10 +52,10 @@ pretty_assertions = { version = "1.4.0", features = ["unstable"] }
 regex = "1.10.3"
 schemars = "0.8.16"
 schematic = { version = "0.17.11", features = [
-    "schema",
-    "yaml",
-    "renderer_template",
-    "renderer_json_schema",
+  "schema",
+  "yaml",
+  "renderer_template",
+  "renderer_json_schema",
 ] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
@@ -69,13 +70,13 @@ tracing = "0.1.40"
 tracing-core = "0.1.32"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tokio = { version = "1.39.3", features = [
-    "process",
-    "fs",
-    "io-util",
-    "macros",
-    "rt-multi-thread",
-    "sync",
-    "time",
+  "process",
+  "fs",
+  "io-util",
+  "macros",
+  "rt-multi-thread",
+  "sync",
+  "time",
 ] }
 tokio-util = { version = "0.7.12", features = ["io"] }
 which = "7.0.2"

--- a/devenv-eval-cache/src/command.rs
+++ b/devenv-eval-cache/src/command.rs
@@ -45,6 +45,10 @@ impl<'a> CachedCommand<'a> {
     }
 
     /// Watch additional paths for changes.
+    ///
+    /// WARN: Be careful watching generated files.
+    /// External tools like direnv are triggered solely by the modification date and don't compare file contents.
+    /// Use [util::write_file_with_lock] to safely write such files.
     pub fn watch_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
         self.extra_paths.push(path.as_ref().to_path_buf());
         self

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -20,6 +20,7 @@ cli-table.workspace = true
 console.workspace = true
 dialoguer.workspace = true
 dotlock.workspace = true
+fd-lock.workspace = true
 hex.workspace = true
 include_dir.workspace = true
 indoc.workspace = true

--- a/devenv/src/lib.rs
+++ b/devenv/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod cnix;
 pub mod config;
 mod devenv;
 pub mod log;
+mod util;
 
 pub use cli::{default_system, GlobalOptions};
 pub use devenv::{Devenv, DevenvOptions, DIRENVRC, DIRENVRC_VERSION};

--- a/devenv/src/util.rs
+++ b/devenv/src/util.rs
@@ -1,0 +1,59 @@
+use fd_lock::RwLock;
+use miette::{miette, IntoDiagnostic, Result};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Safely write a file with locking, avoiding writing if the content hasn't changed.
+///
+/// Returns Ok(true) if the file was written, Ok(false) if no write was needed.
+pub fn write_file_with_lock<P: AsRef<Path>>(path: P, content: &str) -> Result<bool> {
+    let path = path.as_ref();
+
+    // Create parent directories if they don't exist
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .into_diagnostic()
+                .map_err(|e| miette!("Failed to create directory {}: {}", parent.display(), e))?;
+        }
+    }
+
+    // Open or create the file with locking
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(path)
+        .into_diagnostic()
+        .map_err(|e| miette!("Failed to open file {}: {}", path.display(), e))?;
+
+    // Acquire an exclusive lock on the file
+    let mut file_lock = RwLock::new(file);
+    let mut file_handle = file_lock
+        .write()
+        .into_diagnostic()
+        .map_err(|e| miette!("Failed to lock file {}: {}", path.display(), e))?;
+
+    // Read existing content
+    let existing_content = fs::read_to_string(path).unwrap_or_default();
+
+    // Compare and write only if different
+    if content != existing_content {
+        file_handle
+            .set_len(0)
+            .into_diagnostic()
+            .map_err(|e| miette!("Failed to truncate file {}: {}", path.display(), e))?;
+
+        file_handle
+            .write_all(content.as_bytes())
+            .into_diagnostic()
+            .map_err(|e| miette!("Failed to write to file {}: {}", path.display(), e))?;
+
+        // File was written
+        Ok(true)
+    } else {
+        // No write needed
+        Ok(false)
+    }
+}


### PR DESCRIPTION
When watching generated files, we need to take care not to touch the files unless they change. direnv only compares the modification time, not the file contents, so it's triggered every time we write these files. Even worse, the vscode extension is happy to re-evaluate the shell without waiting for the previous one to finish loading.

Fixes #1824.