### PR TITLE
rust: make the mold linker opt-in

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -15320,9 +15320,10 @@ list of string
 
 
 
-Enable mold as the linker.
+Use [mold](https://github.com/rui314/mold) as the linker.
 
-Enabled by default on x86_64 Linux machines when no cross-compilation targets are specified.
+mold is a faster drop-in replacement for existing Unix linkers.
+It is several times quicker than the LLVM lld linker.
 
 
 
@@ -15332,7 +15333,7 @@ boolean
 
 
 *Default:*
-` pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && languages.rust.targets == [ ] `
+` false `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix)

--- a/docs/supported-languages/rust.md
+++ b/docs/supported-languages/rust.md
@@ -67,9 +67,10 @@ list of string
 
 
 
-Enable mold as the linker\.
+Use [mold](https://github\.com/rui314/mold) as the linker\.
 
-Enabled by default on x86_64 Linux machines when no cross-compilation targets are specified\.
+mold is a faster drop-in replacement for existing Unix linkers\.
+It is several times quicker than the LLVM lld linker\.
 
 
 
@@ -79,7 +80,7 @@ boolean
 
 
 *Default:*
-` pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && languages.rust.targets == [ ] `
+` false `
 
 
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -92,13 +92,12 @@ in
 
     mold.enable = lib.mkOption {
       type = lib.types.bool;
-      default = pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && cfg.targets == [ ];
-      defaultText =
-        lib.literalExpression "pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64 && languages.rust.targets == [ ]";
+      default = false;
       description = ''
-        Enable mold as the linker.
+        Use [mold](https://github.com/rui314/mold) as the linker.
 
-        Enabled by default on x86_64 Linux machines when no cross-compilation targets are specified.
+        mold is a faster drop-in replacement for existing Unix linkers.
+        It is several times quicker than the LLVM lld linker.
       '';
     };
 


### PR DESCRIPTION
This feature should be opt-in because we can't guarantee it will work by default.

Examples:

- #1951 If RUSTFLAGS is set, cargo will skip reading .cargo/config.toml.
- #1684 Building for an architecture which doesn't have an explicit target and uses a custom toolchain linker.