### PR TITLE
Add readiness probes for elasticmq

### DIFF
--- a/examples/elasticmq/.test.sh
+++ b/examples/elasticmq/.test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+wait_for_port 9324 60
+
+curl -s http://localhost:9324/health
+
 wait_for_port 9325 60
 
 QUEUE_NAME=$(curl http://localhost:9325/statistics/queues -s | jq .[].name -r)


### PR DESCRIPTION
By default the SQS-REST endpoint will listen on port 9324. If you change this value, I give you the escape hatches to change where to ask the server `/health`. The test in `examples/` has been updated to query the server for the readiness endpoint, as well.

4 seconds may be a long time for a default installation, but that should (hopefully) be sufficient for any customized installations to finish booting.