### PR TITLE
Add opentofu example

### DIFF
--- a/examples/opentofu/.test.sh
+++ b/examples/opentofu/.test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -ex
+tofu --version | grep "1.9.1"

--- a/examples/opentofu/devenv.nix
+++ b/examples/opentofu/devenv.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  languages.opentofu = {
+    enable = true;
+    version = "1.9.1";
+  };
+}

--- a/examples/opentofu/devenv.yaml
+++ b/examples/opentofu/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs-opentofu:
+    url: github:cachix/nixpkgs-opentofu


### PR DESCRIPTION
I noticed that there is not an example for opentofu. I just grabbed/copied the terraform example and modified it to create one for opentofu. Looking at the nixos packages repository I _think_ that this is correct. This is my first PR to this repository and I  may have missed something. Happy to fix or add anything that was missed in the initial commit.