### PR TITLE
fix: load devenv.local.nix from imported directories

### DIFF
--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -68,16 +68,19 @@ rec {
       pkgsBootstrap = mkPkgsForSystem targetSystem;
 
       # Helper to import a path, trying .nix first then /devenv.nix
+      # Returns a list of modules, including devenv.local.nix when present
       tryImport =
         resolvedPath: basePath:
         if lib.hasSuffix ".nix" basePath then
-          import resolvedPath
+          [ (import resolvedPath) ]
         else
           let
             devenvpath = resolvedPath + "/devenv.nix";
+            localpath = resolvedPath + "/devenv.local.nix";
           in
           if builtins.pathExists devenvpath then
-            import devenvpath
+            [ (import devenvpath) ]
+            ++ lib.optional (builtins.pathExists localpath) (import localpath)
           else
             throw (basePath + "/devenv.nix file does not exist");
 
@@ -159,10 +162,10 @@ rec {
           containers.${container_name}.isBuilding = true;
         })
       ]
-      ++ (map importModule (devenv_config.imports or [ ]))
-      ++ (if !skip_local_src then [
+      ++ (lib.flatten (map importModule (devenv_config.imports or [ ])))
+      ++ (if !skip_local_src then
         (importModule (devenv_root + "/devenv.nix"))
-      ] else [ ])
+      else [ ])
       ++ [
         (devenv_config.devenv or { })
         (

--- a/tests/import-local/.test.sh
+++ b/tests/import-local/.test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test that devenv.local.nix in imported directories is loaded
+
+echo "DEBUG: SHARED_VAR=$SHARED_VAR"
+echo "DEBUG: LOCAL_ONLY=$LOCAL_ONLY"
+echo "DEBUG: SHARED_BASE=$SHARED_BASE"
+
+if [ "$LOCAL_ONLY" != "yes" ]; then
+  echo "FAIL: LOCAL_ONLY should be 'yes' but got '$LOCAL_ONLY'"
+  exit 1
+fi
+
+if [ "$SHARED_VAR" != "from_local" ]; then
+  echo "FAIL: SHARED_VAR should be 'from_local' but got '$SHARED_VAR'"
+  exit 1
+fi
+
+if [ "$SHARED_BASE" != "true" ]; then
+  echo "FAIL: SHARED_BASE should be 'true' but got '$SHARED_BASE'"
+  exit 1
+fi
+
+echo "PASS: devenv.local.nix from imported directory is loaded correctly"

--- a/tests/import-local/devenv.nix
+++ b/tests/import-local/devenv.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+{
+  env.MAIN_CONFIG = "true";
+
+  assertions = [
+    {
+      assertion = config.env.SHARED_VAR or "" != "";
+      message = "SHARED_VAR is not set. The ./shared/devenv.nix was not loaded correctly.";
+    }
+    {
+      assertion = config.env.SHARED_BASE or "" != "";
+      message = "SHARED_BASE is not set. The ./shared/devenv.nix was not loaded correctly.";
+    }
+    {
+      assertion = config.env.LOCAL_ONLY or "" == "yes";
+      message = "LOCAL_ONLY should be 'yes' (set by devenv.local.nix), but got: '${config.env.LOCAL_ONLY or ""}'";
+    }
+    {
+      assertion = config.env.SHARED_VAR or "" == "from_local";
+      message = "SHARED_VAR should be 'from_local' (overridden by devenv.local.nix with mkForce), but got: '${config.env.SHARED_VAR or ""}'";
+    }
+  ];
+}

--- a/tests/import-local/devenv.yaml
+++ b/tests/import-local/devenv.yaml
@@ -1,0 +1,10 @@
+imports:
+- ./shared
+
+allowUnfree: false
+allowBroken: false
+impure: false
+
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling

--- a/tests/import-local/shared/devenv.local.nix
+++ b/tests/import-local/shared/devenv.local.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+{
+  # This should override SHARED_VAR from devenv.nix
+  env.SHARED_VAR = lib.mkForce "from_local";
+  # Unique var to verify devenv.local.nix is loaded
+  env.LOCAL_ONLY = "yes";
+}

--- a/tests/import-local/shared/devenv.nix
+++ b/tests/import-local/shared/devenv.nix
@@ -1,0 +1,4 @@
+{
+  env.SHARED_VAR = "from_devenv";
+  env.SHARED_BASE = "true";
+}


### PR DESCRIPTION
## Summary
- Fix for issue #2390 where `devenv.local.nix` files in imported directories were being ignored
- Modified `tryImport` function in `bootstrapLib.nix` to return a list of modules including `devenv.local.nix` when present
- Added `lib.flatten` to properly handle the nested module lists from imports

## Test plan
- [ ] New test `tests/import-local/` verifies that `devenv.local.nix` from imported directories is loaded
- [ ] Existing `tests/imports/` test still passes, confirming no regression

**Note:** To override values from `devenv.nix` in `devenv.local.nix`, use `lib.mkForce` (consistent with NixOS module system semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)