### PR TITLE
feat(postgres): create database's user before running initialSQL

### DIFF
--- a/docs/supported-services/postgres.md
+++ b/docs/supported-services/postgres.md
@@ -277,6 +277,18 @@ list of (submodule)
 SQL commands to run on this specific database during it’s initialization\.
 Multiple SQL expressions can be separated by semicolons\.
 
+**Note**: `initialSQL` runs with superuser privileges\. By default, any tables or objects
+created will be owned by the PostgreSQL superuser, not the specified `user`\.
+
+So you need to transfer ownership explicitly in your `initialSQL`:
+
+```
+CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);
+ALTER TABLE users OWNER TO myuser;
+
+-- Or use schema options, which will run with the specified `user`'s permissions
+```
+
 
 
 *Type:*

--- a/docs/supported-services/postgres.md
+++ b/docs/supported-services/postgres.md
@@ -277,18 +277,6 @@ list of (submodule)
 SQL commands to run on this specific database during it’s initialization\.
 Multiple SQL expressions can be separated by semicolons\.
 
-**Note**: `initialSQL` runs with superuser privileges\. By default, any tables or objects
-created will be owned by the PostgreSQL superuser, not the specified `user`\.
-
-So you need to transfer ownership explicitly in your `initialSQL`:
-
-```
-CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);
-ALTER TABLE users OWNER TO myuser;
-
--- Or use schema options, which will run with the specified `user`'s permissions
-```
-
 
 
 *Type:*

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -67,11 +67,6 @@ let
             if [ 1 -ne "$dbAlreadyExists" ]; then
               echo "Creating database: ${database.name}"
               echo 'CREATE DATABASE "${database.name}";' | psql --dbname postgres
-              if [ ${q database.initialSQL} != null ]
-              then
-                echo "Running initial SQL on database ${database.name}"
-                echo ${q database.initialSQL} | psql --dbname ${database.name}
-              fi
               ${lib.optionalString (database.user != null && database.pass != null) ''
               echo "Creating role ${database.user}..."
               psql --dbname postgres <<'EOF'
@@ -86,6 +81,11 @@ let
               GRANT ALL PRIVILEGES ON SCHEMA public TO "${database.user}";
               EOF
             ''}
+              if [ ${q database.initialSQL} != null ]
+              then
+                echo "Running initial SQL on database ${database.name}"
+                echo ${q database.initialSQL} | psql --dbname ${database.name}
+              fi
               ${lib.optionalString (database.schema != null) ''
               echo "Applying database schema on ${database.name}"
               if [ -f "${database.schema}" ]

--- a/tests/postgresql-customperdbinit/.test.sh
+++ b/tests/postgresql-customperdbinit/.test.sh
@@ -11,10 +11,25 @@ psql \
     --command="SELECT extname FROM pg_extension WHERE extname = 'pg_uuidv7';" \
     | grep -qw pg_uuidv7
 
-# but testdb2 should not have it
+# but testdb2 should not have the extension
 psql \
     --set ON_ERROR_STOP=on \
     --dbname=testdb2 \
     --tuples-only \
     --command="SELECT extname FROM pg_extension WHERE extname = 'pg_uuidv7';" \
     | grep -q pg_uuidv7 && exit 1 || true
+
+# check that the table created by initialSQL is owned by the testuser
+psql \
+    --set ON_ERROR_STOP=on \
+    --dbname=testdb \
+    --tuples-only \
+    --command="SELECT tableowner FROM pg_tables WHERE tablename = 'user_owned_table';" \
+    | grep -qw testuser
+
+# verify testuser can access the table they own
+psql \
+    --set ON_ERROR_STOP=on \
+    --username=testuser \
+    --dbname=testdb \
+    --command="INSERT INTO user_owned_table (name) VALUES ('test'); SELECT * FROM user_owned_table;"

--- a/tests/postgresql-customperdbinit/devenv.nix
+++ b/tests/postgresql-customperdbinit/devenv.nix
@@ -14,9 +14,12 @@
     initialDatabases = [
       {
         name = "testdb";
+        user = "testuser";
         pass = "testuserpass";
         initialSQL = ''
           CREATE EXTENSION IF NOT EXISTS pg_uuidv7;
+          CREATE TABLE user_owned_table (id SERIAL PRIMARY KEY, name TEXT);
+          ALTER TABLE user_owned_table OWNER TO testuser;
         '';
       }
       {


### PR DESCRIPTION
This PR enables referencing the `initialDatabases.*.user` within the `initialDatabases.*.initialSQL`.