### PR TITLE
Remove PHP IDE integration section from documentation

### DIFF
--- a/docs/editor-support/intellij.md
+++ b/docs/editor-support/intellij.md
@@ -1,7 +1,3 @@
-## IDE Integration for PHP Development
-
-When developing PHP applications with Intellij IDEA or PHPStorm, install the [Devenv.sh Support plugin](https://plugins.jetbrains.com/plugin/23136-devenv-sh-support) to enable seamless integration with your devenv environment. This plugin provides first-class PHP support and automatically configures your IDE to work with the devenv-managed PHP interpreter and dependencies.
-
 ## Python Environment Configuration
 
 For Python projects, most IDEs require direct access to the virtual environment to provide features like intelligent code completion, debugging, and package management. Since devenv stores the Python virtual environment in `.devenv/state/venv/`, you can improve IDE compatibility by creating a symbolic link in your project root.


### PR DESCRIPTION
I requested at Jetbrains to mark the plugin as deprecated. I don't use Nix / Devenv anymore and won't want to invest further my free time 