### PR TITLE
feat: add Treefmt tasks

### DIFF
--- a/src/modules/integrations/treefmt.nix
+++ b/src/modules/integrations/treefmt.nix
@@ -70,5 +70,7 @@ in
     # We automatically configure treefmt with the correct tree root for the project.
     # Set an empty default to detect when the user wants to use a custom root file.
     treefmt.config.projectRootFile = lib.mkDefault "";
+
+    tasks."devenv:treefmt:run".exec = "${treefmtWrapper}/bin/treefmt";
   };
 }


### PR DESCRIPTION

Adding a treefmt task can be usefull for defining composite development workflows that require executing multiple commands sequentially, like running a code generator before applying a formatter.
Such as in https://github.com/shikanime-studio/devlib/blob/d506f45cbce4967d02183956d4b43130da248876/modules/devenv/buf.nix
