### PR TITLE
rust: expose `toolchainPackage` and use it correctly override git hooks

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -15648,6 +15648,23 @@ null or package
 
 
 
+## languages.rust.toolchainPackage
+
+
+
+The aggregated toolchain package, which includes the configured components and targets.
+This is automatically set based on the channel and components configuration.
+
+
+
+*Type:*
+package
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix](https://github.com/cachix/devenv/blob/main/src/modules/languages/rust.nix)
+
+
+
 ## languages.rust.version
 
 

--- a/docs/supported-languages/rust.md
+++ b/docs/supported-languages/rust.md
@@ -229,6 +229,20 @@ null or package
 
 
 
+### languages\.rust\.toolchainPackage
+
+
+
+The aggregated toolchain package, which includes the configured components and targets\.
+This is automatically set based on the channel and components configuration\.
+
+
+
+*Type:*
+package
+
+
+
 ### languages\.rust\.version
 
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -179,6 +179,7 @@ in
     (lib.mkIf (cfg.channel == "nixpkgs") {
       languages.rust.toolchainPackage = lib.mkDefault (
         pkgs.symlinkJoin {
+          name = "rust-toolchain-${cfg.channel}";
           paths = builtins.map (c: cfg.toolchain.${c} or (throw "toolchain.${c}")) cfg.components;
         }
       );

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -94,6 +94,13 @@ in
       defaultText = lib.literalExpression "nixpkgs";
       description = "Rust component packages. May optionally define additional components, for example `miri`.";
     };
+
+    toolchainPackage = lib.mkOption {
+      type = lib.types.package;
+      description = ''
+        The aggregated toolchain package, which includes the configured components and targets.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
@@ -163,14 +170,19 @@ in
             CFLAGS = lib.optionalString pkgs.stdenv.isDarwin "-iframework ${config.devenv.profile}/Library/Frameworks";
           };
 
-        git-hooks.tools.cargo = mkOverrideTools cfg.toolchain.cargo or null;
-        git-hooks.tools.rustfmt = mkOverrideTools cfg.toolchain.rustfmt or null;
-        git-hooks.tools.clippy = mkOverrideTools cfg.toolchain.clippy or null;
+        git-hooks.tools.cargo = mkOverrideTools cfg.toolchainPackage;
+        git-hooks.tools.rustfmt = mkOverrideTools cfg.toolchainPackage;
+        git-hooks.tools.clippy = mkOverrideTools cfg.toolchainPackage;
       }
     )
 
     (lib.mkIf (cfg.channel == "nixpkgs") {
-      packages = builtins.map (c: cfg.toolchain.${c} or (throw "toolchain.${c}")) cfg.components;
+      languages.rust.toolchainPackage = lib.mkDefault (
+        pkgs.symlinkJoin {
+          paths = builtins.map (c: cfg.toolchain.${c} or (throw "toolchain.${c}")) cfg.components;
+        }
+      );
+      packages = [ cfg.toolchainPackage ];
     })
 
     (lib.mkIf (cfg.channel != "nixpkgs") (
@@ -245,7 +257,8 @@ in
       in
       {
         languages.rust.toolchain = builtins.mapAttrs (_: lib.mkDefault) toolchainComponents;
-        packages = [ profile ];
+        languages.rust.toolchainPackage = lib.mkDefault profile;
+        packages = [ cfg.toolchainPackage ];
       }
     ))
   ]);

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -99,6 +99,7 @@ in
       type = lib.types.package;
       description = ''
         The aggregated toolchain package, which includes the configured components and targets.
+        This is automatically set based on the channel and components configuration.
       '';
     };
   };


### PR DESCRIPTION
Unlike fenix, rust-overlay does it's patching when building the
toolchain profile from a set of resolved components. For that reason we
can't use the unpatched toolchain components directly to fixup the git
hooks packages.
