### PR TITLE
tests: ensure that the base `enterTest` config comes first

### DIFF
--- a/src/modules/tests.nix
+++ b/src/modules/tests.nix
@@ -24,7 +24,7 @@
   };
 
   config = {
-    enterTest = ''
+    enterTest = lib.mkBefore ''
       # Wait for the port to be open until the timeout is reached
       wait_for_port() {
         local port=$1


### PR DESCRIPTION
There's currently an issue when composing profiles where the base module is placed last. That needs to be tackled separately, but this is a quick fix in the meantime.

Fixes #2254.