### PR TITLE
docs: fix syntax error in /extending/#module-replacement code block.

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -60,7 +60,7 @@ You can replace existing devenv modules using the `disabledModules` mechanism. T
     };
   };
 
-  config = lib.mkIf config.languages.rust..enable {
+  config = lib.mkIf config.languages.rust.enable {
     packages = [ pkgs.rustc ];
   };
 }


### PR DESCRIPTION
Removed extra . causing the following syntax error: `unexpected '.', expecting ID or OR_KW or DOLLAR_CURLY or '"'`