### PR TITLE
Fix devenv issue 2377

### DIFF
--- a/src/modules/services/caddy.nix
+++ b/src/modules/services/caddy.nix
@@ -190,6 +190,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    processes.caddy.exec = ''XDG_DATA_HOME="${cfg.dataDir}/data" XDG_CONFIG_HOME="${cfg.dataDir}/config" ${cfg.package}/bin/${cfg.package.meta.mainProgram} run ${optionalString cfg.resume "--resume"} --config ${configJSON}'';
+    processes.caddy.exec = ''
+      export XDG_DATA_HOME="${cfg.dataDir}/data"
+      export XDG_CONFIG_HOME="${cfg.dataDir}/config"
+      exec ${cfg.package}/bin/${cfg.package.meta.mainProgram} run ${optionalString cfg.resume "--resume"} --config ${configJSON}
+    '';
   };
 }


### PR DESCRIPTION
Bash's exec builtin doesn't support environment variable prefix syntax (exec VAR=value command). Change to export variables before exec to properly set XDG_DATA_HOME and XDG_CONFIG_HOME for the caddy process.

Fixes #2377