### PR TITLE
Docs: Clarify that changes to src/modules does not require rebuilding the binary

### DIFF
--- a/docs/src/community/contributing.md
+++ b/docs/src/community/contributing.md
@@ -33,6 +33,8 @@ We have a rule that new features need to come with documentation and tests (`dev
 
 4. `<PATH-TO-DEVENV-SOURCE-CODE>/result/bin/devenv update`
 
+    Now, that `devenv.yaml` is pointing to the local version of `src/modules`, changes made in `src/modules` will be picked up immediately on next shell activation. (No need to rebuild the binary.)
+
 ## Repository structure
 
 - The `devenv` CLI is in `devenv/src/main.rs`.


### PR DESCRIPTION
As a nix and devenv beginner it was not obvious to me that changes in `src/modules` was picked up without building the devenv binary. Added this to docs.