### PR TITLE
devenv: protect internal Nix builds from untimely GC

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -437,9 +437,10 @@ impl Devenv {
         async move {
             self.assemble(false).await?;
 
+            let sanitized_name = sanitize_container_name(name);
             let gc_root = self
                 .devenv_dot_gc
-                .join(format!("container-{name}-derivation"));
+                .join(format!("container-{sanitized_name}-derivation"));
             let paths = self
                 .nix
                 .build(
@@ -471,7 +472,10 @@ impl Devenv {
         );
 
         async move {
-            let gc_root = self.devenv_dot_gc.join(format!("container-{name}-copy"));
+            let sanitized_name = sanitize_container_name(name);
+            let gc_root = self
+                .devenv_dot_gc
+                .join(format!("container-{sanitized_name}-copy"));
             let paths = self
                 .nix
                 .build(
@@ -527,7 +531,10 @@ impl Devenv {
         );
 
         async move {
-            let gc_root = self.devenv_dot_gc.join(format!("container-{name}-run"));
+            let sanitized_name = sanitize_container_name(name);
+            let gc_root = self
+                .devenv_dot_gc
+                .join(format!("container-{sanitized_name}-run"));
             let paths = self
                 .nix
                 .build(
@@ -1352,6 +1359,12 @@ struct DevenvPackageResult {
     version: String,
     #[table(title = "Description")]
     description: String,
+}
+
+fn sanitize_container_name(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+        .collect::<String>()
 }
 
 fn cleanup_symlinks(root: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -439,11 +439,11 @@ impl Devenv {
 
             let gc_root = self
                 .devenv_dot_gc
-                .join(format!("container-{}-derivation", name));
+                .join(format!("container-{name}-derivation"));
             let paths = self
                 .nix
                 .build(
-                    &[&format!("devenv.containers.{}.derivation", name)],
+                    &[&format!("devenv.containers.{name}.derivation")],
                     None,
                     Some(&gc_root),
                 )
@@ -471,11 +471,11 @@ impl Devenv {
         );
 
         async move {
-            let gc_root = self.devenv_dot_gc.join(format!("container-{}-copy", name));
+            let gc_root = self.devenv_dot_gc.join(format!("container-{name}-copy"));
             let paths = self
                 .nix
                 .build(
-                    &[&format!("devenv.containers.{}.copyScript", name)],
+                    &[&format!("devenv.containers.{name}.copyScript")],
                     None,
                     Some(&gc_root),
                 )
@@ -527,11 +527,11 @@ impl Devenv {
         );
 
         async move {
-            let gc_root = self.devenv_dot_gc.join(format!("container-{}-run", name));
+            let gc_root = self.devenv_dot_gc.join(format!("container-{name}-run"));
             let paths = self
                 .nix
                 .build(
-                    &[&format!("devenv.containers.{}.dockerRun", name)],
+                    &[&format!("devenv.containers.{name}.dockerRun")],
                     None,
                     Some(&gc_root),
                 )

--- a/devenv/src/mcp.rs
+++ b/devenv/src/mcp.rs
@@ -150,7 +150,7 @@ impl DevenvMcpServer {
 
         let options_paths = devenv
             .nix
-            .build(&["optionsJSON"], Some(build_options))
+            .build(&["optionsJSON"], Some(build_options), None)
             .await?;
 
         // Read the options.json file from the build result

--- a/devenv/src/nix.rs
+++ b/devenv/src/nix.rs
@@ -123,6 +123,8 @@ impl Nix {
     /// You should prefer protecting build outputs with options like `--out-link` to avoid race conditions.
     /// A untimely GC run -- the usual culprit is auto-gc with min-free -- could delete the store
     /// path you're trying to protect.
+    ///
+    /// The `build` command supports an optional `gc_root` argument.
     pub async fn add_gc(&self, name: &str, path: &Path) -> Result<()> {
         self.run_nix(
             "nix-store",

--- a/devenv/src/nix.rs
+++ b/devenv/src/nix.rs
@@ -116,6 +116,13 @@ impl Nix {
         Ok(env)
     }
 
+    /// Add a GC root for the given path.
+    ///
+    /// SAFETY
+    ///
+    /// You should prefer protecting build outputs with options like `--out-link` to avoid race conditions.
+    /// A untimely GC run -- the usual culprit is auto-gc with min-free -- could delete the store
+    /// path you're trying to protect.
     pub async fn add_gc(&self, name: &str, path: &Path) -> Result<()> {
         self.run_nix(
             "nix-store",
@@ -935,6 +942,15 @@ impl NixBackend for Nix {
         options: &nix_backend::Options,
     ) -> Result<devenv_eval_cache::Output> {
         self.run_nix(command, args, options).await
+    }
+
+    async fn run_nix_with_substituters(
+        &self,
+        command: &str,
+        args: &[&str],
+        options: &nix_backend::Options,
+    ) -> Result<devenv_eval_cache::Output> {
+        self.run_nix_with_substituters(command, args, options).await
     }
 }
 

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -74,6 +74,14 @@ pub trait NixBackend: Send + Sync {
     async fn dev_env(&self, json: bool, gc_root: &Path) -> Result<Output>;
 
     /// Add a garbage collection root
+    ///
+    /// SAFETY (cnix)
+    ///
+    /// You should prefer protecting build outputs with options like `--out-link` to avoid race conditions.
+    /// A untimely GC run -- the usual culprit is auto-gc with min-free -- could delete the store
+    /// path you're trying to protect.
+    ///
+    /// The `build` command supports an optional `gc_root` argument.
     async fn add_gc(&self, name: &str, path: &Path) -> Result<()>;
 
     /// Open a Nix REPL

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -102,4 +102,12 @@ pub trait NixBackend: Send + Sync {
 
     /// Run a nix command
     async fn run_nix(&self, command: &str, args: &[&str], options: &Options) -> Result<Output>;
+
+    /// Run a nix command with substituters
+    async fn run_nix_with_substituters(
+        &self,
+        command: &str,
+        args: &[&str],
+        options: &Options,
+    ) -> Result<Output>;
 }

--- a/devenv/src/nix_backend.rs
+++ b/devenv/src/nix_backend.rs
@@ -80,7 +80,12 @@ pub trait NixBackend: Send + Sync {
     async fn repl(&self) -> Result<()>;
 
     /// Build the specified attributes
-    async fn build(&self, attributes: &[&str], options: Option<Options>) -> Result<Vec<PathBuf>>;
+    async fn build(
+        &self,
+        attributes: &[&str],
+        options: Option<Options>,
+        gc_root: Option<&Path>,
+    ) -> Result<Vec<PathBuf>>;
 
     /// Evaluate a Nix expression
     async fn eval(&self, attributes: &[&str]) -> Result<String>;

--- a/devenv/src/snix_backend.rs
+++ b/devenv/src/snix_backend.rs
@@ -187,4 +187,14 @@ impl NixBackend for SnixBackend {
         // Snix doesn't use external nix commands
         bail!("Snix backend doesn't use external nix commands")
     }
+
+    async fn run_nix_with_substituters(
+        &self,
+        _command: &str,
+        _args: &[&str],
+        _options: &Options,
+    ) -> Result<Output> {
+        // Snix doesn't use external nix commands
+        bail!("Snix backend doesn't use external nix commands")
+    }
 }

--- a/devenv/src/snix_backend.rs
+++ b/devenv/src/snix_backend.rs
@@ -138,7 +138,12 @@ impl NixBackend for SnixBackend {
         bail!("REPL is not yet implemented for Snix backend")
     }
 
-    async fn build(&self, _attributes: &[&str], _options: Option<Options>) -> Result<Vec<PathBuf>> {
+    async fn build(
+        &self,
+        _attributes: &[&str],
+        _options: Option<Options>,
+        _gc_root: Option<&Path>,
+    ) -> Result<Vec<PathBuf>> {
         // TODO: This requires implementing the build functionality
         // using snix_glue::snix_build
         bail!("Build functionality is not yet implemented for Snix backend")


### PR DESCRIPTION
The `add_gc` approach we use doesn't protect us from Nix garbage-collecting the store path between running `nix build` and calling `add_gc`. This approach uses `out-link` instead to hopefully reduce the risk of losing store paths to auto-gc.

This is particularly important for our CI. The machine to watch is the aarch64-darwin runner, which has a disk much too small for what we're asking it to do 🙃 