### PR TITLE
tests: test flake-related edge-cases with git repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,8 @@ dependencies = [
  "clap",
  "devenv",
  "miette",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "tokio",
 ]

--- a/devenv-eval-cache/src/lib.rs
+++ b/devenv-eval-cache/src/lib.rs
@@ -12,6 +12,13 @@ pub use command::{
 /// These tests require the `integration-tests` feature flag and the `DEVENV_NIX`
 /// environment variable pointing to a Nix installation directory.
 ///
+/// These tests do *not* cover flake-related edge-cases.
+/// For example, this will not catch path resolution issues due to evaluation
+/// restrictions/deficiencies in flakes.
+///
+/// Such behaviours are best tested by devenv-run-tests.
+/// See tests/eval-cache-*
+///
 /// To run these tests:
 /// ```bash
 /// DEVENV_NIX=/path/to/nix cargo test --features integration-tests

--- a/devenv-run-tests/Cargo.toml
+++ b/devenv-run-tests/Cargo.toml
@@ -10,3 +10,5 @@ devenv.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 miette.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true

--- a/devenv-run-tests/README.md
+++ b/devenv-run-tests/README.md
@@ -1,0 +1,191 @@
+# devenv-run-tests
+
+A test runner for devenv that executes integration tests in isolated environments.
+
+## Overview
+
+`devenv-run-tests` runs integration tests by:
+1. Creating temporary directories for each test
+2. Copying test files to the temporary directory
+3. Setting up the devenv environment
+4. Running test scripts in the devenv shell
+5. Reporting results
+
+## Usage
+
+```bash
+# Run all tests in default directories (examples/ and tests/)
+devenv-run-tests
+
+# Run tests in specific directories
+devenv-run-tests path/to/tests another/path
+
+# Run only specific tests
+devenv-run-tests --only test1 --only test2
+
+# Exclude specific tests
+devenv-run-tests --exclude flaky-test --exclude slow-test
+
+# Override inputs in devenv.yaml
+devenv-run-tests --override-input nixpkgs github:NixOS/nixpkgs/nixos-unstable
+```
+
+## Test Structure
+
+Each test is a directory containing:
+- `devenv.nix` - The devenv configuration
+- `devenv.yaml` - Input specifications (optional)
+- Additional test files and scripts
+
+### Test Execution Files
+
+#### `.test.sh` (Optional)
+An optional test script that defines custom test logic. This script runs inside the devenv shell. If not present, the test runner will use `devenv test` which executes the `enterTest` defined in your `devenv.nix`.
+
+```bash
+#!/usr/bin/env bash
+set -ex
+
+# Your test logic here
+echo "Running test..."
+some-command
+```
+
+#### `.setup.sh` (Optional)
+A setup script that runs inside the devenv shell before the test. Use this to prepare the environment or install dependencies.
+
+```bash
+#!/usr/bin/env bash
+set -ex
+
+# Setup logic here
+npm install
+createdb myapp
+```
+
+#### `.patch.sh` (Optional)
+A patch script that runs in the working directory before the devenv shell is created. Use this to modify files before devenv evaluation.
+
+```bash
+#!/usr/bin/env bash
+set -ex
+
+# Patch files before devenv starts
+echo 'additional-config' >> devenv.nix
+sed -i 's/old-value/new-value/' some-file.txt
+```
+
+#### `.test-config.yml` or `.test-config.yaml` (Optional)
+A YAML configuration file that controls test behavior.
+
+```yaml
+# Whether to initialize a git repository for the test
+# Default: true
+git_init: false
+```
+
+## Test Configuration
+
+### Git Repository Behavior
+
+By default, each test runs in a temporary directory with a fresh git repository. This helps:
+- Nix Flakes find the project root
+- git-hooks tests work correctly
+- Tests run in isolation
+
+To disable git repository creation for a test, create a `.test-config.yml` file:
+
+```yaml
+git_init: false
+```
+
+This is useful for:
+- Testing behavior outside of git repositories
+- Testing flake evaluation without git context
+- Debugging caching issues that only occur in non-git environments
+
+## Execution Order
+
+For each test directory, devenv-run-tests:
+
+1. **Copies test files** to a temporary directory
+2. **Changes to the temporary directory**
+3. **Runs `.patch.sh`** (if present) in the working directory
+4. **Initializes git repository** (if `git_init: true` in config)
+5. **Sets up devenv environment**
+6. **Runs `.setup.sh`** (if present) inside the devenv shell
+7. **Runs test**: Either `.test.sh` (if present) or `devenv test` (which executes `enterTest` from `devenv.nix`)
+8. **Reports test results**
+
+## Examples
+
+### Basic Test (using enterTest)
+```
+tests/my-test/
+├── devenv.nix     # Contains enterTest definition
+└── devenv.yaml
+```
+
+### Basic Test (using custom script)
+```
+tests/my-test/
+├── devenv.nix
+├── devenv.yaml
+└── .test.sh       # Custom test script
+```
+
+### Test with Setup
+```
+tests/database-test/
+├── devenv.nix
+├── devenv.yaml
+├── .setup.sh      # Initialize database
+└── .test.sh       # Run database tests
+```
+
+### Test without Git
+```
+tests/no-git-test/
+├── devenv.nix
+├── devenv.yaml
+├── .test-config.yml   # git_init: false
+└── .test.sh
+```
+
+### Test with Patching
+```
+tests/patch-test/
+├── devenv.nix
+├── devenv.yaml
+├── .patch.sh      # Modify files before devenv
+└── .test.sh
+```
+
+## Environment Variables
+
+- `DEVENV_NIX` - Path to the custom Nix build (required)
+- `DEVENV_RUN_TESTS` - Internal flag to control test execution
+
+## Exit Codes
+
+- `0` - All tests passed
+- `1` - One or more tests failed
+
+## Output
+
+The test runner provides:
+- Progress indicators for each test
+- Summary of passed/failed tests
+- Details about failed tests
+
+```
+Running Tests
+Running in directory tests
+  Running my-test
+  Running database-test
+  Running no-git-test
+
+my-test: Failed
+
+Ran 3 tests, 1 failed.
+```

--- a/tests/eval-cache-git/.test.sh
+++ b/tests/eval-cache-git/.test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -ex
+
+# This test verifies eval cache behavior inside git repositories
+echo "Testing eval cache inside git repo..."
+
+# Verify we're in a git repository
+if [ ! -d .git ]; then
+    echo "ERROR: Not in a git repository!"
+    exit 1
+fi
+
+# Run devenv shell to trigger evaluation and caching
+echo "Running devenv shell..."
+devenv shell echo hello
+
+# Verify that .devenv/input-paths.txt exists and contains our test file
+if [ ! -f .devenv/input-paths.txt ]; then
+    echo "ERROR: .devenv/input-paths.txt not found!"
+    exit 1
+fi
+
+echo "Contents of .devenv/input-paths.txt:"
+cat .devenv/input-paths.txt
+
+# Check if our test file is tracked in input-paths.txt
+if grep -q "test-file.txt" .devenv/input-paths.txt; then
+    echo "SUCCESS: test-file.txt found in input-paths.txt"
+else
+    echo "ERROR: test-file.txt not found in input-paths.txt"
+    echo "This suggests the file dependency was not detected"
+    exit 1
+fi
+
+echo "Test completed successfully!"

--- a/tests/eval-cache-git/README.md
+++ b/tests/eval-cache-git/README.md
@@ -1,0 +1,1 @@
+This test verifies eval cache functionality inside git repositories, which tests edge-cases related to flake restrictions and lazy-trees.

--- a/tests/eval-cache-git/devenv.nix
+++ b/tests/eval-cache-git/devenv.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  # Read a file to test caching behavior
+  fileContent = builtins.readFile ./test-file.txt;
+in
+{
+  # Create a simple environment for testing
+  packages = [ ];
+
+  # Use the file content in the environment
+  env.FILE_CONTENT = fileContent;
+
+  # Define a test that verifies the file was read
+  enterTest = ''
+    echo "File content: $FILE_CONTENT"
+    echo "Testing eval cache behavior..."
+  '';
+}

--- a/tests/eval-cache-git/test-file.txt
+++ b/tests/eval-cache-git/test-file.txt
@@ -1,0 +1,1 @@
+Hello from test file

--- a/tests/eval-cache-no-git/.test-config.yml
+++ b/tests/eval-cache-no-git/.test-config.yml
@@ -1,0 +1,1 @@
+git_init: false

--- a/tests/eval-cache-no-git/.test.sh
+++ b/tests/eval-cache-no-git/.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -ex
+
+# This test verifies eval cache behavior outside of git repositories
+echo "Testing eval cache outside git repo..."
+
+# Run devenv shell to trigger evaluation and caching
+echo "Running devenv shell..."
+devenv shell echo hello
+
+# Verify that .devenv/input-paths.txt exists and contains our test file
+if [ ! -f .devenv/input-paths.txt ]; then
+    echo "ERROR: .devenv/input-paths.txt not found!"
+    exit 1
+fi
+
+echo "Contents of .devenv/input-paths.txt:"
+cat .devenv/input-paths.txt
+
+# Check if our test file is tracked in input-paths.txt
+if grep -q "test-file.txt" .devenv/input-paths.txt; then
+    echo "SUCCESS: test-file.txt found in input-paths.txt"
+else
+    echo "ERROR: test-file.txt not found in input-paths.txt"
+    echo "This suggests the file dependency was not detected"
+    exit 1
+fi
+
+echo "Test completed successfully!"

--- a/tests/eval-cache-no-git/README.md
+++ b/tests/eval-cache-no-git/README.md
@@ -1,0 +1,1 @@
+This test verifies eval cache functionality outside of git repositories, which tests edge-cases related to flake restrictions and lazy-trees.

--- a/tests/eval-cache-no-git/devenv.nix
+++ b/tests/eval-cache-no-git/devenv.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  # Read a file to test caching behavior
+  fileContent = builtins.readFile ./test-file.txt;
+in
+{
+  # Create a simple environment for testing
+  packages = [ ];
+
+  # Use the file content in the environment
+  env.FILE_CONTENT = fileContent;
+
+  # Define a test that verifies the file was read
+  enterTest = ''
+    echo "File content: $FILE_CONTENT"
+    echo "Testing eval cache behavior..."
+  '';
+}

--- a/tests/eval-cache-no-git/test-file.txt
+++ b/tests/eval-cache-no-git/test-file.txt
@@ -1,0 +1,1 @@
+Hello from test file


### PR DESCRIPTION
Flakes are designed to work inside of git repos, which helps reduce the cost of copying the source files to the Nix store. This results in two separate code paths for devenv projects using git and (usually ad-hoc) ones running sans git.
See #1990.

These tests are designed to catch regressions in the eval-cache implementation stemming from these differences. If a Nix updates breaks the path resolution, we will hopefully get a warning.