### PR TITLE
tui: show last log line in task suffix

### DIFF
--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -605,12 +605,12 @@ pub fn calculate_display_info(
 
     let remaining_width_without_suffix = available_width - base_width;
 
-    // Check if we can show suffix
+    // Always show suffix if present - let flexbox overflow handle truncation
+    let show_suffix = suffix.is_some();
     let suffix_width = suffix.map(|s| s.len() + 1).unwrap_or(0); // suffix + space prefix
-    let show_suffix = suffix_width <= remaining_width_without_suffix / 3; // Only show suffix if it takes less than 1/3 of remaining space
 
     let remaining_width_for_path = if show_suffix {
-        remaining_width_without_suffix - suffix_width
+        remaining_width_without_suffix.saturating_sub(suffix_width)
     } else {
         remaining_width_without_suffix
     };

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -83,6 +83,7 @@ pub struct TaskActivity {
     pub status: TaskDisplayStatus,
     pub duration: Option<std::time::Duration>,
     pub show_output: bool,
+    pub last_log_line: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
@@ -476,6 +477,7 @@ impl ActivityModel {
                     status: TaskDisplayStatus::Running,
                     duration: None,
                     show_output,
+                    last_log_line: None,
                 });
                 self.create_activity(id, name, parent, detail, variant, ActivityLevel::Info, true);
             }
@@ -812,6 +814,9 @@ impl ActivityModel {
                 }
                 ActivityVariant::Evaluating(eval) => {
                     eval.files_evaluated += 1;
+                }
+                ActivityVariant::Task(task) => {
+                    task.last_log_line = Some(line);
                 }
                 _ => {}
             }

--- a/devenv-tui/tests/snapshots/tui_tests__deep_nesting.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__deep_nesting.snap
@@ -6,7 +6,7 @@ expression: output
   ⎿ ⠋ Building wrapper-scripts buildPhase
     ⎿ ⠋ Downloading bash-5.2 from cache.nixos.org
         ──────────────────────────────────────────────500kB / 1MB at 5MB/s
-      ⎿ ⠋ Downloading readline-8.2
-        ⎿ ⠋ Downloading ncurses-6.4
+      ⎿ ⠋ Downloading readline-8.2 from cache.nixos.org
+        ⎿ ⠋ Downloading ncurses-6.4 from cache.nixos.org
 
  0 of 1 builds  │  0 of 3 downloads                                ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__indeterminate_progress.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__indeterminate_progress.snap
@@ -2,6 +2,6 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-⠋ Downloading large-file.tar.gz
+⠋ Downloading large-file.tar.gz from example.com [42MB]
 
- 0 of 1 downloads         ↑↓ nav
+ 0 of 1 downloads                                 ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
@@ -5,7 +5,7 @@ expression: output
 ⠋ Building shell
   ⎿ ⠋ Fetching github:NixOS/nixpkgs
   ⎿ ⠋ Building hello-2.12 buildPhase
-    ⎿ ⠋ Downloading glibc-2.35
-  ⎿ ⠋ Downloading openssl-3.0.0
+    ⎿ ⠋ Downloading glibc-2.35 from cache.nixos.org
+  ⎿ ⠋ Downloading openssl-3.0.0 from cache.nixos.org
 
- 0 of 1 builds  │  0 of 2 downloa    ↑↓ nav
+ 0 of 1 builds  │  0 of 2 downloads            ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__task_failed_shows_logs.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_failed_shows_logs.snap
@@ -2,9 +2,9 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-✗ test:failing-task failed (3 lines) 0ms
+✗ test:failing-task failed → Expected: 42, Got: 0 0ms
   Running test suite...
   FAILED: assertion error in test_foo
   Expected: 42, Got: 0
 
- 0 of 1 tasks                     ↑↓ nav
+ 0 of 1 tasks                                  ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__task_show_output_false.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_show_output_false.snap
@@ -2,6 +2,6 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-⠋ test:without-output 2 lines
+⠋ test:without-output 2 lines → HIDDEN_OUTPUT_LINE_2
 
- 0 of 1 tasks           ↑↓ nav
+ 0 of 1 tasks                                  ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__task_show_output_true.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_show_output_true.snap
@@ -2,8 +2,8 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-⠋ test:with-output 2 lines
+⠋ test:with-output 2 lines → VISIBLE_OUTPUT_LINE_2
   VISIBLE_OUTPUT_LINE_1
   VISIBLE_OUTPUT_LINE_2
 
- 0 of 1 tasks        ↑↓ nav
+ 0 of 1 tasks                                ↑↓ nav


### PR DESCRIPTION
Display the most recent log line for tasks in the TUI suffix area, giving better visibility into task progress.

Running tasks now show: `⠋ my-task 5 lines → building component...`
Failed tasks show: `✗ my-task failed → Error: something went wrong`

Also removes the 1/3 width restriction for suffixes, letting flexbox overflow handle truncation naturally instead of hiding suffixes entirely.