### PR TITLE
mcp: fix tests and run assemble before mcp commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           path=$(nix build -L --print-out-paths)
           echo "$path/bin" >> $GITHUB_PATH
+      - name: Run cargo integration tests
+        run: devenv shell -- cargo test --all-features
       - name: Run devenv-test-cli
         run: devenv shell devenv-test-cli
       - name: Run tests

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -52,5 +52,5 @@ rmcp-macros.workspace = true
 async-trait.workspace = true
 
 [features]
-default = ["integration-tests"]
+default = []
 integration-tests = []

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -219,10 +219,7 @@ async fn main() -> Result<()> {
             config::write_json_schema().wrap_err("Failed to generate JSON schema")?;
             Ok(())
         }
-        Commands::Mcp {} => {
-            use devenv::mcp;
-            mcp::run_mcp_server(devenv.config).await
-        }
+        Commands::Mcp {} => devenv::mcp::run_mcp_server(devenv.config).await,
         Commands::Direnvrc => unreachable!(),
         Commands::Version => unreachable!(),
     }

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -76,7 +76,10 @@ impl DevenvMcpServer {
             devenv_root: None,
             devenv_dotfile: None,
         };
-        let devenv = Devenv::new(devenv_options).await;
+        let mut devenv = Devenv::new(devenv_options).await;
+
+        // Assemble the devenv to create required flake files
+        devenv.assemble(true).await?;
 
         // Use broad search term to get a wide set of packages
         // We'll limit results later if needed
@@ -128,7 +131,10 @@ impl DevenvMcpServer {
             devenv_root: None,
             devenv_dotfile: None,
         };
-        let devenv = Devenv::new(devenv_options).await;
+        let mut devenv = Devenv::new(devenv_options).await;
+
+        // Assemble the devenv to create required flake files
+        devenv.assemble(true).await?;
 
         // Build the optionsJSON attribute like in devenv.rs search function
         let build_options = cnix::Options {

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -422,6 +422,11 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     async fn test_fetch_packages_live() {
+        // Change to project root directory so the test finds the correct devenv.nix
+        let original_dir = std::env::current_dir().unwrap();
+        let project_root = original_dir.parent().unwrap();
+        std::env::set_current_dir(project_root).unwrap();
+
         let config = Config::default();
         let server = DevenvMcpServer::new(config);
 
@@ -475,14 +480,18 @@ mod tests {
         for package in packages.iter().take(5) {
             println!("  - {} ({})", package.name, package.version);
         }
+
+        // Restore original directory
+        std::env::set_current_dir(original_dir).unwrap();
     }
 
     #[tokio::test]
     #[cfg(feature = "integration-tests")]
     async fn test_fetch_options_live() {
-        // This test requires being run from a proper devenv project root
-        // It will fail in the test environment because it needs access to
-        // the devenv flake and its optionsJSON output
+        // Change to project root directory so the test finds the correct devenv.nix
+        let original_dir = std::env::current_dir().unwrap();
+        let project_root = original_dir.parent().unwrap();
+        std::env::set_current_dir(project_root).unwrap();
 
         let config = Config::default();
         let server = DevenvMcpServer::new(config);
@@ -533,5 +542,8 @@ mod tests {
                 );
             }
         }
+
+        // Restore original directory
+        std::env::set_current_dir(original_dir).unwrap();
     }
 }

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -80,7 +80,7 @@ impl DevenvMcpServer {
 
         // Use empty search term to get a broad set of packages
         // We'll limit results later if needed
-        let search_output = devenv.nix.search("").await?;
+        let search_output = devenv.nix.search(".").await?;
 
         // Parse the search results from JSON
         #[derive(Deserialize)]

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -78,9 +78,9 @@ impl DevenvMcpServer {
         };
         let devenv = Devenv::new(devenv_options).await;
 
-        // Use empty search term to get a broad set of packages
+        // Use broad search term to get a wide set of packages
         // We'll limit results later if needed
-        let search_output = devenv.nix.search(".").await?;
+        let search_output = devenv.nix.search(".*").await?;
 
         // Parse the search results from JSON
         #[derive(Deserialize)]


### PR DESCRIPTION
- **tests: disable integration tests by default and run in ci**
- **tests: fix regex warning in mcp test**
- **tests: run the mcp tests from the project root**
- **fixup! tests: fix regex warning in mcp test**
- **mcp: run assemble beforehand**
- **tests: run mcp tests in temp dir with custom devenv.nix**
- **lint**
