### PR TITLE
tasks: export devenv-tasks in the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,13 @@
     let
       systems = [ "x86_64-linux" "i686-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = f: builtins.listToAttrs (map (name: { inherit name; value = f name; }) systems);
-      mkPackage = pkgs: pkgs.callPackage ./package.nix {
-        inherit (inputs.nix.packages.${pkgs.stdenv.system}) nix;
-        inherit (inputs.cachix.packages.${pkgs.stdenv.system}) cachix;
-      };
+      mkPackage = pkgs: attrs: pkgs.callPackage ./package.nix
+        (
+          {
+            inherit (inputs.nix.packages.${pkgs.stdenv.system}) nix;
+            inherit (inputs.cachix.packages.${pkgs.stdenv.system}) cachix;
+          } // attrs
+        );
       mkDevShellPackage = config: pkgs: import ./src/devenv-devShell.nix { inherit config pkgs; };
       mkDocOptions = pkgs:
         let
@@ -109,7 +112,8 @@
         in
         {
           default = self.packages.${system}.devenv;
-          devenv = mkPackage pkgs;
+          devenv = mkPackage pkgs { };
+          devenv-tasks = mkPackage pkgs { build_tasks = true; };
           devenv-docs-options = options.optionsCommonMark;
           devenv-docs-options-json = options.optionsJSON;
           devenv-generate-individual-docs =

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -23,7 +23,7 @@ let
               #!${binary}
               ${lib.optionalString (!isStatus) "set -e"}
               ${command}
-              ${lib.optionalString (config.exports != [] && !isStatus) "${devenv-tasks}/bin/devenv-tasks export ${lib.concatStringsSep " " config.exports}"}
+              ${lib.optionalString (config.exports != [] && !isStatus) "${inputs.config.task.package}/bin/devenv-tasks export ${lib.concatStringsSep " " config.exports}"}
             '';
       in
       {


### PR DESCRIPTION
Expose `devenv-tasks` in the flake.