### PR TITLE
flakes: fix infinite recursion when using alternative process managers

### DIFF
--- a/src/modules/process-managers/hivemind.nix
+++ b/src/modules/process-managers/hivemind.nix
@@ -22,7 +22,7 @@ in
     };
 
     process.manager.command = lib.mkDefault ''
-      ${cfg.package}/bin/hivemind \
+      ${lib.getExe cfg.package} \
         ${lib.cli.toGNUCommandLineShell {} config.process.manager.args} \
         "$@" ${config.procfile} &
     '';

--- a/src/modules/process-managers/honcho.nix
+++ b/src/modules/process-managers/honcho.nix
@@ -19,11 +19,10 @@ in
   config = lib.mkIf cfg.enable {
     process.manager.args = {
       "f" = config.procfile;
-      "env" = config.procfileEnv;
     };
 
     process.manager.command = lib.mkDefault ''
-      ${cfg.package}/bin/honcho start \
+      ${lib.getExe cfg.package} start \
         ${lib.cli.toGNUCommandLineShell {} config.process.manager.args} \
         "$@" &
     '';

--- a/src/modules/process-managers/mprocs.nix
+++ b/src/modules/process-managers/mprocs.nix
@@ -42,7 +42,7 @@ in
     process.manager.args = { "config" = cfg.configFile; };
 
     process.manager.command = lib.mkDefault ''
-      ${cfg.package}/bin/mprocs \
+      ${lib.getExe cfg.package} \
         ${lib.cli.toGNUCommandLineShell { } config.process.manager.args}
     '';
 

--- a/src/modules/process-managers/overmind.nix
+++ b/src/modules/process-managers/overmind.nix
@@ -18,13 +18,13 @@ in
 
   config = lib.mkIf cfg.enable {
     process.manager.args = {
-      "root" = config.env.DEVENV_ROOT;
+      "root" = config.devenv.root;
       "socket" = "${config.devenv.runtime}/overmind.sock";
       "procfile" = config.procfile;
     };
 
     process.manager.command = lib.mkDefault ''
-      OVERMIND_ENV=${config.procfileEnv} ${cfg.package}/bin/overmind start \
+      ${lib.getExe cfg.package} start \
         ${lib.cli.toGNUCommandLineShell {} config.process.manager.args} \
         "$@" &
     '';

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -43,10 +43,6 @@ let
   supportedImplementations = builtins.attrNames options.process.managers;
 
   implementation = config.process.manager.implementation;
-  envList =
-    lib.mapAttrsToList
-      (name: value: "${name}=${builtins.toJSON value}")
-      config.env;
 in
 {
   imports =
@@ -160,6 +156,12 @@ in
           config.processes));
 
     procfileEnv =
+      let
+        envList =
+          lib.mapAttrsToList
+            (name: value: "${name}=${builtins.toJSON value}")
+            config.env;
+      in
       pkgs.writeText "procfile-env" (lib.concatStringsSep "\n" envList);
 
     procfileScript = pkgs.writeShellScript "devenv-up" ''

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -10,6 +10,7 @@ let
       builtins.map (output: drvOrPackage.${output}) drvOrPackage.outputs
     else
       [ drvOrPackage ];
+
   profile = pkgs.buildEnv {
     name = "devenv-profile";
     paths = lib.flatten (builtins.map drvOrPackageToPaths config.packages);


### PR DESCRIPTION
Fixes a case of infinite recursion in the flakes integration caused by the flake command helpers referencing env vars that themselves referenced the outPaths of the command helpers.

The fix is two-fold:

1. Remove the envs from honcho and overmind. This is in line with how process-compose works. All process commands run through the shell.
2. Add the flake helpers to PATH directly. This will prevent similar issues in the future and also keeps the profile clean of flake-specific stuff.

Fixes #2159.

