### PR TITLE
clickhouse: add timezone data

### DIFF
--- a/src/modules/services/clickhouse.nix
+++ b/src/modules/services/clickhouse.nix
@@ -52,7 +52,7 @@ in
           path: ${cfg.package}/etc//clickhouse-server/users.xml
     '';
     processes.clickhouse-server = {
-      exec = "clickhouse-server --config-file=${pkgs.writeText "clickhouse-config.yaml" cfg.config}";
+      exec = "TZDIR=${pkgs.tzdata}/share/zoneinfo clickhouse-server --config-file=${pkgs.writeText "clickhouse-config.yaml" cfg.config}";
 
       process-compose = {
         readiness_probe = {


### PR DESCRIPTION
clickhouse on unstable is having trouble reading the timezone data. Could just be a configuration issue on our runners, but this seems like a harmless addition.