### PR TITLE
Don't run bun install with `--yarn` argument.

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -1,9 +1,15 @@
-{ pkgs, config, lib, ... }:
+{ pkgs
+, config
+, lib
+, ...
+}:
 
 let
   cfg = config.languages.javascript;
 
-  nodeModulesPath = "${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}node_modules";
+  nodeModulesPath = "${
+    lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+  }node_modules";
 
   initNpmScript = pkgs.writeShellScript "init-npm.sh" ''
     function _devenv-npm-install()
@@ -11,7 +17,9 @@ let
       # Avoid running "npm install" for every shell.
       # Only run it when the "package-lock.json" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "package-lock.json" in node_modules.
-      local ACTUAL_NPM_CHECKSUM="${cfg.npm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}package-lock.json)"
+      local ACTUAL_NPM_CHECKSUM="${cfg.npm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+      }package-lock.json)"
       local NPM_CHECKSUM_FILE="${nodeModulesPath}/package-lock.json.checksum"
       if [ -f "$NPM_CHECKSUM_FILE" ]
         then
@@ -22,7 +30,9 @@ let
 
       if [ "$ACTUAL_NPM_CHECKSUM" != "$EXPECTED_NPM_CHECKSUM" ]
       then
-        if ${cfg.npm.package}/bin/npm install ${lib.optionalString (cfg.directory != config.devenv.root) "--prefix ${cfg.directory}"}
+        if ${cfg.npm.package}/bin/npm install ${
+          lib.optionalString (cfg.directory != config.devenv.root) "--prefix ${cfg.directory}"
+        }
         then
           echo "$ACTUAL_NPM_CHECKSUM" > "$NPM_CHECKSUM_FILE"
         else
@@ -31,9 +41,15 @@ let
       fi
     }
 
-    if [ ! -f ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}package.json ]
+    if [ ! -f ${
+      lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+    }package.json ]
     then
-      echo "No package.json found${lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''}. Run '${lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''}npm init' to create one." >&2
+      echo "No package.json found${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''
+      }. Run '${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''
+      }npm init' to create one." >&2
     else
       _devenv-npm-install
     fi
@@ -45,7 +61,9 @@ let
       # Avoid running "pnpm install" for every shell.
       # Only run it when the "package-lock.json" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "package-lock.json" in node_modules.
-      local ACTUAL_PNPM_CHECKSUM="${cfg.pnpm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}pnpm-lock.yaml)"
+      local ACTUAL_PNPM_CHECKSUM="${cfg.pnpm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+      }pnpm-lock.yaml)"
       local PNPM_CHECKSUM_FILE="${nodeModulesPath}/pnpm-lock.yaml.checksum"
       if [ -f "$PNPM_CHECKSUM_FILE" ]
         then
@@ -56,7 +74,9 @@ let
 
       if [ "$ACTUAL_PNPM_CHECKSUM" != "$EXPECTED_PNPM_CHECKSUM" ]
       then
-        if ${cfg.pnpm.package}/bin/pnpm install ${lib.optionalString (cfg.directory != config.devenv.root) "--dir ${cfg.directory}"}
+        if ${cfg.pnpm.package}/bin/pnpm install ${
+          lib.optionalString (cfg.directory != config.devenv.root) "--dir ${cfg.directory}"
+        }
         then
           echo "$ACTUAL_PNPM_CHECKSUM" > "$PNPM_CHECKSUM_FILE"
         else
@@ -65,9 +85,15 @@ let
       fi
     }
 
-    if [ ! -f ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}package.json ]
+    if [ ! -f ${
+      lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+    }package.json ]
     then
-      echo "No package.json found${lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''}. Run '${lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''}pnpm init' to create one." >&2
+      echo "No package.json found${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''
+      }. Run '${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''
+      }pnpm init' to create one." >&2
     else
       _devenv-pnpm-install
     fi
@@ -79,7 +105,9 @@ let
       # Avoid running "yarn install" for every shell.
       # Only run it when the "yarn.lock" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "yarn.lock" in node_modules.
-      local ACTUAL_YARN_CHECKSUM="${cfg.yarn.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}yarn.lock)"
+      local ACTUAL_YARN_CHECKSUM="${cfg.yarn.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+      }yarn.lock)"
       local YARN_CHECKSUM_FILE="${nodeModulesPath}/yarn.lock.checksum"
       if [ -f "$YARN_CHECKSUM_FILE" ]
         then
@@ -90,7 +118,9 @@ let
 
       if [ "$ACTUAL_YARN_CHECKSUM" != "$EXPECTED_YARN_CHECKSUM" ]
       then
-        if ${cfg.yarn.package}/bin/yarn ${lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"} install
+        if ${cfg.yarn.package}/bin/yarn ${
+          lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"
+        } install
         then
           echo "$ACTUAL_YARN_CHECKSUM" > "$YARN_CHECKSUM_FILE"
         else
@@ -99,21 +129,60 @@ let
       fi
     }
 
-    if [ ! -f ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}package.json ]
+    if [ ! -f ${
+      lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+    }package.json ]
     then
-      echo "No package.json found${lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''}. Run '${lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''}yarn init' to create one." >&2
+      echo "No package.json found${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''
+      }. Run '${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''
+      }yarn init' to create one." >&2
     else
       _devenv-yarn-install
     fi
   '';
 
   initBunScript = pkgs.writeShellScript "init-bun.sh" ''
+    # For Bun versions > 1.2, we can use "bun install" directly, since Bun has a readable lockfile
     function _devenv-bun-install()
+    {
+      # Avoid running "bun install" for every shell.
+      # Only run it when the "bun.lock" file or nodejs version has changed.
+      # We do this by storing the nodejs version and a hash of "bun.lock" in node_modules.
+      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+      }bun.lock)"
+      local BUN_CHECKSUM_FILE="${nodeModulesPath}/bun.lock.checksum"
+      if [ -f "$BUN_CHECKSUM_FILE" ]
+        then
+          read -r EXPECTED_BUN_CHECKSUM < "$BUN_CHECKSUM_FILE"
+        else
+          EXPECTED_BUN_CHECKSUM=""
+      fi
+
+      if [ "$ACTUAL_BUN_CHECKSUM" != "$EXPECTED_BUN_CHECKSUM" ]
+      then
+        if ${cfg.bun.package}/bin/bun install --save-text-lockfile ${
+          lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"
+        }
+        then
+          echo "$ACTUAL_BUN_CHECKSUM" > "$BUN_CHECKSUM_FILE"
+        else
+          echo "Install failed. Run 'bun install' manually."
+        fi
+      fi
+    }
+
+    # For Bun versions <= 1.2, we need to use "bun install --yarn", since Bun didn't have readable lockfiles then
+    function _devenv-bun-install-legacy()
     {
       # Avoid running "bun install --yarn" for every shell.
       # Only run it when the "yarn.lock" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "yarn.lock" in node_modules.
-      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}yarn.lock)"
+      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+      }yarn.lock)"
       local BUN_CHECKSUM_FILE="${nodeModulesPath}/yarn.lock.checksum"
       if [ -f "$BUN_CHECKSUM_FILE" ]
         then
@@ -124,7 +193,9 @@ let
 
       if [ "$ACTUAL_BUN_CHECKSUM" != "$EXPECTED_BUN_CHECKSUM" ]
       then
-        if ${cfg.bun.package}/bin/bun install --yarn ${lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"}
+        if ${cfg.bun.package}/bin/bun install --yarn ${
+          lib.optionalString (cfg.directory != config.devenv.root) "--cwd ${cfg.directory}"
+        }
         then
           echo "$ACTUAL_BUN_CHECKSUM" > "$BUN_CHECKSUM_FILE"
         else
@@ -133,11 +204,22 @@ let
       fi
     }
 
-    if [ ! -f ${lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''}package.json ]
+    if [ ! -f ${
+      lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
+    }package.json ]
     then
-      echo "No package.json found${lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''}. Run '${lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''}bun init' to create one." >&2
+      echo "No package.json found${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"in ${cfg.directory}"''
+      }. Run '${
+        lib.optionalString (cfg.directory != config.devenv.root) ''"cd ${cfg.directory}/ && "''
+      }bun init' to create one." >&2
     else
-      _devenv-bun-install
+      ${
+        if (lib.strings.versionAtLeast cfg.bun.package.version "1.2") then
+          "_devenv-bun-install"
+        else
+          "_devenv-bun-install-legacy"
+      }
     fi
   '';
 in
@@ -221,29 +303,33 @@ in
   config = lib.mkIf cfg.enable {
     packages
       # Node ships with npm. If npm is enabled, use its package instead.
-      = lib.optional (!cfg.npm.enable) cfg.package
+      =
+      lib.optional (!cfg.npm.enable) cfg.package
       ++ lib.optional cfg.npm.enable (cfg.npm.package)
       ++ lib.optional cfg.pnpm.enable (cfg.pnpm.package)
       ++ lib.optional cfg.yarn.enable (cfg.yarn.package.override { nodejs = cfg.package; })
       ++ lib.optional cfg.bun.enable (cfg.bun.package)
-      ++ lib.optional cfg.corepack.enable (pkgs.runCommand "corepack-enable" { } ''
-      mkdir -p $out/bin
-      ${cfg.package}/bin/corepack enable --install-directory $out/bin
-    '');
+      ++ lib.optional cfg.corepack.enable (
+        pkgs.runCommand "corepack-enable" { } ''
+          mkdir -p $out/bin
+          ${cfg.package}/bin/corepack enable --install-directory $out/bin
+        ''
+      );
 
     enterShell = lib.concatStringsSep "\n" (
       (lib.optional cfg.npm.install.enable ''
         source ${initNpmScript}
-      '') ++
-      (lib.optional cfg.pnpm.install.enable ''
+      '')
+      ++ (lib.optional cfg.pnpm.install.enable ''
         source ${initPnpmScript}
-      '') ++
-      (lib.optional cfg.yarn.install.enable ''
+      '')
+      ++ (lib.optional cfg.yarn.install.enable ''
         source ${initYarnScript}
-      '') ++
-      (lib.optional cfg.bun.install.enable ''
+      '')
+      ++ (lib.optional cfg.bun.install.enable ''
         source ${initBunScript}
-      '') ++ [
+      '')
+      ++ [
         ''
           export PATH="${nodeModulesPath}/.bin:$PATH"
         ''

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -168,6 +168,13 @@ let
         }
         then
           echo "$ACTUAL_BUN_CHECKSUM" > "$BUN_CHECKSUM_FILE"
+
+          if -f "${cfg.directory}/yarn.lock"
+          then
+            echo "yarn.lock is no longer needed when using bun."
+            echo "Starting with Bun 1.2, bun uses its own lockfile (bun.lock)."
+            echo "You can remove yarn.lock."
+          fi
         else
           echo "Install failed. Run 'bun install' manually."
         fi


### PR DESCRIPTION
Starting with Bun v1.2, Bun uses its own text lockfile, `bun.lock`.

See https://bun.sh/blog/bun-lock-text-lockfile

This means that the logic devenv used, which called `bun install --yarn`, is no longer necessary.

This PR intelligently picks either a new Bun install script that uses `bun install --save-text-lockfile`, or the existing script to preserve backwards compatibility.