### PR TITLE
devenv: support `pkg` as a type for `--option`

### DIFF
--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -166,7 +166,7 @@ pub struct GlobalOptions {
         num_args = 2,
         value_names = ["OPTION", "VALUE"],
         help = "Override configuration options with typed values",
-        long_help = "Override configuration options with typed values.\n\nOPTION must include a type: <attribute>:<type>\nSupported types: string, int, float, bool, path, pkgs\n\nExamples:\n  --option languages.rust.channel:string beta\n  --option services.postgres.enable:bool true\n  --option languages.python.version:string 3.10\n  --option packages:pkgs \"ncdu git\""
+        long_help = "Override configuration options with typed values.\n\nOPTION must include a type: <attribute>:<type>\nSupported types: string, int, float, bool, path, pkg, pkgs\n\nExamples:\n  --option languages.rust.channel:string beta\n  --option services.postgres.enable:bool true\n  --option languages.python.version:string 3.10\n  --option packages:pkgs \"ncdu git\""
     )]
     pub option: Vec<String>,
 }

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -1075,7 +1075,8 @@ impl Devenv {
         if !self.global_options.option.is_empty() {
             let mut cli_options = String::from("{ pkgs, lib, config, ... }: {\n");
 
-            const SUPPORTED_TYPES: &[&str] = &["string", "int", "float", "bool", "path", "pkgs"];
+            const SUPPORTED_TYPES: &[&str] =
+                &["string", "int", "float", "bool", "path", "pkg", "pkgs"];
 
             for chunk in self.global_options.option.chunks_exact(2) {
                 // Parse the path and type from the first value
@@ -1095,6 +1096,7 @@ impl Devenv {
                     "float" => chunk[1].clone(),
                     "bool" => chunk[1].clone(), // true/false will work directly in Nix
                     "path" => format!("./{}", &chunk[1]), // relative path
+                    "pkg" => format!("pkgs.{}", &chunk[1]),
                     "pkgs" => {
                         // Split by whitespace and format as a Nix list of package references
                         let items = chunk[1]


### PR DESCRIPTION
For example:

`devenv shell --option "languages.java.jdk.package" "graalvm-oracle"`

Fixes #1987.