### PR TITLE
feat: add enable/disable toggles for realm export

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -19442,6 +19442,28 @@ list of absolute path
 
 
 
+## services.keycloak.processes.exportRealms
+
+
+
+Global toggle to enable/disable the realms export process ` keycloak-realm-export-all `
+if any realms have ` realms.«name».export == true `.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix)
+
+
+
 ## services.keycloak.realms
 
 
@@ -19553,6 +19575,28 @@ null or relative path not in the Nix store
 
 *Example:*
 ` "./realms/a.json" `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix)
+
+
+
+## services.keycloak.scripts.exportRealm
+
+
+
+Global toggle to enable/disable the **single** realm export
+script ` keycloak-realm-export `.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/keycloak.nix)

--- a/docs/supported-services/keycloak.md
+++ b/docs/supported-services/keycloak.md
@@ -110,6 +110,25 @@ list of absolute path
 
 
 
+## services\.keycloak\.processes\.exportRealms
+
+
+
+Global toggle to enable/disable the realms export process ` keycloak-realm-export-all `
+if any realms have ` realms.«name».export == true `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
+
+
+
 ## services\.keycloak\.realms
 
 
@@ -212,6 +231,25 @@ null or relative path not in the Nix store
 
 *Example:*
 ` "./realms/a.json" `
+
+
+
+## services\.keycloak\.scripts\.exportRealm
+
+
+
+Global toggle to enable/disable the **single** realm export
+script ` keycloak-realm-export `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` true `
 
 
 


### PR DESCRIPTION
- Enable and disable realm export with
  ```nix
  scripts.exportRealm = false;
  processes.exportRealms = false;
  ```
  
- Only make the process `keycloak-realm-export-all` show up if at least some `realm.XXX.export = true` are set.

