### PR TITLE
eval-cache: bust eval-cache when inputs to .devenv.flake.nix change

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -48,7 +48,7 @@ pub static DIRENVRC_VERSION: Lazy<u8> = Lazy::new(|| {
         .unwrap_or(0)
 });
 // project vars
-const DEVENV_FLAKE: &str = ".devenv.flake.nix";
+pub(crate) const DEVENV_FLAKE: &str = ".devenv.flake.nix";
 
 #[derive(Default, Debug)]
 pub struct DevenvOptions {

--- a/devenv/src/nix.rs
+++ b/devenv/src/nix.rs
@@ -1,5 +1,7 @@
-use crate::nix_backend::{self, NixBackend};
-use crate::{cli, config};
+use crate::{
+    cli, config, devenv,
+    nix_backend::{self, NixBackend},
+};
 use async_trait::async_trait;
 use futures::future;
 use miette::{bail, IntoDiagnostic, Result, WrapErr};
@@ -360,6 +362,7 @@ impl Nix {
             let pool = self.pool.get().unwrap();
             let mut cached_cmd = CachedCommand::new(pool);
 
+            cached_cmd.watch_path(self.paths.root.join(devenv::DEVENV_FLAKE));
             cached_cmd.watch_path(self.paths.root.join("devenv.yaml"));
             cached_cmd.watch_path(self.paths.root.join("devenv.lock"));
             cached_cmd.watch_path(self.paths.dotfile.join("flake.json"));

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -2420,7 +2420,7 @@ string
 
 
 *Default:*
-` "1.8" `
+` "1.8.1" `
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/update-check.nix](https://github.com/cachix/devenv/blob/main/src/modules/update-check.nix)


### PR DESCRIPTION
This effectively watches all of the template arguments passed to the flake for changes.

We previously removed this because it caused issues with direnv's file watching. With safeguards now in place to avoid touching unchanged files, this should be safe to re-introduce.

Fixes #2048.