### PR TITLE
Add --option CLI flag for overriding configuration options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 ## Code Style Guidelines
 - **Imports**: Group by category (std lib first, then external crates, then internal)
 - **Naming**: Use `snake_case` for functions/variables, `CamelCase` for types/traits
-- **Error Handling**: Use `thiserror` crate with custom error types and `?` operator
+- **Error Handling**: Use `thiserror` crate with custom error types, `bail!` (instead of `panic~`) and `?` operator
 - **Types**: Prefer strong typing with descriptive names and appropriate generics
 - **Formatting**: Follow standard rustfmt rules, use pre-commit hooks
 - **Documentation**: Document public APIs with rustdoc comments

--- a/devenv-tasks/src/lib.rs
+++ b/devenv-tasks/src/lib.rs
@@ -1045,7 +1045,10 @@ mod test {
         if let Err(Error::CycleDetected(task)) = result {
             assert_eq!(task, "myapp:task_2".to_string());
         } else {
-            panic!("Expected Error::CycleDetected, got {:?}", result);
+            return Err(Error::TaskNotFound(format!(
+                "Expected Error::CycleDetected, got {:?}",
+                result
+            )));
         }
         Ok(())
     }

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -144,6 +144,15 @@ pub struct GlobalOptions {
         help = "Override inputs in devenv.yaml."
     )]
     pub override_input: Vec<String>,
+
+    #[arg(
+        long,
+        global = true,
+        num_args = 2,
+        value_delimiter = ' ',
+        help = "Override configuration options with typed values, e.g. --option languages.rust.version:string beta"
+    )]
+    pub option: Vec<String>,
 }
 
 impl Default for GlobalOptions {
@@ -165,6 +174,7 @@ impl Default for GlobalOptions {
             nix_debugger: false,
             nix_option: vec![],
             override_input: vec![],
+            option: vec![],
         }
     }
 }

--- a/devenv/src/cnix.rs
+++ b/devenv/src/cnix.rs
@@ -386,8 +386,9 @@ impl Nix {
             cached_cmd.watch_path(self.devenv_root.join("devenv.yaml"));
             cached_cmd.watch_path(self.devenv_root.join("devenv.lock"));
             cached_cmd.watch_path(self.devenv_dotfile.join("flake.json"));
+            cached_cmd.watch_path(self.devenv_dotfile.join("cli-options.nix"));
 
-            // Ignore anything in .devenv.
+            // Ignore anything in .devenv except for the specifically watched files above.
             cached_cmd.unwatch_path(&self.devenv_dotfile);
 
             if self.global_options.refresh_eval_cache || options.refresh_cached_output {

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -91,6 +91,7 @@
               ./devenv.nix
               (devenv.devenv or { })
               (if builtins.pathExists ./devenv.local.nix then ./devenv.local.nix else { })
+              (if builtins.pathExists (devenv_dotfile + "/cli-options.nix") then import (devenv_dotfile + "/cli-options.nix") else { })
             ];
           };
           config = project.config;

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -36,22 +36,16 @@ jq-1.6
 hello
 ```
 
-
-
-
-See [Nix language tutorial](https://nix.dev/tutorials/first-steps/nix-language) for a 1-2 hour deep dive 
+See [Nix language tutorial](https://nix.dev/tutorials/first-steps/nix-language) for a 1-2 hour deep dive
 that will allow you to read any Nix file.
 
-!!! note
-
-    We're running [a fundraiser to improve the developer experience around error messages](https://opencollective.com/nix-errors-enhancement), with the goal of lowering the barrier to learning Nix.
 
 ## Environment Summary
 
 If you'd like to print the summary of the current environment:
 
 ```shell-session
-$ devenv info 
+$ devenv info
 ...
 
 # env
@@ -68,3 +62,21 @@ $ devenv info
 # processes
 
 ```
+
+## Options overrides
+
+You can override configuration options temporarily using the `--option` flag:
+
+```shell-session
+$ devenv shell --option languages.redis.enable:bool true
+```
+
+The option requires you to specify the inferred Nix type:
+
+- `:string` for string values
+- `:int` for integer values
+- `:float` for floating-point values
+- `:bool` for boolean values (true/false)
+- `:path` for file paths (interpreted as relative paths)
+
+This is useful for temporarily changing the configuration without modifying your `devenv.nix` file, such as when testing different configurations or creating option matrices.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -63,12 +63,14 @@ $ devenv info
 
 ```
 
-## Options overrides
+## CLI Options Overrides
+
+!!! info "New in 1.6"
 
 You can override configuration options temporarily using the `--option` flag:
 
 ```shell-session
-$ devenv shell --option languages.redis.enable:bool true
+$ devenv shell --option env.GREET:string Hello --option languages.rust.enable:bool true
 ```
 
 The option requires you to specify the inferred Nix type:

--- a/tests/cli-options/.test.sh
+++ b/tests/cli-options/.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Test CLI options feature
+cd "$(dirname "$0")"
+
+# Test basic string and bool types
+OUTPUT=$(devenv --option languages.rust.channel:string beta --option services.redis.enable:bool true info)
+
+# Check for expected RUST_VERSION
+echo "$OUTPUT" | grep -E "RUST_VERSION:.*beta" || {
+  echo "ERROR: Expected CLI option override for RUST_VERSION to be 'beta'"
+  echo $OUTPUT
+  exit 1
+}
+
+# Check for expected REDIS_ENABLED
+echo "$OUTPUT" | grep -E "REDIS_ENABLED:.*1" || {
+  echo "ERROR: Expected CLI option override for REDIS_ENABLED to be '1'"
+  echo $OUTPUT
+  exit 1
+}
+
+# Test int type
+OUTPUT=$(devenv --option env.TEST_INT:int 42 info)
+echo "$OUTPUT" | grep -E "TEST_INT:.*42" || {
+  echo "ERROR: Expected CLI option override for TEST_INT to be '42'"
+  echo $OUTPUT
+  exit 1
+}
+
+# Test float type
+OUTPUT=$(devenv --option env.TEST_FLOAT:float 3.14 info)
+echo "$OUTPUT" | grep -E "TEST_FLOAT:.*3.14" || {
+  echo "ERROR: Expected CLI option override for TEST_FLOAT to be '3.14'"
+  echo $OUTPUT
+  exit 1
+}
+
+# Test path type
+OUTPUT=$(devenv --option env.TEST_PATH:path somepath info)
+echo "$OUTPUT" | grep -E "TEST_PATH:.*/somepath" || {
+  echo "ERROR: Expected CLI option override for TEST_PATH to include 'somepath'"
+  echo $OUTPUT
+  exit 1
+}
+
+# Test invalid type (should fail)
+if devenv --option languages.rust.version:invalid value info &> /dev/null; then
+  echo "ERROR: Expected CLI option with invalid type to fail"
+  echo $OUTPUT
+  exit 1
+fi
+
+# Test missing type (should fail)
+if devenv --option languages.rust.version value info &> /dev/null; then
+  echo "ERROR: Expected CLI option without type specification to fail"
+  echo $OUTPUT
+  exit 1
+fi

--- a/tests/cli-options/devenv.nix
+++ b/tests/cli-options/devenv.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib, config, ... }:
+
+{
+  languages.rust.enable = true;
+  languages.rust.channel = lib.mkDefault "stable";
+
+  env = {
+    RUST_VERSION = config.languages.rust.channel;
+    REDIS_ENABLED = builtins.toString config.services.redis.enable;
+  };
+}

--- a/tests/cli-options/devenv.yaml
+++ b/tests/cli-options/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  fenix:
+    url: github:nix-community/fenix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
It's common to be able to build matrix on CI jobs, so let's allow passing options via CLI:

```
devenv --option services.redis.enable:bool true test
```

cc @staticdev 