### PR TITLE
devenv: fix broken shell when using `--clean`

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -319,12 +319,7 @@ impl Devenv {
             };
 
             let filtered_env = std::env::vars().filter(|(k, _)| keep.contains(k));
-
-            shell_cmd
-                .env_clear()
-                .envs(filtered_env)
-                .arg("--norc")
-                .arg("--noprofile");
+            shell_cmd.env_clear().envs(filtered_env);
         }
 
         shell_cmd.env("SHELL", &bash);


### PR DESCRIPTION
`--norc` should not have been added here.
It prevents the shell rcfile from being evaluated.
