### PR TITLE
process-compose: remove unreleased `--task-file` option

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -127,7 +127,7 @@ in
         processes = lib.mapAttrs
           (name: value:
             let
-              taskCmd = "${config.task.package}/bin/devenv-tasks run --task-file ${config.task.config} --mode all devenv:processes:${name}";
+              taskCmd = "${config.task.package}/bin/devenv-tasks run --mode all devenv:processes:${name}";
               command =
                 if value.process-compose.is_elevated or false
                 then taskCmd


### PR DESCRIPTION
Leaked from a different PR during a rebase.

Fixes #2180.