### PR TITLE
devenv: implement `permittedUnfreePackages`

### DIFF
--- a/devenv/src/config.rs
+++ b/devenv/src/config.rs
@@ -30,6 +30,8 @@ pub struct NixpkgsConfig {
     pub cuda_capabilities: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub permitted_insecure_packages: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub permitted_unfree_packages: Vec<String>,
 }
 
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -30,16 +30,15 @@
           overlays = nixpkgs.lib.flatten (nixpkgs.lib.mapAttrsToList getOverlays (devenv.inputs or { }));
           permittedUnfreePackages = devenv.nixpkgs.per-platform."${system}".permittedUnfreePackages or devenv.nixpkgs.permittedUnfreePackages or [ ];
           pkgs = import nixpkgs {
-            inherit system;
+            inherit overlays system;
             config = {
               allowUnfree = devenv.nixpkgs.per-platform."${system}".allowUnfree or devenv.nixpkgs.allowUnfree or devenv.allowUnfree or false;
               allowBroken = devenv.nixpkgs.per-platform."${system}".allowBroken or devenv.nixpkgs.allowBroken or devenv.allowBroken or false;
               cudaSupport = devenv.nixpkgs.per-platform."${system}".cudaSupport or devenv.nixpkgs.cudaSupport or false;
               cudaCapabilities = devenv.nixpkgs.per-platform."${system}".cudaCapabilities or devenv.nixpkgs.cudaCapabilities or [ ];
               permittedInsecurePackages = devenv.nixpkgs.per-platform."${system}".permittedInsecurePackages or devenv.nixpkgs.permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
-              allowUnfreePredicate = if permittedUnfreePackages != [ ] then (pkg: builtins.elem (lib.getName pkg) permittedUnfreePackages) else null;
+              allowUnfreePredicate = if (permittedUnfreePackages != [ ]) then (pkg: builtins.elem (nixpkgs.lib.getName pkg) permittedUnfreePackages) else (_: false)
             };
-            inherit overlays;
           };
           lib = pkgs.lib;
           importModule = path:

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -28,6 +28,7 @@
                   input.overlays.${overlay} or (throw "Input `${inputName}` has no overlay called `${overlay}`. Supported overlays: ${nixpkgs.lib.concatStringsSep ", " (builtins.attrNames input.overlays)}"))
               inputAttrs.overlays or [ ];
           overlays = nixpkgs.lib.flatten (nixpkgs.lib.mapAttrsToList getOverlays (devenv.inputs or { }));
+          permittedUnfreePackages = devenv.nixpkgs.per-platform."${system}".permittedUnfreePackages or devenv.nixpkgs.permittedUnfreePackages or [ ];
           pkgs = import nixpkgs {
             inherit system;
             config = {
@@ -36,6 +37,7 @@
               cudaSupport = devenv.nixpkgs.per-platform."${system}".cudaSupport or devenv.nixpkgs.cudaSupport or false;
               cudaCapabilities = devenv.nixpkgs.per-platform."${system}".cudaCapabilities or devenv.nixpkgs.cudaCapabilities or [ ];
               permittedInsecurePackages = devenv.nixpkgs.per-platform."${system}".permittedInsecurePackages or devenv.nixpkgs.permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
+              allowUnfreePredicate = if permittedUnfreePackages != [ ] then (pkg: builtins.elem (lib.getName pkg) permittedUnfreePackages) else null;
             };
             inherit overlays;
           };

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -37,7 +37,7 @@
               cudaSupport = devenv.nixpkgs.per-platform."${system}".cudaSupport or devenv.nixpkgs.cudaSupport or false;
               cudaCapabilities = devenv.nixpkgs.per-platform."${system}".cudaCapabilities or devenv.nixpkgs.cudaCapabilities or [ ];
               permittedInsecurePackages = devenv.nixpkgs.per-platform."${system}".permittedInsecurePackages or devenv.nixpkgs.permittedInsecurePackages or devenv.permittedInsecurePackages or [ ];
-              allowUnfreePredicate = if (permittedUnfreePackages != [ ]) then (pkg: builtins.elem (nixpkgs.lib.getName pkg) permittedUnfreePackages) else (_: false)
+              allowUnfreePredicate = if (permittedUnfreePackages != [ ]) then (pkg: builtins.elem (nixpkgs.lib.getName pkg) permittedUnfreePackages) else (_: false);
             };
           };
           lib = pkgs.lib;

--- a/docs/devenv.schema.json
+++ b/docs/devenv.schema.json
@@ -150,6 +150,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "permittedUnfreePackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -172,6 +178,12 @@
           "type": "boolean"
         },
         "permittedInsecurePackages": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permittedUnfreePackages": {
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/reference/yaml-options.md
+++ b/docs/reference/yaml-options.md
@@ -20,12 +20,14 @@
 | nixpkgs.cudaCapabilities                                      | Select CUDA capabilities for nixpkgs. Defaults to `[]`                        |
 | nixpkgs.cudaSupport                                           | Enable CUDA support for nixpkgs. Defaults to `false`.                         |
 | nixpkgs.permittedInsecurePackages                             | A list of insecure permitted packages. Defaults to `[]`                       |
+| nixpkgs.permittedUnfreePackages                               | A list of unfree packages to allow by name. Defaults to `[]`                  |
 |                                                               |                                                                               |
 | nixpkgs.per-platform.&lt;system&gt;.allowBroken               | (per-platform) Allow packages marked as broken. Defaults to `false`.          |
 | nixpkgs.per-platform.&lt;system&gt;.allowUnfree               | (per-platform) Allow unfree packages. Defaults to `false`.                    |
 | nixpkgs.per-platform.&lt;system&gt;.cudaCapabilities          | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
 | nixpkgs.per-platform.&lt;system&gt;.cudaSupport               | (per-platform) Enable CUDA support for nixpkgs. Defaults to `false`.          |
-| nixpkgs.per-platform.&lt;system&gt;.permittedInsecurePackages | (per-platform) Select CUDA capabilities for nixpkgs. Defaults to `[]`         |
+| nixpkgs.per-platform.&lt;system&gt;.permittedInsecurePackages | (per-platform) A list of insecure permitted packages. Defaults to `[]`        |
+| nixpkgs.per-platform.&lt;system&gt;.permittedUnfreePackages   | (per-platform) A list of unfree packages to allow by name. Defaults to `[]`   |
 |                                                               |                                                                               |
 | secretspec.enable                                             | Enable [secretspec integration](../integrations/secretspec.md). Defaults to `false`.                           |
 | secretspec.profile                                            | Secretspec profile name to use.                                               |
@@ -90,6 +92,28 @@ imports:
 !!! note "Added in 1.0"
 
     - relative file support in imports: `./mymodule.nix`
+
+## Using permittedUnfreePackages
+
+Instead of allowing all unfree packages with `nixpkgs.allowUnfree: true`, you can selectively permit specific unfree packages by name:
+
+```yaml
+# Use the nixpkgs-scoped configuration
+nixpkgs:
+  permittedUnfreePackages:
+    - terraform
+    - vscode
+
+# Or configure per-platform
+nixpkgs:
+  per-platform:
+    x86_64-linux:
+      permittedUnfreePackages:
+        - some-package
+    aarch64-darwin:
+      permittedUnfreePackages:
+        - some-package
+```
 
 ### What if a package is out of date?
 

--- a/tests/permitted-unfree/devenv.nix
+++ b/tests/permitted-unfree/devenv.nix
@@ -1,0 +1,19 @@
+{ pkgs, ... }:
+
+{
+  # This test demonstrates using permittedUnfreePackages
+  # to allow specific unfree packages by name
+  packages = [
+    pkgs.terraform  # This is an unfree package
+  ];
+
+  enterTest = ''
+    echo "Testing permittedUnfreePackages functionality"
+    echo "Terraform (unfree package) should be available:"
+    if ! terraform version; then
+      echo "ERROR: Terraform not found"
+      exit 1
+    fi
+    echo "SUCCESS: Terraform is available"
+  '';
+}

--- a/tests/permitted-unfree/devenv.yaml
+++ b/tests/permitted-unfree/devenv.yaml
@@ -1,0 +1,3 @@
+nixpkgs:
+  permittedUnfreePackages:
+    - terraform


### PR DESCRIPTION
Fixes #2081.

This doesn't exist yet in nixpkgs and is built on top of `allowUnfreePredicate`.