### PR TITLE
feat: add all-groups for Python dependency

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -9272,8 +9272,6 @@ boolean
 
 ## git-hooks.hooks.pylint.description
 
-
-
 Description of the hook. Used for metadata purposes only.
 
 
@@ -11391,8 +11389,6 @@ string
 
 
 ## git-hooks.hooks.yamllint.settings.format
-
-
 
 Format for parsing output.
 
@@ -14413,6 +14409,27 @@ boolean
 
 
 
+## languages.python.poetry.install.allGroups
+
+
+
+Whether to install all groups. See ` --all-groups `.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/python.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/python.nix)
+
+
+
 ## languages.python.poetry.install.compile
 
 
@@ -14680,6 +14697,27 @@ boolean
 
 
 Whether to install all extras. See ` --all-extras `.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/python.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/python.nix)
+
+
+
+## languages.python.uv.sync.allGroups
+
+
+
+Whether to install all groups. See ` --all-groups `.
 
 
 
@@ -18536,8 +18574,6 @@ signed integer
 
 
 ## services.elasticsearch.single_node
-
-
 
 Start a single-node cluster
 
@@ -23526,8 +23562,6 @@ package
 
 
 ## services.tideways.environment
-
-
 
 Sets the Environment for Tideways Daemon.
 

--- a/docs/supported-languages/python.md
+++ b/docs/supported-languages/python.md
@@ -212,6 +212,24 @@ boolean
 
 
 
+## languages\.python\.poetry\.install\.allGroups
+
+
+
+Whether to install all groups\. See ` --all-groups `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
 ## languages\.python\.poetry\.install\.compile
 
 
@@ -443,6 +461,24 @@ boolean
 
 
 Whether to install all extras\. See ` --all-extras `\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
+## languages\.python\.uv\.sync\.allGroups
+
+
+
+Whether to install all groups\. See ` --all-groups `\.
 
 
 

--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -139,6 +139,11 @@ let
         UV_SYNC_COMMAND+=(--group "${group}")
       '') cfg.uv.sync.groups}
 
+      # Add all-groups flag if enabled
+      ${lib.optionalString cfg.uv.sync.allGroups ''
+        UV_SYNC_COMMAND+=(--all-groups)
+      ''}
+
       # Avoid running "uv sync" for every shell.
       # Only run it when the "pyproject.toml" file or Python interpreter has changed.
       local ACTUAL_UV_CHECKSUM="${package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 pyproject.toml):''${UV_SYNC_COMMAND[@]}"
@@ -343,6 +348,11 @@ in
           default = [ ];
           description = "Which dependency groups to install. See `--group`.";
         };
+        allGroups = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to install all groups. See `--all-groups`.";
+        };
       };
     };
 
@@ -391,6 +401,11 @@ in
           default = [ ];
           description = "Which dependency groups to exclusively install. See `--only`.";
         };
+        allGroups = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to install all groups. See `--all-groups`.";
+        };
         extras = lib.mkOption {
           type = lib.types.listOf lib.types.str;
           default = [ ];
@@ -431,6 +446,7 @@ in
       lib.optionals (cfg.poetry.install.groups != [ ]) [ "--with" ''"${lib.concatStringsSep "," cfg.poetry.install.groups}"'' ] ++
       lib.optionals (cfg.poetry.install.ignoredGroups != [ ]) [ "--without" ''"${lib.concatStringsSep "," cfg.poetry.install.ignoredGroups}"'' ] ++
       lib.optionals (cfg.poetry.install.onlyGroups != [ ]) [ "--only" ''"${lib.concatStringsSep " " cfg.poetry.install.onlyGroups}"'' ] ++
+      lib.optional cfg.poetry.install.allGroups "--all-groups" ++
       lib.optionals (cfg.poetry.install.extras != [ ]) [ "--extras" ''"${lib.concatStringsSep " " cfg.poetry.install.extras}"'' ] ++
       lib.optional cfg.poetry.install.allExtras "--all-extras" ++
       lib.optional (cfg.poetry.install.verbosity == "little") "-v" ++

--- a/tests/python-uv-sync-all-groups/devenv.nix
+++ b/tests/python-uv-sync-all-groups/devenv.nix
@@ -1,0 +1,13 @@
+{ pkgs, config, inputs, ... }: {
+  languages.python = {
+    enable = true;
+    venv.enable = true;
+    uv = {
+      enable = true;
+      sync = {
+        enable = true;
+        allGroups = true;
+      };
+    };
+  };
+}

--- a/tests/python-uv-sync-all-groups/pyproject.toml
+++ b/tests/python-uv-sync-all-groups/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "python-uv-sync-all-groups"
+version = "0.1.0"
+description = "Test project for uv sync with dependency groups"
+authors = [{ name = "Claude", email = "claude@anthropic.com" }]
+dependencies = ["requests"]
+
+[dependency-groups]
+test = ["pytest", "pytest-cov"]
+docs = ["sphinx", "sphinx-rtd-theme"]


### PR DESCRIPTION
This PR adds support for the `--all-groups` flag in devenv's Python module, allowing users to install all dependency groups defined in their `pyproject.toml` file with a single flag.

Currently, devenv supports the `--all-extras` flag to install all optional dependencies, but there's no equivalent functionality for dependency groups. Users who want to install all groups must specify each one individually, which can be cumbersome when working with projects that have multiple dependency groups.

## Changes

- Added a new `allGroups` option to the Python module configuration
- When `allGroups` is enabled, the `--all-groups` flag is passed to the underlying package manager commands
- The implementation follows the same pattern as the existing `--all-extras` functionality

## Uv

Docs: https://docs.astral.sh/uv/reference/cli/#uv-sync--all-groups

```bash
$ uv sync --all-groups
$ uv sync --help | grep groups
      --no-default-groups                        Ignore the default dependency groups
      --all-groups                               Include dependencies from all dependency groups
````

### Usage

```nix
{
  languages.python = {
    enable = true;
    vent.enable = true;
    uv.enable = true;
    uv.sync.enable = true;
    uv.sync.allGroups = true;
  };
}
```

## Poetry

Docs: https://python-poetry.org/docs/cli/#install

```bash
$ poetry install --all-groups
$ poetry install --help | grep groups
      --without=WITHOUT      The dependency groups to ignore. (multiple values allowed)
      --with=WITH            The optional dependency groups to include. (multiple values allowed)
      --only=ONLY            The only dependency groups to include. (multiple values allowed)
      --sync                 Synchronize the environment with the locked packages and the specified groups. (Deprecated)
      --all-groups           Install dependencies from all groups.
````

### Usage

```nix
{
  languages.python = {
    enable = true;
    poetry.enable = true;
    poetry.install.allGroups = true;
  };
}
```
