### PR TITLE
fix: make test_multiple_tasks deterministic with start_paused

### DIFF
--- a/devenv-tasks/src/task_cache.rs
+++ b/devenv-tasks/src/task_cache.rs
@@ -7,7 +7,7 @@ use devenv_cache_core::{
     file::TrackedFile,
     time,
 };
-use glob::{glob_with, MatchOptions};
+use glob::{MatchOptions, glob_with};
 use serde_json::Value;
 use sqlx::Row;
 use std::path::PathBuf;

--- a/devenv-tasks/src/tests/mod.rs
+++ b/devenv-tasks/src/tests/mod.rs
@@ -3146,7 +3146,9 @@ echo "Dotfiles task executed successfully"
             // This is the expected case
         }
         other => {
-            panic!("Expected Skipped status on third run after dotfile modification, got: {other:?}");
+            panic!(
+                "Expected Skipped status on third run after dotfile modification, got: {other:?}"
+            );
         }
     }
 

--- a/tokio-shutdown/Cargo.toml
+++ b/tokio-shutdown/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { workspace = true, features = [
 ] }
 tokio-util = { workspace = true }
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/tokio-shutdown/src/lib.rs
+++ b/tokio-shutdown/src/lib.rs
@@ -402,7 +402,8 @@ mod tests {
         assert!(cancelled.load(std::sync::atomic::Ordering::Relaxed));
     }
 
-    #[tokio::test]
+    // Use start_paused to make time deterministic and avoid race conditions
+    #[tokio::test(start_paused = true)]
     async fn test_multiple_tasks() {
         let shutdown = Shutdown::new();
 


### PR DESCRIPTION
The test was flaky due to race conditions between task spawning and the shutdown timer. Using tokio's start_paused feature makes time deterministic.

Also includes rustfmt formatting fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)