### PR TITLE
chore: Add flake-parts input to enable overwrites by users

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,18 @@
     url = "github:edolstra/flake-compat";
     flake = false;
   };
+  inputs.flake-parts = {
+    url = "github:hercules-ci/flake-parts";
+    inputs = {
+      nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
   inputs.nix = {
     url = "github:cachix/nix/devenv-2.30";
     inputs = {
       nixpkgs.follows = "nixpkgs";
       flake-compat.follows = "flake-compat";
+      flake-parts.follows = "flake-parts";
       git-hooks-nix.follows = "git-hooks";
       nixpkgs-23-11.follows = "";
       nixpkgs-regression.follows = "";


### PR DESCRIPTION
Currently, it is not possible for users of devenv to set a `inputs.flake-parts.follows` to overwrite the source of `flake-parts` which is a depedency of `nix`. This results in duplicated entries for `flake-parts` in the flake.lock file for users. This PR aims to fix that by providing a flake parts input for devenv directly.