### PR TITLE
fix: separate TMPDIR from DEVENV_RUNTIME to avoid XDG_RUNTIME_DIR for build artifacts

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -242,19 +242,24 @@ in
             hashedRoot = builtins.hashString "sha256" config.devenv.state;
             # same length as git's abbreviated commit hashes
             shortHash = builtins.substring 0 7 hashedRoot;
+            # XDG_RUNTIME_DIR is the correct location for runtime files like sockets
+            # per the XDG Base Directory Specification
+            xdg = builtins.getEnv "XDG_RUNTIME_DIR";
+            base = if xdg != "" then xdg else config.devenv.tmpdir;
           in
-          "${config.devenv.tmpdir}/devenv-${shortHash}";
+          "${base}/devenv-${shortHash}";
       };
 
       tmpdir = lib.mkOption {
         type = types.str;
         internal = true;
+        # Used for TMPDIR override - should NOT use XDG_RUNTIME_DIR as that's
+        # a small tmpfs meant for runtime files (sockets), not build artifacts
         default =
           let
-            xdg = builtins.getEnv "XDG_RUNTIME_DIR";
             tmp = builtins.getEnv "TMPDIR";
           in
-          if xdg != "" then xdg else if tmp != "" then tmp else "/tmp";
+          if tmp != "" then tmp else "/tmp";
       };
 
       profile = lib.mkOption {


### PR DESCRIPTION
## Summary

- Fixes TMPDIR being incorrectly set to XDG_RUNTIME_DIR (a small tmpfs at `/run/user/<uid>`)
- Build tools like `go build` were running out of space when writing large temporary files
- Separates concerns: `devenv.runtime` (sockets) uses XDG_RUNTIME_DIR, `devenv.tmpdir` (build artifacts) uses TMPDIR or /tmp

## Problem

On Linux systems with systemd-logind, XDG_RUNTIME_DIR points to a small tmpfs mount (typically ~10% of RAM). The previous implementation set TMPDIR to this directory, causing "out of space" errors for build tools that write gigabytes of temporary files.

## Root Cause

Commit 910e2b87 correctly identified XDG_RUNTIME_DIR for `DEVENV_RUNTIME` (Unix domain sockets), but the implementation shared the same base for both runtime files and the TMPDIR override.

Per the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/):
- **XDG_RUNTIME_DIR**: For runtime files, sockets, and named pipes (strict size constraints)
- **TMPDIR**: For general temporary files, including large build artifacts

## Fix

| Variable | Before | After |
|----------|--------|-------|
| `devenv.runtime` | XDG_RUNTIME_DIR → TMPDIR → /tmp | XDG_RUNTIME_DIR → TMPDIR → /tmp (unchanged) |
| `devenv.tmpdir` | XDG_RUNTIME_DIR → TMPDIR → /tmp | TMPDIR → /tmp (no XDG_RUNTIME_DIR) |

## Test plan

- [x] Build succeeds
- [x] Unit tests pass
- [x] Manual verification: `TMPDIR=/tmp devenv shell -- bash -c 'echo TMPDIR=$TMPDIR; echo DEVENV_RUNTIME=$DEVENV_RUNTIME'`
  - Before: `TMPDIR=/run/user/1000`, `DEVENV_RUNTIME=/run/user/1000/devenv-*`
  - After: `TMPDIR=/tmp`, `DEVENV_RUNTIME=/run/user/1000/devenv-*`

🤖 Generated with [Claude Code](https://claude.ai/code)