### PR TITLE
tasks: don't chomp previous terminal lines in quiet mode

### DIFF
--- a/devenv-tasks/src/lib.rs
+++ b/devenv-tasks/src/lib.rs
@@ -847,7 +847,8 @@ impl TasksUi {
                 );
                 if !tasks_status.lines.is_empty() {
                     let output = console::Style::new().apply_to(output);
-                    if last_list_height > 0 {
+                    // Only move cursor and clear screen if not in quiet mode
+                    if !self.quiet && last_list_height > 0 {
                         self.term.move_cursor_up(last_list_height as usize)?;
                         self.term.clear_to_end_of_screen()?;
                     }


### PR DESCRIPTION
A temporary patch to prevent the task TUI from chomping previous lines.

I'd like to refactor this block to group all terminal printing in one go after running any update logic.

Fixes #1857.