### PR TITLE
modules: replace self with devenv.source

### DIFF
--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -215,6 +215,7 @@ rec {
       baseProject = lib.evalModules {
         specialArgs = inputs // {
           inherit inputs secretspec;
+          self = throw "use config.devenv.source instead of self";
         };
         modules = [
           (
@@ -580,6 +581,7 @@ rec {
           specialArgs = allInputs // {
             inputs = allInputs;
             secretspec = null;
+            self = throw "use config.devenv.source instead of self";
           };
           modules = [
             ({ config, ... }: {

--- a/devenv.lock
+++ b/devenv.lock
@@ -78,6 +78,26 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -215,16 +235,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1764580874,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "dcf61356c3ab25f1362b4a4428a6d871e84f1d1d",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -232,13 +253,12 @@
       "inputs": {
         "devenv": "devenv",
         "devenv-claude-agents": "devenv-claude-agents",
+        "flake-utils": "flake-utils",
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ],
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
       }
     },
     "rust-overlay": {
@@ -257,6 +277,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -84,7 +84,9 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "gitignore": "gitignore",
+        "gitignore": [
+          "gitignore"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -106,16 +108,15 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "git-hooks",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
@@ -203,6 +204,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
+        "gitignore": "gitignore",
         "nix": "nix",
         "nixd": "nixd",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,12 @@
     inputs = {
       nixpkgs.follows = "nixpkgs";
       flake-compat.follows = "flake-compat";
+      gitignore.follows = "gitignore";
     };
+  };
+  inputs.gitignore = {
+    url = "github:hercules-ci/gitignore.nix";
+    inputs.nixpkgs.follows = "nixpkgs";
   };
   inputs.flake-compat = {
     url = "github:edolstra/flake-compat";
@@ -57,6 +62,7 @@
     { self
     , nixpkgs
     , git-hooks
+    , gitignore
     , nix
     , ...
     }@inputs:
@@ -169,7 +175,7 @@
           }:
           let
             # TODO: deprecate default git-hooks input
-            defaultInputs = { inherit git-hooks; };
+            defaultInputs = { inherit git-hooks gitignore; };
             finalInputs = defaultInputs // inputs;
 
             specialArgs = finalInputs // {

--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, self, ... }:
+{ pkgs, config, lib, ... }:
 
 let
   projectName = name:
@@ -7,6 +7,7 @@ let
     else config.name;
   types = lib.types;
   envContainerName = builtins.getEnv "DEVENV_CONTAINER";
+  inherit (config.devenv) source;
 
   nix2containerInput = config.lib.getInput {
     name = "nix2container";
@@ -204,9 +205,9 @@ let
 
       copyToRoot = lib.mkOption {
         type = types.either types.path (types.listOf types.path);
-        description = "Add a path to the container. Defaults to the whole git repo.";
-        default = self;
-        defaultText = lib.literalExpression "self";
+        description = "Add a path to the container. Defaults to the project source filtered by .gitignore.";
+        default = source;
+        defaultText = lib.literalExpression "config.devenv.source";
       };
 
       startupCommand = lib.mkOption {

--- a/src/modules/integrations/dotenv.nix
+++ b/src/modules/integrations/dotenv.nix
@@ -1,11 +1,12 @@
-{ config, lib, self, ... }:
+{ config, lib, ... }:
 
 let
   cfg = config.dotenv;
 
   normalizeFilenames = filenames: if lib.isList filenames then filenames else [ filenames ];
   dotenvFiles = normalizeFilenames cfg.filename;
-  dotenvPaths = map (filename: (self + ("/" + filename))) dotenvFiles;
+  devenvRoot = /. + config.devenv.root;
+  dotenvPaths = map (filename: devenvRoot + "/" + filename) dotenvFiles;
 
   parseLine = line:
     let

--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -1,5 +1,4 @@
 { pkgs
-, self
 , lib
 , config
 , inputs
@@ -52,7 +51,7 @@ let
           modules = [
             (git-hooks + "/modules/all-modules.nix")
             {
-              rootSrc = self;
+              rootSrc = config.devenv.source;
               package = lib.mkDefault pkgs.pre-commit;
               tools = import (git-hooks + "/nix/call-tools.nix") pkgs;
             }

--- a/src/modules/machines.nix
+++ b/src/modules/machines.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, lib, self, ... }:
+{ pkgs, config, lib, ... }:
 
 let
   machineOptions = lib.types.submodule ({ name, config, ... }: {


### PR DESCRIPTION
Remove direct usage of flake `self` from all modules by introducing a new `devenv.source` option that provides filtered project source.

For flake users, `self` (passed via inputs) is used directly since it's already git-filtered. For non-flake users, gitignore.nix filters the source (with lib.cleanSource as fallback).

- Add gitignore.nix as direct flake input
- Add devenv.source option in top-level.nix
- containers.nix: copyToRoot defaults to devenv.source
- git-hooks.nix: rootSrc uses devenv.source
- dotenv.nix: uses devenv.root (raw path for file reading)
- machines.nix: remove unused self parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)