### PR TITLE
treefmt: make treefmt run at enter shell

### DIFF
--- a/src/modules/integrations/treefmt.nix
+++ b/src/modules/integrations/treefmt.nix
@@ -70,6 +70,9 @@ in
     # Set an empty default to detect when the user wants to use a custom root file.
     treefmt.config.projectRootFile = lib.mkDefault "";
 
-    tasks."devenv:treefmt:run".exec = "${treefmtWrapper}/bin/treefmt";
+    tasks."devenv:treefmt:run" = {
+      before = [ "devenv:enterShell" ];
+      exec = "${treefmtWrapper}/bin/treefmt";
+    };
   };
 }


### PR DESCRIPTION
Implementing treefmt to run on enterShell within devenv significantly improves the developer experience by addressing two key points: first, it eliminates workspace noise by immediately formatting files produced by generation tasks (like devcontainer.json or custom tasks such as generating protobuff code, github actions workflows, yacc parser...) that would otherwise appear as "dirty" or unformatted changes in Git; second, it can warming up the treefmt cache during shell initialization, ensuring that subsequent runs faster.

Furthermore, relying on task dependencies like `custom:protoc:generate.before = [ "devenv:treefmt:run" ]` is insufficient, as this ordering only dictates sequence and fails to actually trigger the formatter after the `devenv:enterShell`, leaving the resulting files in a perpetually unformatted and "changed" state.

Change-Id: Iea12f498132115be70d8eef1e4179c796a6a6964