### PR TITLE
init: add shellcheck directive to default .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # ^ for code highlighting
-# Used by https://direnv.net
 set -euo pipefail
 
 # External users should eval `devenv direnvrc` or use `source_url` to load this file

--- a/devenv/init/.envrc
+++ b/devenv/init/.envrc
@@ -1,10 +1,12 @@
+# shellcheck shell=bash
+
 export DIRENV_WARN_TIMEOUT=20s
 
 eval "$(devenv direnvrc)"
 
 # `use devenv` supports the same options as the `devenv shell` command.
 #
-# To silence the output, use `--quiet`.
+# To silence all output, use `--quiet`.
 #
 # Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
 use devenv

--- a/docs/automatic-shell-activation.md
+++ b/docs/automatic-shell-activation.md
@@ -14,6 +14,8 @@ To enable automatic shell activation, create an `.envrc` file in your project di
 === "v1.4+"
 
     ``` bash title=".envrc"
+    # shellcheck shell=bash
+
     eval "$(devenv direnvrc)"
 
     # You can pass flags to the devenv command
@@ -24,6 +26,7 @@ To enable automatic shell activation, create an `.envrc` file in your project di
 === "v1.3 and older"
 
     ``` bash title=".envrc"
+    # shellcheck shell=bash
     source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
 
     use devenv
@@ -103,6 +106,7 @@ To use it in your `.envrc`, first compute its sha256 hash:
 ```shell-session
 direnv fetchurl "https://raw.githubusercontent.com/cachix/devenv/VERSION/direnvrc"
 ```
+
 ```shell-session
 Found hash: <HASH>
 ```

--- a/examples/nur/.envrc
+++ b/examples/nur/.envrc
@@ -1,4 +1,0 @@
-watch_file devenv.nix 
-watch_file devenv.yaml 
-watch_file devenv.lock
-eval "$(devenv print-dev-env)"

--- a/examples/simple/.envrc
+++ b/examples/simple/.envrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 export DIRENV_WARN_TIMEOUT=20s
 
 eval "$(devenv direnvrc)"

--- a/examples/supported-languages/.envrc
+++ b/examples/supported-languages/.envrc
@@ -1,3 +1,0 @@
-source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
-
-use devenv

--- a/templates/flake-parts/.envrc
+++ b/templates/flake-parts/.envrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
@@ -9,8 +10,7 @@ watch_file flake.lock
 
 mkdir -p "$PWD/.devenv"
 DEVENV_ROOT_FILE="$PWD/.devenv/root"
-printf %s "$PWD" > "$DEVENV_ROOT_FILE"
-if ! use flake . --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"
-then
+printf %s "$PWD" >"$DEVENV_ROOT_FILE"
+if ! use flake . --override-input devenv-root "file+file://$DEVENV_ROOT_FILE"; then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi

--- a/templates/simple/.envrc
+++ b/templates/simple/.envrc
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
@@ -6,7 +7,6 @@ export DEVENV_IN_DIRENV_SHELL=true
 
 watch_file flake.nix
 watch_file flake.lock
-if ! use flake . --no-pure-eval
-then
+if ! use flake . --no-pure-eval; then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi

--- a/templates/terraform/.envrc
+++ b/templates/terraform/.envrc
@@ -1,10 +1,10 @@
+# shellcheck shell=bash
 if ! has nix_direnv_version || ! nix_direnv_version 3.1.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.1.0/direnvrc" "sha256-yMJ2OVMzrFaDPn7q8nCBZFRYpL/f0RcHzhmw/i6btJM="
 fi
 
 nix_direnv_watch_file flake.nix
 nix_direnv_watch_file flake.lock
-if ! use flake . --impure
-then
+if ! use flake . --impure; then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi


### PR DESCRIPTION
Tells shellcheck that the .envrc file is bash out of the box.

Fixes #2121.