### PR TITLE
git-hooks: support `git-hooks` being an optional input

### DIFF
--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -26,25 +26,23 @@ let
   # Uses freeformType to accept any attributes (tools, hooks, etc.) without type errors.
   defaultModule = lib.types.submoduleWith {
     modules = [
-      ({ ... }: {
-        freeformType = lib.types.attrsOf lib.types.anything;
-        options = {
-          enable = lib.mkOption {
-            type = lib.types.bool;
-            description = ''
-              Whether to enable the pre-commit hooks module.
+      (
+        { ... }:
+        {
+          freeformType = lib.types.attrsOf lib.types.anything;
+          options = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              description = ''
+                Whether to enable the pre-commit hooks module.
 
-              When set to false, this disables the entire module.
-            '';
-            default = false;
+                When set to false, this disables the entire module.
+              '';
+              default = false;
+            };
           };
-          hooks = lib.mkOption {
-            type = lib.types.attrsOf lib.types.attrs;
-            description = "Configuration for individual pre-commit hooks.";
-            default = { };
-          };
-        };
-      })
+        }
+      )
     ];
   };
 
@@ -103,14 +101,7 @@ in
       assertions = [
         {
           assertion = !cfg.enable || git-hooks != null;
-          message = ''
-            The git-hooks input is required when using git-hooks.
-
-            Run the following command to add it:
-
-              $ devenv inputs add git-hooks github:cachix/git-hooks.nix --follows nixpkgs
-
-          '';
+          message = config.lib._mkInputError inputArgs;
         }
       ];
     }

--- a/src/modules/lib.nix
+++ b/src/modules/lib.nix
@@ -8,7 +8,9 @@
   };
 
   config.lib = {
-    getInput = { name, url, attribute, follows ? [ ] }:
+    # Internal function to format input requirement messages.
+    # Underscore prefix signals this is not part of the public API.
+    _mkInputError = { name, url, attribute, follows ? [ ] }:
       let
         flags = lib.concatStringsSep " " (map (i: "--follows ${i}") follows);
         yaml_follows = lib.concatStringsSep "\n      " (map (i: "${i}:\n        follows: ${i}") follows);
@@ -39,7 +41,10 @@
                   ${if follows != [] then "inputs:\n      ${yaml_follows}" else ""}
           '';
       in
-        inputs.${name} or (throw "To use '${attribute}', ${command}\n\n");
+        "To use '${attribute}', ${command}";
+
+    getInput = args:
+      inputs.${args.name} or (throw "${config.lib._mkInputError args}\n\n");
 
     tryGetInput = { name, url, attribute, follows ? [ ] }:
       inputs.${name} or null;


### PR DESCRIPTION
The `git-hooks` input is currently always added by the devenv CLI.
This was done out of development convenience (for ourselves, mostly), but as devenv grows, it makes sense to make this large integration optional.

Another tricky bit is that the integration is enabled whenever any of the hooks are enabled. There's also a global `enable`, but that's imported as part of the submodule. This is why the integration here is quite a bit more complicated than, for example, treefmt.

Future versions of the devenv CLI will remove the default `git-hooks` input.