### PR TITLE
Remove --frozen and --no-install-workspace from default uv.sync arguments

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -329,7 +329,7 @@ in
         enable = lib.mkEnableOption "uv sync during devenv initialisation";
         arguments = lib.mkOption {
           type = lib.types.listOf lib.types.str;
-          default = [ "--frozen" "--no-install-workspace" ];
+          default = [ ];
           description = "Command line arguments pass to `uv sync` during devenv initialisation.";
           internal = true;
         };


### PR DESCRIPTION
If `--frozen` is specified, then uv just uses the existing lockfile as-is, without checking `pyproject.toml`, defeating the purpose of the checksum calculated on `pyproject.toml`.