### PR TITLE
python: LD_LIBRARY_PATH suffix instead of prefix

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -19,13 +19,13 @@ let
     requiredPythonModules = cfg.package.pkgs.requiredPythonModules;
     makeWrapperArgs =
       [
-        "--prefix"
+        "--suffix"
         "LD_LIBRARY_PATH"
         ":"
         libraries
       ]
       ++ lib.optionals pkgs.stdenv.isDarwin [
-        "--prefix"
+        "--suffix"
         "DYLD_LIBRARY_PATH"
         ":"
         libraries


### PR DESCRIPTION
This fixes the nixglhost and nixGL problems described in #1973.

It is relevant for systems that are not on NixOS and want to use cuda inside devenv.

I am not sure if there are any disadvantages of setting the python as a suffix instead of a prefix in `LD_LIBRARY_PATH`. If it is set as a prefix there is no way for the user to override what libraries are loaded, `./devenv/profile` always takes preference. As a suffix, we give more flexibility to the user. It is always possible to set the `LD_LIBRARY_PATH` variable in the environment variables in devenv.nix.

Let me know if you want me to provide more infos, or testing.