### PR TITLE
version: show git revision and suppress dev version warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1368,6 +1368,7 @@ dependencies = [
  "tracing-indicatif",
  "tracing-subscriber",
  "valuable",
+ "vergen-gitcl",
  "which 8.0.0",
  "whoami",
  "xdg",
@@ -1688,7 +1689,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1837,7 +1838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1887,7 +1888,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3557,7 +3558,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3642,6 +3643,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4772,7 +4782,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4785,7 +4795,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4853,7 +4863,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6159,7 +6169,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6291,7 +6301,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -7050,6 +7062,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib 9.1.0",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib 0.1.6",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7338,7 +7398,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/devenv-core/src/nix_args.rs
+++ b/devenv-core/src/nix_args.rs
@@ -268,6 +268,9 @@ pub struct NixArgs<'a> {
     /// The devenv CLI version (e.g., "1.10.1")
     pub version: &'a str,
 
+    /// Whether this is a development build (not from a release tag)
+    pub is_development_version: bool,
+
     /// The system string (e.g., "x86_64-linux", "aarch64-darwin")
     pub system: &'a str,
 
@@ -367,6 +370,7 @@ mod tests {
         let cli_options = CliOptionsConfig::default();
         let args = NixArgs {
             version,
+            is_development_version: false,
             system,
             devenv_root: &root,
             skip_local_src: false,
@@ -470,6 +474,7 @@ mod tests {
 
         let args = NixArgs {
             version,
+            is_development_version: false,
             system,
             devenv_root: &root,
             skip_local_src: false,

--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -23,6 +23,7 @@ rec {
   # This is the full-featured version used by default.nix
   mkDevenvForSystem =
     { version
+    , is_development_version ? false
     , system
     , devenv_root
     , git_root ? null
@@ -126,10 +127,15 @@ rec {
           {
             config.devenv = lib.mkMerge [
               {
-                cliVersion = version;
                 root = devenv_root;
                 dotfile = devenv_dotfile;
               }
+              (if builtins.hasAttr "cli" options.devenv then {
+                cli.version = version;
+                cli.isDevelopment = is_development_version;
+              } else {
+                cliVersion = version;
+              })
               (lib.optionalAttrs (builtins.hasAttr "tmpdir" options.devenv) {
                 tmpdir = devenv_tmpdir;
               })

--- a/devenv-nix-backend/tests/test_flake_lock.rs
+++ b/devenv-nix-backend/tests/test_flake_lock.rs
@@ -38,6 +38,7 @@ impl TestNixArgs {
     ) -> NixArgs<'a> {
         NixArgs {
             version: "1.0.0",
+            is_development_version: false,
             system: get_current_system(),
             devenv_root: &paths.root,
             skip_local_src: false,

--- a/devenv-nix-backend/tests/test_nix_backend.rs
+++ b/devenv-nix-backend/tests/test_nix_backend.rs
@@ -116,6 +116,7 @@ impl TestNixArgs {
     ) -> NixArgs<'a> {
         NixArgs {
             version: "1.0.0",
+            is_development_version: false,
             system: get_current_system(),
             devenv_root: &paths.root,
             skip_local_src: false,

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -81,6 +81,9 @@ snix-build = { workspace = true, optional = true }
 nix-compat = { workspace = true, optional = true }
 nix-compat-derive = { workspace = true, optional = true }
 
+[build-dependencies]
+vergen-gitcl = "1.0"
+
 [dev-dependencies]
 devenv-nix-backend-macros.workspace = true
 

--- a/devenv/build.rs
+++ b/devenv/build.rs
@@ -1,4 +1,7 @@
-fn main() {
+use std::process::Command;
+use vergen_gitcl::{Emitter, GitclBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "cargo:rustc-env=TARGET_ARCH={}",
         std::env::var("CARGO_CFG_TARGET_ARCH").unwrap()
@@ -9,4 +12,35 @@ fn main() {
     );
     // Rerun if init directory changes
     println!("cargo:rerun-if-changed=init");
+
+    // Git revision info via vergen (works when .git is available)
+    let gitcl = GitclBuilder::default().sha(true).dirty(true).build()?;
+
+    Emitter::default().add_instructions(&gitcl)?.emit()?;
+
+    // Rerun when git state changes (for tag detection and SHA)
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+
+    // Detect if HEAD is on a release tag (for cargo builds with .git)
+    let on_tag = Command::new("git")
+        .args(["describe", "--tags", "--exact-match", "HEAD"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    println!("cargo:rustc-env=DEVENV_ON_RELEASE_TAG={on_tag}");
+
+    // Forward DEVENV_GIT_REV for Nix builds where .git is unavailable
+    println!("cargo:rerun-if-env-changed=DEVENV_GIT_REV");
+    if let Ok(rev) = std::env::var("DEVENV_GIT_REV") {
+        println!("cargo:rustc-env=DEVENV_GIT_REV={rev}");
+    }
+
+    // Forward DEVENV_IS_RELEASE for Nix release builds
+    println!("cargo:rerun-if-env-changed=DEVENV_IS_RELEASE");
+    if let Ok(val) = std::env::var("DEVENV_IS_RELEASE") {
+        println!("cargo:rustc-env=DEVENV_IS_RELEASE={val}");
+    }
+
+    Ok(())
 }

--- a/devenv/package.nix
+++ b/devenv/package.nix
@@ -2,6 +2,8 @@
 , version
 , cargoLock
 , cargoProfile ? "release"
+, gitRev ? ""
+, isRelease ? false
 , lib
 , stdenv
 , makeBinaryWrapper
@@ -25,6 +27,9 @@ rustPlatform.buildRustPackage {
   inherit src version cargoLock;
 
   RUSTFLAGS = "--cfg tracing_unstable";
+  DEVENV_GIT_REV = gitRev;
+  DEVENV_IS_RELEASE = if isRelease then "1" else "";
+  VERGEN_IDEMPOTENT = "1";
 
   cargoBuildFlags = [ "-p devenv -p devenv-run-tests" ];
   buildType = cargoProfile;

--- a/devenv/src/devenv.rs
+++ b/devenv/src/devenv.rs
@@ -1648,6 +1648,7 @@ impl Devenv {
         let nixpkgs_config = config.nixpkgs_config(&self.global_options.system);
         let args = NixArgs {
             version: crate_version!(),
+            is_development_version: crate::is_development_version(),
             system: &self.global_options.system,
             devenv_root: &self.devenv_root,
             skip_local_src: self.global_options.from.is_some(),

--- a/devenv/src/lib.rs
+++ b/devenv/src/lib.rs
@@ -21,3 +21,18 @@ pub use devenv_core::{
     CachixCacheInfo, CachixManager, CachixPaths, Config, DevenvPaths, GlobalOptions, NixArgs,
     NixBackend, Options, SecretspecData, default_system,
 };
+
+/// Returns true if this binary was NOT built from a release tag.
+///
+/// Uses build-time info from build.rs:
+/// - `DEVENV_ON_RELEASE_TAG`: "true" when HEAD is on an exact tag (cargo builds with .git)
+/// - `DEVENV_IS_RELEASE`: "1" for Nix release builds (set in package.nix, .git unavailable)
+pub fn is_development_version() -> bool {
+    if env!("DEVENV_ON_RELEASE_TAG") == "true" {
+        return false;
+    }
+    if option_env!("DEVENV_IS_RELEASE") == Some("1") {
+        return false;
+    }
+    true
+}

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -99,11 +99,12 @@ fn main() -> Result<()> {
     // Handle commands that don't need a runtime
     match &cli.command {
         None | Some(Commands::Version) => {
-            println!(
-                "devenv {} ({})",
-                crate_version!(),
-                cli.global_options.system
-            );
+            let version = crate_version!();
+            let system = &cli.global_options.system;
+            match build_rev() {
+                Some(rev) => println!("devenv {version}+{rev} ({system})"),
+                None => println!("devenv {version} ({system})"),
+            }
             return Ok(());
         }
         Some(Commands::Direnvrc) => {
@@ -493,4 +494,25 @@ async fn run_devenv(cli: Cli, shutdown: Arc<Shutdown>) -> Result<CommandResult> 
     };
 
     Ok(result)
+}
+
+/// Returns the git revision suffix for the version string.
+///
+/// Prefers the vergen-injected SHA (available when building from a git checkout),
+/// falls back to DEVENV_GIT_REV (set by Nix builds where .git is unavailable).
+fn build_rev() -> Option<String> {
+    let sha = env!("VERGEN_GIT_SHA");
+    // vergen emits "VERGEN_IDEMPOTENT_OUTPUT" when git is unavailable
+    if !sha.is_empty() && sha != "VERGEN_IDEMPOTENT_OUTPUT" {
+        let dirty = env!("VERGEN_GIT_DIRTY");
+        if dirty == "true" {
+            return Some(format!("{sha}-dirty"));
+        }
+        return Some(sha.to_string());
+    }
+
+    // Nix builds pass the flake's git rev via this env var
+    option_env!("DEVENV_GIT_REV")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,8 @@
             })
           ];
           pkgs = import nixpkgs { inherit overlays system; };
-          workspace = pkgs.callPackage ./workspace.nix { };
+          gitRev = self.shortRev or (self.dirtyShortRev or "");
+          workspace = pkgs.callPackage ./workspace.nix { inherit gitRev; };
         in
         {
           inherit (workspace.crates) devenv devenv-tasks devenv-tasks-fast-build;

--- a/workspace.nix
+++ b/workspace.nix
@@ -2,7 +2,8 @@
 { lib
 , callPackage
 , cargoProfile ? "release"
-,
+, gitRev ? ""
+, isRelease ? false
 }:
 
 let
@@ -59,6 +60,8 @@ in
         version
         cargoLock
         cargoProfile
+        gitRev
+        isRelease
         ;
     };
 


### PR DESCRIPTION
## Summary

- Display git commit hash in `devenv version` output (e.g. `devenv 2.0.0+36641e54-dirty`) using `vergen-gitcl` for build-time git info, with `DEVENV_GIT_REV` env var fallback for Nix sandbox builds
- Detect development builds (not from a release tag) and suppress the "is newer than devenv input" warning, since the version comparison is meaningless during development
- Restructure `devenv.cliVersion` to `devenv.cli.version` and add `devenv.cli.isDevelopment`, with `mkAliasOptionModule` for backwards compatibility with older binaries/modules

Closes #194

## Test plan

- [x] `cargo build -p devenv` succeeds
- [x] `cargo test -p devenv -p devenv-core` passes (46 tests)
- [x] `cargo run -- version` outputs `devenv 2.0.0+<hash>-dirty (x86_64-linux)`
- [ ] Verify `devenv shell` no longer shows "is newer" warning with dev build
- [ ] Verify `nix build` works with `DEVENV_GIT_REV` and `VERGEN_IDEMPOTENT` env vars
- [ ] Verify old binary + new modules works (cliVersion alias)
- [ ] Verify new binary + old modules works (optionalAttrs guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)