### PR TITLE
flake-compat: only use env vars for root and tmpdir in flake mode

### DIFF
--- a/src/modules/flake-compat.nix
+++ b/src/modules/flake-compat.nix
@@ -1,3 +1,4 @@
+# Compatibility layer for devenv to work inside of a `nix develop` shell.
 { config
 , pkgs
 , lib
@@ -119,6 +120,26 @@ let
 in
 {
   config = lib.mkIf config.devenv.flakesIntegration {
+    assertions = [
+      {
+        assertion = config.devenv.root != "";
+        message = ''
+          devenv was not able to determine the current directory.
+
+          See https://devenv.sh/guides/using-with-flakes/ how to use it with flakes.
+        '';
+      }
+    ];
+
+    devenv.root = lib.mkDefault (builtins.getEnv "PWD");
+    # Used for TMPDIR override - should NOT use XDG_RUNTIME_DIR as that's
+    # a small tmpfs meant for runtime files (sockets), not build artifacts
+    devenv.tmpdir =
+      let
+        tmp = builtins.getEnv "TMPDIR";
+      in
+      lib.mkDefault (if tmp != "" then tmp else "/tmp");
+
     env.DEVENV_FLAKE_SHELL = shellName;
 
     # Add the flake command helpers directly to the path.

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -228,7 +228,6 @@ in
       root = lib.mkOption {
         type = types.str;
         internal = true;
-        default = builtins.getEnv "PWD";
       };
 
       dotfile = lib.mkOption {
@@ -265,13 +264,6 @@ in
       tmpdir = lib.mkOption {
         type = types.str;
         internal = true;
-        # Used for TMPDIR override - should NOT use XDG_RUNTIME_DIR as that's
-        # a small tmpfs meant for runtime files (sockets), not build artifacts
-        default =
-          let
-            tmp = builtins.getEnv "TMPDIR";
-          in
-          if tmp != "" then tmp else "/tmp";
       };
 
       profile = lib.mkOption {
@@ -308,14 +300,6 @@ in
 
   config = {
     assertions = [
-      {
-        assertion = config.devenv.root != "";
-        message = ''
-          devenv was not able to determine the current directory.
-
-          See https://devenv.sh/guides/using-with-flakes/ how to use it with flakes.
-        '';
-      }
       {
         assertion = config.devenv.flakesIntegration || config.overlays == [ ] || (config.devenv.cli.version != null && lib.versionAtLeast config.devenv.cli.version "1.4.2");
         message = ''


### PR DESCRIPTION
Move the env var defaults to the flake compat module. The defaults are only used in flake mode with `impure` eval.

`tmpdir` was added to the CLI in 1.0, making this change incompatible with devenv < 1.0