### PR TITLE
rust: drop `-iframework` flag on darwin

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -165,7 +165,6 @@ in
               else pkgs.rustPlatform.rustLibSrc;
             RUSTFLAGS = optionalEnv (moldFlags != "" || cfg.rustflags != "") (lib.concatStringsSep " " (lib.filter (x: x != "") [ moldFlags cfg.rustflags ]));
             RUSTDOCFLAGS = optionalEnv (moldFlags != "") moldFlags;
-            CFLAGS = lib.optionalString pkgs.stdenv.isDarwin "-iframework ${config.devenv.profile}/Library/Frameworks";
           };
 
         git-hooks.tools =


### PR DESCRIPTION
This flag should no longer be necessary + the path was incorrect.

Fixes #2071.