### PR TITLE
Pass proper arguments to devenv-tasks in devenv-flake-tasks

### DIFF
--- a/src/modules/flake-compat.nix
+++ b/src/modules/flake-compat.nix
@@ -92,7 +92,19 @@ let
   # `devenv tasks` helper command
   devenv-flake-tasks =
     pkgs.writeShellScriptBin "devenv-flake-tasks" ''
-      exec ${config.task.package}/bin/devenv-tasks "$@"
+      subcommand=$1
+      shift
+      case "$subcommand" in
+        run)
+          exec ${config.task.package}/bin/devenv-tasks run \
+            --cache-dir ${lib.escapeShellArg config.devenv.dotfile} \
+            --runtime-dir ${lib.escapeShellArg config.devenv.runtime} \
+            "$@"
+          ;;
+        *)
+          exec ${config.task.package}/bin/devenv-tasks "$subcommand" "$@"
+          ;;
+      esac
     '';
 
   devenvFlakeCompat = pkgs.symlinkJoin {


### PR DESCRIPTION
Without those arguments, `devenv task` when running in a flake shell fails with error:
<img width="938" height="162" alt="image" src="https://github.com/user-attachments/assets/d29b133a-d968-43da-80ec-c0a638304810" />
