### PR TITLE
devenv: improve how the dotfile path is used in `.devenv.flake.nix`

### DIFF
--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -1397,7 +1397,7 @@ impl Devenv {
             "version = \"{}\";
             system = \"{}\";
             devenv_root = \"{}\";
-            devenv_dotfile = ./{};
+            devenv_dotfile = \"{}\";
             devenv_dotfile_string = \"{}\";
             container_name = {};
             devenv_tmpdir = \"{}\";
@@ -1408,7 +1408,7 @@ impl Devenv {
             crate_version!(),
             self.global_options.system,
             self.devenv_root.display(),
-            self.devenv_dotfile.file_name().unwrap().to_str().unwrap(),
+            self.devenv_dotfile.display(),
             self.devenv_dotfile.file_name().unwrap().to_str().unwrap(),
             self.container_name
                 .as_deref()

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -1398,7 +1398,6 @@ impl Devenv {
             system = \"{}\";
             devenv_root = \"{}\";
             devenv_dotfile = \"{}\";
-            devenv_dotfile_string = \"{}\";
             container_name = {};
             devenv_tmpdir = \"{}\";
             devenv_runtime = \"{}\";
@@ -1409,7 +1408,6 @@ impl Devenv {
             self.global_options.system,
             self.devenv_root.display(),
             self.devenv_dotfile.display(),
-            self.devenv_dotfile.file_name().unwrap().to_str().unwrap(),
             self.container_name
                 .as_deref()
                 .map(|s| format!("\"{}\"", s))

--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -72,7 +72,7 @@
               {
                 devenv.cliVersion = version;
                 devenv.root = devenv_root;
-                devenv.dotfile = devenv_root + "/" + devenv_dotfile_string;
+                devenv.dotfile = devenv_dotfile;
               }
               ({ options, ... }: {
                 config.devenv = lib.mkMerge [


### PR DESCRIPTION
This PR passes in `devenv_dotfile` into the flake template as a string.

This:

1. Removes the need for `devenv_dotfile_string` and extra path computation.
2. Removes an extra eval where Nix first tries to resolve the relative path. This extra step was adding a broken-ish path to our cache tracker, since it expects absolute paths.
3. `devenv_root` is already absolute path string. This extends the pattern to the dotfile path.