### PR TITLE
devenv: async-ify the core state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "dialoguer",
  "dotlock",
  "fd-lock",
+ "futures",
  "hex",
  "http-client-tls",
  "include_dir",

--- a/devenv-run-tests/src/main.rs
+++ b/devenv-run-tests/src/main.rs
@@ -128,7 +128,7 @@ async fn run_tests_in_directory(args: &Args) -> Result<Vec<TestResult>> {
                     ..Default::default()
                 }),
             };
-            let mut devenv = Devenv::new(options).await;
+            let devenv = Devenv::new(options).await;
 
             eprintln!("  Running {}", dir_name);
 

--- a/devenv-tasks/src/task_cache.rs
+++ b/devenv-tasks/src/task_cache.rs
@@ -271,9 +271,9 @@ impl TaskCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
     use tempfile::TempDir;
+    use tokio::fs::File;
+    use tokio::io::AsyncWriteExt;
 
     #[sqlx::test]
     async fn test_task_cache_initialization() {
@@ -299,9 +299,9 @@ mod tests {
 
         // Create a test file
         {
-            let mut file = File::create(&file_path).unwrap();
-            file.write_all(b"initial content").unwrap();
-            file.sync_all().unwrap(); // Ensure file is fully written to disk
+            let mut file = File::create(&file_path).await.unwrap();
+            file.write_all(b"initial content").await.unwrap();
+            file.sync_all().await.unwrap(); // Ensure file is fully written to disk
         }
 
         let task_name = "test_task";
@@ -326,13 +326,15 @@ mod tests {
 
         // Modify file content and set mtime to ensure detection
         {
-            let mut file = File::create(&file_path).unwrap();
-            file.write_all(b"modified content with more text").unwrap();
-            file.sync_all().unwrap(); // Force flush to filesystem
+            let mut file = File::create(&file_path).await.unwrap();
+            file.write_all(b"modified content with more text")
+                .await
+                .unwrap();
+            file.sync_all().await.unwrap(); // Force flush to filesystem
 
             // Set mtime to ensure it's different from original
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(1);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the modification
@@ -356,7 +358,7 @@ mod tests {
         let cache = TaskCache::with_db_path(db_path).await.unwrap();
         let test_temp_dir = TempDir::new().unwrap();
         let dir_path = test_temp_dir.path().join("test_dir");
-        std::fs::create_dir(&dir_path).unwrap();
+        tokio::fs::create_dir(&dir_path).await.unwrap();
 
         let task_name = "test_task_dir";
         let dir_path_str = dir_path.to_str().unwrap().to_string();
@@ -376,13 +378,13 @@ mod tests {
         // Add a new file in the directory
         let file_path = dir_path.join("test_file.txt");
         {
-            let mut file = File::create(&file_path).unwrap();
-            file.write_all(b"new file content").unwrap();
-            file.sync_all().unwrap();
+            let mut file = File::create(&file_path).await.unwrap();
+            file.write_all(b"new file content").await.unwrap();
+            file.sync_all().await.unwrap();
 
             // Set mtime to ensure directory modification is detected
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(1);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the directory modification
@@ -399,13 +401,13 @@ mod tests {
 
         // Modify an existing file
         {
-            let mut file = File::create(&file_path).unwrap();
-            file.write_all(b"modified file content").unwrap();
-            file.sync_all().unwrap();
+            let mut file = File::create(&file_path).await.unwrap();
+            file.write_all(b"modified file content").await.unwrap();
+            file.sync_all().await.unwrap();
 
             // Set mtime to ensure directory modification is detected
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the directory modification
@@ -416,12 +418,15 @@ mod tests {
 
         // Create a subdirectory and set its mtime
         let subdir_path = dir_path.join("subdir");
-        std::fs::create_dir(&subdir_path).unwrap();
+        tokio::fs::create_dir(&subdir_path).await.unwrap();
 
         // Set subdirectory mtime to ensure detection
         let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(3);
-        std::fs::File::open(&subdir_path)
+        File::open(&subdir_path)
+            .await
             .unwrap()
+            .into_std()
+            .await
             .set_modified(new_time)
             .unwrap();
 
@@ -434,13 +439,13 @@ mod tests {
         // Add a file in the subdirectory
         let subdir_file_path = subdir_path.join("nested_file.txt");
         {
-            let mut file = File::create(&subdir_file_path).unwrap();
-            file.write_all(b"nested file content").unwrap();
-            file.sync_all().unwrap();
+            let mut file = File::create(&subdir_file_path).await.unwrap();
+            file.write_all(b"nested file content").await.unwrap();
+            file.sync_all().await.unwrap();
 
             // Set mtime to ensure directory modification is detected
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(4);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the directory modification
@@ -457,11 +462,11 @@ mod tests {
 
         // Create a deeply nested directory structure
         let deep_dir1 = subdir_path.join("level1");
-        std::fs::create_dir(&deep_dir1).unwrap();
+        tokio::fs::create_dir(&deep_dir1).await.unwrap();
         let deep_dir2 = deep_dir1.join("level2");
-        std::fs::create_dir(&deep_dir2).unwrap();
+        tokio::fs::create_dir(&deep_dir2).await.unwrap();
         let deep_dir3 = deep_dir2.join("level3");
-        std::fs::create_dir(&deep_dir3).unwrap();
+        tokio::fs::create_dir(&deep_dir3).await.unwrap();
 
         // Check should detect the deep directory modification
         assert!(cache
@@ -478,13 +483,13 @@ mod tests {
         // Add a file deep in the nested structure
         let deep_file_path = deep_dir3.join("deep_file.txt");
         {
-            let mut file = File::create(&deep_file_path).unwrap();
-            file.write_all(b"deep nested file content").unwrap();
-            file.sync_all().unwrap();
+            let mut file = File::create(&deep_file_path).await.unwrap();
+            file.write_all(b"deep nested file content").await.unwrap();
+            file.sync_all().await.unwrap();
 
             // Set mtime to ensure directory modification is detected
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the deep file modification
@@ -495,16 +500,17 @@ mod tests {
 
         // Update the deep file
         {
-            let mut file = std::fs::OpenOptions::new()
+            let mut file = tokio::fs::OpenOptions::new()
                 .append(true)
                 .open(&deep_file_path)
+                .await
                 .unwrap();
-            file.write_all(b" with additional content").unwrap();
-            file.sync_all().unwrap();
+            file.write_all(b" with additional content").await.unwrap();
+            file.sync_all().await.unwrap();
 
             // Set mtime to ensure directory modification is detected
             let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(6);
-            file.set_modified(new_time).unwrap();
+            file.into_std().await.set_modified(new_time).unwrap();
         }
 
         // Check should detect the deep file update
@@ -514,7 +520,7 @@ mod tests {
             .unwrap());
 
         // Remove a deep file
-        std::fs::remove_file(&deep_file_path).unwrap();
+        tokio::fs::remove_file(&deep_file_path).await.unwrap();
 
         // Check should detect the removal
         assert!(cache
@@ -523,7 +529,7 @@ mod tests {
             .unwrap());
 
         // Remove a deep directory
-        std::fs::remove_dir(&deep_dir3).unwrap();
+        tokio::fs::remove_dir(&deep_dir3).await.unwrap();
 
         // Check should detect the directory removal
         assert!(cache

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -22,6 +22,7 @@ console.workspace = true
 dialoguer.workspace = true
 dotlock.workspace = true
 fd-lock.workspace = true
+futures.workspace = true
 hex.workspace = true
 include_dir.workspace = true
 indoc.workspace = true

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -157,13 +157,14 @@ pub struct Config {
 }
 
 // TODO: https://github.com/moonrepo/schematic/issues/105
-pub fn write_json_schema() -> Result<()> {
+pub async fn write_json_schema() -> Result<()> {
     let schema = schema_for!(Config);
     let schema = serde_json::to_string_pretty(&schema)
         .into_diagnostic()
         .wrap_err("Failed to serialize JSON schema")?;
     let path = Path::new("docs/devenv.schema.json");
-    std::fs::write(path, &schema)
+    tokio::fs::write(path, &schema)
+        .await
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to write json schema to {}", path.display()))?;
     Ok(())
@@ -185,11 +186,12 @@ impl Config {
         Ok(result?.config)
     }
 
-    pub fn write(&self) -> Result<()> {
+    pub async fn write(&self) -> Result<()> {
         let yaml = serde_yaml::to_string(&self)
             .into_diagnostic()
             .wrap_err("Failed to serialize config to YAML")?;
-        std::fs::write(YAML_CONFIG, yaml)
+        tokio::fs::write(YAML_CONFIG, yaml)
+            .await
             .into_diagnostic()
             .wrap_err("Failed to write devenv.yaml")?;
         Ok(())

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -535,7 +535,7 @@ impl Devenv {
 
     pub async fn repl(&self) -> Result<()> {
         self.assemble(false).await?;
-        self.nix.repl()
+        self.nix.repl().await
     }
 
     pub async fn gc(&self) -> Result<()> {

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -81,11 +81,13 @@ pub struct Devenv {
     devenv_tmp: String,
     devenv_runtime: PathBuf,
 
+    // Whether assemble has been run.
+    // Assemble creates critical runtime directories and files.
     assembled: Arc<AtomicBool>,
-    has_processes: Arc<RwLock<Option<bool>>>,
-
-    // Coordination primitives
+    // Semaphore to prevent multiple concurrent assembles
     assemble_lock: Arc<Semaphore>,
+
+    has_processes: Arc<RwLock<Option<bool>>>,
 
     // TODO: make private.
     // Pass as an arg or have a setter.
@@ -171,8 +173,8 @@ impl Devenv {
             devenv_runtime,
             nix: Arc::new(nix),
             assembled: Arc::new(AtomicBool::new(false)),
-            has_processes: Arc::new(RwLock::new(None)),
             assemble_lock: Arc::new(Semaphore::new(1)),
+            has_processes: Arc::new(RwLock::new(None)),
             container_name: None,
         }
     }

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -5,19 +5,19 @@ use clap::crate_version;
 use cli_table::Table;
 use cli_table::{print_stderr, WithTitle};
 use include_dir::{include_dir, Dir};
-use miette::{bail, Context, IntoDiagnostic, Result};
+use miette::{bail, miette, Context, IntoDiagnostic, Result};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
 use sha2::Digest;
 use similar::{ChangeTag, TextDiff};
 use std::collections::{BTreeMap, HashMap};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::os::unix::{fs::PermissionsExt, process::CommandExt};
-use std::{
-    fs::{self, File},
-    path::{Path, PathBuf},
-    process,
-};
+use std::path::{Path, PathBuf};
+use std::process::{Output, Stdio};
+use tokio::fs::{self, File};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process;
 use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
 
 // templates
@@ -118,7 +118,8 @@ impl Devenv {
         xdg_dirs
             .create_data_directory(Path::new("devenv"))
             .expect("Failed to create DEVENV_HOME directory");
-        std::fs::create_dir_all(&devenv_home_gc)
+        tokio::fs::create_dir_all(&devenv_home_gc)
+            .await
             .expect("Failed to create DEVENV_HOME_GC directory");
 
         // Determine backend type from config
@@ -176,9 +177,9 @@ impl Devenv {
     }
 
     pub fn init(&self, target: &Option<PathBuf>) -> Result<()> {
-        let target = target
-            .clone()
-            .unwrap_or_else(|| fs::canonicalize(".").expect("Failed to get current directory"));
+        let target = target.clone().unwrap_or_else(|| {
+            std::fs::canonicalize(".").expect("Failed to get current directory")
+        });
 
         // create directory target if not exists
         if !target.exists() {
@@ -222,16 +223,16 @@ impl Devenv {
         };
 
         // run direnv allow
-        let _ = std::process::Command::new(direnv)
+        let _ = process::Command::new(direnv)
             .arg("allow")
             .current_dir(&target)
-            .exec();
+            .spawn();
         Ok(())
     }
 
-    pub fn inputs_add(&mut self, name: &str, url: &str, follows: &[String]) -> Result<()> {
+    pub async fn inputs_add(&mut self, name: &str, url: &str, follows: &[String]) -> Result<()> {
         self.config.add_input(name, url, follows)?;
-        self.config.write()?;
+        self.config.write().await?;
         Ok(())
     }
 
@@ -287,7 +288,7 @@ impl Devenv {
         &mut self,
         cmd: &Option<String>,
         args: &[String],
-    ) -> Result<std::process::Command> {
+    ) -> Result<process::Command> {
         let DevEnv { output, .. } = self.get_dev_environment(false).await?;
 
         let bash = match self.get_bash(false).await {
@@ -298,7 +299,7 @@ impl Devenv {
             Ok(bash) => bash,
         };
 
-        let mut shell_cmd = std::process::Command::new(&bash);
+        let mut shell_cmd = process::Command::new(&bash);
         let path = self.devenv_runtime.join("shell");
 
         // Load the user's bashrc if it exists and if we're in an interactive shell.
@@ -366,30 +367,29 @@ impl Devenv {
     }
 
     pub async fn shell(mut self) -> Result<()> {
-        let mut shell_cmd = self.prepare_shell(&None, &[]).await?;
+        let shell_cmd = self.prepare_shell(&None, &[]).await?;
         let span = info_span!("entering_shell", devenv.user_message = "Entering shell",);
-        let _ = shell_cmd.exec().instrument(span);
+        let _ = shell_cmd.into_std().exec().instrument(span);
         Ok(())
     }
 
-    pub async fn exec_in_shell(
-        &mut self,
-        cmd: String,
-        args: &[String],
-    ) -> Result<std::process::Output> {
+    pub async fn exec_in_shell(&mut self, cmd: String, args: &[String]) -> Result<Output> {
         let mut shell_cmd = self.prepare_shell(&Some(cmd), args).await?;
         let span = info_span!(
             "executing_in_shell",
             devenv.user_message = "Executing in shell"
         );
-        span.in_scope(|| {
+        async move {
             shell_cmd
-                .stdin(std::process::Stdio::inherit())
-                .stdout(std::process::Stdio::inherit())
-                .stderr(std::process::Stdio::inherit())
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
                 .output()
+                .await
                 .into_diagnostic()
-        })
+        }
+        .instrument(span)
+        .await
     }
 
     pub async fn update(&mut self, input_name: &Option<String>) -> Result<()> {
@@ -465,11 +465,12 @@ impl Devenv {
 
             info!("Running {copy_script_string} {}", command_args.join(" "));
 
-            let status = std::process::Command::new(copy_script)
+            let status = process::Command::new(copy_script)
                 .args(command_args)
-                .stdout(std::process::Stdio::inherit())
-                .stderr(std::process::Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
                 .status()
+                .await
                 .expect("Failed to run copy script");
 
             if !status.success() {
@@ -505,8 +506,9 @@ impl Devenv {
                 .build(&[&format!("devenv.containers.{name}.dockerRun")], None)
                 .await?;
 
-            let status = std::process::Command::new(&run_script[0])
+            let status = process::Command::new(&run_script[0])
                 .status()
+                .await
                 .expect("Failed to run container script");
 
             if !status.success() {
@@ -587,7 +589,9 @@ impl Devenv {
             .join("doc")
             .join("nixos")
             .join("options.json");
-        let options_contents = fs::read(options_path).expect("Failed to read options.json");
+        let options_contents = fs::read(options_path)
+            .await
+            .expect("Failed to read options.json");
         let options_json: OptionResults =
             serde_json::from_slice(&options_contents).expect("Failed to parse options.json");
 
@@ -671,8 +675,9 @@ impl Devenv {
                 .await?
         };
         // parse tasks config
-        let tasks_json =
-            std::fs::read_to_string(&tasks_json_file[0]).expect("Failed to read config file");
+        let tasks_json = fs::read_to_string(&tasks_json_file[0])
+            .await
+            .expect("Failed to read config file");
         let tasks: Vec<tasks::TaskConfig> =
             serde_json::from_str(&tasks_json).expect("Failed to parse tasks config");
         // run tasks
@@ -719,12 +724,14 @@ impl Devenv {
 
         let script = format!("env > {}", env_path.to_string_lossy());
         fs::write(&script_path, script)
+            .await
             .into_diagnostic()
             .wrap_err(format!(
                 "Failed to write script to {}",
                 script_path.display()
             ))?;
-        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
+        fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .await
             .into_diagnostic()
             .wrap_err(format!(
                 "Failed to set execute permissions on {}",
@@ -734,32 +741,33 @@ impl Devenv {
         // Run script and capture its environment exports
         self.prepare_shell(&Some(script_path.to_string_lossy().into()), &[])
             .await?
-            .stderr(process::Stdio::inherit())
-            .stdout(process::Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .stdout(Stdio::inherit())
             .spawn()
             .into_diagnostic()
             .wrap_err("Failed to execute environment capture script")?
             .wait()
+            .await
             .into_diagnostic()
             .wrap_err("Failed to wait for environment capture script to complete")?;
 
         // Parse the environment variables
-        let file = File::open(&env_path).into_diagnostic().wrap_err(format!(
-            "Failed to open environment file at {}",
-            env_path.display()
-        ))?;
+        let file = File::open(&env_path)
+            .await
+            .into_diagnostic()
+            .wrap_err(format!(
+                "Failed to open environment file at {}",
+                env_path.display()
+            ))?;
         let reader = BufReader::new(file);
-        let shell_envs = reader
-            .lines()
-            .map_while(Result::ok)
-            .filter_map(|line| {
-                let mut parts = line.splitn(2, '=');
-                match (parts.next(), parts.next()) {
-                    (Some(key), Some(value)) => Some((key.to_string(), value.to_string())),
-                    _ => None,
-                }
-            })
-            .collect::<Vec<_>>();
+        let mut shell_envs = Vec::new();
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let mut parts = line.splitn(2, '=');
+            if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+                shell_envs.push((key.to_string(), value.to_string()));
+            }
+        }
 
         let config_clean = self.config.clean.clone().unwrap_or_default();
         let mut envs: HashMap<String, String> = {
@@ -824,6 +832,7 @@ impl Devenv {
                     test_script
                 ))?
                 .wait_with_output()
+                .await
                 .into_diagnostic()
                 .wrap_err("Failed to get output from test process")
         }
@@ -831,7 +840,7 @@ impl Devenv {
         .await?;
 
         if self.has_processes().await? {
-            self.down()?;
+            self.down().await?;
         }
 
         if !result.status.success() {
@@ -945,9 +954,11 @@ impl Devenv {
                 exec {proc_script_string} {processes}
             "},
             )
+            .await
             .expect("Failed to write PROCESSES_SCRIPT");
 
-            fs::set_permissions(&processes_script, fs::Permissions::from_mode(0o755))
+            fs::set_permissions(&processes_script, std::fs::Permissions::from_mode(0o755))
+                .await
                 .expect("Failed to set permissions");
 
             let mut cmd = if let Some(envs) = options.envs {
@@ -962,29 +973,33 @@ impl Devenv {
             };
 
             if options.detach {
-                let log_file =
-                    fs::File::create(self.processes_log()).expect("Failed to create PROCESSES_LOG");
                 let process = if !options.log_to_file {
-                    cmd.stdout(process::Stdio::inherit())
-                        .stderr(process::Stdio::inherit())
+                    cmd.stdout(Stdio::inherit())
+                        .stderr(Stdio::inherit())
                         .spawn()
                         .expect("Failed to spawn process")
                 } else {
+                    let log_file = std::fs::File::create(self.processes_log())
+                        .expect("Failed to create PROCESSES_LOG");
                     cmd.stdout(log_file.try_clone().expect("Failed to clone Stdio"))
                         .stderr(log_file)
                         .spawn()
                         .expect("Failed to spawn process")
                 };
 
-                fs::write(self.processes_pid(), process.id().to_string())
+                let pid = process
+                    .id()
+                    .ok_or_else(|| miette!("Failed to get process ID"))?;
+                fs::write(self.processes_pid(), pid.to_string())
+                    .await
                     .expect("Failed to write PROCESSES_PID");
-                info!("PID is {}", process.id());
+                info!("PID is {}", pid);
                 if options.log_to_file {
                     info!("See logs:  $ tail -f {}", self.processes_log().display());
                 }
                 info!("Stop:      $ devenv processes stop");
             } else {
-                let err = cmd.exec();
+                let err = cmd.into_std().exec();
                 bail!(err);
             }
             Ok(())
@@ -993,13 +1008,14 @@ impl Devenv {
         .await
     }
 
-    pub fn down(&self) -> Result<()> {
+    pub async fn down(&self) -> Result<()> {
         if !PathBuf::from(&self.processes_pid()).exists() {
             error!("No processes running.");
             bail!("No processes running");
         }
 
         let pid = fs::read_to_string(self.processes_pid())
+            .await
             .expect("Failed to read PROCESSES_PID")
             .parse::<i32>()
             .expect("Failed to parse PROCESSES_PID");
@@ -1015,7 +1031,9 @@ impl Devenv {
             }
         }
 
-        fs::remove_file(self.processes_pid()).expect("Failed to remove PROCESSES_PID");
+        fs::remove_file(self.processes_pid())
+            .await
+            .expect("Failed to remove PROCESSES_PID");
         Ok(())
     }
 
@@ -1033,7 +1051,7 @@ impl Devenv {
             "});
         }
 
-        fs::create_dir_all(&self.devenv_dot_gc).map_err(|e| {
+        fs::create_dir_all(&self.devenv_dot_gc).await.map_err(|e| {
             miette::miette!("Failed to create {}: {}", self.devenv_dot_gc.display(), e)
         })?;
 
@@ -1067,9 +1085,11 @@ impl Devenv {
             self.config.imports.join("\n"),
         )?;
 
-        fs::create_dir_all(&self.devenv_runtime).map_err(|e| {
-            miette::miette!("Failed to create {}: {}", self.devenv_runtime.display(), e)
-        })?;
+        fs::create_dir_all(&self.devenv_runtime)
+            .await
+            .map_err(|e| {
+                miette::miette!("Failed to create {}: {}", self.devenv_runtime.display(), e)
+            })?;
 
         // Create cli-options.nix if there are CLI options
         if !self.global_options.option.is_empty() {
@@ -1121,7 +1141,9 @@ impl Devenv {
             // Remove the file if it exists but there are no CLI options
             let cli_options_path = self.devenv_dotfile.join("cli-options.nix");
             if cli_options_path.exists() {
-                fs::remove_file(&cli_options_path).expect("Failed to remove cli-options.nix");
+                fs::remove_file(&cli_options_path)
+                    .await
+                    .expect("Failed to remove cli-options.nix");
             }
         }
 
@@ -1282,14 +1304,14 @@ fn cleanup_symlinks(root: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
         std::fs::create_dir_all(root).expect("Failed to create gc directory");
     }
 
-    for entry in fs::read_dir(root).expect("Failed to read directory") {
+    for entry in std::fs::read_dir(root).expect("Failed to read directory") {
         let entry = entry.expect("Failed to read entry");
         let path = entry.path();
         if path.is_symlink() {
             if !path.exists() {
                 removed_symlinks.push(path.clone());
             } else {
-                let target = fs::canonicalize(&path).expect("Failed to read link");
+                let target = std::fs::canonicalize(&path).expect("Failed to read link");
                 to_gc.push(target);
             }
         }

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -225,7 +225,10 @@ async fn main() -> Result<()> {
                 .wrap_err("Failed to generate JSON schema")?;
             Ok(())
         }
-        Commands::Mcp {} => devenv::mcp::run_mcp_server(devenv.config).await,
+        Commands::Mcp {} => {
+            let config = devenv.config.lock().await.clone();
+            devenv::mcp::run_mcp_server(config).await
+        }
         Commands::Direnvrc => unreachable!(),
         Commands::Version => unreachable!(),
     }

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -188,7 +188,7 @@ async fn main() -> Result<()> {
             }
         },
         Commands::Search { name } => devenv.search(&name).await,
-        Commands::Gc {} => devenv.gc(),
+        Commands::Gc {} => devenv.gc().await,
         Commands::Info {} => devenv.info().await,
         Commands::Repl {} => devenv.repl().await,
         Commands::Build { attributes } => devenv.build(&attributes).await,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -226,7 +226,7 @@ async fn main() -> Result<()> {
             Ok(())
         }
         Commands::Mcp {} => {
-            let config = devenv.config.lock().await.clone();
+            let config = devenv.config.read().await.clone();
             devenv::mcp::run_mcp_server(config).await
         }
         Commands::Direnvrc => unreachable!(),

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -206,19 +206,23 @@ async fn main() -> Result<()> {
         }
         Commands::Processes {
             command: ProcessesCommand::Down {},
-        } => devenv.down(),
+        } => devenv.down().await,
         Commands::Tasks { command } => match command {
             TasksCommand::Run { tasks, mode } => devenv.tasks_run(tasks, mode).await,
         },
         Commands::Inputs { command } => match command {
-            InputsCommand::Add { name, url, follows } => devenv.inputs_add(&name, &url, &follows),
+            InputsCommand::Add { name, url, follows } => {
+                devenv.inputs_add(&name, &url, &follows).await
+            }
         },
 
         // hidden
         Commands::Assemble => devenv.assemble(false).await,
         Commands::PrintDevEnv { json } => devenv.print_dev_env(json).await,
         Commands::GenerateJSONSchema => {
-            config::write_json_schema().wrap_err("Failed to generate JSON schema")?;
+            config::write_json_schema()
+                .await
+                .wrap_err("Failed to generate JSON schema")?;
             Ok(())
         }
         Commands::Mcp {} => devenv::mcp::run_mcp_server(devenv.config).await,

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -89,7 +89,7 @@ impl DevenvMcpServer {
 
         // Use broad search term to get a wide set of packages
         // We'll limit results later if needed
-        let search_output = devenv.nix.lock().await.search(".*").await?;
+        let search_output = devenv.nix.search(".*").await?;
 
         // Parse the search results from JSON
         #[derive(Deserialize)]
@@ -150,8 +150,6 @@ impl DevenvMcpServer {
 
         let options_paths = devenv
             .nix
-            .lock()
-            .await
             .build(&["optionsJSON"], Some(build_options))
             .await?;
 

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -82,14 +82,14 @@ impl DevenvMcpServer {
             devenv_root: self.devenv_root.clone(),
             ..Default::default()
         };
-        let mut devenv = Devenv::new(devenv_options).await;
+        let devenv = Devenv::new(devenv_options).await;
 
         // Assemble the devenv to create required flake files
         devenv.assemble(true).await?;
 
         // Use broad search term to get a wide set of packages
         // We'll limit results later if needed
-        let search_output = devenv.nix.search(".*").await?;
+        let search_output = devenv.nix.lock().await.search(".*").await?;
 
         // Parse the search results from JSON
         #[derive(Deserialize)]
@@ -136,7 +136,7 @@ impl DevenvMcpServer {
             devenv_root: self.devenv_root.clone(),
             ..Default::default()
         };
-        let mut devenv = Devenv::new(devenv_options).await;
+        let devenv = Devenv::new(devenv_options).await;
 
         // Assemble the devenv to create required flake files
         devenv.assemble(true).await?;
@@ -150,6 +150,8 @@ impl DevenvMcpServer {
 
         let options_paths = devenv
             .nix
+            .lock()
+            .await
             .build(&["optionsJSON"], Some(build_options))
             .await?;
 

--- a/devenv/src/nix.rs
+++ b/devenv/src/nix.rs
@@ -133,7 +133,7 @@ impl Nix {
         Ok(())
     }
 
-    pub fn repl(&self) -> Result<()> {
+    pub async fn repl(&self) -> Result<()> {
         let mut cmd = self.prepare_command("nix", &["repl", "."], &self.options)?;
         let _ = cmd.exec();
         Ok(())
@@ -888,8 +888,8 @@ impl NixBackend for Nix {
         self.add_gc(name, path).await
     }
 
-    fn repl(&self) -> Result<()> {
-        self.repl()
+    async fn repl(&self) -> Result<()> {
+        self.repl().await
     }
 
     async fn build(

--- a/devenv/src/nix.rs
+++ b/devenv/src/nix.rs
@@ -248,7 +248,7 @@ impl Nix {
         .await
     }
 
-    pub fn gc(&self, paths: Vec<PathBuf>) -> Result<()> {
+    pub async fn gc(&self, paths: Vec<PathBuf>) -> Result<()> {
         let paths: std::collections::HashSet<&str> = paths
             .iter()
             .filter_map(|path_buf| path_buf.to_str())
@@ -256,9 +256,8 @@ impl Nix {
         for path in paths {
             info!("Deleting {}...", path);
             let args: Vec<&str> = ["store", "delete", path].to_vec();
-            let cmd = self.prepare_command("nix", &args, &self.options);
             // we ignore if this command fails, because root might be in use
-            let _ = cmd?.output();
+            let _ = self.run_nix("nix", &args, &self.options).await;
         }
         Ok(())
     }
@@ -917,8 +916,8 @@ impl NixBackend for Nix {
         self.search(name).await
     }
 
-    fn gc(&self, paths: Vec<PathBuf>) -> Result<()> {
-        self.gc(paths)
+    async fn gc(&self, paths: Vec<PathBuf>) -> Result<()> {
+        self.gc(paths).await
     }
 
     fn name(&self) -> &'static str {

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -66,7 +66,7 @@ impl Default for Options {
 
 /// Trait defining the interface for Nix evaluation backends
 #[async_trait(?Send)]
-pub trait NixBackend {
+pub trait NixBackend: Send + Sync {
     /// Initialize and assemble the backend (e.g., set up database connections)
     async fn assemble(&mut self) -> Result<()>;
 

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -68,7 +68,7 @@ impl Default for Options {
 #[async_trait(?Send)]
 pub trait NixBackend: Send + Sync {
     /// Initialize and assemble the backend (e.g., set up database connections)
-    async fn assemble(&mut self) -> Result<()>;
+    async fn assemble(&self) -> Result<()>;
 
     /// Get the development environment
     async fn dev_env(&self, json: bool, gc_root: &Path) -> Result<Output>;

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -77,7 +77,7 @@ pub trait NixBackend: Send + Sync {
     async fn add_gc(&self, name: &str, path: &Path) -> Result<()>;
 
     /// Open a Nix REPL
-    fn repl(&self) -> Result<()>;
+    async fn repl(&self) -> Result<()>;
 
     /// Build the specified attributes
     async fn build(&self, attributes: &[&str], options: Option<Options>) -> Result<Vec<PathBuf>>;

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -95,7 +95,7 @@ pub trait NixBackend: Send + Sync {
     async fn search(&self, name: &str) -> Result<Output>;
 
     /// Garbage collect the specified paths
-    fn gc(&self, paths: Vec<PathBuf>) -> Result<()>;
+    async fn gc(&self, paths: Vec<PathBuf>) -> Result<()>;
 
     /// Get the backend name (for debugging/logging)
     fn name(&self) -> &'static str;

--- a/devenv/src/snix_backend.rs
+++ b/devenv/src/snix_backend.rs
@@ -173,7 +173,7 @@ impl NixBackend for SnixBackend {
         bail!("Package search is not yet implemented for Snix backend")
     }
 
-    fn gc(&self, _paths: Vec<PathBuf>) -> Result<()> {
+    async fn gc(&self, _paths: Vec<PathBuf>) -> Result<()> {
         // TODO: Implement garbage collection
         warn!("Garbage collection not yet implemented for Snix backend");
         Ok(())

--- a/devenv/src/snix_backend.rs
+++ b/devenv/src/snix_backend.rs
@@ -118,7 +118,7 @@ impl SnixBackend {
 
 #[async_trait(?Send)]
 impl NixBackend for SnixBackend {
-    async fn assemble(&mut self) -> Result<()> {
+    async fn assemble(&self) -> Result<()> {
         // Initialize the evaluator on first use
         self.init_evaluator().await?;
         Ok(())

--- a/devenv/src/snix_backend.rs
+++ b/devenv/src/snix_backend.rs
@@ -133,7 +133,7 @@ impl NixBackend for SnixBackend {
         Ok(())
     }
 
-    fn repl(&self) -> Result<()> {
+    async fn repl(&self) -> Result<()> {
         // TODO: Implement REPL functionality
         bail!("REPL is not yet implemented for Snix backend")
     }


### PR DESCRIPTION
We have a few places in the codebase that are, as they say, embarrassingly parallel. But any effort to improve on that is hindered by the use of `mut self`, both in the devenv struct and in the Nix backend.

This PR removes those limitations allowing both devenv and nix commands to be called concurrently.