### PR TITLE
fix: prevent PID file overwrite in detached mode

### DIFF
--- a/tests/processes-detach-twice/.gitignore
+++ b/tests/processes-detach-twice/.gitignore
@@ -1,0 +1,3 @@
+.devenv*
+devenv.lock
+.direnv

--- a/tests/processes-detach-twice/devenv.nix
+++ b/tests/processes-detach-twice/devenv.nix
@@ -1,0 +1,42 @@
+{
+  processes.dummy.exec = "sleep 60";
+
+  enterTest = ''
+    # Test that running devenv up -d twice should fail when processes are already running
+
+    # Start processes in detached mode
+    devenv up -d
+
+    # Wait a moment for processes to start
+    sleep 2
+
+    # Try to start again - this should fail with an error about processes already running
+    if devenv up -d 2>&1 | grep -q "Processes already running"; then
+      echo "✓ Second 'devenv up -d' correctly detected running processes"
+    else
+      echo "✗ Second 'devenv up -d' did not detect running processes"
+      devenv processes down
+      exit 1
+    fi
+
+    # Stop the processes
+    devenv processes down
+
+    # Wait for processes to fully stop
+    sleep 2
+
+    # Now we should be able to start processes again
+    devenv up -d
+
+    # Verify it started successfully
+    if [ -f .devenv/processes.pid ]; then
+      echo "✓ Processes started successfully after stopping"
+    else
+      echo "✗ Failed to start processes after stopping"
+      exit 1
+    fi
+
+    # Clean up
+    devenv processes down
+  '';
+}

--- a/tests/processes-detach-twice/devenv.yaml
+++ b/tests/processes-detach-twice/devenv.yaml
@@ -1,0 +1,3 @@
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixos-24.05


### PR DESCRIPTION
When running `devenv up -d` consecutively without stopping previously started processes, devenv would overwrite the PID file stored in .devenv/processes.pid, causing `devenv processes down` to fail with "Process with PID not found" error.

Added a check before spawning detached processes that:
- Verifies if a PID file already exists
- Checks if the process is still running using signal::kill
- Fails with clear error if processes are already running
- Cleans up stale PID files if process is not running

Includes test case to verify the fix.

Fixes process management reliability in detached mode.

Fixes https://github.com/cachix/devenv/issues/2198