### PR TITLE
python: fix darwin library resolution mismatches

### DIFF
--- a/src/modules/languages/python/default.nix
+++ b/src/modules/languages/python/default.nix
@@ -276,7 +276,7 @@ in
           ]
           ++ lib.optionals pkgs.stdenv.isDarwin [
             "--prefix"
-            "DYLD_LIBRARY_PATH"
+            "DYLD_FALLBACK_LIBRARY_PATH"
             ":"
             (lib.makeLibraryPath libraries)
           ];


### PR DESCRIPTION
Since nixos-25.11, I have an issue running python3 in our devenv environment on darwin.

```
❯ python3
dyld[29918]: Symbol not found: _libiconv
  Referenced from: <07957CEF-EEB5-36BA-82E1-F4E59E3214F5> /nix/store/0xympds8qr7n3zaich3gdvwmccbc8p74-libidn2-2.3.8/lib/libidn2.0.dylib
  Expected in:     <0761956A-9436-33A8-A866-3B69FA204723> /nix/store/9kffgbvhza212ishsam4p8wklh92ih9v-libiconv-109.100.2/lib/libiconv.2.dylib
fish: Job 1, 'python3' terminated by signal SIGABRT (Abort)
```

After investigating, this only happens because the python wrapper overrides `DYLD_LIBRARY_PATH` with `.devenv/profile`, which overrides the default rpath-based library resolution. 

I'd propose ithat instead of setting `DYLD_LIBRARY_PATH`, it sets `DYLD_FALLBACK_LIBRARY_PATH`, which first attempts to load the library using LC_RPATH, and falls back to the .devenv/profile directory if this fails.

This fixes the issue on our end.

Relates to #1562