### PR TITLE
fix: invalidate execIfModified cache when command path changes

### DIFF
--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -58,8 +58,16 @@ impl TaskState {
             return Ok(false);
         }
 
+        // Include the command path in the files to check, so that
+        // changes to the task's exec script or dependencies will invalidate the cache.
+        // This works because Nix store paths are content-addressed.
+        let mut files_to_check = self.task.exec_if_modified.clone();
+        if let Some(cmd) = &self.task.command {
+            files_to_check.push(cmd.clone());
+        }
+
         cache
-            .check_modified_files(&self.task.name, &self.task.exec_if_modified)
+            .check_modified_files(&self.task.name, &files_to_check)
             .await
     }
 


### PR DESCRIPTION
When using execIfModified, changes to the task's exec script or Nix dependencies (like packages) would not trigger a re-run because only the explicitly listed files were tracked.

Now the command path (Nix store path) is included in the cache check. Since Nix store paths are content-addressed, any change to the task definition causes a different path, invalidating the cache.

Fixes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)