### PR TITLE
process-compose: fix overriding per-process options

### DIFF
--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -22710,7 +22710,7 @@ Override the configuration file used by OpenTelemetry Collector.
 By default, a configuration is generated from ` services.opentelemetry-collector.settings `.
 
 If overriding, enable the ` health_check ` extension to allow process-compose to check whether the Collector is ready.
-Otherwise, disable the readiness probe by setting ` processes.opentelemetry-collector.process-compose.readiness_probe = {}; `.
+Otherwise, disable the readiness probe by setting ` processes.opentelemetry-collector.process-compose.readiness_probe = lib.mkForce {}; `.
 
 
 

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -17722,7 +17722,7 @@ Only used when using ` process.manager.implementation = "process-compose"; `
 
 
 *Type:*
-attribute set
+YAML value
 
 
 

--- a/docs/supported-services/opentelemetry-collector.md
+++ b/docs/supported-services/opentelemetry-collector.md
@@ -52,7 +52,7 @@ Override the configuration file used by OpenTelemetry Collector\.
 By default, a configuration is generated from ` services.opentelemetry-collector.settings `\.
 
 If overriding, enable the ` health_check ` extension to allow process-compose to check whether the Collector is ready\.
-Otherwise, disable the readiness probe by setting ` processes.opentelemetry-collector.process-compose.readiness_probe = {}; `\.
+Otherwise, disable the readiness probe by setting ` processes.opentelemetry-collector.process-compose.readiness_probe = lib.mkForce {}; `\.
 
 
 

--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -96,7 +96,7 @@ in
     process.manager.command = lib.mkDefault ''
       # Ensure the log directory exists
       mkdir -p "${config.env.DEVENV_STATE}/process-compose"
-      
+
       ${if cfg.unixSocket.enable then ''
       # Check if process-compose server is already running on the socket
       if [ -S "${cfg.unixSocket.path}" ]; then

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -10,7 +10,8 @@ let
       };
 
       process-compose = lib.mkOption {
-        type = types.attrs; # TODO: type this explicitly?
+        # TODO: type up as a submodule for discoverability
+        type = (pkgs.formats.yaml { }).type;
         default = { };
         description = ''
           process-compose.yaml specific process attributes.

--- a/src/modules/services/opentelemetry-collector.nix
+++ b/src/modules/services/opentelemetry-collector.nix
@@ -40,7 +40,7 @@ in
         By default, a configuration is generated from `services.opentelemetry-collector.settings`.
 
         If overriding, enable the `health_check` extension to allow process-compose to check whether the Collector is ready.
-        Otherwise, disable the readiness probe by setting `processes.opentelemetry-collector.process-compose.readiness_probe = {};`.
+        Otherwise, disable the readiness probe by setting `processes.opentelemetry-collector.process-compose.readiness_probe = lib.mkForce {};`.
       '';
       default = null;
       example = lib.literalExpression ''


### PR DESCRIPTION
`type.attrs` does not merge options, making it impossible to override.

Partial fix for #2156.