### PR TITLE
Update settings file path in claude.nix

### DIFF
--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -593,7 +593,7 @@ in
 
   config = lib.mkIf cfg.enable {
     files = lib.mkMerge [
-      { "${settingsPath}".json = settingsContent; }
+      { "${cfg.settingsPath}".json = settingsContent; }
 
       # MCP configuration file
       (lib.mkIf (cfg.mcpServers != { }) {


### PR DESCRIPTION
The settingsPath is not used, use it in place of the hardcoded file to allow users to write to settings.local.json instead if conflicting with hand-written config in repo.