### PR TITLE
add an ability to override jdk version for flutter development (fix #2197)

### DIFF
--- a/src/modules/integrations/android.nix
+++ b/src/modules/integrations/android.nix
@@ -269,18 +269,18 @@ in
 
     # Nested conditional for flutter
     languages = lib.mkMerge [
-      { java.enable = true; }
+      { java.enable = lib.mkDefault true; }
       (lib.mkIf cfg.flutter.enable {
         dart.enable = true;
         # By default, Flutter uses the JDK version that ships Android Studio.
         # Sync with https://developer.android.com/build/jdks
-        java.jdk.package = pkgs.jdk17;
+        java.jdk.package = lib.mkDefault pkgs.jdk17;
       })
       (lib.mkIf cfg.reactNative.enable {
         javascript.enable = true;
         javascript.npm.enable = true;
         # Sync with https://reactnative.dev/docs/set-up-your-environment
-        java.jdk.package = pkgs.jdk17;
+        java.jdk.package = lib.mkDefault pkgs.jdk17;
       })
     ];
 


### PR DESCRIPTION
fix https://github.com/cachix/devenv/issues/2197