### PR TITLE
fix(tasks): @complete task failures should not cause non-zero exit code

### DIFF
--- a/devenv-tasks/src/types.rs
+++ b/devenv-tasks/src/types.rs
@@ -73,6 +73,10 @@ pub struct TasksStatus {
     pub skipped: usize,
     pub dependency_failed: usize,
     pub cancelled: usize,
+    /// Tasks that failed but are exclusively `@complete` (soft) dependencies
+    pub soft_failed: usize,
+    /// Tasks marked DependencyFailed whose root cause is exclusively a soft failure
+    pub soft_dependency_failed: usize,
 }
 
 impl Default for TasksStatus {
@@ -92,6 +96,8 @@ impl TasksStatus {
             skipped: 0,
             dependency_failed: 0,
             cancelled: 0,
+            soft_failed: 0,
+            soft_dependency_failed: 0,
         }
     }
 
@@ -100,9 +106,10 @@ impl TasksStatus {
         self.pending == 0 && self.running == 0
     }
 
-    /// Check if any tasks failed
+    /// Check if any tasks failed (excluding soft `@complete`-only failures)
     pub fn has_failures(&self) -> bool {
-        self.failed > 0 || self.dependency_failed > 0
+        (self.failed - self.soft_failed) > 0
+            || (self.dependency_failed - self.soft_dependency_failed) > 0
     }
 
     /// Get total number of tasks

--- a/tests/tasks-complete-soft-failure/.test-config.yml
+++ b/tests/tasks-complete-soft-failure/.test-config.yml
@@ -1,0 +1,2 @@
+# Run test outside the shell since we're testing shell entry and task exit codes
+use_shell: false

--- a/tests/tasks-complete-soft-failure/.test.sh
+++ b/tests/tasks-complete-soft-failure/.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test 1: devenv tasks run should exit 0 when only @complete deps fail
+if devenv tasks run devenv:enterShell --mode all 2>&1; then
+  echo "PASS: tasks run exited 0 with only @complete failure"
+else
+  echo "FAIL: tasks run exited non-zero despite only @complete failure"
+  exit 1
+fi
+
+# Test 2: devenv shell should enter successfully
+if devenv shell -- echo "SHELL_OK" 2>&1; then
+  echo "PASS: shell entered despite @complete task failure"
+else
+  echo "FAIL: shell failed to enter"
+  exit 1
+fi

--- a/tests/tasks-complete-soft-failure/devenv.nix
+++ b/tests/tasks-complete-soft-failure/devenv.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+{
+  # A task that always fails, used as a @complete (soft) dependency.
+  # Its failure should NOT cause a non-zero exit code because it is
+  # only depended on via @complete edges.
+  tasks."test:will-fail" = {
+    description = "Task that fails intentionally";
+    exec = ''
+      echo "This task is failing..."
+      exit 1
+    '';
+  };
+
+  # Override the default enterShell dependency to use @complete
+  # so that the failure of test:will-fail does not propagate.
+  tasks."devenv:enterShell".after = [ "test:will-fail@complete" ];
+}


### PR DESCRIPTION
## Summary

- Classify task failures as "soft" when the failed task is exclusively a `@complete` dependency, and exclude them from `has_failures()` so they don't cause a non-zero exit code
- Set `DEVENV_SKIP_TASKS=1` in `capture_shell_environment()` to prevent the legacy shellHook task runner from aborting env capture on `@complete` task failures
- Add unit tests for soft/hard/mixed failure classification and a integration test

Fixes #2480

## Test plan

- [x] `cargo test -p devenv-tasks` — all 69 tests pass
- [x] `cargo build` — full workspace compiles
- [ ] `devenv-run-tests run tests --only tasks-complete-soft-failure` — integration test
- [ ] Manual: `devenv tasks run devenv:enterShell --mode all` with a failing `@complete` dependency returns exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)