### PR TITLE
Fix debugger support 

### DIFF
--- a/devenv-nix-backend/src/anyhow_ext.rs
+++ b/devenv-nix-backend/src/anyhow_ext.rs
@@ -5,6 +5,7 @@ pub trait AnyhowToMiette<T> {
 
 impl<T> AnyhowToMiette<T> for anyhow::Result<T> {
     fn to_miette(self) -> miette::Result<T> {
-        self.map_err(|e| miette::miette!("{e}"))
+        // Use {e:#} to show the full error chain including underlying causes
+        self.map_err(|e| miette::miette!("{e:#}"))
     }
 }

--- a/devenv-nix-backend/src/logger.rs
+++ b/devenv-nix-backend/src/logger.rs
@@ -168,6 +168,14 @@ fn create_log_callback(
         // Convert level to Verbosity
         let verbosity = level.try_into().unwrap_or(Verbosity::Info);
 
+        // Store error-level messages to be printed after TUI exits.
+        // This ensures Nix evaluation errors are displayed cleanly
+        // before the REPL, not mixed with TUI output.
+        if level == 0 {
+            // Level 0 = Error
+            bridge.store_pre_repl_error(msg.to_string());
+        }
+
         let log = InternalLog::Msg {
             msg: msg.to_string(),
             raw_msg: None,


### PR DESCRIPTION
When --nix-debugger is enabled and an error occurs during evaluation, devenv now launches the Nix debugger REPL instead of just printing the error. This allows interactive inspection of the evaluation state at the point of failure.

Changes:
- Introduce DevenvOutput struct to carry command result alongside Devenv instance, enabling debugger execution after the tokio runtime stops
- Add DebuggerResult enum to distinguish debugger launch from normal exit
- Split run_devenv into setup (run_devenv) and execution (run_devenv_inner) phases so Devenv can be captured even when errors occur
- Store error-level Nix log messages in NixLogBridge for display before REPL (ensures errors are visible after TUI exits)
- Reset activity logger before REPL to restore normal stderr output
- Check for pending debugger sessions in repl() and run debugger REPL if one exists, otherwise run the standard devenv REPL
- Use {:#} format for anyhow errors to show full error chain