### PR TITLE
Fix: Docs: `devenv up` fails because of  missing library: cairo.

### DIFF
--- a/docs/devenv.nix
+++ b/docs/devenv.nix
@@ -9,6 +9,8 @@
   # Disable browserlist warnings that break git hooks
   env.BROWSERSLIST_IGNORE_OLD_DATA = "1";
 
+  packages = [ pkgs.cairo ];
+
   git-hooks.hooks = {
     generate-doc-css = {
       enable = true;


### PR DESCRIPTION
Added `cairo` to docs devenv.nix packages.

Running docs `devenv up` failed with:

```
--- devenv:processes:docs failed with error: Task exited with status: exit status: 1
--- devenv:processes:docs stdout:
0000.08: 
0000.08: Aborted with a BuildError!
--- devenv:processes:docs stderr:
0000.09: INFO    -  Building documentation...
0000.08: ERROR   -  "cairosvg" Python module is installed, but it crashed with:
0000.08: no library called "cairo-2" was found
0000.08: no library called "cairo" was found
0000.08: no library called "libcairo-2" was found
0000.08: cannot load library 'libcairo.so.2': libcairo.so.2: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo.so.2'
0000.08: cannot load library 'libcairo.2.dylib': libcairo.2.dylib: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo.2.dylib'
0000.08: cannot load library 'libcairo-2.dll': libcairo-2.dll: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo-2.dll'
0000.08: 
0000.08: --> Check out the troubleshooting guide: https://t.ly/MfX6u
---
```