### PR TITLE
Rust: import functionality

### DIFF
--- a/docs/blog/posts/closing-the-nix-gap-from-tools-to-packaged-applications.md
+++ b/docs/blog/posts/closing-the-nix-gap-from-tools-to-packaged-applications.md
@@ -1,0 +1,96 @@
+---
+draft: false
+date: 2025-08-22
+authors:
+  - domenkozar
+---
+
+# Closing the Nix Gap: From Environments to Packaged Applications for Rust
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Should I use crate2nix, cargo2nix, or naersk for packaging my Rust application?</p>&mdash; (@jvmncs) <a href="https://twitter.com/jvmncs/status/1927120951918891508">January 21, 2025</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+This tweet shows a common problem in Nix: "Should I use crate2nix, cargo2nix, or naersk for packaging my Rust application?"
+
+devenv solved this for development environments differently: instead of making developers package everything with Nix, we provide tools through a simple `languages.rust.enable`. You get `cargo`, `rustc`, and `rust-analyzer` in your shell without understanding Nix packaging.
+
+But when you're ready to deploy, you face the same problem: which lang2nix tool should you use? Developers don't want to compare `crate2nix` vs `cargo2nix` vs `naersk` vs `crane`—they want a tested solution that works.
+
+devenv now provides `languages.rust.import`, which packages Rust applications using [crate2nix](https://github.com/nix-community/crate2nix). We evaluated the available tools and chose crate2nix, so you don't have to.
+
+We've done this before. In [PR #1500](https://github.com/cachix/devenv/pull/1500), we replaced [fenix](https://github.com/nix-community/fenix) with [rust-overlay](https://github.com/oxalica/rust-overlay) for Rust toolchains because rust-overlay was better maintained. Users didn't need to change anything—devenv handled the transition while keeping the same `languages.rust.enable = true` interface.
+
+## One Interface for All Languages
+
+The typical workflow:
+
+1. **Development**: Enable the language (`languages.rust.enable = true`) to get tools like `cargo`, `rustc`, and `rust-analyzer`.
+2. **Packaging**: When ready to deploy, use `languages.rust.import` to package with Nix.
+
+The same pattern works for all languages:
+
+```nix
+{ config, ... }: {
+  languages = {
+    rust.enable = true;
+    python.enable = true;
+    go.enable = true;
+  };
+
+  outputs = {
+    rust-app = config.languages.rust.import ./rust-app {};
+    python-app = config.languages.python.import ./python-app {};
+    go-app = config.languages.go.import ./go-app {};
+  };
+}
+```
+
+## Starting with Rust
+
+`languages.rust.import` automatically generates Nix expressions from `Cargo.toml` and `Cargo.lock`.
+
+Add the crate2nix input:
+
+```shell-session
+$ devenv inputs add crate2nix github:nix-community/crate2nix --follows nixpkgs
+```
+
+Import your Rust application:
+
+```nix
+{ config, ... }:
+let
+  # ./app is the directory containing your Rust project's Cargo.toml
+  myapp = config.languages.rust.import ./app {};
+in
+{
+  # Provide developer environment
+  languages.rust.enable = true;
+
+  # Expose our application inside the environment
+  packages = [ myapp ];
+
+  # Nix outputs
+  outputs = {
+    inherit myapp;
+  };
+}
+```
+
+Build your application:
+
+```shell-session
+$ devenv build outputs.myapp
+```
+
+## Other Languages
+
+This API extends to other languages, each using the best packaging tool:
+
+We've also started using [uv2nix](https://github.com/pyproject-nix/uv2nix) to provide a similar interface for Python in [PR #2115](https://github.com/cachix/devenv/pull/2115).
+
+## That's it
+
+For feedback, join our [Discord community](https://discord.gg/naMgvexb6q).
+
+Domen

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -16076,6 +16076,36 @@ list of string
 
 
 
+## languages.rust.import
+
+
+
+Import a Cargo project using cargo2nix.
+
+This function takes a path to a directory containing a Cargo.toml file
+and returns a derivation that builds the Rust project using cargo2nix.
+
+Example usage:
+
+```nix
+let
+mypackage = config.languages.rust.import ./path/to/cargo/project {};
+in {
+languages.rust.enable = true;
+packages = [ mypackage ];
+}
+```
+
+
+
+*Type:*
+function that evaluates to a(n) function that evaluates to a(n) package
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix)
+
+
+
 ## languages.rust.mold.enable
 
 
@@ -17153,7 +17183,7 @@ null or string
 
 
 *Default:*
-` null `
+` "devenv-shell" `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)

--- a/docs/supported-languages/rust.md
+++ b/docs/supported-languages/rust.md
@@ -125,44 +125,6 @@ For more control over versions and features, use the `stable`, `beta`, or `night
 <!-- profile = "default" -->
 <!-- ``` -->
 
-## Packaging applications using Nix
-
-devenv can automatically package Rust projects using [crate2nix](https://github.com/nix-community/crate2nix).
-
-### Setup
-
-First, add the crate2nix input:
-
-```bash
-devenv inputs add crate2nix github:nix-community/crate2nix --follows nixpkgs
-```
-
-### Basic usage
-
-```nix
-{ config, ... }:
-let
-  myapp = config.languages.rust.import ./path/to/cargo/project {};
-in
-{
-  languages.rust.enable = true;
-  packages = [ myapp ];
-  
-  # Expose as outputs for building
-  outputs = {
-    inherit myapp;
-  };
-}
-```
-
-Then build the package:
-
-```bash
-devenv build outputs.myapp
-```
-
-The imported package will be available in your environment and can be built as an [output](/reference/options/#outputs).
-
 ## Integration with other tools
 
 ### Git hooks
@@ -239,6 +201,33 @@ list of string
 
 *Default:*
 ` [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ] `
+
+
+
+### languages\.rust\.import
+
+
+
+Import a Cargo project using cargo2nix\.
+
+This function takes a path to a directory containing a Cargo\.toml file
+and returns a derivation that builds the Rust project using cargo2nix\.
+
+Example usage:
+
+```nix
+let
+mypackage = config.languages.rust.import ./path/to/cargo/project {};
+in {
+languages.rust.enable = true;
+packages = [ mypackage ];
+}
+```
+
+
+
+*Type:*
+function that evaluates to a(n) function that evaluates to a(n) package
 
 
 

--- a/docs/supported-languages/rust.md
+++ b/docs/supported-languages/rust.md
@@ -125,6 +125,44 @@ For more control over versions and features, use the `stable`, `beta`, or `night
 <!-- profile = "default" -->
 <!-- ``` -->
 
+## Packaging applications using Nix
+
+devenv can automatically package Rust projects using [crate2nix](https://github.com/nix-community/crate2nix).
+
+### Setup
+
+First, add the crate2nix input:
+
+```bash
+devenv inputs add crate2nix github:nix-community/crate2nix --follows nixpkgs
+```
+
+### Basic usage
+
+```nix
+{ config, ... }:
+let
+  myapp = config.languages.rust.import ./path/to/cargo/project {};
+in
+{
+  languages.rust.enable = true;
+  packages = [ myapp ];
+  
+  # Expose as outputs for building
+  outputs = {
+    inherit myapp;
+  };
+}
+```
+
+Then build the package:
+
+```bash
+devenv build outputs.myapp
+```
+
+The imported package will be available in your environment and can be built as an [output](/reference/options/#outputs).
+
 ## Integration with other tools
 
 ### Git hooks

--- a/examples/rust/.test.sh
+++ b/examples/rust/.test.sh
@@ -6,5 +6,23 @@ rustc --version
 [[ "$CARGO_INSTALL_ROOT" == "$DEVENV_STATE/cargo-install" ]]
 echo "$PATH" | grep -- "$CARGO_INSTALL_ROOT/bin"
 
+# Test the original cargo workflow
 cd app
 cargo run
+
+# Test the crate2nix import functionality
+cd ..
+echo "Testing crate2nix import..."
+
+# The myapp package should be available as a derivation
+devenv build outputs.myapp
+
+# Verify the package can be built
+if command -v app &> /dev/null; then
+    echo "crate2nix imported package 'app' is available in PATH"
+    app
+else
+    echo "Note: app binary not in PATH during devenv shell"
+fi
+
+echo "crate2nix import test completed successfully!"

--- a/examples/rust/devenv.nix
+++ b/examples/rust/devenv.nix
@@ -1,5 +1,9 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 
+let
+  # Test the crate2nix import functionality
+  myapp = config.languages.rust.import ./app { };
+in
 {
   languages.rust = {
     enable = true;
@@ -7,6 +11,14 @@
     channel = "nightly";
 
     components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
+  };
+
+  # Include the imported package in the environment
+  packages = [ myapp ];
+
+  # Expose the package as an output for testing
+  outputs = {
+    inherit myapp;
   };
 
   git-hooks.hooks = {

--- a/examples/rust/devenv.yaml
+++ b/examples/rust/devenv.yaml
@@ -4,3 +4,8 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
+  crate2nix:
+    url: github:nix-community/crate2nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
Allow packaging Rust projects using [cargo2nix](https://github.com/cargo2nix/cargo2nix).

```nix
{ pkgs, lib, config, ... }:

let
  mypackage = config.languages.rust.import ./. {};
in {
  languages.rust.enable = true;

  packages = [ mypackage ];

  outputs = {
   inherit mypackage;
  };
}
```

- [x] update docs
- [x] tests pass