### PR TITLE
tasks: support running in an elevated shell

### DIFF
--- a/devenv-tasks/Cargo.toml
+++ b/devenv-tasks/Cargo.toml
@@ -25,7 +25,7 @@ shell-escape.workspace = true
 glob = "0.3.3"
 
 [target.'cfg(unix)'.dependencies]
-nix.workspace = true
+nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/devenv-tasks/src/config.rs
+++ b/devenv-tasks/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use crate::SudoContext;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskConfig {
@@ -38,6 +39,8 @@ pub struct Config {
     pub tasks: Vec<TaskConfig>,
     pub roots: Vec<String>,
     pub run_mode: RunMode,
+    #[serde(skip)]
+    pub sudo_context: Option<SudoContext>,
 }
 
 impl TryFrom<serde_json::Value> for Config {

--- a/devenv-tasks/src/lib.rs
+++ b/devenv-tasks/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod error;
+mod privileges;
 pub mod signal_handler;
 mod task_cache;
 mod task_state;
@@ -9,6 +10,7 @@ pub mod ui;
 
 pub use config::{Config, RunMode, TaskConfig};
 pub use error::Error;
+pub use privileges::SudoContext;
 pub use tasks::{Tasks, TasksBuilder};
 pub use types::{Outputs, VerbosityLevel};
 pub use ui::{TasksStatus, TasksUi, TasksUiBuilder};

--- a/devenv-tasks/src/privileges.rs
+++ b/devenv-tasks/src/privileges.rs
@@ -1,0 +1,39 @@
+use std::env;
+use nix::unistd::{Uid, Gid, setuid, setgid, geteuid};
+
+/// Context information about the original user when running under sudo
+#[derive(Debug, Clone)]
+pub struct SudoContext {
+    pub user: String,
+    pub uid: Uid,
+    pub gid: Gid,
+}
+
+impl SudoContext {
+    /// Detect if we're running under sudo and extract the original user context
+    pub fn detect() -> Option<Self> {
+        // Only if we're running as root AND have SUDO_USER set
+        if !geteuid().is_root() {
+            return None;
+        }
+
+        let user = env::var("SUDO_USER").ok()?;
+        let uid = env::var("SUDO_UID").ok()?.parse().ok()?;
+        let gid = env::var("SUDO_GID").ok()?.parse().ok()?;
+
+        Some(SudoContext {
+            user,
+            uid: Uid::from_raw(uid),
+            gid: Gid::from_raw(gid),
+        })
+    }
+
+    /// Drop privileges to the original user
+    ///
+    /// Order matters: we must set GID first, then UID, because once we drop UID privileges we can't change GID anymore.
+    pub fn drop_privileges(&self) -> Result<(), nix::Error> {
+        setgid(self.gid)?;
+        setuid(self.uid)?;
+        Ok(())
+    }
+}

--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -90,6 +90,7 @@ impl TasksBuilder {
                 task,
                 self.verbosity,
                 self.cancellation_token.clone(),
+                self.config.sudo_context.clone(),
             ))));
             task_indices.insert(name, index);
         }

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -789,6 +789,7 @@ impl Devenv {
             roots,
             tasks,
             run_mode,
+            sudo_context: None,
         };
         debug!(
             "Tasks config: {}",

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -152,7 +152,7 @@ in
 
     procfile =
       pkgs.writeText "procfile" (lib.concatStringsSep "\n"
-        (lib.mapAttrsToList (name: process: "${name}: exec ${config.task.package}/bin/devenv-tasks run --mode all devenv:processes:${name}")
+        (lib.mapAttrsToList (name: process: "${name}: exec ${config.task.package}/bin/devenv-tasks run --task-file ${config.task.config} --mode all --devenv:processes:${name}")
           config.processes));
 
     procfileEnv =

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -165,8 +165,6 @@ in
   };
 
   config = {
-    env.DEVENV_TASKS = builtins.toJSON tasksJSON;
-
     assertions = [
       {
         assertion = lib.all (task: task.package.meta.mainProgram == "bash" || task.binary == "bash" || task.exports == [ ]) (lib.attrValues config.tasks);
@@ -178,12 +176,14 @@ in
       }
     ];
 
+    env.DEVENV_TASKS = builtins.toJSON tasksJSON;
+    env.DEVENV_TASK_FILE = config.task.config;
+    task.config = (pkgs.formats.json { }).generate "tasks.json" tasksJSON;
+
     infoSections."tasks" =
       lib.mapAttrsToList
         (name: task: "${name}: ${task.description} (${if task.command == null then "no command" else task.command})")
         config.tasks;
-
-    task.config = (pkgs.formats.json { }).generate "tasks.json" tasksJSON;
 
     tasks = {
       "devenv:enterShell" = {


### PR DESCRIPTION
If a user enables `process-compose.is_elevated`, our task runner should be able to handle being run under `sudo`.

This involves:
- configuring process-compose to pass-through a few required variables
- dropping privileges during setup (i.e. writing to filesystem) and `sudo`-ing the task process directly

Also:

- devenv-tasks will now show a much better error is no task config is found, instead of `NotPresent`.
- devenv-tasks now accepts a `task-file` directly and via an env var

Our task/process runner should handle this directly in the future, i.e. have options to run certain processes in an elevated shell. What we don't currently have is a UI flow to request the auth, which is handled by process-compose.

Fixes #2157.
