### PR TITLE
devenv: fix missing `git` option regression

### DIFF
--- a/devenv/src/flake.tmpl.nix
+++ b/devenv/src/flake.tmpl.nix
@@ -78,13 +78,13 @@
                     _module.args.pkgs = pkgs.appendOverlays (config.overlays or [ ]);
                   })
                   (inputs.devenv.modules + /top-level.nix)
-                  {
-                    devenv.cliVersion = version;
-                    devenv.root = devenv_root;
-                    devenv.dotfile = devenv_dotfile;
-                  }
                   ({ options, ... }: {
                     config.devenv = lib.mkMerge [
+                      {
+                        cliVersion = version;
+                        root = devenv_root;
+                        dotfile = devenv_dotfile;
+                      }
                       (pkgs.lib.optionalAttrs (builtins.hasAttr "tmpdir" options.devenv) {
                         tmpdir = devenv_tmpdir;
                       })
@@ -100,9 +100,9 @@
                     ];
                   })
                   ({ options, ... }: {
-                    config.git = lib.mkMerge [
+                    config = lib.mkMerge [
                       (pkgs.lib.optionalAttrs (builtins.hasAttr "git" options) {
-                        root = git_root;
+                        git.root = git_root;
                       })
                     ];
                   })

--- a/tests/cli-module-regression/README.md
+++ b/tests/cli-module-regression/README.md
@@ -1,0 +1,2 @@
+Run the devenv CLI against an older module revision (in this case `latest`).
+The goal is to catch regressions that make the new CLI incompatible with older module revisions.

--- a/tests/cli-module-regression/devenv.nix
+++ b/tests/cli-module-regression/devenv.nix
@@ -1,0 +1,6 @@
+{
+  enterTest = ''
+    echo "Regression test: unreleased CLI with latest-tagged modules"
+    exit 0
+  '';
+}

--- a/tests/cli-module-regression/devenv.yaml
+++ b/tests/cli-module-regression/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  devenv:
+    url: github:cachix/devenv/latest?dir=src/modules


### PR DESCRIPTION
Fixes the feature check for the new git option, making the new CLI compatible with older module revisions.
Added a very basic test to try to catch regressions like this.

Fixes #2193.