### PR TITLE
tasks: allow running multi-level sub-tasks

### DIFF
--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -8,6 +8,7 @@ use crate::types::{
 use petgraph::algo::toposort;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -98,16 +99,16 @@ impl Tasks {
             }
 
             // Check if this is a namespace prefix (with or without colon)
-            let search_prefix = if name.ends_with(':') {
-                name.clone()
+            let search_prefix: Cow<str> = if name.ends_with(':') {
+                Cow::Borrowed(&name)
             } else {
-                format!("{}:", name)
+                Cow::Owned(format!("{}:", name))
             };
 
             // Find all tasks with this prefix
             let matching_tasks: Vec<_> = task_indices
                 .iter()
-                .filter(|(task_name, _)| task_name.starts_with(&search_prefix))
+                .filter(|(task_name, _)| task_name.starts_with(&*search_prefix))
                 .map(|(_, &index)| index)
                 .collect();
 

--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -68,17 +68,29 @@ impl Tasks {
         let mut resolved_roots = Vec::new();
 
         for name in roots {
+            let trimmed_name = name.trim();
+
+            // Validate namespace name
+            if trimmed_name.is_empty() {
+                return Err(Error::TaskNotFound(name.clone()));
+            }
+
+            // Reject invalid namespace patterns
+            if trimmed_name == ":" || trimmed_name.starts_with(':') || trimmed_name.contains("::") {
+                return Err(Error::TaskNotFound(name.clone()));
+            }
+
             // Check for exact match first
-            if let Some(index) = task_indices.get(name) {
+            if let Some(index) = task_indices.get(trimmed_name) {
                 resolved_roots.push(*index);
                 continue;
             }
 
             // Check if this is a namespace prefix (with or without colon)
-            let search_prefix: Cow<str> = if name.ends_with(':') {
-                Cow::Borrowed(name)
+            let search_prefix: Cow<str> = if trimmed_name.ends_with(':') {
+                Cow::Borrowed(trimmed_name)
             } else {
-                Cow::Owned(format!("{}:", name))
+                Cow::Owned(format!("{}:", trimmed_name))
             };
 
             // Find all tasks with this prefix

--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -97,19 +97,23 @@ impl Tasks {
                 continue;
             }
 
-            // Check if this is a namespace prefix (no colon)
-            if !name.contains(':') {
-                // This is a namespace prefix, find all tasks with this prefix
-                let matching_tasks: Vec<_> = task_indices
-                    .iter()
-                    .filter(|(task_name, _)| task_name.starts_with(&format!("{}:", name)))
-                    .map(|(_, &index)| index)
-                    .collect();
+            // Check if this is a namespace prefix (with or without colon)
+            let search_prefix = if name.ends_with(':') {
+                name.clone()
+            } else {
+                format!("{}:", name)
+            };
 
-                if !matching_tasks.is_empty() {
-                    roots.extend(matching_tasks);
-                    continue;
-                }
+            // Find all tasks with this prefix
+            let matching_tasks: Vec<_> = task_indices
+                .iter()
+                .filter(|(task_name, _)| task_name.starts_with(&search_prefix))
+                .map(|(_, &index)| index)
+                .collect();
+
+            if !matching_tasks.is_empty() {
+                roots.extend(matching_tasks);
+                continue;
             }
 
             return Err(Error::TaskNotFound(name));


### PR DESCRIPTION
For example, for 3 level tasks, you can now run the second level:

```
devenv tasks run ci:lint
```

Fixes #2017.



