### PR TITLE
tui: fix up key starting at top instead of bottom

### DIFF
--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -210,7 +210,7 @@ impl UiState {
         }
         match self.selected_activity {
             None => {
-                self.selected_activity = selectable.first().copied();
+                self.selected_activity = selectable.last().copied();
             }
             Some(current_id) => {
                 if let Some(current_pos) = selectable.iter().position(|&id| id == current_id) {


### PR DESCRIPTION
When no activity was selected, pressing up would select the first (topmost) item, same as down. Now up correctly selects the last (bottommost) item, following conventional list navigation:
- Down: start at top, navigate downward
- Up: start at bottom, navigate upward