### PR TITLE
feat(files): add cleanup for orphaned files

### DIFF
--- a/tests/files-cleanup/.gitignore
+++ b/tests/files-cleanup/.gitignore
@@ -1,0 +1,3 @@
+a.txt
+b.txt
+subdir

--- a/tests/files-cleanup/.patch.sh
+++ b/tests/files-cleanup/.patch.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+# First run: create files with initial config
+devenv shell true
+
+# Verify initial files were created
+test -L a.txt
+test -L b.txt
+test -L subdir/nested.txt
+test -d subdir
+
+# Verify state was saved
+test -f .devenv/state/files.json
+
+# Now modify config to remove b.txt and subdir/nested.txt
+cat > devenv.nix << 'EOF'
+{ pkgs, ... }: {
+  files."a.txt".text = "a";
+
+  # Verify cleanup happened
+  enterTest = ''
+    # a.txt should still exist
+    test -L "$DEVENV_ROOT/a.txt" || { echo "a.txt missing"; exit 1; }
+
+    # b.txt should be removed (was in previous config)
+    test ! -e "$DEVENV_ROOT/b.txt" || { echo "b.txt not cleaned up"; exit 1; }
+
+    # subdir/nested.txt should be removed
+    test ! -e "$DEVENV_ROOT/subdir/nested.txt" || { echo "subdir/nested.txt not cleaned up"; exit 1; }
+
+    # subdir should be removed (empty after cleanup)
+    test ! -d "$DEVENV_ROOT/subdir" || { echo "subdir not cleaned up"; exit 1; }
+
+    # State should track only a.txt
+    jq -e '.managedFiles | length == 1' "$DEVENV_ROOT/.devenv/state/files.json"
+  '';
+}
+EOF

--- a/tests/files-cleanup/devenv.nix
+++ b/tests/files-cleanup/devenv.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }: {
+  files."a.txt".text = "a";
+  files."b.txt".text = "b";
+  files."subdir/nested.txt".text = "nested";
+}

--- a/tests/files/.test.sh
+++ b/tests/files/.test.sh
@@ -36,3 +36,6 @@ assert_file script.sh <<EOF
 #!/bin/bash
 echo hello
 EOF
+
+# Verify state tracking
+test -f .devenv/state/files.json


### PR DESCRIPTION
## Summary

- When files are removed from config, their symlinks are now automatically cleaned up
- When a file path changes, the old symlink is removed
- State is tracked in `.devenv/state/files.json`
- Empty parent directories are cleaned up after file removal

## Safety

- Only removes **symlinks** (regular files are never touched)
- Only removes symlinks pointing to `/nix/store/*` (user symlinks are safe)
- Partial state is saved (even if some files conflict, successful ones are tracked)

Fixes #2324
Fixes #2351

## Test plan

- [x] Existing `files` test passes
- [x] New `files-cleanup` test verifies cleanup behavior including nested directories

🤖 Generated with [Claude Code](https://claude.ai/code)