### PR TITLE
fix: ensure process output is captured for process-compose logs

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -159,6 +159,8 @@ in
             type = "process";
             exec = process.exec;
             cwd = process.cwd;
+            # Always show output for process tasks so process-compose can capture it
+            showOutput = true;
           };
         })
         config.processes;


### PR DESCRIPTION
When running under process-compose, devenv-tasks was suppressing output because it defaulted to Quiet mode (to avoid TUI corruption). However, when there's no TTY, there's no TUI to corrupt, and process-compose needs to capture stdout/stderr for its log_location feature.

This fix:
1. Checks for TTY presence before defaulting to Quiet mode - if no TTY, use Normal verbosity instead
2. Sets showOutput=true for process tasks in processes.nix, ensuring process output is always visible

Fixes #2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)