### PR TITLE
Add headers support for HTTP-based MCP for LLM agent

### DIFF
--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -219,11 +219,11 @@ Agents are specialized AI assistants that handle specific tasks with their own c
         - Security vulnerabilities
         - Performance issues
         - Adherence to project conventions
-        
+
         Provide constructive feedback with specific suggestions for improvement.
       '';
     };
-    
+
     test-writer = {
       description = "Specialized in writing comprehensive test suites";
       proactive = false;  # Only invoked explicitly
@@ -236,7 +236,7 @@ Agents are specialized AI assistants that handle specific tasks with their own c
         - Have clear test names that describe what is being tested
       '';
     };
-    
+
     docs-updater = {
       description = "Updates project documentation based on code changes";
       proactive = true;
@@ -316,6 +316,15 @@ MCP (Model Context Protocol) servers provide additional capabilities and context
       type = "http";
       url = "https://mcp.linear.app/mcp";
     };
+
+    # HTTP-based MCP server with authentication
+    github = {
+      type = "http";
+      url = "https://api.githubcopilot.com/mcp/";
+      headers = {
+        Authorization = "Bearer GITHUB_PAT";
+      };
+    };
   };
 }
 ```
@@ -329,6 +338,7 @@ MCP (Model Context Protocol) servers provide additional capabilities and context
 
 - **http**: Connects to an HTTP-based MCP server
   - `url`: The server URL
+  - `headers`: HTTP headers for authentication or custom configuration (optional)
 
 When MCP servers are configured, devenv generates a `.mcp.json` file that Claude Code uses to connect to these servers.
 

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -77,6 +77,8 @@ let
         else {
           type = "http";
           url = server.url;
+        } // lib.optionalAttrs (server.headers != { }) {
+          headers = server.headers;
         }
       else throw "Invalid MCP server type: ${server.type}"
     )
@@ -245,7 +247,7 @@ in
         Custom Claude Code sub-agents to create in the project.
         Sub-agents are specialized AI assistants that handle specific tasks
         with their own context window and can be invoked automatically or explicitly.
-        
+
         For more details, see: https://docs.anthropic.com/en/docs/claude-code/sub-agents
       '';
       example = lib.literalExpression ''
@@ -261,11 +263,11 @@ in
               - Security vulnerabilities
               - Performance issues
               - Adherence to project conventions
-              
+
               Provide constructive feedback with specific suggestions for improvement.
             ''';
           };
-          
+
           test-writer = {
             description = "Specialized in writing comprehensive test suites";
             proactive = false;
@@ -397,6 +399,11 @@ in
               default = null;
               description = "URL for HTTP MCP servers.";
             };
+            headers = lib.mkOption {
+              type = lib.types.attrsOf lib.types.str;
+              default = { };
+              description = "HTTP headers for HTTP MCP servers (e.g., for authentication).";
+            };
           };
         }
       );
@@ -412,6 +419,13 @@ in
             command = lib.getExe pkgs.awslabs-iam-mcp-server;
             args = [ ];
             env = { };
+          };
+          github = {
+            type = "http";
+            url = "https://api.githubcopilot.com/mcp/";
+            headers = {
+              Authorization = "Bearer GITHUB_PAT";
+            };
           };
           linear = {
             type = "http";


### PR DESCRIPTION
Current HTTP-based MCP supports `headers` attribute for authentication (see vscode [documentation](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_http-and-serversent-events-sse-servers)), e.g., [GitHub MCP](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-claude.md). This PR adds a new attribute `headers` for MCP.