### PR TITLE
ci: allow overriding the nixpkgs used in tests

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,6 +15,10 @@ on:
         description: "Runner to use"
         required: true
         type: string
+      nixpkgs-input:
+        description: "An optional nixpkgs input to test against"
+        required: false
+        type: string
 
 jobs:
   generate-examples:
@@ -75,4 +79,7 @@ jobs:
           path=$(nix build -L --print-out-paths)
           echo "$path/bin" >> $GITHUB_PATH
       - name: Run examples
-        run: devenv-run-tests run --only ${{ matrix.example.name }} examples
+        run: |
+          devenv-run-tests \
+            ${{ inputs.nixpkgs-input && format('--override-input nixpkgs {0}', inputs.nixpkgs-input) || '' }} \
+            run --only ${{ matrix.example.name }} examples

--- a/.github/workflows/per-system-pipeline.yml
+++ b/.github/workflows/per-system-pipeline.yml
@@ -15,6 +15,10 @@ on:
         description: "Git ref to checkout"
         required: false
         type: string
+      nixpkgs-input:
+        description: "An optional nixpkgs input to test against"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -33,6 +37,7 @@ jobs:
       system: ${{ inputs.system }}
       runs-on: ${{ inputs.runs-on }}
       ref: ${{ inputs.ref }}
+      nixpkgs-input: ${{ inputs.nixpkgs-input }}
 
   examples:
     needs: [build, test]
@@ -43,3 +48,4 @@ jobs:
       system: ${{ inputs.system }}
       runs-on: ${{ inputs.runs-on }}
       ref: ${{ inputs.ref }}
+      nixpkgs-input: ${{ inputs.nixpkgs-input }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
         description: "Runner to use"
         required: true
         type: string
+      nixpkgs-input:
+        description: "An optional nixpkgs input to test against"
+        required: false
+        type: string
 
 jobs:
   tests:
@@ -40,9 +44,15 @@ jobs:
       - name: Test tasks outside shell
         run: devenv tasks run devenv:enterShell
       - name: Run devenv-test-cli
-        run: devenv shell devenv-test-cli
+        run: |
+          devenv \
+            ${{ inputs.nixpkgs-input && format('--override-input nixpkgs {0}', inputs.nixpkgs-input) || '' }} \
+            shell devenv-test-cli
       - name: Run tests
-        run: devenv-run-tests run tests
+        run: |
+          devenv-run-tests \
+            ${{ inputs.nixpkgs-input && format('--override-input nixpkgs {0}', inputs.nixpkgs-input) || '' }} \
+            run tests
 
 
   direnv:
@@ -75,7 +85,10 @@ jobs:
           devenv_dir=$PWD
           tmp="$(mktemp -d)"
           pushd "$tmp"
-            nix shell nixpkgs#direnv -c devenv --override-input devenv path:$devenv_dir?dir=src/modules init
+            nix shell nixpkgs#direnv -c devenv \
+              ${{ inputs.nixpkgs-input && format('--override-input nixpkgs {0}', inputs.nixpkgs-input) || '' }} \
+              --override-input devenv path:$devenv_dir?dir=src/modules \
+              init
           popd
 
   fish-zsh:


### PR DESCRIPTION
This is to allow reusing these workflows in devenv-nixpkgs.