### PR TITLE
docs: add defaultText for ports value option

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -23,6 +23,7 @@ let
         type = types.port;
         readOnly = true;
         description = "Resolved port value (allocated by devenv)";
+        defaultText = lib.literalMD "Allocated port based on `allocate`";
         # Pass process name and port name for stable caching across evaluations
         default = allocatePort processName name config.allocate;
       };


### PR DESCRIPTION
The default depends on the allocate option which has no default, so docs generation fails when trying to evaluate it.