### PR TITLE
feat(languages): add lsp.enable and lsp.package options to all langua…

### DIFF
--- a/examples/supported-languages/.patch.sh
+++ b/examples/supported-languages/.patch.sh
@@ -10,5 +10,7 @@ cat > devenv.local.nix << EOF
   languages.odin.enable = lib.mkForce (!(pkgs.stdenv.isDarwin || (pkgs.stdenv.isLinux && pkgs.stdenv.isAarch64)));
   # macOS is broken.
   languages.racket.enable = lib.mkForce (!pkgs.stdenv.isDarwin);
+  # Swift broken on Linux with GCC 14 - https://github.com/NixOS/nixpkgs/pull/468796
+  languages.swift.enable = lib.mkForce pkgs.stdenv.isDarwin;
 }
 EOF

--- a/examples/supported-languages/devenv.yaml
+++ b/examples/supported-languages/devenv.yaml
@@ -1,1 +1,8 @@
 allowUnfree: true
+
+inputs:
+  purescript-overlay:
+    url: github:thomashoneyman/purescript-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/src/modules/languages/ansible.nix
+++ b/src/modules/languages/ansible.nix
@@ -2,6 +2,8 @@
 
 let
   cfg = config.languages.ansible;
+  # ansible-language-server may not be available in all nixpkgs versions
+  hasLsp = pkgs ? ansible-language-server && (builtins.tryEval pkgs.ansible-language-server).success;
 in
 {
   options.languages.ansible = {
@@ -13,13 +15,26 @@ in
       defaultText = lib.literalExpression "pkgs.ansible";
       description = "The Ansible package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Ansible Language Server" // {
+        default = hasLsp;
+      };
+
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = if hasLsp then pkgs.ansible-language-server else null;
+        defaultText = lib.literalExpression "pkgs.ansible-language-server";
+        description = "The Ansible language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
-      ansible-lint
+    packages = [
+      pkgs.ansible-lint
       cfg.package
-    ];
+    ] ++ lib.optional (cfg.lsp.enable && cfg.lsp.package != null) cfg.lsp.package;
   };
 }
 

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -7,6 +7,16 @@ in
   options.languages.c = {
     enable = lib.mkEnableOption "tools for C development";
 
+    lsp = {
+      enable = lib.mkEnableOption "C Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.ccls;
+        defaultText = lib.literalExpression "pkgs.ccls";
+        description = "The C language server package to use.";
+      };
+    };
+
     debugger = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
       default =
@@ -26,9 +36,9 @@ in
       clang-tools
       stdenv
       gnumake
-      ccls
       pkg-config
-    ] ++ lib.optional (cfg.debugger != null) cfg.debugger
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package
+    ++ lib.optional (cfg.debugger != null) cfg.debugger
     ++ lib.optional (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.valgrind && !pkgs.valgrind.meta.broken) pkgs.valgrind;
   };
 }

--- a/src/modules/languages/clojure.nix
+++ b/src/modules/languages/clojure.nix
@@ -6,15 +6,25 @@ in
 {
   options.languages.clojure = {
     enable = lib.mkEnableOption "tools for Clojure development";
+
+    lsp = {
+      enable = lib.mkEnableOption "Clojure Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.clojure-lsp;
+        defaultText = lib.literalExpression "pkgs.clojure-lsp";
+        description = "The Clojure language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
-      (clojure.override {
+    packages = [
+      (pkgs.clojure.override {
         jdk = config.languages.java.jdk.package;
       })
-      clojure-lsp
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
     languages.java.enable = true;
   };
 }

--- a/src/modules/languages/cplusplus.nix
+++ b/src/modules/languages/cplusplus.nix
@@ -6,6 +6,16 @@ in
 {
   options.languages.cplusplus = {
     enable = lib.mkEnableOption "tools for C++ development";
+
+    lsp = {
+      enable = lib.mkEnableOption "C++ Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.ccls;
+        defaultText = lib.literalExpression "pkgs.ccls";
+        description = "The C++ language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -13,7 +23,6 @@ in
       clang-tools
       cmake
       clang
-      ccls
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/crystal.nix
+++ b/src/modules/languages/crystal.nix
@@ -26,6 +26,16 @@ in
       description = "Configuration for shards";
       default = { };
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Crystal Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.crystalline;
+        defaultText = lib.literalExpression "pkgs.crystalline";
+        description = "The Crystal language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -35,6 +45,6 @@ in
     packages = [
       cfg.package
       cfg.shards.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/cue.nix
+++ b/src/modules/languages/cue.nix
@@ -13,11 +13,22 @@ in
       defaultText = lib.literalExpression "pkgs.cue";
       description = "The CUE package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "CUE Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.cuelsp;
+        defaultText = lib.literalExpression "pkgs.cuelsp";
+        description = "The CUE language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/dotnet.nix
+++ b/src/modules/languages/dotnet.nix
@@ -13,12 +13,26 @@ in
       defaultText = lib.literalExpression "pkgs.dotnet-sdk";
       description = "The .NET SDK package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption ".NET Language Server" // {
+        # csharp-ls crashes on aarch64-darwin due to missing code signatures
+        # https://github.com/razzmatazz/csharp-language-server/issues/211
+        default = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.csharp-ls;
+      };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.csharp-ls;
+        defaultText = lib.literalExpression "pkgs.csharp-ls";
+        description = "The .NET language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env.DOTNET_ROOT = "${
         if lib.hasAttr "unwrapped" cfg.package

--- a/src/modules/languages/elixir.nix
+++ b/src/modules/languages/elixir.nix
@@ -13,6 +13,17 @@ in
       default = pkgs.elixir;
       defaultText = lib.literalExpression "pkgs.elixir";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Elixir Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.elixir-ls;
+        defaultText = lib.literalExpression "pkgs.elixir-ls";
+        description = "The Elixir language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable
@@ -24,9 +35,8 @@ in
         mix-test.package = cfg.package;
       };
 
-      packages = with pkgs; [
+      packages = [
         cfg.package
-        elixir-ls
-      ];
+      ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
     };
 }

--- a/src/modules/languages/elm.nix
+++ b/src/modules/languages/elm.nix
@@ -6,6 +6,17 @@ in
 {
   options.languages.elm = {
     enable = lib.mkEnableOption "tools for Elm development";
+
+    lsp = {
+      enable = lib.mkEnableOption "Elm Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.elmPackages.elm-language-server;
+        defaultText = lib.literalExpression "pkgs.elmPackages.elm-language-server";
+        description = "The Elm language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -13,8 +24,7 @@ in
       elmPackages.elm
       elmPackages.elm-format
       elmPackages.elm-test
-      elmPackages.elm-language-server
       elm2nix
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/erlang.nix
+++ b/src/modules/languages/erlang.nix
@@ -17,13 +17,23 @@ in
       default = pkgs.erlang;
       defaultText = lib.literalExpression "pkgs.erlang";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Erlang Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.erlang-language-platform;
+        defaultText = lib.literalExpression "pkgs.erlang-language-platform";
+        description = "The Erlang language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.erlang-language-platform
       rebar3
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/fortran.nix
+++ b/src/modules/languages/fortran.nix
@@ -13,12 +13,22 @@ in
       defaultText = lib.literalExpression "pkgs.gfortran";
       description = "The Fortran package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Fortran Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.fortls;
+        defaultText = lib.literalExpression "pkgs.fortls";
+        description = "The Fortran language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
+      cfg.package
       fortran-fpm
-      fortran-language-server
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/go.nix
+++ b/src/modules/languages/go.nix
@@ -59,6 +59,16 @@ in
       default = false;
       description = "Enable hardening workaround required for Delve debugger (https://github.com/go-delve/delve/issues/3085)";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Go Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.gopls;
+        defaultText = lib.literalExpression "pkgs.gopls";
+        description = "The Go language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -78,12 +88,11 @@ in
       (buildWithSpecificGo pkgs.gomodifytags)
       (buildWithSpecificGo pkgs.impl)
       (buildWithSpecificGo pkgs.go-tools)
-      (buildWithSpecificGo pkgs.gopls)
       (buildWithSpecificGo pkgs.gotests)
 
       # Required by vim-go
       (buildWithSpecificGo pkgs.iferr)
-    ];
+    ] ++ lib.optional cfg.lsp.enable (buildWithSpecificGo cfg.lsp.package);
 
     hardeningDisable = lib.optional (cfg.enableHardeningWorkaround) "fortify";
 

--- a/src/modules/languages/haskell.nix
+++ b/src/modules/languages/haskell.nix
@@ -16,6 +16,10 @@ let
   ghcVersion = lib.replaceStrings [ "." ] [ "" ] cfg.package.version;
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "languages" "haskell" "languageServer" ] [ "languages" "haskell" "lsp" "package" ])
+  ];
+
   options.languages.haskell = {
     enable = lib.mkEnableOption "tools for Haskell development";
 
@@ -28,16 +32,18 @@ in
       '';
     };
 
-    languageServer = lib.mkOption {
-      type = lib.types.nullOr lib.types.package;
-      default = pkgs.haskell-language-server.override
-        {
-          supportedGhcVersions = [ ghcVersion ];
-        };
-      defaultText = lib.literalExpression "pkgs.haskell-language-server";
-      description = ''
-        Haskell language server to use.
-      '';
+    lsp = {
+      enable = lib.mkEnableOption "Haskell Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.haskell-language-server.override
+          {
+            supportedGhcVersions = [ ghcVersion ];
+          };
+        defaultText = lib.literalExpression "pkgs.haskell-language-server";
+        description = "The Haskell language server package to use.";
+      };
     };
 
     stack = {
@@ -93,7 +99,7 @@ in
       zlib
       hpack
     ]
-    ++ (lib.optional (cfg.languageServer != null) cfg.languageServer)
+    ++ (lib.optional cfg.lsp.enable cfg.lsp.package)
     ++ (lib.optional cfg.cabal.enable cfg.cabal.package)
     ++ (lib.optional cfg.stack.enable stackWrapper);
   };

--- a/src/modules/languages/helm.nix
+++ b/src/modules/languages/helm.nix
@@ -18,6 +18,11 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "languages" "helm" "languageServer" "enable" ] [ "languages" "helm" "lsp" "enable" ])
+    (lib.mkRenamedOptionModule [ "languages" "helm" "languageServer" "package" ] [ "languages" "helm" "lsp" "package" ])
+  ];
+
   options.languages.helm = {
     enable = lib.mkEnableOption "tools for Helm development";
 
@@ -39,14 +44,14 @@ in
       '';
     };
 
-    languageServer = {
-      enable = lib.mkEnableOption "Helm language server";
+    lsp = {
+      enable = lib.mkEnableOption "Helm Language Server" // { default = true; };
 
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.helm-ls;
         defaultText = lib.literalExpression "pkgs.helm-ls";
-        description = "The Helm language server package to include.";
+        description = "The Helm language server package to use.";
       };
     };
   };
@@ -54,7 +59,7 @@ in
   config = lib.mkIf cfg.enable {
     packages =
       [ cfg.package ]
-      ++ lib.optional cfg.languageServer.enable cfg.languageServer.package;
+      ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env.HELM_PLUGINS = "${helm-plugins-dir}";
   };

--- a/src/modules/languages/idris.nix
+++ b/src/modules/languages/idris.nix
@@ -14,11 +14,22 @@ in {
       '';
       example = lib.literalExpression "pkgs.idris";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Idris Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.idris2Packages.idris2Lsp;
+        defaultText = lib.literalExpression "pkgs.idris2Packages.idris2Lsp";
+        description = "The Idris language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/java.nix
+++ b/src/modules/languages/java.nix
@@ -46,6 +46,15 @@ in
         '';
       };
     };
+    lsp = {
+      enable = mkEnableOption "Java Language Server" // { default = true; };
+      package = mkOption {
+        type = types.package;
+        default = pkgs.jdt-language-server;
+        defaultText = literalExpression "pkgs.jdt-language-server";
+        description = "The Java language server package to use.";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -53,7 +62,8 @@ in
     languages.java.gradle.package = mkDefault (pkgs.gradle.override { java = cfg.jdk.package; });
     packages = (optional cfg.enable cfg.jdk.package)
       ++ (optional cfg.maven.enable cfg.maven.package)
-      ++ (optional cfg.gradle.enable cfg.gradle.package);
+      ++ (optional cfg.gradle.enable cfg.gradle.package)
+      ++ (optional cfg.lsp.enable cfg.lsp.package);
 
     env.JAVA_HOME = cfg.jdk.package.home;
   };

--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -305,6 +305,16 @@ in
       };
       install.enable = lib.mkEnableOption "bun install during devenv initialisation";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "TypeScript Language Server for JavaScript" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.typescript-language-server;
+        defaultText = lib.literalExpression "pkgs.typescript-language-server";
+        description = "The TypeScript/JavaScript language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -321,7 +331,8 @@ in
           mkdir -p $out/bin
           ${cfg.package}/bin/corepack enable --install-directory $out/bin
         ''
-      );
+      )
+      ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     enterShell = lib.concatStringsSep "\n" (
       (lib.optional cfg.npm.install.enable ''

--- a/src/modules/languages/jsonnet.nix
+++ b/src/modules/languages/jsonnet.nix
@@ -6,11 +6,22 @@ in
 {
   options.languages.jsonnet = {
     enable = lib.mkEnableOption "tools for jsonnet development";
+
+    lsp = {
+      enable = lib.mkEnableOption "Jsonnet Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.jsonnet-language-server;
+        defaultText = lib.literalExpression "pkgs.jsonnet-language-server";
+        description = "The Jsonnet language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
-      go-jsonnet
-    ];
+    packages = [
+      pkgs.go-jsonnet
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/kotlin.nix
+++ b/src/modules/languages/kotlin.nix
@@ -6,12 +6,21 @@ in
 {
   options.languages.kotlin = {
     enable = lib.mkEnableOption "tools for Kotlin development";
+    lsp = {
+      enable = lib.mkEnableOption "Kotlin Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.kotlin-language-server;
+        defaultText = lib.literalExpression "pkgs.kotlin-language-server";
+        description = "The Kotlin language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       kotlin
       gradle
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/lua.nix
+++ b/src/modules/languages/lua.nix
@@ -13,12 +13,21 @@ in
       defaultText = lib.literalExpression "pkgs.lua";
       description = "The Lua package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Lua Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.lua-language-server;
+        defaultText = lib.literalExpression "pkgs.lua-language-server";
+        description = "The Lua language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.lua-language-server
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/nim.nix
+++ b/src/modules/languages/nim.nix
@@ -13,12 +13,21 @@ in
       defaultText = lib.literalExpression "pkgs.nim";
       description = "The Nim package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Nim Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.nimlangserver;
+        defaultText = lib.literalExpression "pkgs.nimlangserver";
+        description = "The Nim language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.nimlangserver
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/nix.nix
+++ b/src/modules/languages/nix.nix
@@ -14,11 +14,16 @@ in
 {
   options.languages.nix = {
     enable = lib.mkEnableOption "tools for Nix development";
-    lsp.package = lib.mkOption {
-      type = lib.types.package;
-      default = pkgs.nil;
-      defaultText = lib.literalExpression "pkgs.nil";
-      description = "The LSP package to use";
+
+    lsp = {
+      enable = lib.mkEnableOption "Nix Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.nixd;
+        defaultText = lib.literalExpression "pkgs.nixd";
+        description = "The Nix language server package to use.";
+      };
     };
   };
 
@@ -26,8 +31,8 @@ in
     packages = with pkgs; [
       statix
       deadnix
-      cfg.lsp.package
       vulnix
-    ] ++ (lib.optional config.cachix.enable cachix);
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package
+      ++ lib.optional config.cachix.enable cachix;
   };
 }

--- a/src/modules/languages/ocaml.nix
+++ b/src/modules/languages/ocaml.nix
@@ -14,19 +14,28 @@ in
         default = pkgs.ocaml-ng.ocamlPackages;
         defaultText = lib.literalExpression "pkgs.ocaml-ng.ocamlPackages_4_12";
       };
+
+    lsp = {
+      enable = lib.mkEnableOption "OCaml Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.ocamlPackages.ocaml-lsp;
+        defaultText = lib.literalExpression "pkgs.ocamlPackages.ocaml-lsp";
+        description = "The OCaml language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.packages.ocaml
       cfg.packages.dune_3
-      cfg.packages.ocaml-lsp
       cfg.packages.merlin
       cfg.packages.utop
       cfg.packages.odoc
       cfg.packages.ocp-indent
       cfg.packages.findlib
       pkgs.ocamlformat
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/odin.nix
+++ b/src/modules/languages/odin.nix
@@ -26,6 +26,16 @@ in
         The default is `gdb`, if supported on the current system.
       '';
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Odin Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.ols;
+        defaultText = lib.literalExpression "pkgs.ols";
+        description = "The Odin language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -35,6 +45,6 @@ in
       gnumake
       cfg.package
     ] ++ lib.optional (cfg.debugger != null) cfg.debugger
-    ++ lib.optional (lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.ols) pkgs.ols;
+    ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/opentofu.nix
+++ b/src/modules/languages/opentofu.nix
@@ -13,6 +13,17 @@ in
       defaultText = lib.literalExpression "pkgs.opentofu";
       description = "The OpenTofu package to use.";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "OpenTofu Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.terraform-ls;
+        defaultText = lib.literalExpression "pkgs.terraform-ls";
+        description = "The OpenTofu language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -23,6 +34,6 @@ in
 
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/perl.nix
+++ b/src/modules/languages/perl.nix
@@ -13,6 +13,16 @@ in
         default = [ ];
         example = [ "Mojolicious" ];
       };
+
+    lsp = {
+      enable = lib.mkEnableOption "Perl Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.perlnavigator;
+        defaultText = lib.literalExpression "pkgs.perlnavigator";
+        description = "The Perl language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -20,6 +30,6 @@ in
       (perl.withPackages (p: (with builtins; map
         (pkg: p.${ replaceStrings [ "::" ] [ "" ] pkg })
         cfg.packages)))
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/php.nix
+++ b/src/modules/languages/php.nix
@@ -230,6 +230,16 @@ in
       '';
     };
 
+    lsp = {
+      enable = lib.mkEnableOption "PHP Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.phpactor;
+        defaultText = lib.literalExpression "pkgs.phpactor";
+        description = "The PHP language server package to use.";
+      };
+    };
+
     fpm = {
       settings = mkOption {
         type = with types; attrsOf (oneOf [ str int bool ]);
@@ -332,7 +342,8 @@ in
 
       packages = with pkgs; [
         cfg.package
-      ] ++ lib.optional (cfg.packages.composer != null) cfg.packages.composer;
+      ] ++ lib.optional (cfg.packages.composer != null) cfg.packages.composer
+        ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
       env.PHPFPMDIR = runtimeDir;
 

--- a/src/modules/languages/purescript.nix
+++ b/src/modules/languages/purescript.nix
@@ -1,7 +1,19 @@
-{ pkgs, config, lib, ... }:
+{ pkgs
+, config
+, lib
+, ...
+}:
 
 let
   cfg = config.languages.purescript;
+
+  purescript-overlay = config.lib.getInput {
+    name = "purescript-overlay";
+    url = "github:thomashoneyman/purescript-overlay";
+    attribute = "languages.purescript.enable";
+    follows = [ "nixpkgs" ];
+  };
+
   # supported via rosetta
   supportAarch64Darwin = package: package.overrideAttrs (attrs: {
     meta = attrs.meta // {
@@ -15,20 +27,48 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = (supportAarch64Darwin pkgs.purescript);
-      defaultText = lib.literalExpression "pkgs.purescript";
-      description = "The PureScript package to use.";
+      default = purescript-overlay.packages.${pkgs.stdenv.system}.purs;
+      defaultText = lib.literalExpression "purescript-overlay.packages.\${pkgs.stdenv.system}.purs";
+      description = ''
+        The PureScript compiler package to use.
+        Uses [purescript-overlay](https://github.com/thomashoneyman/purescript-overlay) by default.
+      '';
     };
 
+    spago = {
+      enable = lib.mkEnableOption "Spago package manager" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = purescript-overlay.packages.${pkgs.stdenv.system}.spago;
+        defaultText = lib.literalExpression "purescript-overlay.packages.\${pkgs.stdenv.system}.spago";
+        description = ''
+          The Spago package manager to use.
+          Uses [purescript-overlay](https://github.com/thomashoneyman/purescript-overlay) by default.
+        '';
+      };
+    };
+
+    lsp = {
+      enable = lib.mkEnableOption "PureScript Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = purescript-overlay.packages.${pkgs.stdenv.system}.purescript-language-server;
+        defaultText = lib.literalExpression "purescript-overlay.packages.\${pkgs.stdenv.system}.purescript-language-server";
+        description = ''
+          The PureScript language server package to use.
+          Uses [purescript-overlay](https://github.com/thomashoneyman/purescript-overlay) by default.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.nodePackages.purescript-language-server
-      pkgs.nodePackages.purs-tidy
-      pkgs.purescript-psa
-      (supportAarch64Darwin pkgs.psc-package)
-    ];
+    ]
+    ++ lib.optional cfg.spago.enable cfg.spago.package
+    ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/python/default.nix
+++ b/src/modules/languages/python/default.nix
@@ -467,6 +467,16 @@ in
       };
     };
 
+    lsp = {
+      enable = lib.mkEnableOption "Python Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.pyright;
+        defaultText = lib.literalExpression "pkgs.pyright";
+        description = "The Python language server package to use.";
+      };
+    };
+
     poetry = {
       enable = lib.mkEnableOption "poetry";
       install = {
@@ -599,7 +609,8 @@ in
       cfg.package
     ]
     ++ (lib.optional cfg.poetry.enable cfg.poetry.package)
-    ++ (lib.optional cfg.uv.enable cfg.uv.package);
+    ++ (lib.optional cfg.uv.enable cfg.uv.package)
+    ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env =
       (lib.optionalAttrs cfg.uv.enable {

--- a/src/modules/languages/r.nix
+++ b/src/modules/languages/r.nix
@@ -21,9 +21,23 @@ in
         description = "The radian package to use.";
       };
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "R Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.rPackages.languageserver;
+        defaultText = lib.literalExpression "pkgs.rPackages.languageserver";
+        description = "The R language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [ cfg.package ] ++ lib.lists.optional cfg.radian.enable cfg.radian.package;
+    packages = [
+      cfg.package
+    ] ++ lib.optional cfg.radian.enable cfg.radian.package
+      ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/ruby.nix
+++ b/src/modules/languages/ruby.nix
@@ -65,6 +65,16 @@ in
     documentation = {
       enable = lib.mkEnableOption "documentation support for Ruby packages";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Ruby Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.solargraph;
+        defaultText = lib.literalExpression "pkgs.solargraph";
+        description = "The Ruby language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -107,7 +117,7 @@ in
 
     packages = lib.optional cfg.bundler.enable cfg.bundler.package ++ [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env.BUNDLE_PATH = config.env.DEVENV_STATE + "/.bundle";
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -81,6 +81,16 @@ in
       '';
     };
 
+    lsp = {
+      enable = lib.mkEnableOption "Rust Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.rust-analyzer;
+        defaultText = lib.literalExpression "pkgs.rust-analyzer";
+        description = "The Rust language server package to use.";
+      };
+    };
+
     toolchain = lib.mkOption {
       type = lib.types.submodule ({
         freeformType = lib.types.attrsOf lib.types.package;
@@ -241,7 +251,8 @@ in
 
         packages =
           lib.optional cfg.mold.enable pkgs.mold-wrapped
-          ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv;
+          ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv
+          ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
         # enable compiler tooling by default to expose things like cc
         languages.c.enable = lib.mkDefault true;

--- a/src/modules/languages/scala.nix
+++ b/src/modules/languages/scala.nix
@@ -36,6 +36,16 @@ in
         default = "mill";
       };
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Scala Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.metals;
+        defaultText = lib.literalExpression "pkgs.metals";
+        description = "The Scala language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -43,10 +53,10 @@ in
       with pkgs;
       [
         (cfg.package.override { jre = java.jdk.package; })
-        (metals.override { jre = java.jdk.package; })
         (coursier.override { jre = java.jdk.package; })
         (scalafmt.override { jre = java.jdk.package; })
       ]
+      ++ lib.optional cfg.lsp.enable (cfg.lsp.package.override { jre = java.jdk.package; })
       ++ lib.optionals cfg.sbt.enable [
         (sbt.override (
           old:

--- a/src/modules/languages/shell.nix
+++ b/src/modules/languages/shell.nix
@@ -6,14 +6,23 @@ in
 {
   options.languages.shell = {
     enable = lib.mkEnableOption "tools for shell development";
+
+    lsp = {
+      enable = lib.mkEnableOption "Shell Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.bash-language-server;
+        defaultText = lib.literalExpression "pkgs.bash-language-server";
+        description = "The Shell language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       (pkgs.bats.withLibraries (p: [ p.bats-assert p.bats-file p.bats-support ]))
-      nodePackages.bash-language-server
       shellcheck
       shfmt
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/standardml.nix
+++ b/src/modules/languages/standardml.nix
@@ -15,13 +15,23 @@ in
         The Standard ML package to use.
       '';
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Standard ML Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.millet;
+        defaultText = lib.literalExpression "pkgs.millet";
+        description = "The Standard ML language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.millet
       pkgs.smlfmt
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/swift.nix
+++ b/src/modules/languages/swift.nix
@@ -15,13 +15,23 @@ in
         The Swift package to use.
       '';
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Swift Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.sourcekit-lsp;
+        defaultText = lib.literalExpression "pkgs.sourcekit-lsp";
+        description = "The Swift language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
       pkgs.clang
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env.CC = "${pkgs.clang}/bin/clang";
   };

--- a/src/modules/languages/terraform.nix
+++ b/src/modules/languages/terraform.nix
@@ -29,6 +29,17 @@ in
       '';
       example = "1.5.0 or 1.6.2";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Terraform Language Server" // { default = true; };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.terraform-ls;
+        defaultText = lib.literalExpression "pkgs.terraform-ls";
+        description = "The Terraform language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -45,10 +56,9 @@ in
           or (throw "Unsupported Terraform version, update the nixpkgs-terraform input or go to https://github.com/stackbuilders/nixpkgs-terraform/blob/main/versions.json for the full list of supported versions.")
     );
 
-    packages = with pkgs; [
+    packages = [
       cfg.package
-      terraform-ls
-      tfsec
-    ];
+      pkgs.tfsec
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/texlive.nix
+++ b/src/modules/languages/texlive.nix
@@ -20,8 +20,18 @@ in
       example = [ "algorithms" "latexmk" ];
       description = "Extra packages to add to the base TeX Live set";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "TeX Live Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.texlab;
+        defaultText = lib.literalExpression "pkgs.texlab";
+        description = "The TeX Live language server package to use.";
+      };
+    };
   };
   config = lib.mkIf cfg.enable {
-    packages = [ package ];
+    packages = [ package ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/typescript.nix
+++ b/src/modules/languages/typescript.nix
@@ -6,12 +6,21 @@ in
 {
   options.languages.typescript = {
     enable = lib.mkEnableOption "tools for TypeScript development";
+
+    lsp = {
+      enable = lib.mkEnableOption "TypeScript Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.typescript-language-server;
+        defaultText = lib.literalExpression "pkgs.typescript-language-server";
+        description = "The TypeScript language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [
-      typescript
-      nodePackages.typescript-language-server
-    ];
+    packages = [
+      pkgs.typescript
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/typst.nix
+++ b/src/modules/languages/typst.nix
@@ -25,14 +25,23 @@ in
       defaultText = lib.literalExpression "[]";
       example = lib.literalExpression ''[ "''${pkgs.roboto}/share/fonts/truetype" ]'';
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Typst Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.tinymist;
+        defaultText = lib.literalExpression "pkgs.tinymist";
+        description = "The Typst language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-      pkgs.tinymist # lsp
       pkgs.typstyle # formatter
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
     env.TYPST_FONT_PATHS = if cfg.fontPaths != [ ] then (lib.concatStringsSep ":" cfg.fontPaths) else null;
   };

--- a/src/modules/languages/vala.nix
+++ b/src/modules/languages/vala.nix
@@ -14,11 +14,21 @@ in
       description = "The Vala package to use.";
       example = lib.literalExpression "pkgs.vala_0_54";
     };
+
+    lsp = {
+      enable = lib.mkEnableOption "Vala Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.vala-language-server;
+        defaultText = lib.literalExpression "pkgs.vala-language-server";
+        description = "The Vala language server package to use.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     packages = [
       cfg.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/src/modules/languages/zig.nix
+++ b/src/modules/languages/zig.nix
@@ -33,6 +33,10 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "languages" "zig" "zls" "package" ] [ "languages" "zig" "lsp" "package" ])
+  ];
+
   options.languages.zig = {
     enable = lib.mkEnableOption "tools for Zig development";
 
@@ -41,7 +45,7 @@ in
       default = null;
       description = ''
         The Zig version to use.
-        This automatically sets the `languages.zig.package` and `languages.zig.zls.package` using [zig-overlay](https://github.com/mitchellh/zig-overlay).
+        This automatically sets the `languages.zig.package` and `languages.zig.lsp.package` using [zig-overlay](https://github.com/mitchellh/zig-overlay).
       '';
       example = "0.15.1";
     };
@@ -53,11 +57,14 @@ in
       defaultText = lib.literalExpression "pkgs.zig";
     };
 
-    zls.package = lib.mkOption {
-      type = lib.types.package;
-      description = "Which package of zls to use.";
-      default = pkgs.zls;
-      defaultText = lib.literalExpression "pkgs.zls";
+    lsp = {
+      enable = lib.mkEnableOption "Zig Language Server" // { default = true; };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.zls;
+        defaultText = lib.literalExpression "pkgs.zls";
+        description = "The Zig language server package to use.";
+      };
     };
   };
 
@@ -66,13 +73,12 @@ in
       zig-overlay.packages.${pkgs.stdenv.system}.${cfg.version}
     );
 
-    languages.zig.zls.package = lib.mkIf (cfg.version != null) (
+    languages.zig.lsp.package = lib.mkIf (cfg.version != null) (
       zls.packages.${pkgs.stdenv.system}.zls
     );
 
     packages = [
       cfg.package
-      cfg.zls.package
-    ];
+    ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }


### PR DESCRIPTION
…ge modules

Adds configurable LSP support to all language modules with:
- `lsp.enable` option (defaults to true) to control LSP package installation
- `lsp.package` option to customize which LSP server package to use

🤖 Generated with [Claude Code](https://claude.com/claude-code)