### PR TITLE
docs: Update link to Profiles guide in blog post

### DIFF
--- a/docs/blog/posts/devenv-v1.6-extensible-ad-hoc-nix-environments.md
+++ b/docs/blog/posts/devenv-v1.6-extensible-ad-hoc-nix-environments.md
@@ -82,7 +82,7 @@ $ devenv --option profile:string backend up
 
 This enables you to switch between frontend, backend, or other custom profiles without modifying your configuration files.
 
-See our [Profiles guide](https://devenv.sh/guides/profiles/) for more details on setting up and using profiles.
+See our [Profiles guide](https://devenv.sh/profiles/) for more details on setting up and using profiles.
 
 For complete documentation on this feature, visit our [Ad-hoc Developer Environments guide](https://devenv.sh/ad-hoc-developer-environments/).
 


### PR DESCRIPTION
This PR updates a link in the blog post [devenv 1.6: Extensible Ad-Hoc Nix Environments](https://devenv.sh/blog/2025/04/25/devenv-16-extensible-ad-hoc-nix-environments/).