### PR TITLE
devenv: fix building containers

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -463,13 +463,16 @@ impl Devenv {
         skip(self),
         fields(devenv.user_message = format!("Building {name} container"))
     )]
-    pub async fn container_build(&self, name: &str) -> Result<String> {
+    pub async fn container_build(&mut self, name: &str) -> Result<String> {
         if cfg!(target_os = "macos") {
             bail!(
                 "Containers are not supported on macOS yet: https://github.com/cachix/devenv/issues/430"
             );
         }
 
+        // This container name is passed to the flake as an argument and tells the module system
+        // that we're 1. building a container 2. which container we're building.
+        self.container_name = Some(name.to_string());
         self.assemble(false).await?;
 
         let sanitized_name = sanitize_container_name(name);
@@ -489,7 +492,7 @@ impl Devenv {
     }
 
     pub async fn container_copy(
-        &self,
+        &mut self,
         name: &str,
         copy_args: &[String],
         registry: Option<&str>,
@@ -540,7 +543,7 @@ impl Devenv {
     }
 
     pub async fn container_run(
-        &self,
+        &mut self,
         name: &str,
         copy_args: &[String],
         registry: Option<&str>,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -108,8 +108,6 @@ async fn main() -> Result<()> {
             name,
             command,
         } => {
-            devenv.container_name = name.clone();
-
             // Backwards compatibility for the legacy container flags:
             //   `devenv container <name> --copy` is now `devenv container copy <name>`
             //   `devenv container <name> --docker-run` is now `devenv container run <name>`


### PR DESCRIPTION
When refactoring the container options, I moved around `devenv.container_name` which broke container builds. Instead of using the `name` from the command, it was always set to the legacy `name` option.

This bug was not released.