### PR TITLE
Allow configuration of the Nixpkgs instance on a per-system basis

### DIFF
--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -108,6 +108,20 @@ pub struct Clean {
 #[derive(schematic::Config, Clone, Serialize, Debug, JsonSchema)]
 #[config(rename_all = "camelCase", allow_unknown_fields)]
 #[serde(rename_all = "camelCase")]
+pub struct Nixpkgs {
+    #[serde(flatten)]
+    pub config_: NixpkgsConfig,
+    #[serde(
+        rename = "per-platform",
+        skip_serializing_if = "BTreeMap::is_empty",
+        default
+    )]
+    pub per_platform: BTreeMap<String, NixpkgsConfig>,
+}
+
+#[derive(schematic::Config, Clone, Serialize, Debug, JsonSchema)]
+#[config(rename_all = "camelCase", allow_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct Config {
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     #[setting(nested)]
@@ -120,9 +134,9 @@ pub struct Config {
     pub cuda_support: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub cuda_capabilities: Vec<String>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(nested)]
-    pub config: BTreeMap<String, NixpkgsConfig>,
+    pub nixpkgs: Option<Nixpkgs>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub imports: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -130,10 +130,6 @@ pub struct Config {
     pub allow_unfree: bool,
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     pub allow_broken: bool,
-    #[serde(skip_serializing_if = "is_false", default = "false_default")]
-    pub cuda_support: bool,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub cuda_capabilities: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(nested)]
     pub nixpkgs: Option<Nixpkgs>,

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -100,6 +100,8 @@ pub struct Config {
     pub allow_unfree: bool,
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     pub allow_broken: bool,
+    #[serde(skip_serializing_if = "is_false", default = "false_default")]
+    pub cuda_support: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub imports: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -9,6 +9,22 @@ const YAML_CONFIG: &str = "devenv.yaml";
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[config(rename_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
+pub struct NixpkgsConfig {
+    #[serde(skip_serializing_if = "is_false", default = "false_default")]
+    pub allow_unfree: bool,
+    #[serde(skip_serializing_if = "is_false", default = "false_default")]
+    pub allow_broken: bool,
+    #[serde(skip_serializing_if = "is_false", default = "false_default")]
+    pub cuda_support: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub cuda_capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub permitted_insecure_packages: Vec<String>,
+}
+
+#[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[config(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub struct Input {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
@@ -102,6 +118,11 @@ pub struct Config {
     pub allow_broken: bool,
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     pub cuda_support: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub cuda_capabilities: Vec<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    #[setting(nested)]
+    pub config: BTreeMap<String, NixpkgsConfig>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub imports: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -33,6 +33,7 @@
             config = {
               allowUnfree = devenv.allowUnfree or false;
               allowBroken = devenv.allowBroken or false;
+              cudaSupport = devenv.cudaSupport or false;
               permittedInsecurePackages = devenv.permittedInsecurePackages or [ ];
             };
             inherit overlays;

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -31,10 +31,11 @@
           pkgs = import nixpkgs {
             inherit system;
             config = {
-              allowUnfree = devenv.allowUnfree or false;
-              allowBroken = devenv.allowBroken or false;
-              cudaSupport = devenv.cudaSupport or false;
-              permittedInsecurePackages = devenv.permittedInsecurePackages or [ ];
+              allowUnfree = devenv.config."${system}".allowUnfree or devenv.allowUnfree or false;
+              allowBroken = devenv.config."${system}".allowBroken or devenv.allowBroken or false;
+              cudaSupport = devenv.config."${system}".cudaSupport or devenv.cudaSupport or false;
+              cudaCapabilities = devenv.config."${system}".cudaCapabilities or devenv.cudaCapabilities or [ ];
+              permittedInsecurePackages = devenv.config."${system}".permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
             };
             inherit overlays;
           };

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -28,16 +28,14 @@
                   input.overlays.${overlay} or (throw "Input `${inputName}` has no overlay called `${overlay}`. Supported overlays: ${nixpkgs.lib.concatStringsSep ", " (builtins.attrNames input.overlays)}"))
               inputAttrs.overlays or [ ];
           overlays = nixpkgs.lib.flatten (nixpkgs.lib.mapAttrsToList getOverlays (devenv.inputs or { }));
-          getNixpkgsConfigVar = system: name: default:
-            devenv.nixpkgs.per-platform."${system}".${name} or devenv.nixpkgs.${name} or devenv.${name} or default;
           pkgs = import nixpkgs {
             inherit system;
             config = {
-              allowUnfree = getNixpkgsConfigVar system "allowUnfree" false;
-              allowBroken = getNixpkgsConfigVar system "allowBroken" false;
-              cudaSupport = getNixpkgsConfigVar system "cudaSupport" false;
-              cudaCapabilities = getNixpkgsConfigVar system "cudaCapabilities" [ ];
-              permittedInsecurePackages = getNixpkgsConfigVar system "permittedInsecurePackages" [ ];
+              allowUnfree = devenv.nixpkgs.per-platform."${system}".allowUnfree or devenv.nixpkgs.allowUnfree or devenv.allowUnfree or false;
+              allowBroken = devenv.nixpkgs.per-platform."${system}".allowBroken or devenv.nixpkgs.allowBroken or devenv.allowBroken or false;
+              cudaSupport = devenv.nixpkgs.per-platform."${system}".cudaSupport or devenv.nixpkgs.cudaSupport or false;
+              cudaCapabilities = devenv.nixpkgs.per-platform."${system}".cudaCapabilities or devenv.nixpkgs.cudaCapabilities or [ ];
+              permittedInsecurePackages = devenv.nixpkgs.per-platform."${system}".permittedInsecurePackages or devenv.nixpkgs.permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
             };
             inherit overlays;
           };

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -28,14 +28,16 @@
                   input.overlays.${overlay} or (throw "Input `${inputName}` has no overlay called `${overlay}`. Supported overlays: ${nixpkgs.lib.concatStringsSep ", " (builtins.attrNames input.overlays)}"))
               inputAttrs.overlays or [ ];
           overlays = nixpkgs.lib.flatten (nixpkgs.lib.mapAttrsToList getOverlays (devenv.inputs or { }));
+          getNixpkgsConfigVar = system: name: default:
+            devenv.nixpkgs.per-platform."${system}".${name} or devenv.nixpkgs.${name} or devenv.${name} or default;
           pkgs = import nixpkgs {
             inherit system;
             config = {
-              allowUnfree = devenv.config."${system}".allowUnfree or devenv.allowUnfree or false;
-              allowBroken = devenv.config."${system}".allowBroken or devenv.allowBroken or false;
-              cudaSupport = devenv.config."${system}".cudaSupport or devenv.cudaSupport or false;
-              cudaCapabilities = devenv.config."${system}".cudaCapabilities or devenv.cudaCapabilities or [ ];
-              permittedInsecurePackages = devenv.config."${system}".permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
+              allowUnfree = getNixpkgsConfigVar system "allowUnfree" false;
+              allowBroken = getNixpkgsConfigVar system "allowBroken" false;
+              cudaSupport = getNixpkgsConfigVar system "cudaSupport" false;
+              cudaCapabilities = getNixpkgsConfigVar system "cudaCapabilities" [ ];
+              permittedInsecurePackages = getNixpkgsConfigVar system "permittedInsecurePackages" [ ];
             };
             inherit overlays;
           };

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -34,12 +34,6 @@
         "$ref": "#/definitions/Input"
       }
     },
-    "nixpkgs": {
-      "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/NixpkgsConfig"
-      }
-    },
     "permittedInsecurePackages": {
       "type": "array",
       "items": {
@@ -95,38 +89,6 @@
             "string",
             "null"
           ]
-        }
-      }
-    },
-    "NixpkgsConfig": {
-      "type": "object",
-      "properties": {
-        "allowBroken": {
-          "type": "boolean"
-        },
-        "allowUnfree": {
-          "type": "boolean"
-        },
-        "cudaSupport": {
-          "type": "boolean"
-        },
-        "cudaCapabilities": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "permittedInsecurePackages": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "per-platforms": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/NixpkgsConfig"
-          }
         }
       }
     }

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -34,6 +34,16 @@
         "$ref": "#/definitions/Input"
       }
     },
+    "nixpkgs": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Nixpkgs"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "permittedInsecurePackages": {
       "type": "array",
       "items": {
@@ -89,6 +99,64 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "Nixpkgs": {
+      "type": "object",
+      "properties": {
+        "allowBroken": {
+          "type": "boolean"
+        },
+        "allowUnfree": {
+          "type": "boolean"
+        },
+        "cudaCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cudaSupport": {
+          "type": "boolean"
+        },
+        "per-platform": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/NixpkgsConfig"
+          }
+        },
+        "permittedInsecurePackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NixpkgsConfig": {
+      "type": "object",
+      "properties": {
+        "allowBroken": {
+          "type": "boolean"
+        },
+        "allowUnfree": {
+          "type": "boolean"
+        },
+        "cudaCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cudaSupport": {
+          "type": "boolean"
+        },
+        "permittedInsecurePackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -9,15 +9,6 @@
     "allowUnfree": {
       "type": "boolean"
     },
-    "cudaSupport": {
-      "type": "boolean"
-    },
-    "cudaCapabilities": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "clean": {
       "anyOf": [
         {

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -37,6 +37,12 @@
         "$ref": "#/definitions/Input"
       }
     },
+    "config": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/NixpkgsConfig"
+      }
+    },
     "permittedInsecurePackages": {
       "type": "array",
       "items": {
@@ -92,6 +98,32 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "NixpkgsConfig": {
+      "type": "object",
+      "properties": {
+        "allowBroken": {
+          "type": "boolean"
+        },
+        "allowUnfree": {
+          "type": "boolean"
+        },
+        "cudaSupport": {
+          "type": "boolean"
+        },
+        "cudaCapabilities": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permittedInsecurePackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -12,6 +12,12 @@
     "cudaSupport": {
       "type": "boolean"
     },
+    "cudaCapabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "clean": {
       "anyOf": [
         {
@@ -37,7 +43,7 @@
         "$ref": "#/definitions/Input"
       }
     },
-    "config": {
+    "nixpkgs": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/NixpkgsConfig"
@@ -123,6 +129,12 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "per-platforms": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/NixpkgsConfig"
           }
         }
       }

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -9,6 +9,9 @@
     "allowUnfree": {
       "type": "boolean"
     },
+    "cudaSupport": {
+      "type": "boolean"
+    },
     "clean": {
       "anyOf": [
         {

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -9267,8 +9267,6 @@ boolean
 
 ## git-hooks.hooks.pylint.description
 
-
-
 Description of the hook. Used for metadata purposes only.
 
 
@@ -11386,8 +11384,6 @@ string
 
 
 ## git-hooks.hooks.yamllint.settings.format
-
-
 
 Format for parsing output.
 
@@ -13858,8 +13854,6 @@ attribute set of (submodule)
 
 ## languages.php.fpm.pools.\<name>.extraConfig
 
-
-
 Extra lines that go into the pool configuration.
 See the documentation on ` php-fpm.conf ` for
 details on configuration directives.
@@ -16178,8 +16172,6 @@ boolean
 
 
 ## languages.vala.package
-
-
 
 The Vala package to use.
 
@@ -18630,8 +18622,6 @@ package
 
 ## services.influxdb.config
 
-
-
 Configuration for InfluxDB-server
 
 
@@ -21059,8 +21049,6 @@ lazy attribute set of lazy attribute set of anything
 
 ## services.mysql.useDefaultsExtraFile
 
-
-
 Whether to use defaults-exta-file for the mysql command instead of defaults-file.
 This is useful if you want to provide a config file on the command line.
 However this can problematic if you have MySQL installed globaly because its config might leak into your environment.
@@ -23478,8 +23466,6 @@ boolean
 
 
 ## services.trafficserver.package
-
-
 
 Apache Traffic Server package
 

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -1,25 +1,32 @@
 # devenv.yaml
 
-| Key                                             | Value                                                                         |
-| ----------------------------------------------- | ----------------------------------------------------------------------------- |
-| allowUnfree                                     | Allow unfree packages. Defaults to `false`.                                   |
-| allowBroken                                     | Allow packages marked as broken. Defaults to `false`.                         |
-| cudaSupport                                     | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
-| inputs                                          | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |
-| inputs.&lt;name&gt;                             | Identifier name used when passing the input in your ``devenv.nix`` function.  |
-| inputs.&lt;name&gt;.url                         | URI specification of the input, see below for possible values.                |
-| inputs.&lt;name&gt;.flake                       | Does the input contain ``flake.nix`` or ``devenv.nix``. Defaults to ``true``. |
-| inputs.&lt;name&gt;.overlays                    | A list of overlays to include from the input.                                 |
-| imports                                         | A list of relative paths or references to inputs to import ``devenv.nix``.    |
-| permittedInsecurePackages                       | A list of insecure permitted packages.                                        |
-| clean.enabled                                   | Clean the environment when entering the shell. Defaults to `false`.           |
-| clean.keep                                      | A list of environment variables to keep when cleaning the environment.        |
-| config.&lt;system&gt;.allowUnfree               | (per-system) Allow unfree packages. Defaults to `false`.                      |
-| config.&lt;system&gt;.allowBroken               | (per-system) Allow packages marked as broken. Defaults to `false`.            |
-| config.&lt;system&gt;.cudaSupport               | (per-system) Enable CUDA support for nixpkgs. Defaults to `false`.            |
-| config.&lt;system&gt;.cudaCapabilities          | (per-system) Select CUDA capabilities for nixpkgs. Defaults to `[]`           |
-| config.&lt;system&gt;.permittedInsecurePackages | (per-system) Select CUDA capabilities for nixpkgs. Defaults to `[]`           |
-| impure                                          | Relax the hermeticity of the environment.                                     |
+| Key                                                   | Value                                                                         |
+|-------------------------------------------------------|-------------------------------------------------------------------------------|
+| allowBroken                                           | (deprecated) Allow packages marked as broken. Defaults to `false`.            |
+| allowUnfree                                           | (deprecated) Allow unfree packages. Defaults to `false`.                      |
+| clean.enabled                                         | Clean the environment when entering the shell. Defaults to `false`.           |
+| clean.keep                                            | A list of environment variables to keep when cleaning the environment.        |
+| cudaSupport                                           | (deprecated) Enable CUDA support for nixpkgs. Defaults to `false`.            |
+| imports                                               | A list of relative paths or references to inputs to import ``devenv.nix``.    |
+| impure                                                | Relax the hermeticity of the environment.                                     |
+| inputs                                                | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |
+| inputs.&lt;name&gt;                                   | Identifier name used when passing the input in your ``devenv.nix`` function.  |
+| inputs.&lt;name&gt;.flake                             | Does the input contain ``flake.nix`` or ``devenv.nix``. Defaults to ``true``. |
+| inputs.&lt;name&gt;.overlays                          | A list of overlays to include from the input.                                 |
+| inputs.&lt;name&gt;.url                               | URI specification of the input, see below for possible values.                |
+| permittedInsecurePackages                             | (deprecated) A list of insecure permitted packages.                           |
+|                                                       |                                                                               |
+| nixpkgs.allowBroken                                   | Allow packages marked as broken. Defaults to `false`.                         |
+| nixpkgs.allowUnfree                                   | Allow unfree packages. Defaults to `false`.                                   |
+| nixpkgs.cudaCapabilities                              | Select CUDA capabilities for nixpkgs. Defaults to `[]`                        |
+| nixpkgs.cudaSupport                                   | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
+| nixpkgs.permittedInsecurePackages                     | A list of insecure permitted packages. Defaults to `[]`                       |
+|                                                       |                                                                               |
+| nixpkgs.&lt;per-platfom&gt;.allowBroken               | (per-platform) Allow packages marked as broken. Defaults to `false`.          |
+| nixpkgs.&lt;per-platfom&gt;.allowUnfree               | (per-platform) Allow unfree packages. Defaults to `false`.                    |
+| nixpkgs.&lt;per-platfom&gt;.cudaCapabilities          | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
+| nixpkgs.&lt;per-platfom&gt;.cudaSupport               | (per-platform) Enable CUDA support for nixpkgs. Defaults to `false`.          |
+| nixpkgs.&lt;per-platfom&gt;.permittedInsecurePackages | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
 
 !!! note "Added in 1.0"
 

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -1,20 +1,25 @@
 # devenv.yaml
 
-| Key                          | Value                                                                         |
-| ---------------------------- | ----------------------------------------------------------------------------- |
-| allowUnfree                  | Allow unfree packages. Defaults to `false`.                                   |
-| allowBroken                  | Allow packages marked as broken. Defaults to `false`.                         |
-| cudaSupport                  | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
-| inputs                       | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |
-| inputs.&lt;name&gt;          | Identifier name used when passing the input in your ``devenv.nix`` function.  |
-| inputs.&lt;name&gt;.url      | URI specification of the input, see below for possible values.                |
-| inputs.&lt;name&gt;.flake    | Does the input contain ``flake.nix`` or ``devenv.nix``. Defaults to ``true``. |
-| inputs.&lt;name&gt;.overlays | A list of overlays to include from the input.                                 |
-| imports                      | A list of relative paths or references to inputs to import ``devenv.nix``.    |
-| permittedInsecurePackages    | A list of insecure permitted packages.                                        |
-| clean.enabled                | Clean the environment when entering the shell. Defaults to `false`.           |
-| clean.keep                   | A list of environment variables to keep when cleaning the environment.        |
-| impure                       | Relax the hermeticity of the environment.                                     |
+| Key                                             | Value                                                                         |
+| ----------------------------------------------- | ----------------------------------------------------------------------------- |
+| allowUnfree                                     | Allow unfree packages. Defaults to `false`.                                   |
+| allowBroken                                     | Allow packages marked as broken. Defaults to `false`.                         |
+| cudaSupport                                     | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
+| inputs                                          | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |
+| inputs.&lt;name&gt;                             | Identifier name used when passing the input in your ``devenv.nix`` function.  |
+| inputs.&lt;name&gt;.url                         | URI specification of the input, see below for possible values.                |
+| inputs.&lt;name&gt;.flake                       | Does the input contain ``flake.nix`` or ``devenv.nix``. Defaults to ``true``. |
+| inputs.&lt;name&gt;.overlays                    | A list of overlays to include from the input.                                 |
+| imports                                         | A list of relative paths or references to inputs to import ``devenv.nix``.    |
+| permittedInsecurePackages                       | A list of insecure permitted packages.                                        |
+| clean.enabled                                   | Clean the environment when entering the shell. Defaults to `false`.           |
+| clean.keep                                      | A list of environment variables to keep when cleaning the environment.        |
+| config.&lt;system&gt;.allowUnfree               | (per-system) Allow unfree packages. Defaults to `false`.                      |
+| config.&lt;system&gt;.allowBroken               | (per-system) Allow packages marked as broken. Defaults to `false`.            |
+| config.&lt;system&gt;.cudaSupport               | (per-system) Enable CUDA support for nixpkgs. Defaults to `false`.            |
+| config.&lt;system&gt;.cudaCapabilities          | (per-system) Select CUDA capabilities for nixpkgs. Defaults to `[]`           |
+| config.&lt;system&gt;.permittedInsecurePackages | (per-system) Select CUDA capabilities for nixpkgs. Defaults to `[]`           |
+| impure                                          | Relax the hermeticity of the environment.                                     |
 
 !!! note "Added in 1.0"
 

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -6,7 +6,6 @@
 | allowUnfree                                           | (deprecated) Allow unfree packages. Defaults to `false`.                      |
 | clean.enabled                                         | Clean the environment when entering the shell. Defaults to `false`.           |
 | clean.keep                                            | A list of environment variables to keep when cleaning the environment.        |
-| cudaSupport                                           | (deprecated) Enable CUDA support for nixpkgs. Defaults to `false`.            |
 | imports                                               | A list of relative paths or references to inputs to import ``devenv.nix``.    |
 | impure                                                | Relax the hermeticity of the environment.                                     |
 | inputs                                                | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -4,7 +4,8 @@
 | ---------------------------- | ----------------------------------------------------------------------------- |
 | allowUnfree                  | Allow unfree packages. Defaults to `false`.                                   |
 | allowBroken                  | Allow packages marked as broken. Defaults to `false`.                         |
-| inputs                       | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.      |
+| cudaSupport                  | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
+| inputs                       | Defaults to `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.       |
 | inputs.&lt;name&gt;          | Identifier name used when passing the input in your ``devenv.nix`` function.  |
 | inputs.&lt;name&gt;.url      | URI specification of the input, see below for possible values.                |
 | inputs.&lt;name&gt;.flake    | Does the input contain ``flake.nix`` or ``devenv.nix``. Defaults to ``true``. |

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -28,6 +28,10 @@
 | nixpkgs.&lt;per-platfom&gt;.cudaSupport               | (per-platform) Enable CUDA support for nixpkgs. Defaults to `false`.          |
 | nixpkgs.&lt;per-platfom&gt;.permittedInsecurePackages | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
 
+!!! note "Added in 1.7"
+
+    - `nixpkgs`
+
 !!! note "Added in 1.0"
 
     - relative file support in imports: `./mymodule.nix`

--- a/tests/nixpkgs-config/devenv.nix
+++ b/tests/nixpkgs-config/devenv.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }: {
+  env = {
+    CUDA_SUPPORT = pkgs.lib.boolToString (pkgs.config.cudaSupport or false);
+    CUDA_CAPABILITIES = builtins.toString (pkgs.config.cudaCapabilities or [ ]);
+  };
+
+  enterTest = ''
+    if [ -z "$DEVENV_NIX" ]; then
+      echo "DEVENV_NIX is not set"
+      exit 1
+    fi
+
+    if [[ "$CUDA_SUPPORT" != "true" ]]; then
+      echo "CUDA_SUPPORT ($CUDA_SUPPORT) != true"
+      exit 1
+    fi
+    if [[ "$CUDA_CAPABILITIES" != "8.0" ]]; then
+      echo "CUDA_CAPABILITIES ($CUDA_CAPABILITIES) != 8.0"
+      exit 1
+    fi
+  '';
+}

--- a/tests/nixpkgs-config/devenv.nix
+++ b/tests/nixpkgs-config/devenv.nix
@@ -1,5 +1,6 @@
 { pkgs, ... }: {
   env = {
+    ALLOW_UNFREE = pkgs.lib.boolToString (pkgs.config.allowUnfree or false);
     CUDA_SUPPORT = pkgs.lib.boolToString (pkgs.config.cudaSupport or false);
     CUDA_CAPABILITIES = builtins.toString (pkgs.config.cudaCapabilities or [ ]);
   };
@@ -10,6 +11,10 @@
       exit 1
     fi
 
+    if [[ "$ALLOW_UNFREE" != "true" ]]; then
+      echo "ALLOW_UNFREE ($ALLOW_UNFREE) != true"
+      exit 1
+    fi
     if [[ "$CUDA_SUPPORT" != "true" ]]; then
       echo "CUDA_SUPPORT ($CUDA_SUPPORT) != true"
       exit 1

--- a/tests/nixpkgs-config/devenv.yaml
+++ b/tests/nixpkgs-config/devenv.yaml
@@ -2,13 +2,11 @@ inputs:
   devenv:
     url: path:../../?dir=src/modules
 
+# This value is overridden in the platform-specific config below on purpose
 allowUnfree: false
-cudaSupport: false
-cudaCapabilities: []
 
 nixpkgs:
-  # These values need to be overriden by the platform-specific values below
-  allowUnfree: false
+  # These values are overridden in the platform-specific config below on purpose
   cudaSupport: false
   cudaCapabilities: []
 

--- a/tests/nixpkgs-config/devenv.yaml
+++ b/tests/nixpkgs-config/devenv.yaml
@@ -1,0 +1,20 @@
+inputs:
+  devenv:
+    url: path:../../?dir=src/modules
+
+config:
+  i386-linux:
+    cudaSupport: true
+    cudaCapabilities: [ "8.0" ]
+  x86_64-linux:
+    cudaSupport: true
+    cudaCapabilities: [ "8.0" ]
+  aarch64-linux:
+    cudaSupport: true
+    cudaCapabilities: [ "8.0" ]
+  aarch64-darwin:
+    cudaSupport: true
+    cudaCapabilities: [ "8.0" ]
+  x86_64-darmin:
+    cudaSupport: true
+    cudaCapabilities: [ "8.0" ]

--- a/tests/nixpkgs-config/devenv.yaml
+++ b/tests/nixpkgs-config/devenv.yaml
@@ -2,19 +2,34 @@ inputs:
   devenv:
     url: path:../../?dir=src/modules
 
-config:
-  i386-linux:
-    cudaSupport: true
-    cudaCapabilities: [ "8.0" ]
-  x86_64-linux:
-    cudaSupport: true
-    cudaCapabilities: [ "8.0" ]
-  aarch64-linux:
-    cudaSupport: true
-    cudaCapabilities: [ "8.0" ]
-  aarch64-darwin:
-    cudaSupport: true
-    cudaCapabilities: [ "8.0" ]
-  x86_64-darmin:
-    cudaSupport: true
-    cudaCapabilities: [ "8.0" ]
+allowUnfree: false
+cudaSupport: false
+cudaCapabilities: []
+
+nixpkgs:
+  # These values need to be overriden by the platform-specific values below
+  allowUnfree: false
+  cudaSupport: false
+  cudaCapabilities: []
+
+  per-platform:
+    i386-linux:
+      allowUnfree: true
+      cudaSupport: true
+      cudaCapabilities: [ "8.0" ]
+    x86_64-linux:
+      allowUnfree: true
+      cudaSupport: true
+      cudaCapabilities: [ "8.0" ]
+    aarch64-linux:
+      allowUnfree: true
+      cudaSupport: true
+      cudaCapabilities: [ "8.0" ]
+    aarch64-darwin:
+      allowUnfree: true
+      cudaSupport: true
+      cudaCapabilities: [ "8.0" ]
+    x86_64-darmin:
+      allowUnfree: true
+      cudaSupport: true
+      cudaCapabilities: [ "8.0" ]


### PR DESCRIPTION
# Description

This PR aims to allow setting some of the attribute of the `config` attribute set that is normally passed as argument when importing Nixpkgs.

An example that is currently not supported (but would be after this PR):
```nix
{
  pkgs = import nixpkgs {
    inherit system;
    overlays = [ ... ];
    config = {
      allowUnfree = true;
      allowBroken = true;
      cudaSupport = true;
      cudaCapabilities = [
        "7.5"
        "8.6"
        "8.9"
      ];
    };
  };
}
```

## Context

We have a project where we work with CUDA and override various packages (e.g. OpenCV) to have CUDA support enabled. Currently, we are using `devenv` with the flake integration, but would like to now migrate to using the `devenv` command and `devenv.yaml`/`devenv.nix` to benefit from faster load times.

We also have the added complexity of supporting 2 architectures: x86 and aarch64 with incompatible sets of CUDA capabilities. We therefore needed to patch `devenv` in order to allow us to configure those settings on a per-system basis.

## Changes in a nutshell

This PR modifies the config structure of the `devenv.yaml` file in the following ways:

- Add a top-level element to enable/disable CUDA support for `nixpkgs` globally: `cudaSupport`
- Add a new top-level element: `config` that can be used to configure on a per-system basis how `devenv` later configures its Nixpkgs instance

Here's an example of this new format for the config file:
```yaml
# ... usual config

config:
  x86_64-linux:
    allowUnfree: true
    allowBroken: true
    cudaSupport: true
    cudaCapabilities:
      - "7.5"
      - "8.6"
      - "8.9"
  aarch64-linux:
    allowUnfree: true
    allowBroken: true
    cudaSupport: true
    cudaCapabilities:
      - "8.7"
```

The `devenv/src/flake.tmpl.nix` was modified in such a way that the `config.<system>.<keys>` take precedence over `<keys>` if present, but should not otherwise have an impact on existing configurations.
