### PR TITLE
feat: add MCP server support to Claude Code integration

### DIFF
--- a/docs/integrations/claude-code.md
+++ b/docs/integrations/claude-code.md
@@ -286,6 +286,52 @@ Common tools that can be assigned to agents:
 
 For more details on agents, see the [official Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/sub-agents).
 
+## MCP Servers
+
+MCP (Model Context Protocol) servers provide additional capabilities and context to Claude Code. You can configure both stdio and HTTP-based MCP servers:
+
+```nix
+{
+  claude.code.mcpServers = {
+    # Local devenv MCP server
+    devenv = {
+      type = "stdio";
+      command = "devenv";
+      args = [ "mcp" ];
+      env = {
+        DEVENV_ROOT = config.devenv.root;
+      };
+    };
+
+    # AWS IAM MCP server
+    awslabs-iam-mcp-server = {
+      type = "stdio";
+      command = lib.getExe pkgs.awslabs-iam-mcp-server;
+      args = [ ];
+      env = { };
+    };
+
+    # HTTP-based MCP server
+    linear = {
+      type = "http";
+      url = "https://mcp.linear.app/mcp";
+    };
+  };
+}
+```
+
+### Server Types
+
+- **stdio**: Executes a command that communicates via stdin/stdout
+  - `command`: The executable to run
+  - `args`: Command line arguments (optional)
+  - `env`: Environment variables (optional)
+
+- **http**: Connects to an HTTP-based MCP server
+  - `url`: The server URL
+
+When MCP servers are configured, devenv generates a `.mcp.json` file that Claude Code uses to connect to these servers.
+
 ## Composable Specialized Agents
 
 The [devenv-claude-agents](https://github.com/cachix/devenv-claude-agents) repository provides a composable collection of specialized agents:

--- a/docs/reference/options.md
+++ b/docs/reference/options.md
@@ -1493,6 +1493,156 @@ string
 
 
 
+## claude.code.mcpServers
+
+
+
+MCP (Model Context Protocol) servers to configure.
+These servers provide additional capabilities and context to Claude Code.
+
+
+
+*Type:*
+attribute set of (submodule)
+
+
+
+*Default:*
+` { } `
+
+
+
+*Example:*
+
+```
+{
+  awslabs-iam-mcp-server = {
+    type = "stdio";
+    command = lib.getExe pkgs.awslabs-iam-mcp-server;
+    args = [ ];
+    env = { };
+  };
+  linear = {
+    type = "http";
+    url = "https://mcp.linear.app/mcp";
+  };
+  devenv = {
+    type = "stdio";
+    command = "devenv";
+    args = [ "mcp" ];
+    env = {
+      DEVENV_ROOT = config.devenv.root;
+    };
+  };
+}
+
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
+## claude.code.mcpServers.\<name>.args
+
+
+
+Arguments to pass to the command for stdio MCP servers.
+
+
+
+*Type:*
+list of string
+
+
+
+*Default:*
+` [ ] `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
+## claude.code.mcpServers.\<name>.command
+
+
+
+Command to execute for stdio MCP servers.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
+## claude.code.mcpServers.\<name>.env
+
+
+
+Environment variables for stdio MCP servers.
+
+
+
+*Type:*
+attribute set of string
+
+
+
+*Default:*
+` { } `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
+## claude.code.mcpServers.\<name>.type
+
+
+
+Type of MCP server connection.
+
+
+
+*Type:*
+one of “stdio”, “http”
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
+## claude.code.mcpServers.\<name>.url
+
+
+
+URL for HTTP MCP servers.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+` null `
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
 ## claude.code.model
 
 
@@ -2298,8 +2448,6 @@ string
 
 ## devcontainer.settings.overrideCommand
 
-
-
 Override the default command.
 
 
@@ -2428,6 +2576,8 @@ string
 
 
 ## devenv.warnOnNewVersion
+
+
 
 Whether to warn when a new version of either devenv or the direnv integration is available.
 
@@ -5129,8 +5279,6 @@ string
 
 ## git-hooks.hooks.credo.settings.strict
 
-
-
 Whether to auto-promote the changes.
 
 
@@ -5249,6 +5397,8 @@ list of string
 
 
 ## git-hooks.hooks.deadnix.settings.hidden
+
+
 
 Recurse into hidden subdirectories and process hidden .\*.nix files.
 
@@ -7171,8 +7321,6 @@ string
 
 ## git-hooks.hooks.lychee.settings.flags
 
-
-
 Flags passed to lychee. See all available [here](https://lychee.cli.rs/\#/usage/cli).
 
 
@@ -7307,6 +7455,8 @@ boolean
 
 
 ## git-hooks.hooks.mdl.description
+
+
 
 Description of the hook. Used for metadata purposes only.
 


### PR DESCRIPTION
Addresses #2160 by adding declarative MCP server configuration to devenv's Claude Code integration.

## Changes
- Add `mcpServers` option to configure MCP servers declaratively
- Support both stdio and http server types with validation
- Generate `.mcp.json` file automatically when configured
- Include MCP servers in integration info display
- Provide comprehensive examples for common MCP servers

## Testing
Users can now configure MCP servers like:
```nix
claude.code = {
  enable = true;
  mcpServers = {
    awslabs-iam-mcp-server = {
      type = "stdio";
      command = lib.getExe pkgs.awslabs-iam-mcp-server;
    };
    linear = {
      type = "http";
      url = "https://mcp.linear.app/mcp";
    };
  };
};
```

Generated with [Claude Code](https://claude.ai/code)