### PR TITLE
terraform: support the new `terraform-${version}` terraform-nixpkgs API

### DIFF
--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -32,9 +32,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    languages.terraform.package = lib.mkMerge [
-      (lib.mkIf (cfg.version != null) (nixpkgs-terraform.packages.${pkgs.stdenv.system}.${cfg.version} or (throw "Unsupported Terraform version, update the nixpkgs-terraform input or go to https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")))
-    ];
+    languages.terraform.package = lib.mkIf (cfg.version != null) (
+      let
+        terraform-pkgs = nixpkgs-terraform.packages.${pkgs.stdenv.system};
+      in
+      terraform-pkgs."terraform-${cfg.version}" or terraform-pkgs.${cfg.version}
+        or (throw "Unsupported Terraform version, update the nixpkgs-terraform input or go to https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")
+    );
 
     packages = with pkgs; [
       cfg.package


### PR DESCRIPTION
Bare versions are deprecated in favor or prefixed versions like `terraform-1.13.0`.

See https://github.com/stackbuilders/nixpkgs-terraform/pull/158.