### PR TITLE
docs: fix installing in home-manager

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,10 +71,17 @@
     nix profile install nixpkgs#devenv
     ```
 
-=== "NixOS/nix-darwin/home-manager"
+=== "NixOS/nix-darwin"
 
     ```nix title="configuration.nix"
     environment.systemPackages = [
+      pkgs.devenv
+    ];
+    ```
+=== "home-manager"
+
+    ```nix title="home.nix"
+    home.packages = [
       pkgs.devenv
     ];
     ```


### PR DESCRIPTION
home-manager doesn't have an option named `environment.systemPackages`.