### PR TITLE
Integrate secretspec.dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +498,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -537,6 +566,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -662,6 +701,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "combine"
@@ -836,6 +885,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +1009,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42a16374481d92aed73ae45b1f120207d8e71d24fb89f357fadbd8f946fd84b"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "futures-util",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "sha2",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1121,7 @@ dependencies = [
  "rmcp-macros",
  "schemars 0.8.22",
  "schematic",
+ "secretspec",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1164,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1303,18 @@ dependencies = [
  "libc",
  "redox_users 0.4.6",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1391,6 +1516,15 @@ name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "equivalent"
@@ -2265,6 +2399,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "inquire"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33e7c1ddeb15c9abcbfef6029d8e29f69b52b6d6c891031b88ed91b5065803b"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2537,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb06f73ca0ea1cbd3858e54404585e33dccb860cb4fc8a66ad5e75a5736f3f19"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 3.2.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +2715,26 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2774,6 +2976,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,6 +3121,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +3159,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2948,6 +3192,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -4027,6 +4282,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4044,6 +4310,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4304,6 +4580,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secretspec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72620b607cd717e513e50671603e7ff560581052b8b9dcfd269ca050465fb8fb"
+dependencies = [
+ "clap",
+ "colored",
+ "directories",
+ "dotenvy",
+ "http",
+ "inquire",
+ "keyring",
+ "linkme",
+ "miette",
+ "rpassword",
+ "serde",
+ "serde-envfile",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "toml 0.8.23",
+ "url",
+ "whoami",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,6 +4654,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-envfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891532ca829b3211b301e61c7bad9001b077de1c2da350240c492e684e60bd6d"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "envy",
+ "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4546,6 +4861,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,7 +5069,7 @@ dependencies = [
  "tabwriter",
  "test-strategy",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.6.0",
  "vu128",
 ]
 
@@ -5560,6 +5896,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5573,6 +5921,9 @@ name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5594,9 +5945,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime 0.6.11",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"

--- a/devenv.nix
+++ b/devenv.nix
@@ -27,7 +27,8 @@
     pkgs.cargo-outdated # Find outdated crates
     pkgs.cargo-machete # Find unused crates
     pkgs.cargo-edit # Adds the set-version command
-    pkgs.protobuf
+    pkgs.protobuf # snix
+    pkgs.dbus # secretspec
   ];
 
   languages.nix.enable = true;

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -53,6 +53,7 @@ shell-escape.workspace = true
 rmcp.workspace = true
 rmcp-macros.workspace = true
 async-trait.workspace = true
+secretspec = "0.2.0"
 
 # Optional snix dependencies
 snix-eval = { git = "https://github.com/cachix/snix", optional = true }

--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -158,6 +158,20 @@ pub struct Config {
     pub impure: bool,
     #[serde(default, skip_serializing_if = "is_default")]
     pub backend: NixBackendType,
+    #[setting(nested)]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub secretspec: Option<SecretspecConfig>,
+}
+
+#[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct SecretspecConfig {
+    #[serde(skip_serializing_if = "is_false", default = "false_default")]
+    #[setting(default = false)]
+    pub enable: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub provider: Option<String>,
 }
 
 // TODO: https://github.com/moonrepo/schematic/issues/105

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -52,6 +52,16 @@
       "items": {
         "type": "string"
       }
+    },
+    "secretspec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SecretspecConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -166,6 +176,26 @@
           "items": {
             "type": "string"
           }
+        }
+      }
+    },
+    "SecretspecConfig": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean"
+        },
+        "profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provider": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }

--- a/docs/integrations/.nav.yml
+++ b/docs/integrations/.nav.yml
@@ -1,5 +1,6 @@
 nav:
    - .env: dotenv.md
+   - secretspec: secretspec.md
    - Android: android.md
    - Wordpress: wordpress.md
    - GitHub Actions: github-actions.md

--- a/docs/integrations/secretspec.md
+++ b/docs/integrations/secretspec.md
@@ -1,0 +1,55 @@
+# SecretSpec
+
+[SecretSpec](https://secretspec.dev) separates secret declaration from secret provisioning. You define what secrets your application needs in a `secretspec.toml` file, and each developer, CI system, and production environment can provide those secrets from their preferred secure provider.
+
+## Quick Start
+
+Follow [SecretSpec Quick Start](https://secretspec.dev/quick-start/).
+
+## Best Practice: Runtime Loading
+
+While you can enable SecretSpec in devenv to load secrets into `secretspec.secrets` option, we recommend:
+
+a) [Use Rust SDK](https://secretspec.dev/sdk/rust/)
+
+b) Your application load secrets at runtime instead:
+
+```bash
+$ devenv shell
+$ secretspec run -- npm start
+```
+
+This approach:
+- Keeps secrets out of your shell environment
+- Reduces exposure of sensitive data
+- Makes secret rotation easier
+- Follows the principle of least privilege
+
+## Configuration (Optional)
+
+If you do need secrets in your devenv environment:
+
+```yaml title="devenv.yaml"
+secretspec:
+  enable: true
+  # these are optional global overrides
+  provider: keyring  # keyring, dotenv, env, 1password, lastpass
+  profile: default   # profile from secretspec.toml
+```
+
+Then access in `devenv.nix`:
+
+```nix title="devenv.nix"
+{ config, ... }:
+
+{
+  env.DATABASE_URL = config.secretspec.secrets.DATABASE_URL or "";
+}
+```
+
+## Learn More
+
+- [secretspec.dev](https://secretspec.dev)
+- [Providers](https://secretspec.dev/docs/providers) - Keyring, 1Password, dotenv, and more
+- [Profiles](https://secretspec.dev/docs/profiles) - Environment-specific configurations
+- [Rust SDK](https://secretspec.dev/docs/rust-sdk) - Type-safe secret access

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -17142,6 +17142,90 @@ string
 
 
 
+## secretspec.enable
+
+
+
+Whether secretspec integration is enabled (automatically true when secrets are loaded)
+
+
+
+*Type:*
+boolean *(read only)*
+
+
+
+*Default:*
+` false `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix)
+
+
+
+## secretspec.profile
+
+
+
+The secretspec profile that was used to load secrets (read-only)
+
+
+
+*Type:*
+null or string *(read only)*
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix)
+
+
+
+## secretspec.provider
+
+
+
+The secretspec provider that was used to load secrets (read-only)
+
+
+
+*Type:*
+null or string *(read only)*
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix)
+
+
+
+## secretspec.secrets
+
+
+
+Secrets loaded from secretspec.toml (read-only)
+
+
+
+*Type:*
+attribute set of string *(read only)*
+
+
+
+*Default:*
+` { } `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/secretspec.nix)
+
+
+
 ## services.adminer.enable
 
 

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -26,6 +26,14 @@
 | nixpkgs.per-platform.&lt;system&gt;.cudaCapabilities          | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
 | nixpkgs.per-platform.&lt;system&gt;.cudaSupport               | (per-platform) Enable CUDA support for nixpkgs. Defaults to `false`.          |
 | nixpkgs.per-platform.&lt;system&gt;.permittedInsecurePackages | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
+|                                                               |                                                                               |
+| secretspec.enable                                             | Enable [secretspec integration](../integrations/secretspec.md). Defaults to `false`.                           |
+| secretspec.profile                                            | Secretspec profile name to use.                                               |
+| secretspec.provider                                           | Secretspec provider to use.                                                   |
+
+!!! note "Added in 1.8"
+
+    - `secretspec`
 
 !!! note "Added in 1.7"
 

--- a/package.nix
+++ b/package.nix
@@ -6,6 +6,7 @@
 , nix
 , cachix ? null
 , openssl
+, dbus
 , apple-sdk_11
 , protobuf
 , pkg-config
@@ -56,8 +57,11 @@ rustPlatform.buildRustPackage {
     protobuf
   ];
 
-  buildInputs = [ openssl ]
-    ++ lib.optional stdenv.isDarwin apple-sdk_11;
+  buildInputs = [
+    openssl
+  ] ++ lib.optional stdenv.isDarwin apple-sdk_11
+  # secretspec
+  ++ lib.optional (!stdenv.isDarwin) dbus;
 
   # Fix proto files for snix dependencies
   preBuild = ''

--- a/src/modules/integrations/secretspec.nix
+++ b/src/modules/integrations/secretspec.nix
@@ -1,0 +1,44 @@
+{ config, lib, pkgs, ... }:
+
+let
+  # Parse SECRETSPEC_SECRETS environment variable if it exists
+  secretspecData =
+    let
+      envVar = builtins.getEnv "SECRETSPEC_SECRETS";
+    in
+    if envVar != "" then
+      builtins.fromJSON envVar
+    else
+      null;
+in
+{
+  options.secretspec = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = if secretspecData != null then true else false;
+      readOnly = true;
+      description = "Whether secretspec integration is enabled (automatically true when secrets are loaded)";
+    };
+
+    profile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = if secretspecData != null then secretspecData.profile else null;
+      readOnly = true;
+      description = "The secretspec profile that was used to load secrets (read-only)";
+    };
+
+    provider = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = if secretspecData != null then secretspecData.provider else null;
+      readOnly = true;
+      description = "The secretspec provider that was used to load secrets (read-only)";
+    };
+
+    secrets = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = if secretspecData != null then secretspecData.secrets else { };
+      readOnly = true;
+      description = "Secrets loaded from secretspec.toml (read-only)";
+    };
+  };
+}

--- a/tests/secretspec/devenv.nix
+++ b/tests/secretspec/devenv.nix
@@ -1,0 +1,28 @@
+{ pkgs, config, ... }:
+
+{
+  # Test that secrets are available in Nix
+  enterShell = ''
+    # Expected JSON structure based on .env values
+    expected_json='{"TEST_API_KEY":"test-api-key-123","TEST_DATABASE_URL":"postgresql://test:test@localhost/testdb","TEST_OPTIONAL":"optional-value"}'
+    
+    # Actual JSON from config
+    actual_json='${builtins.toJSON config.secretspec.secrets}'
+    
+    # Print both for comparison
+    echo "Expected JSON:"
+    echo "$expected_json"
+    echo ""
+    echo "Actual JSON:"
+    echo "$actual_json"
+    echo ""
+    
+    # Assert they match
+    if [ "$expected_json" = "$actual_json" ]; then
+      echo "✓ JSON assertion passed: secrets match expected structure"
+    else
+      echo "✗ JSON assertion failed: secrets don't match expected structure"
+      exit 1
+    fi
+  '';
+}

--- a/tests/secretspec/devenv.yaml
+++ b/tests/secretspec/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  devenv:
+    url: path:../../?dir=src/modules
+
+secretspec:
+  enable: true
+  provider: dotenv
+  profile: test

--- a/tests/secretspec/secretspec.toml
+++ b/tests/secretspec/secretspec.toml
@@ -1,0 +1,8 @@
+[project]
+name = "secretspec-test"
+revision = "1.0"
+
+[profiles.test]
+TEST_API_KEY = { description = "Test API key", required = true }
+TEST_DATABASE_URL = { description = "Test database URL", required = true }
+TEST_OPTIONAL = { description = "Optional test secret", required = false }


### PR DESCRIPTION
We've long supported [.env](https://devenv.sh/integrations/dotenv/) integration, but that has quite a few issues:

- app is disconnected from what secrets are provided 
- parsing .env is unclear #1040 
- it's tricky to use password managers with `.env`
- lock-in to `.env` provider
- lack of encryption

So we've created https://secretspec.dev and [integrated it](https://secretspec.devenv.pages.dev/integrations/secretspec/).