### PR TITLE
feat(claude): add model option to agents configuration

### DIFF
--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -235,6 +235,11 @@ in
               default = [ ];
               description = "List of allowed tools for this sub-agent";
             };
+            model = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "opus" "sonnet" "haiku" ]);
+              default = null;
+              description = "Override the model for this agent.";
+            };
             prompt = lib.mkOption {
               type = lib.types.lines;
               description = "The system prompt for the sub-agent";
@@ -255,6 +260,7 @@ in
           code-reviewer = {
             description = "Expert code review specialist that checks for quality, security, and best practices";
             proactive = true;
+            model = "opus";
             tools = [ "Read" "Grep" "TodoWrite" ];
             prompt = '''
               You are an expert code reviewer. When reviewing code, check for:
@@ -488,6 +494,7 @@ in
               description: ${agent.description}
               proactive: ${lib.boolToString agent.proactive}
               ${lib.optionalString (agent.tools != []) "tools:\n${lib.concatMapStringsSep "\n" (tool: "  - ${tool}") agent.tools}"}
+              ${lib.optionalString (agent.model != null) "model: ${agent.model}"}
               ---
 
               ${agent.prompt}


### PR DESCRIPTION
## Summary

Fix #2394 

- Add `model` option to `claude.code.agents` submodule
- Type: `lib.types.nullOr (lib.types.enum [ "opus" "sonnet" "haiku" ])`
- Default: `null` (uses Claude Code default)
- Generated agent `.md` files include `model: <value>` in YAML frontmatter when specified

Different agents benefit from different models:
- `haiku` - Fast/cheap for simple tasks (git commits, recording)
- `sonnet` - Balanced for standard implementation  
- `opus` - High quality for planning, review, complex logic

## Example usage
```nix
claude.code.agents = {
  code-reviewer = {
    description = "Reviews code quality";
    model = "opus";
    tools = [ "Read" "Grep" ];
    prompt = "You are a code reviewer...";
  };
};
```
