### PR TITLE
Fix DOTNET_ROOT

### DIFF
--- a/src/modules/languages/dotnet.nix
+++ b/src/modules/languages/dotnet.nix
@@ -16,11 +16,15 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
+    packages = [
       cfg.package
     ];
 
-    env.DOTNET_ROOT = "${cfg.package}";
+    env.DOTNET_ROOT = "${
+        if lib.hasAttr "unwrapped" cfg.package
+        then cfg.package.unwrapped
+        else cfg.package
+    }/share/dotnet";
     env.LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:${lib.makeLibraryPath [ pkgs.icu ]}";
   };
 }


### PR DESCRIPTION
Newer nixpkgs wrap the actual dotnet package, and therefore DOTNET_ROOT should point to the unwrapped package.

Also, pointing DOTNET_ROOT to the actual dotnet location (in /share/dotnet) fixes some packages that may have problems finding dotnet using the binary (like omnisharp)

Will most likely fix https://github.com/cachix/devenv/issues/1722