### PR TITLE
fix(git-hooks): set worktree-safe core.hooksPath

### DIFF
--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -145,7 +145,6 @@ in
 
               did_install_hooks=0
               hooks_path_needs_restore=0
-              local_hooks_path_needs_restore=0
               worktree_config_needs_restore=0
 
               restore_hooks_path() {
@@ -154,14 +153,6 @@ in
                     ${git} config "$config_scope" core.hooksPath "$previous_hooks_path" || true
                   else
                     ${git} config "$config_scope" --unset-all core.hooksPath || true
-                  fi
-                fi
-
-                if [ "$local_hooks_path_needs_restore" -eq 1 ]; then
-                  if [ "$previous_local_hooks_path_set" -eq 1 ]; then
-                    ${git} config --local core.hooksPath "$previous_local_hooks_path" || true
-                  else
-                    ${git} config --local --unset-all core.hooksPath || true
                   fi
                 fi
 
@@ -188,12 +179,6 @@ in
                 config_scope="--local"
                 hooks_path="$common_dir/hooks"
 
-                previous_local_hooks_path_set=0
-                previous_local_hooks_path=""
-                if previous_local_hooks_path=$(${git} config --local --get core.hooksPath 2>/dev/null); then
-                  previous_local_hooks_path_set=1
-                fi
-
                 previous_worktree_config_set=0
                 previous_worktree_config=""
                 if previous_worktree_config=$(${git} config --local --bool --get extensions.worktreeConfig 2>/dev/null); then
@@ -203,8 +188,6 @@ in
                 if [ "$git_dir_abs" != "$common_dir_abs" ] && [ "$common_is_bare" != "true" ]; then
                   ${git} config --local extensions.worktreeConfig true
                   worktree_config_needs_restore=1
-                  ${git} config --local --unset-all core.hooksPath || true
-                  local_hooks_path_needs_restore=1
                   config_scope="--worktree"
                 elif [ "$git_dir_abs" != "$common_dir_abs" ] && [ "$common_is_bare" = "true" ]; then
                   hooks_path="$common_dir_abs/hooks"
@@ -256,7 +239,6 @@ in
               if [ "$did_install_hooks" -eq 1 ]; then
                 ${git} config "$config_scope" core.hooksPath "$hooks_path"
                 hooks_path_needs_restore=0
-                local_hooks_path_needs_restore=0
                 worktree_config_needs_restore=0
               fi
             '';


### PR DESCRIPTION
## Summary
- reset `core.hooksPath` before running `prek install` so repeated installs do not fail when hooksPath is already set
- set `core.hooksPath` after install using `git rev-parse --path-format=relative --git-common-dir`, which works for linked worktrees where the common dir is outside the worktree root
- keep hook installation behavior unchanged otherwise (same install stages/default stage logic)

## Verification
- reproduced the setup from [cachix/git-hooks.nix#688](https://github.com/cachix/git-hooks.nix/issues/688) with a bare repo at `/tmp/gh688-devenv-repro3/test-repo/.bare` and linked worktree at `/tmp/gh688-devenv-repro3/test-worktree`
- ran local devenv from this branch in that worktree (`nix develop <repo> -c cargo run --manifest-path <repo>/Cargo.toml -- shell true`)
- confirmed `git config --local --get core.hooksPath` is now `../test-repo/.bare/hooks`
- created a commit in the worktree and verified the installed `no-op` hook executed (`.hook-ran` created with one line)

Fixes https://github.com/cachix/git-hooks.nix/issues/688

---
_Updated by OpenCode on behalf of @schickling._