### PR TITLE
devenv-generate: patch for CVE-2025-62518

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1257,7 @@ dependencies = [
 name = "devenv-generate"
 version = "1.10.1"
 dependencies = [
+ "astral-tokio-tar",
  "binaryornot",
  "clap",
  "devenv",
@@ -1254,7 +1271,6 @@ dependencies = [
  "similar",
  "tokio",
  "tokio-shutdown",
- "tokio-tar",
  "tokio-util",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio-shutdown = { path = "tokio-shutdown" }
 xtask = { path = "xtask" }
 
 ansiterm = "0.12.2"
+astral-tokio-tar = "0.5.6"
 async-trait = "0.1"
 binaryornot = "1.0.0"
 blake3 = "1.8.2"
@@ -90,7 +91,6 @@ tokio-util = { version = "0.7.16", features = ["io"] }
 which = "8.0.0"
 whoami = "1.6.1"
 xdg = "3.0.0"
-tokio-tar = "0.3.1"
 walkdir = "2.5"
 
 # The version of rustls must match the version used by reqwest to set up rustls-platform-verifier.

--- a/devenv-generate/Cargo.toml
+++ b/devenv-generate/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 devenv.workspace = true
 http-client-tls.workspace = true
 
+astral-tokio-tar.workspace = true
 binaryornot.workspace = true
 clap = { workspace = true, features = ["derive"] }
 dialoguer.workspace = true
@@ -18,7 +19,6 @@ serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-shutdown.workspace = true
-tokio-tar.workspace = true
 tracing.workspace = true
 tokio-util.workspace = true
 similar.workspace = true


### PR DESCRIPTION
Switches `devenv-generate` to a maintained fork of `tokio-tar`, patched for [CVE-2025-62518](https://github.com/advisories/GHSA-j5gw-2vrg-8fgx).

No other `devenv` crates are affected by this.