### PR TITLE
enable submodules by default

### DIFF
--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -8,6 +8,7 @@
       pre-commit-hooks.follows = "git-hooks";
       nixpkgs.url = "github:cachix/devenv-nixpkgs/rolling";
       devenv.url = "github:cachix/devenv?dir=src/modules";
+      self.submodules = true;
       } // (if builtins.pathExists (devenv_dotfile + "/flake.json")
       then builtins.fromJSON (builtins.readFile (devenv_dotfile +  "/flake.json"))
       else { });


### PR DESCRIPTION
```
 /nix/store/ma2fs2a60gz04xsgxkdxqhqxxvinwn5h-nix-devenv-2.30.0pre20250626_afa41b0/bin/nix --extra-experimental-features flakes --option lazy-trees true --option warn-dirty false --keep-going --max-jobs 8 --option eval-cache false print-dev-env --profile /home/domen/dev/cachix/cdevenv/.devenv/gc/shell -vv --log-format internal-json
@nix {"action":"msg","level":4,"msg":"evaluating file '<nix/derivation-internal.nix>'"}
@nix {"action":"start","id":5924662571696128,"level":4,"parent":0,"text":"evaluating derivation 'git+file:///home/domen/dev/cachix/devenv#devShells.x86_64-linux.default'","type":0}
@nix {"action":"msg","level":4,"msg":"evaluating file '/home/domen/dev/cachix/devenv/.devenv.flake.nix'"}
nix: ../canon-path.cc:56: nix::CanonPath nix::CanonPath::removePrefix(const nix::CanonPath&) const: Assertion `isWithin(prefix)' failed.
Aborted (core dumped)
```