### PR TITLE
devenv: deprecate feature detection output flags

### DIFF
--- a/src/modules/flake.nix
+++ b/src/modules/flake.nix
@@ -3,7 +3,5 @@
     { ... }:
     {
       modules = ./.;
-      isTmpDir = builtins.warn "`inputs.devenv.isTmpDir` is deprecated. Use `config.devenv.tmpdir` directly instead." true;
-      hasIsTesting = builtins.warn "`inputs.devenv.hasIsTesting` is deprecated. Use `config.devenv.isTesting` directly instead." true;
     };
 }

--- a/src/modules/flake.nix
+++ b/src/modules/flake.nix
@@ -1,7 +1,9 @@
 {
-  outputs = { ... }: {
-    modules = ./.;
-    isTmpDir = true;
-    hasIsTesting = true;
-  };
+  outputs =
+    { ... }:
+    {
+      modules = ./.;
+      isTmpDir = builtins.warn "`inputs.devenv.isTmpDir` is deprecated. Use `config.devenv.tmpdir` directly instead." true;
+      hasIsTesting = builtins.warn "`inputs.devenv.hasIsTesting` is deprecated. Use `config.devenv.isTesting` directly instead." true;
+    };
 }


### PR DESCRIPTION
We can query the options attrset directly instead of using custom outputs.

In case anyone is depending on these (for whatever reason), there will be a brief deprecation period.
