### PR TITLE
fix up args to join with space

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -894,7 +894,7 @@ impl Devenv {
 
         let span = info_span!("up", devenv.user_message = "Starting processes");
         async {
-            let processes = processes.join("");
+            let processes = processes.join(" ");
 
             let processes_script = self.devenv_dotfile.join("processes");
             // we force disable process compose tui if detach is enabled


### PR DESCRIPTION
hi, there's a regression in 1.6 that joins the `devenv up` args without a space so it doesn't work properly with multiple args