### PR TITLE
Repatched postgres readiness fix from commit bc69744

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -431,7 +431,7 @@ in
       ready = {
         exec = ''
           if [[ -f "$PGDATA/.devenv_initialized" ]]; then
-            ${postgresPkg}/bin/pg_isready -d template1 && \
+            ${postgresPkg}/bin/pg_isready -d template1 && \\
             ${postgresPkg}/bin/psql -c "SELECT 1" template1 > /dev/null 2>&1
           else
             echo "Waiting for PostgreSQL initialization to complete..." 2>&1


### PR DESCRIPTION
This is related to [bc69744](https://github.com/cachix/devenv/commit/bc697443a9653586e5be5150b4458f3096a93f67).

Postgres readiness check is exiting with exit code 1 and the error is the same as in the commit referenced. This patch fixes it. Is there a better way of doing this, and what is the source of the problem?

Lock file reference for the project where error is present:
[devenv.lock.txt](https://github.com/user-attachments/files/25387324/devenv.lock.txt)

