### PR TITLE
process-compose: check the socket for liveness before attaching

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -97,16 +97,18 @@ in
       # Ensure the log directory exists
       mkdir -p "${config.env.DEVENV_STATE}/process-compose"
 
-      ${if cfg.unixSocket.enable then ''
-      # Check if process-compose server is already running on the socket
-      if [ -S "${cfg.unixSocket.path}" ]; then
-        echo "Attaching to existing process-compose server at ${cfg.unixSocket.path}"
-        exec ${cfg.package}/bin/process-compose --unix-socket "${cfg.unixSocket.path}" attach "$@"
+      ${lib.optionalString cfg.unixSocket.enable ''
+      # Attach to an existing process-compose instance if:
+      # - The unix socket is enabled
+      # - There's an active process listening on the socket
+      if ${lib.getExe pkgs.lsof} "$PC_SOCKET_PATH" >/dev/null 2>&1; then
+        echo "Attaching to existing process-compose server at $PC_SOCKET_PATH" >&2
+        exec ${lib.getExe cfg.package} --unix-socket "$PC_SOCKET_PATH" attach "$@"
       fi
-      '' else ""}
+      ''}
 
-      # Start a new process-compose server if none exists
-      ${cfg.package}/bin/process-compose \
+      # Start a new process-compose server
+      ${lib.getExe cfg.package} \
         ${lib.cli.toGNUCommandLineShell { } config.process.manager.args} \
         -t="''${PC_TUI_ENABLED:-${lib.boolToString cfg.tui.enable}}" \
         up "$@" &
@@ -123,10 +125,11 @@ in
         processes = lib.mapAttrs
           (name: value:
             let
+              taskCmd = "${config.task.package}/bin/devenv-tasks run --task-file ${config.task.config} --mode all devenv:processes:${name}";
               command =
                 if value.process-compose.is_elevated or false
-                then "${config.task.package}/bin/devenv-tasks run --mode all devenv:processes:${name}"
-                else "exec ${config.task.package}/bin/devenv-tasks run --mode all devenv:processes:${name}";
+                then taskCmd
+                else "exec ${taskCmd}";
             in
             { inherit command; } // value.process-compose
           )

--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -100,8 +100,10 @@ in
       ${lib.optionalString cfg.unixSocket.enable ''
       # Attach to an existing process-compose instance if:
       # - The unix socket is enabled
+      # - The socket file exists
+      # - The file is a unix socket
       # - There's an active process listening on the socket
-      if ${lib.getExe pkgs.lsof} "$PC_SOCKET_PATH" >/dev/null 2>&1; then
+      if ${pkgs.coreutils}/bin/timeout 1 ${lib.getExe pkgs.socat} - "UNIX-CONNECT:$PC_SOCKET_PATH" </dev/null >/dev/null 2>&1; then
         echo "Attaching to existing process-compose server at $PC_SOCKET_PATH" >&2
         exec ${lib.getExe cfg.package} --unix-socket "$PC_SOCKET_PATH" attach "$@"
       fi


### PR DESCRIPTION
We've had a lot of complaints about `process-compose` trying to attach to non-existent instances in recent months.
I think the issue is this commit: https://github.com/cachix/devenv/commit/053c79211a274098b5a48ccf2ff47873316e048b

`process-compose` will skip cleaning up the socket file if it exits abnormally.
While `process-compose up` is capable of restarting in this situation, `process-compose attach` is not and will continue trying to reconnect. Our simple file check is not a robust enough check.

This PR uses `socat` to test for all 3 conditions: the file exists, the file is a socket, the socket has a bound listener.


#### Related

We've also had feedback that it wasn't intuitive that `devenv up` would try to reconnect to another `process-compose` instance.
This is believable because the "Attaching to x" message is essentially impossible to see before TUI goes up. The TUI also doesn't seem to indicate that it's in any kind of "client mode" either.
