### PR TITLE
fix: isolate profile state in separate directories

### DIFF
--- a/devenv/direnvrc
+++ b/devenv/direnvrc
@@ -113,7 +113,9 @@ use_devenv() {
   fi
 
   devenv_dir=.
-  env_deps_path="$devenv_dir/.devenv/input-paths.txt"
+  # Get computed paths from devenv (handles profile-aware state isolation)
+  eval "$("${devenv_cmd[@]}" print-paths)"
+  env_deps_path="$DEVENV_DOTFILE/input-paths.txt"
 
   local default_watches
   default_watches=(".envrc" "$HOME/.direnvrc" "$HOME/.config/direnv/direnvrc")

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -149,6 +149,10 @@ pub enum Commands {
     #[clap(hide = true)]
     GenerateJSONSchema,
 
+    /// Print computed paths (dotfile, gc, etc.) for shell integration
+    #[clap(hide = true)]
+    PrintPaths,
+
     #[command(about = "Launch Model Context Protocol server for AI assistants")]
     Mcp {
         #[arg(

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -178,6 +178,27 @@ pub struct Devenv {
     shutdown: Arc<tokio_shutdown::Shutdown>,
 }
 
+/// Sanitize profile name to be filesystem-safe
+fn sanitize_profile_name(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ' ' | '\0' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c => c,
+        })
+        .collect()
+}
+
+/// Compute the profile directory suffix for state isolation
+fn compute_profile_dir_suffix(profiles: &[String]) -> Option<String> {
+    if profiles.is_empty() {
+        None
+    } else {
+        let mut sorted: Vec<String> = profiles.iter().map(|p| sanitize_profile_name(p)).collect();
+        sorted.sort();
+        Some(format!("profiles/{}", sorted.join("-")))
+    }
+}
+
 impl Devenv {
     pub async fn new(options: DevenvOptions) -> Self {
         let xdg_dirs = xdg::BaseDirectories::with_prefix("devenv");
@@ -191,10 +212,21 @@ impl Devenv {
             .devenv_root
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
-        let devenv_dotfile = options
+
+        // Get global_options early to access profiles for state directory isolation
+        let global_options = options.global_options.unwrap_or_default();
+
+        // Compute profile-aware dotfile path for state isolation
+        let base_devenv_dotfile = options
             .devenv_dotfile
             .map(|p| p.to_path_buf())
             .unwrap_or(devenv_root.join(".devenv"));
+        let devenv_dotfile =
+            if let Some(suffix) = compute_profile_dir_suffix(&global_options.profile) {
+                base_devenv_dotfile.join(suffix)
+            } else {
+                base_devenv_dotfile
+            };
         let devenv_dot_gc = devenv_dotfile.join("gc");
 
         let devenv_tmp =
@@ -209,8 +241,6 @@ impl Devenv {
             hex::encode(result)
         };
         let devenv_runtime = devenv_tmp.join(format!("devenv-{}", &devenv_state_hash[..7]));
-
-        let global_options = options.global_options.unwrap_or_default();
 
         xdg_dirs
             .create_data_directory(Path::new("devenv"))

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -472,6 +472,16 @@ async fn run_devenv(cli: Cli, shutdown: Arc<Shutdown>) -> Result<CommandResult> 
                 .wrap_err("Failed to generate JSON schema")?;
             CommandResult::Done
         }
+        Commands::PrintPaths => {
+            let paths = devenv.paths();
+            let output = format!(
+                "DEVENV_DOTFILE=\"{}\"\nDEVENV_ROOT=\"{}\"\nDEVENV_GC=\"{}\"",
+                paths.dotfile.display(),
+                paths.root.display(),
+                paths.dot_gc.display()
+            );
+            CommandResult::Print(output)
+        }
         Commands::Mcp { http } => {
             let config = devenv.config.read().await.clone();
             devenv::mcp::run_mcp_server(config, http.map(|p| p.unwrap_or(8080))).await?;


### PR DESCRIPTION
Each profile now gets its own state directory to prevent old state from persisting when switching profiles. This fixes the issue where environment variables, processes, and GC roots from one profile would leak into another.

- No profile: uses `.devenv/` (backward compatible)
- With profiles: uses `.devenv/profiles/<sorted-joined-names>/`
- Example: `--profile backend --profile frontend` → `.devenv/profiles/backend-frontend/`

All state files are now profile-isolated:
- gc/shell, processes.pid, processes.log, input-paths.txt, etc.

Fixes #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)