### PR TITLE
claude.code.hooks: add missing hookType values

### DIFF
--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -153,6 +153,11 @@ let
       SubagentStop = buildHooks "SubagentStop" (groupedHooks.SubagentStop or [ ]);
       PreCompact = buildHooks "PreCompact" (groupedHooks.PreCompact or [ ]);
       PermissionRequest = buildHooks "PermissionRequest" (groupedHooks.PermissionRequest or [ ]);
+      WorktreeCreate = buildHooks "WorktreeCreate" (groupedHooks.WorktreeCreate or [ ]);
+      WorktreeRemove = buildHooks "WorktreeRemove" (groupedHooks.WorktreeRemove or [ ]);
+      TeammateIdle = buildHooks "TeammateIdle" (groupedHooks.TeammateIdle or [ ]);
+      TaskCompleted = buildHooks "TaskCompleted" (groupedHooks.TaskCompleted or [ ]);
+      ConfigChange = buildHooks "ConfigChange" (groupedHooks.ConfigChange or [ ]);
     };
     inherit (cfg)
       apiKeyHelper
@@ -200,6 +205,11 @@ in
                 "SubagentStop"
                 "PreCompact"
                 "PermissionRequest"
+                "WorktreeCreate"
+                "WorktreeRemove"
+                "TeammateIdle"
+                "TaskCompleted"
+                "ConfigChange"
               ];
               default = "PostToolUse";
               description = ''
@@ -216,6 +226,11 @@ in
                 - SubagentStop: Runs when subagent tasks complete
                 - PreCompact: Runs before message compaction
                 - PermissionRequest: Runs when a permission is requested
+                - WorktreeCreate: Runs when a new worktree is created
+                - WorktreeRemove: Runs when a worktree is removed
+                - TeammateIdle: Runs when a teammate agent becomes idle
+                - TaskCompleted: Runs when a task is completed
+                - ConfigChange: Runs when configuration changes
               '';
             };
             matcher = lib.mkOption {


### PR DESCRIPTION
## Summary
- Add 5 missing hookType enum values: `WorktreeCreate`, `WorktreeRemove`, `TeammateIdle`, `TaskCompleted`, `ConfigChange`
- Add corresponding entries in settingsContent hooks builder
- Add descriptions for each new hook type

`WorktreeCreate`/`WorktreeRemove` enable VCS-agnostic isolation patterns (e.g. per-worktree dev databases).

Closes #2522