### PR TITLE
remove usage of debrecated literalExample

### DIFF
--- a/src/modules/outputs.nix
+++ b/src/modules/outputs.nix
@@ -3,7 +3,7 @@
     outputs = lib.mkOption {
       type = config.lib.types.outputOf lib.types.attrs;
       default = { };
-      example = lib.literalExample ''
+      example = lib.literalExpression ''
         {
           git = pkgs.git;
           foo = {


### PR DESCRIPTION
lib.literalExample is deprecated, use lib.literalExpression instead

see https://github.com/NixOS/nixpkgs/blob/26be80f33b8dd36165f6f929755fad9be068a312/lib/options.nix#L690