### PR TITLE
fix: add `UV_PYTHON` to force uv to use the correct python

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -445,6 +445,8 @@ in
       UV_PROJECT_ENVIRONMENT = "${config.env.DEVENV_STATE}/venv";
       # Force uv not to download a Python binary when the version in pyproject.toml does not match the one installed by devenv
       UV_PYTHON_DOWNLOADS = "never";
+      # Force uv to always use the correct python interpreter.
+      UV_PYTHON = "${cfg.package.interpreter}";
     }) // (lib.optionalAttrs cfg.poetry.enable {
       # Make poetry use DEVENV_ROOT/.venv
       POETRY_VIRTUALENVS_IN_PROJECT = "true";


### PR DESCRIPTION
In this module case:

```
{
          languages.python = {
            enable = true;
            package = pkgsPinned.python;
            uv.enable = true;
          };
}
```
when I run `uv venv ...` it will take up my python version from a virtual environment (activated on shell entry by `.zshrc` etc , of course this I should avoid). But here is a simple fix which IMO was missed. 

- `uv` must always use the correct python version by forcing it to use it with `UV_PYTHON`.
- No fix for poetry so far, as poetry does not nicely play with this and is also deprecated in terms of modernity.

