### PR TITLE
Fix clangd error: compile_commands.json not found when enabling languages.c and languages.cplusplus

### DIFF
--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -23,6 +23,7 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      clang-tools
       stdenv
       gnumake
       ccls

--- a/src/modules/languages/cplusplus.nix
+++ b/src/modules/languages/cplusplus.nix
@@ -10,6 +10,7 @@ in
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      clang-tools
       cmake
       clang
       ccls


### PR DESCRIPTION
Adding clang after clang-tools in dependency chain can cause issue with clangd of kind (compile_commands.json
Fixes issue from #1387 by adding clangd(clang-tools) as a dependency into languages.cplusplus / languages.c
This issue was also mentioned in Nixpkgs: https://github.com/NixOS/nixpkgs/issues/76486

Important note: clang-tools must be added before clang (there's some issue in initialization if otherwise)