### PR TITLE
deprecate(template): redundant nixConfig

### DIFF
--- a/docs/src/guides/using-with-flakes.md
+++ b/docs/src/guides/using-with-flakes.md
@@ -73,11 +73,6 @@ See [the reference documentation](../reference/options.md) for the possible opti
     devenv.url = "github:cachix/devenv";
   };
 
-  nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
-  };
-
   outputs = { self, nixpkgs, devenv, ... } @ inputs:
     let
       system = "x86_64-linux";

--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -15,11 +15,6 @@
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
   };
 
-  nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
-  };
-
   outputs = inputs@{ flake-parts, devenv-root, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [

--- a/templates/flake/flake.nix
+++ b/templates/flake/flake.nix
@@ -6,11 +6,6 @@
     devenv.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
-  };
-
   outputs = { self, nixpkgs, devenv, systems, ... } @ inputs:
     let
       forEachSystem = nixpkgs.lib.genAttrs (import systems);

--- a/templates/terraform/flake.nix
+++ b/templates/terraform/flake.nix
@@ -8,8 +8,8 @@
   };
 
   nixConfig = {
-    extra-substituters = "https://devenv.cachix.org https://nixpkgs-terraform.cachix.org";
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
+    extra-substituters = "https://nixpkgs-terraform.cachix.org";
+    extra-trusted-public-keys = "nixpkgs-terraform.cachix.org-1:8Sit092rIdAVENA3ZVeH9hzSiqI/jng6JiCrQ1Dmusw=";
   };
 
   outputs = { self, devenv, nixpkgs, systems, ... }@inputs:


### PR DESCRIPTION
Since `nixConfig` is already present in the top level flake.nix :

https://github.com/cachix/devenv/blob/0f006b2e9f591cc44cf219048b5e33793530403b/flake.nix#L4-L7

Having them duplicated in [templates](https://github.com/cachix/devenv/tree/main/templates?rgh-link-date=2026-02-08T17%3A42%3A21.000Z) is redundant