### PR TITLE
opensearch: link core plugins and disable security by default

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -21456,6 +21456,30 @@ string
 
 
 
+## services.opensearch.settings."plugins.security.disabled"
+
+
+
+Whether to disable the security plugin. When set to false, SSL configuration is required.
+To enable SSL, set ` plugins.security.ssl.transport.keystore_filepath ` or both
+` plugins.security.ssl.transport.server.pemcert_filepath ` and
+` plugins.security.ssl.transport.client.pemcert_filepath `.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/opensearch.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/opensearch.nix)
+
+
+
 ## services.opensearch.settings."transport.port"
 
 

--- a/docs/supported-services/opensearch.md
+++ b/docs/supported-services/opensearch.md
@@ -208,6 +208,27 @@ string
 
 
 
+## services\.opensearch\.settings\."plugins\.security\.disabled"
+
+
+
+Whether to disable the security plugin\. When set to false, SSL configuration is required\.
+To enable SSL, set ` plugins.security.ssl.transport.keystore_filepath ` or both
+` plugins.security.ssl.transport.server.pemcert_filepath ` and
+` plugins.security.ssl.transport.client.pemcert_filepath `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
+
+
+
 ## services\.opensearch\.settings\."transport\.port"
 
 

--- a/src/modules/services/opensearch.nix
+++ b/src/modules/services/opensearch.nix
@@ -107,6 +107,17 @@ in
             The port to listen on for transport traffic.
           '';
         };
+
+        options."plugins.security.disabled" = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Whether to disable the security plugin. When set to false, SSL configuration is required.
+            To enable SSL, set `plugins.security.ssl.transport.keystore_filepath` or both
+            `plugins.security.ssl.transport.server.pemcert_filepath` and
+            `plugins.security.ssl.transport.client.pemcert_filepath`.
+          '';
+        };
       };
 
       default = { };

--- a/src/modules/services/opensearch.nix
+++ b/src/modules/services/opensearch.nix
@@ -25,7 +25,7 @@ let
 
     # Install plugins
     rm -rf "$OPENSEARCH_DATA/plugins"
-    mkdir -p "$OPENSEARCH_DATA/plugins"
+    ln -sf "${cfg.package}/plugins" "$OPENSEARCH_DATA/plugins"
 
     rm -f "$OPENSEARCH_DATA/lib"
     ln -sf ${cfg.package}/lib "$OPENSEARCH_DATA/lib"


### PR DESCRIPTION
- Links the core plugins that ship with opensearch.
- Disable the security module, which otherwise fails OOTB if SSL is not configured.

For plugins, it would be nice to have a plugins option that uses `buildEnv`. These should be packaged in nixpkgs: https://github.com/opensearch-project/OpenSearch/tree/main/plugins, much like `elasticsearchPlugins`.

Fixes https://github.com/cachix/devenv/issues/1870.