### PR TITLE
tasks: fix process output being red

### DIFF
--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -366,8 +366,10 @@ impl TaskState {
                 result = stdout_reader.next_line(), if !stdout_closed => {
                     match result {
                         Ok(Some(line)) => {
-                            if self.verbosity == VerbosityLevel::Verbose || is_process {
-                                eprintln!("[{}] {}", self.task.name, line);
+                            if self.verbosity == VerbosityLevel::Verbose {
+                                println!("[{}] {}", self.task.name, line);
+                            } else if is_process {
+                                println!("{}", line);
                             }
                             stdout_lines.push((std::time::Instant::now(), line));
                         },


### PR DESCRIPTION
Fixes #2211 by changing process output from stderr (eprintln!) to stdout (println!).

Previously, all process output was printed to stderr which appears red in most terminals. Now process output goes to stdout while maintaining the verbose mode behavior with task name prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)