### PR TITLE
fix(python): make `uv` discover the correct python

### DIFF
--- a/src/modules/languages/python.nix
+++ b/src/modules/languages/python.nix
@@ -513,6 +513,9 @@ in
         UV_PROJECT_ENVIRONMENT = "${config.env.DEVENV_STATE}/venv";
         # Force uv not to download a Python binary when the version in pyproject.toml does not match the one installed by devenv
         UV_PYTHON_DOWNLOADS = "never";
+        # Make uv choose the first python on PATH that is not uv provided. 
+        # The one it finds is then consistently the one from nix (which is what we want).
+        UV_PYTHON_PREFERENCE = "only-system";
       })
       // (lib.optionalAttrs cfg.poetry.enable {
         # Make poetry use DEVENV_ROOT/.venv


### PR DESCRIPTION
Setting `UV_PYTHON_PREFERENCE=system-only` make `uv` only using the python interpreter it finds on the `PATH` which si what we want. 

Maybe in the future that can be relaxed, but I think this is a special knob to escape into the system which is not the purpose of determinism.

Fixes: #1959