### PR TITLE
docs: add treefmt-nix to inputs

### DIFF
--- a/docs/src/integrations/treefmt.md
+++ b/docs/src/integrations/treefmt.md
@@ -2,6 +2,12 @@
 
 ## Set up
 
+Add `treefmt-nix` to your inputs:
+
+```shell-session
+$ devenv inputs add treefmt-nix github:numtide/treefmt-nix
+```
+
 Check the available integrations in [the list of all available integrations](/reference/options.md#treefmtenable).
 
 Add your desired integration to your `devenv.nix` file. For example, the following code would enable `treefmt` with the `nixpkgs-fmt` and `rustfmt` integrations:


### PR DESCRIPTION
Hi,

First of all, thank you for the great tool. I've switched all my projects to it 😄 

I ran into an input related error when enabling treefmt integration in my `devenv.nix` file. I thought the relevant input  would be automatically added since it wasn't mentioned in the docs but turns out we need to add it manually.