### PR TITLE
fix: correctly set UV_PYTHON to the wrapped python interpreter

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -472,7 +472,7 @@ in
       # Force uv not to download a Python binary when the version in pyproject.toml does not match the one installed by devenv
       UV_PYTHON_DOWNLOADS = "never";
       # Force uv to always use the correct python interpreter.
-      UV_PYTHON = "${cfg.package.interpreter}";
+      UV_PYTHON = "${package.interpreter}";
     }) // (lib.optionalAttrs cfg.poetry.enable {
       # Make poetry use DEVENV_ROOT/.venv
       POETRY_VIRTUALENVS_IN_PROJECT = "true";


### PR DESCRIPTION
**Underlying Issue**
Since #1959, UV_PYTHON is forced to devenv's python interpreter. However, it is the unwrapped interpreter. This of course breaks the native libs functionality.

**To reproduce**
Create a devenv.nix with `languages.python.uv.sync.enable = true`:
```nix
{ pkgs, config, inputs, ... }:
{
  languages.python = {
    enable = true;
    venv.enable = true;
    uv = {
      enable = true;
      sync.enable = true;
    };
  };
}
```
Check UV_PYTHON variable from shell:
```sh
echo $UV_PYTHON
> /nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/bin/python3.12 <- This is an unwrapped interpreter
```




**Fix**
Just use the wrapped python bound to `package` in `python.nix`

