### PR TITLE
devenv: fix race conditions setting up the shell during tests

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -659,6 +659,11 @@ impl Devenv {
             self.up(vec![], &true, &false).await?;
         }
 
+        let processes_pid = self.processes_pid();
+        while !processes_pid.exists() {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+
         let span = info_span!("test", devenv.user_message = "Running tests");
         let result = async {
             debug!("Running command: {test_script}");

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -687,8 +687,8 @@ impl Devenv {
         // Run script and capture its environment exports
         self.prepare_shell(&Some(script_path.to_string_lossy().into()), &[])
             .await?
-            .stderr(std::process::Stdio::inherit())
-            .stdout(std::process::Stdio::inherit())
+            .stderr(process::Stdio::inherit())
+            .stdout(process::Stdio::inherit())
             .spawn()
             .expect("Failed to execute script")
             .wait()
@@ -739,7 +739,7 @@ impl Devenv {
         let span = info_span!("test", devenv.user_message = "Running tests");
         let result = async {
             debug!("Running command: {test_script}");
-            std::process::Command::new(test_script)
+            process::Command::new(test_script)
                 .env_clear()
                 .envs(envs)
                 .spawn()
@@ -867,7 +867,7 @@ impl Devenv {
             )
             .expect("Failed to write PROCESSES_SCRIPT");
 
-            fs::set_permissions(&processes_script, std::fs::Permissions::from_mode(0o755))
+            fs::set_permissions(&processes_script, fs::Permissions::from_mode(0o755))
                 .expect("Failed to set permissions");
 
             let mut cmd = if let Some(envs) = options.envs {
@@ -919,7 +919,7 @@ impl Devenv {
             bail!("No processes running");
         }
 
-        let pid = std::fs::read_to_string(self.processes_pid())
+        let pid = fs::read_to_string(self.processes_pid())
             .expect("Failed to read PROCESSES_PID")
             .parse::<i32>()
             .expect("Failed to parse PROCESSES_PID");
@@ -935,7 +935,7 @@ impl Devenv {
             }
         }
 
-        std::fs::remove_file(self.processes_pid()).expect("Failed to remove PROCESSES_PID");
+        fs::remove_file(self.processes_pid()).expect("Failed to remove PROCESSES_PID");
         Ok(())
     }
 

--- a/devenv/src/lib.rs
+++ b/devenv/src/lib.rs
@@ -6,5 +6,5 @@ pub mod log;
 mod util;
 
 pub use cli::{default_system, GlobalOptions};
-pub use devenv::{Devenv, DevenvOptions, DIRENVRC, DIRENVRC_VERSION};
+pub use devenv::{Devenv, DevenvOptions, ProcessOptions, DIRENVRC, DIRENVRC_VERSION};
 pub use devenv_tasks as tasks;

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -184,13 +184,20 @@ async fn main() -> Result<()> {
         Commands::Repl {} => devenv.repl().await,
         Commands::Build { attributes } => devenv.build(&attributes).await,
         Commands::Update { name } => devenv.update(&name).await,
-        Commands::Up { processes, detach } => devenv.up(processes, &detach, &detach).await,
-        Commands::Processes { command } => match command {
-            ProcessesCommand::Up { processes, detach } => {
-                devenv.up(processes, &detach, &detach).await
-            }
-            ProcessesCommand::Down {} => devenv.down(),
-        },
+        Commands::Up { processes, detach }
+        | Commands::Processes {
+            command: ProcessesCommand::Up { processes, detach },
+        } => {
+            let options = devenv::ProcessOptions {
+                detach,
+                log_to_file: detach,
+                ..Default::default()
+            };
+            devenv.up(processes, &options).await
+        }
+        Commands::Processes {
+            command: ProcessesCommand::Down {},
+        } => devenv.down(),
         Commands::Tasks { command } => match command {
             TasksCommand::Run { tasks } => devenv.tasks_run(tasks).await,
         },

--- a/src/modules/tests.nix
+++ b/src/modules/tests.nix
@@ -17,9 +17,6 @@
       type = lib.types.package;
       internal = true;
       default = pkgs.writeShellScript "devenv-test" ''
-        echo "• Setting up shell environment ..."
-        ${config.enterShell}
-
         set -euo pipefail
         echo "• Testing ..."
         ${config.enterTest}


### PR DESCRIPTION
Evaluates the dev env once and applies it to both the spawned processes and the tests. This reduces the number of shell evaluations we need to do and prevents task conflicts.