### PR TITLE
feat: run shell in a sandbox

### DIFF
--- a/devenv-core/src/nix_backend.rs
+++ b/devenv-core/src/nix_backend.rs
@@ -134,6 +134,14 @@ pub trait NixBackend: Send + Sync {
     /// Get the bash shell executable path
     async fn get_bash(&self, refresh_cached_output: bool) -> Result<String>;
 
+    /// Get package executable path
+    async fn get_executable(
+        &self,
+        package_name: &str,
+        name: &str,
+        refresh_cached_output: bool,
+    ) -> Result<String>;
+
     /// Check if the current user is a trusted user of the Nix store
     async fn is_trusted_user(&self) -> Result<bool>;
 

--- a/devenv-snix-backend/src/lib.rs
+++ b/devenv-snix-backend/src/lib.rs
@@ -199,6 +199,16 @@ impl NixBackend for SnixBackend {
         bail!("get_bash is not yet implemented for Snix backend")
     }
 
+    async fn get_executable(
+        &self,
+        _package: &str,
+        _name: &str,
+        _refresh_cached_output: bool,
+    ) -> Result<String> {
+        // TODO: Implement bash shell acquisition for Snix backend
+        bail!("get_executable is not yet implemented for Snix backend")
+    }
+
     async fn is_trusted_user(&self) -> Result<bool> {
         // TODO: Implement trusted user check for Snix backend
         bail!("is_trusted_user is not yet implemented for Snix backend")

--- a/devenv/src/util.rs
+++ b/devenv/src/util.rs
@@ -71,3 +71,24 @@ pub fn write_file_with_lock<P: AsRef<Path>, S: AsRef<str>>(path: P, content: S) 
         Ok(false)
     }
 }
+
+pub fn expand_path(path: &str) -> String {
+    let mut expanded = path.to_string();
+
+    let re_braces = regex::Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").unwrap();
+    let re_simple = regex::Regex::new(r"\$([A-Za-z_][A-Za-z0-9_]*)").unwrap();
+
+    expanded = re_braces
+        .replace_all(&expanded, |caps: &regex::Captures| {
+            std::env::var(&caps[1]).unwrap_or_default()
+        })
+        .into_owned();
+
+    expanded = re_simple
+        .replace_all(&expanded, |caps: &regex::Captures| {
+            std::env::var(&caps[1]).unwrap_or_default()
+        })
+        .into_owned();
+
+    expanded
+}


### PR DESCRIPTION
Use `bubblewrap` to spawn devenv shell process in an isolated sandbox. Early PoC just to get some feedback.

Limitations:

- Tested on NixOS only
- Linux Only/No MacOS support


example `devenv.local.yaml`

```yaml
sandbox:
  enable: true
  network:
    enable: true
  mounts:
    - path: /nix/store
    - path: /dev
      mode: dev
    - path: /dev/null
      mode: dev
    - path: /dev/random
      mode: dev
    - path: /dev/urandom
      mode: dev
    - path: $NIX_USER_PROFILE_DIR/profile
    - path: $HOME
      mode: overlay
```