### PR TITLE
docs: document how to use profiles

### DIFF
--- a/docs/blog/posts/devenv-v1.6-ad-hoc-developer-environments.md
+++ b/docs/blog/posts/devenv-v1.6-ad-hoc-developer-environments.md
@@ -90,6 +90,16 @@ This feature is particularly useful for:
 
 When used with an existing `devenv.nix` file, `--option` values will override the configuration in the file, making it easy to temporarily modify your environment.
 
+## Switching Between Environment Profiles
+
+Ad-hoc options are perfect for switching between predefined profiles in your development environment:
+
+```shell-session
+$ devenv --option profile:string backend up
+```
+
+This allows you to easily switch between frontend, backend, or other custom profiles without changing your configuration files. See our [Profiles guide](https://devenv.sh/guides/profiles/) for more details on setting up and using profiles.
+
 For full documentation on this feature, visit our [Ad-hoc Developer Environments guide](https://devenv.sh/ad-hoc-developer-environments/).
 
 We're excited to see how you'll use ad-hoc environments to streamline your development workflow. Let us know what you think on [GitHub](https://github.com/cachix/devenv) or [join our Discord community](https://discord.gg/MycroftAI)!

--- a/docs/guides/.pages
+++ b/docs/guides/.pages
@@ -1,3 +1,4 @@
 nav:
+   - Profiles: profiles.md
    - Using with Flakes: using-with-flakes.md
    - Using with flake.parts: using-with-flake-parts.md

--- a/docs/guides/profiles.md
+++ b/docs/guides/profiles.md
@@ -1,0 +1,81 @@
+# Using Profiles in devenv
+
+Profiles are an effective way to configure different aspects of your development environment based on specific needs. 
+
+For example, you might have separate profiles for frontend and backend development.
+
+## Defining Profiles
+
+First, define profiles in your `devenv.nix` file:
+
+```nix
+{ lib, config, ... }:
+
+{
+  options = {
+    profile = lib.mkOption {
+      type = lib.types.enum [ "backend" "frontend" "full" ];
+      default = "full";
+      description = "Development profile to use";
+    };
+  };
+
+  # Use profile value in your config
+  config = {
+    # Example: Conditionally enable services based on profile
+    services.redis.enable = lib.mkIf (config.profile == "backend" || config.profile == "full") true;
+    
+    # Example: Profile-specific processes
+    processes = {
+      # Backend processes
+      api-server = lib.mkIf (config.profile == "backend" || config.profile == "full") {
+        exec = "python api.py";
+        process-compose.environment = {
+          PORT = "8000";
+        };
+      };
+      
+      # Frontend processes
+      dev-server = lib.mkIf (config.profile == "frontend" || config.profile == "full") {
+        exec = "npm run dev";
+        process-compose.environment = {
+          PORT = "3000";
+        };
+      };
+    };
+  };
+}
+```
+
+## Using Profiles
+
+### Temporary Profile Selection
+
+You can temporarily use a specific profile by using [ad-hoc developer environments](../ad-hoc-developer-environments.md) on the command line:
+
+```shell-session
+$ devenv --option profile:string backend up
+```
+
+This will start only backend processes. For frontend development, you can run:
+
+```shell-session
+$ devenv --option profile:string frontend up
+```
+
+And this will only start the frontend dev server.
+
+### Persistent Profile Selection
+
+For a more permanent selection, create a `devenv.local.nix` file (which should be added to `.gitignore`) with your preferred profile:
+
+```nix
+{ pkgs, lib, config, ... }: {
+  profile = "frontend";
+}
+```
+
+This allows each developer to choose their preferred profile without affecting others.
+
+This approach is particularly useful for testing specific configurations or when you need a specialized environment for a particular task.
+


### PR DESCRIPTION
Sometimes it's useful to be able to only run a subset of developer environment and choose.

[guide preview](https://docs-profiles.devenv.pages.dev/guides/profiles/)

Fixes #1426 