### PR TITLE
fix(javascript): enableNpm option have been removed from nixpkgs

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -260,9 +260,9 @@ in
       enable = lib.mkEnableOption "install npm";
       package = lib.mkOption {
         type = lib.types.package;
-        default = cfg.package.override {
-          enableNpm = true;
-        };
+        default =
+          # Nixpkgs releases 26.05 no longer expose enableNpm option
+          cfg.package.override (args: args // lib.optionalAttrs (lib.hasAttr "enableNpm" args) { enableNpm = true; });
         defaultText = lib.literalExpression "languages.javascript.package";
         description = "The Node.js package to use.";
       };


### PR DESCRIPTION

Fixes: https://github.com/cachix/devenv/issues/2538
Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I3f64d53a63ef26dd285c3575276f10686a6a6964
