### PR TITLE
Fix spurious environment re-evaluation

### DIFF
--- a/devenv-core/src/cachix.rs
+++ b/devenv-core/src/cachix.rs
@@ -82,8 +82,8 @@ impl CachixManager {
     pub async fn get_nix_settings(
         &self,
         cachix_caches: &CachixCacheInfo,
-    ) -> Result<HashMap<String, String>> {
-        let mut settings = HashMap::new();
+    ) -> Result<BTreeMap<String, String>> {
+        let mut settings = BTreeMap::new();
 
         // Configure pull caches (substituters and trusted keys)
         if !cachix_caches.caches.pull.is_empty() {


### PR DESCRIPTION
I was tracing unexpected evals while no changes were made to the local files, and I noticed a cache miss due to shuffled nix command options (for extra-substituters and extra-trusted-public-keys). 

This changes `get_nix_settings` to return a BTreeMap instead of a HashMap, thereby guaranteeing lexicographic ordering.

<details><summary>Logs</summary>
<p>
Additional logging courtesy of claude-code

  2025-11-25T23:06:12.139092Z TRACE devenv_eval_cache::command: cache hit,              cmd: cd "/home/mrene/spaces/devenv-eval-logging/backend" && "/nix/store/407pr2lkcfqz8l79qdscw8lx95qa5hls-nix-devenv-2.30.0pre20251028_3e5644d/bin/nix" "--show-trace" "--extra-experimental-features" "nix-command" "--extra-experimental-features" "flakes" "--option" "lazy-trees" "true" "--option" "warn-dirty" "false" "--keep-going" "--max-jobs" "8" "--option" "eval-cache" "false" "--option" "always-allow-substitutes" "true" "--option" "http-connections" "100" "--option" "extra-trusted-public-keys" "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" "--option" "extra-substituters" "https://devenv.cachix.org https://nix-community.cachix.org" "print-dev-env" "--profile" "/home/mrene/spaces/devenv-eval-logging/backend/.devenv/gc/shell"

  2025-11-25T23:06:24.699520Z TRACE devenv_eval_cache::command: cache miss: not cached, cmd: cd "/home/mrene/spaces/devenv-eval-logging/backend" && "/nix/store/407pr2lkcfqz8l79qdscw8lx95qa5hls-nix-devenv-2.30.0pre20251028_3e5644d/bin/nix" "--show-trace" "--extra-experimental-features" "nix-command" "--extra-experimental-features" "flakes" "--option" "lazy-trees" "true" "--option" "warn-dirty" "false" "--keep-going" "--max-jobs" "8" "--option" "eval-cache" "false" "--option" "always-allow-substitutes" "true" "--option" "http-connections" "100" "--option" "extra-substituters" "https://devenv.cachix.org https://nix-community.cachix.org" "--option" "extra-trusted-public-keys" "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=" "print-dev-env" "--profile" "/home/mrene/spaces/devenv-eval-logging/backend/.devenv/gc/shell"
    at devenv-eval-cache/src/command.rs:555

</p>
</details> 
