### PR TITLE
Fix container compatibility with Gitlab CI

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -30,9 +30,12 @@ let
     source ${shell.envScript}
 
     # expand any envvars before exec
-    cmd="`echo "$@"|${pkgs.envsubst}/bin/envsubst`"
+    expanded_args=()
+    for arg in "$@"; do
+        expanded_args+=("$(printf '%s' "$arg" | ${pkgs.envsubst}/bin/envsubst)")
+    done
 
-    ${bash} -c "$cmd"
+    exec "''${expanded_args[@]}"
   '';
   user = "user";
   group = "user";


### PR DESCRIPTION
This commit updates the default `config.containers.shell.entrypoint` to execute the startup command with exec rather than as a shell call. This allows Gitlab CI runnners to properly send scripts to CI jobs running the shell container image.

For [reference][gitlab], here's how Gitlab runners bring up a container and run the script:

> 1.The runner starts a Docker container using the defined entrypoint. The
> default from Dockerfile that may be overridden in the .gitlab-ci.yml file.
>
> ...
>
> 4. The runner sends the script to the container’s shell stdin and receives
> the output.

---

This pattern of integrating with Gitlab CI produces improved latency over the [current recommended pattern][devenv-ci]:
- pipelines build the shell once and then reuse the image in each shell CI job
- pipelines can skip unnecessary build jobs using CI rules
- shell CI jobs only load the shell image, not the large [devenv image][devenv-image]
- shell CI jobs run script commands as soon as the job container is ready

Users can implement this pattern as follows:

```nix
# devenv.nix

{ pkgs, ... }:
{
  env.GREET = "hello";

  packages = [ pkgs.jq ];

  containers.shell.name = "hello-world";
}
```

```yaml
# .gitlab-ci.yaml

# Build the shell container image and copy it to <registry>/hello-world
# Note: defining change rules allows users to skip unnecessary builds

build:
  stage: build
  image: ghcr.io/cachix/devenv/devenv:v1.6
  script:
    - devenv container copy shell
  rules:
    - changes:
      - devenv.nix
      - devenv.lock

.devenv-shell:
  image: <registry>/hello-world
  needs:
    - build

# Run CI workloads using the shell container image
# Note: script runs as soon as the job container is ready

greet:
  stage: test
  extends: .devenv-shell
  image: <registry>/hello-world
  script:
    - echo $GREET

jq-version:
  stage: test
  image: <registry>/hello-world
  script:
    - jq --version
```

[gitlab]: https://docs.gitlab.com/ci/docker/using_docker_images/#override-the-entrypoint-of-an-image
[devenv-ci]: https://github.com/cachix/devenv/blob/v1.6.1/docs/integrations/devenv-container.md?plain=1#L14-L20
[devenv-image]: https://github.com/cachix/devenv/pkgs/container/devenv%2Fdevenv/402654685?tag=v1.6