### PR TITLE
direnv: pass `DEVENV_CMDLINE` to the shell

### DIFF
--- a/devenv/direnvrc
+++ b/devenv/direnvrc
@@ -102,13 +102,16 @@ _devenv_watches() {
 use_devenv() {
   _nix_direnv_preflight
 
+  # Capture all arguments passed to use_devenv for DEVENV_CMDLINE
+  export DEVENV_CMDLINE="$*"
+
   # Remaining parameters are passed as flags to devenv
   local devenv_cmd=("${DEVENV_BIN}")
   # Add all arguments passed to use_devenv
   if (( $# > 0 )); then
     devenv_cmd+=("$@")
   fi
-  
+
   devenv_dir=.
   env_deps_path="$devenv_dir/.devenv/input-paths.txt"
 

--- a/devenv/init/.envrc
+++ b/devenv/init/.envrc
@@ -2,6 +2,9 @@ export DIRENV_WARN_TIMEOUT=20s
 
 eval "$(devenv direnvrc)"
 
-# The use_devenv function supports passing flags to the devenv command
-# For example: use devenv --impure --option services.postgres.enable:bool true
+# `use devenv` supports the same options as the `devenv shell` command.
+#
+# To silence the output, use `--quiet`.
+#
+# Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
 use devenv

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -21,11 +21,8 @@ async fn main() -> Result<()> {
         Ok(())
     };
 
-    let args: Vec<String> = env::args().skip(1).collect();
-
-    let args_as_string = args.join(" ");
-
-    env::set_var("DEVENV_CMDLINE", args_as_string);
+    let args = env::args().skip(1).collect::<Vec<_>>().join(" ");
+    env::set_var("DEVENV_CMDLINE", args);
 
     let command = match cli.command {
         None | Some(Commands::Version) => return print_version(),

--- a/tests/direnv/.test.sh
+++ b/tests/direnv/.test.sh
@@ -22,10 +22,13 @@ cat > $XDG_CONFIG_HOME/.config/direnv/direnv.toml << 'EOF'
 strict_env = true
 EOF
 
+# Define the devenv arguments
+DEVENV_ARGS="--verbose"
+
 # Initialize direnv
-cat > .envrc << 'EOF'
-  eval "$(devenv direnvrc)"
-  use devenv
+cat > .envrc << EOF
+  eval "\$(devenv direnvrc)"
+  use devenv $DEVENV_ARGS
 EOF
 
 # Load the environment
@@ -34,6 +37,13 @@ direnv_eval
 
 # Enter shell and capture initial watches
 DIRENV_WATCHES_BEFORE=$DIRENV_WATCHES
+
+# Verify DEVENV_CMDLINE matches the expected arguments
+if [[ "${DEVENV_CMDLINE:-}" != "$DEVENV_ARGS" ]]; then
+  echo "FAIL: DEVENV_CMDLINE is not set to '$DEVENV_ARGS', got: '${DEVENV_CMDLINE:-}'" >&2
+  exit 1
+fi
+echo "PASS: DEVENV_CMDLINE is correctly set to: $DEVENV_CMDLINE" >&2
 
 # Execute some operations that should not cause direnv to reload
 echo "Running commands that should not trigger direnv reload..." >&2


### PR DESCRIPTION
This lets tasks configure logging when used via direnv.

Fixes #2098.