### PR TITLE
mcp: fix race condition in tests

### DIFF
--- a/devenv-cache-core/src/file.rs
+++ b/devenv-cache-core/src/file.rs
@@ -251,10 +251,13 @@ mod tests {
         assert!(!tracked.is_modified().unwrap());
 
         // Modify the file
-        std::thread::sleep(std::time::Duration::from_millis(10)); // Ensure modification time changes
         {
             let mut file = File::create(&file_path).unwrap();
             file.write_all(b"modified content").unwrap();
+
+            // Set mtime to ensure it's different from original
+            let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(1);
+            file.set_modified(new_time).unwrap();
         }
 
         // Modification check should now return true

--- a/package.nix
+++ b/package.nix
@@ -40,13 +40,6 @@ rustPlatform.buildRustPackage {
 
   doCheck = !build_tasks;
 
-  # Explicitly exclude the failing tests
-  cargoTestFlags = [
-    "--"
-    "--skip=test_fetch_options_live"
-    "--skip=test_fetch_packages_live"
-  ];
-
   cargoLock = {
     lockFile = ./Cargo.lock;
   };


### PR DESCRIPTION
Continuation of #1955.

The `set_current_dir` approach is not safe when the tests are run in parallel. We explicitly provide the temp root dir to the MCP server in this case.

Removed the thread sleeps in task tests in favour of modifying the mtime to speed things up. macOS has a resolution limit of 1 second, so this should let us spend less time waiting around in tests.