### PR TITLE
fix: set mprocs procs to use cwd parameter

### DIFF
--- a/src/modules/process-managers/mprocs.nix
+++ b/src/modules/process-managers/mprocs.nix
@@ -53,11 +53,18 @@ in
       configFile =
         lib.mkDefault (settingsFormat.generate "mprocs.yaml" cfg.settings);
       settings = {
-        procs = lib.mapAttrs
-          (name: value:
-            let scriptPath = pkgs.writeShellScript name value.exec;
-            in { cmd = [ "${scriptPath}" ]; })
-          config.processes;
+        procs =
+          lib.mapAttrs
+            (
+              name: value:
+                let scriptPath = pkgs.writeShellScript name value.exec;
+                in
+                {
+                  cmd = [ scriptPath ];
+                }
+                // lib.optionalAttrs (lib.hasAttr "cwd" value && value.cwd != null) { cwd = value.cwd; }
+            )
+            config.processes;
       };
     };
   };


### PR DESCRIPTION
sets the `cwd` parameter for mprocs in order to be consistent in behavior with the tasks. before the process gets executed in the root directory of the devenv.