### PR TITLE
keycloak: fix health check when using `http-relative-path`

### DIFF
--- a/src/modules/services/keycloak.nix
+++ b/src/modules/services/keycloak.nix
@@ -427,7 +427,7 @@ in
       );
 
       keycloak-health = pkgs.writeShellScriptBin "keycloak-health" ''
-        ${pkgs.curl}/bin/curl -k --head -fsS "https://localhost:9000/health/ready"
+        ${pkgs.curl}/bin/curl -k --head -fsS "https://localhost:${toString cfg.settings.http-management-port}${lib.removeSuffix "/" cfg.settings.http-management-relative-path}/health/ready"
       '';
     in
     mkIf cfg.enable {
@@ -449,6 +449,8 @@ in
           db = cfg.database.type;
 
           health-enabled = true;
+          http-management-port = 9000;
+          http-management-relative-path = "/";
 
           log-console-level = "info";
           log-level = "info";


### PR DESCRIPTION
When using `http-relative-path`, the health endpoint also changes prefix, making the health check fail continuously. This behaviour can be changed by setting the `http-management-relative-path` option.