### PR TITLE
mysql: add ensureUsers.*.host option

### DIFF
--- a/src/modules/services/mysql.nix
+++ b/src/modules/services/mysql.nix
@@ -118,10 +118,10 @@ with lib; let
           if [ "${user.name}" = "root" ] && [ -n "$password" ]; then
             echo "ALTER USER 'root'@'localhost' IDENTIFIED BY '$password';"
           else
-            echo "CREATE USER IF NOT EXISTS '${user.name}'@'localhost' ${optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
+            echo "CREATE USER IF NOT EXISTS '${user.name}'@'${user.host}' ${optionalString (user.password != null) "IDENTIFIED BY '$password'"};"
           fi
           ${concatStringsSep "\n" (mapAttrsToList (database: permission: ''
-            echo 'GRANT ${permission} ON ${database} TO `${user.name}`@`localhost`;'
+            echo 'GRANT ${permission} ON ${database} TO `${user.name}`@`${user.host}`;'
           '')
           user.ensurePermissions)}
         ) | MYSQL_PWD="" ${mysqlWrappedEmpty}/bin/mysql -u root -N
@@ -228,6 +228,14 @@ in
             description = ''
               Name of the user to ensure.
             '';
+          };
+
+          host = lib.mkOption {
+            type = types.str;
+            description = ''
+              Host of the user to ensure.
+            '';
+            default = "localhost";
           };
 
           password = lib.mkOption {


### PR DESCRIPTION
We're currently running some services on docker while we're porting things to nix. In these cases it's necessary to customize the host parameter of the mysql users being created, as localhost is specific to each container's network namespace.