### PR TITLE
Clarify docs on postgres service

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -331,7 +331,7 @@ in
             type = types.nullOr types.str;
             default = null;
             description = ''
-              Username of owner of the database (if null, the default $USER is used).
+              Username of owner of the database (if null, the default $USER is used, only takes effect if `pass` is not `null`).
             '';
           };
           pass = lib.mkOption {
@@ -380,7 +380,8 @@ in
         SQL expressions separated by a semi-colon.
         Use `initialScript` for server-wide setup, such as creating roles or configuring
         global settings. For database-specific initialization, use `initialSQL` within
-        `initialDatabases`.
+        `initialDatabases`. `initialScript` is executed after the `initialDatabases`
+        setup is done.
       '';
       example = lib.literalExpression ''
         CREATE ROLE postgres SUPERUSER;


### PR DESCRIPTION
If only user is set for a database, but not password, the user setting is ignored.

This tries to clarify the docs a bit, and also highlights the order of execution between service-wide `initialScript` and per-database `initialSQL`, as I would have expected `initialScript` to run first.