### PR TITLE
Clarify contributing-guide: local devenv input

### DIFF
--- a/docs/src/community/contributing.md
+++ b/docs/src/community/contributing.md
@@ -22,12 +22,14 @@ We have a rule that new features need to come with documentation and tests (`dev
 
 2. `<PATH-TO-DEVENV-SOURCE-CODE>/result/bin/devenv init`
 
-3. Add devenv input pointing to local source directory to `devenv.yaml`
+3. Add devenv input pointing to local source directory to `devenv.yaml` under `inputs`
 
-```
-devenv:
-  url: path:<PATH-TO-DEVENV-SOURCE-CODE>?dir=src/modules
-```
+    ```
+    inputs:
+      ...
+      devenv:
+        url: path:<PATH-TO-DEVENV-SOURCE-CODE>?dir=src/modules
+    ```
 
 4. `<PATH-TO-DEVENV-SOURCE-CODE>/result/bin/devenv update`
 


### PR DESCRIPTION
I made the mistake of putting `devenv: url: path:<PATH-TO-DEVENV-SOURCE-CODE>?dir=src/modules` in the top-level of `devenv.yaml`. Instead in should go under the top-level key `inputs`, like `nixpkgs` already is.

I hope this documentation update will help the next person.

This diff also fixes so that bullet (4) is (4) and not (1) by indenting code-block with 4 spaces.