### PR TITLE
outputs: fixes `devenv build` when building all outputs

### DIFF
--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -112,11 +112,13 @@
               );
           };
 
+          # Recursively search for outputs in the config.
+          # This is used when not building a specific output by attrpath.
           build = options: config:
             lib.concatMapAttrs
               (name: option:
-                if builtins.hasAttr "type" option then
-                  if option.type.name == "output" || option.type.name == "outputOf" then {
+                if lib.isOption option then
+                  if lib.isType "output" option || lib.isType "outputOf" option then {
                     ${name} = config.${name};
                   } else { }
                 else

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -16285,6 +16285,11 @@ outputOf (attribute set)
 
 
 *Default:*
+` { } `
+
+
+
+*Example:*
 
 ```
 {

--- a/src/modules/outputs.nix
+++ b/src/modules/outputs.nix
@@ -2,13 +2,8 @@
   options = {
     outputs = lib.mkOption {
       type = config.lib.types.outputOf lib.types.attrs;
-      default = {
-        git = pkgs.git;
-        foo = {
-          ncdu = pkgs.ncdu;
-        };
-      };
-      defaultText = lib.literalExpression ''
+      default = { };
+      example = lib.literalExample ''
         {
           git = pkgs.git;
           foo = {

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -123,7 +123,7 @@ in
       description = "The generated tasks.json file.";
     };
     task.package = lib.mkOption {
-      type = config.lib.types.output;
+      type = types.package;
       internal = true;
       default = lib.getBin devenv-tasks;
     };


### PR DESCRIPTION
Improve how we inspect options and their types by using the module helper functions.

This fixes #1902, where `services.keycloak.database` was being incorrectly classified as an option because it has a nested option named `type`.