### PR TITLE
docs: add defaultText for process.manager.implementation

### DIFF
--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -317,6 +317,7 @@ in
           if lib.versionAtLeast config.devenv.cliVersion "2.0"
           then "native"
           else "process-compose";
+        defaultText = lib.literalMD "`native` for devenv 2.0+, `process-compose` otherwise";
         example = "process-compose";
       };
 


### PR DESCRIPTION
The default references devenv.cliVersion, which is provided by the CLI at evaluation time and unavailable during documentation generation.