### PR TITLE
fix languages.rust.channel: include makeWrapper in mkAggregated import

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -319,7 +319,7 @@ in
         # Import the mkAggregated function.
         # This symlinkJoins and patches the individual components.
         mkAggregated = import (rust-overlay + "/lib/mk-aggregated.nix") {
-          inherit (pkgs) lib stdenv symlinkJoin bash curl;
+          inherit (pkgs) lib stdenv symlinkJoin bash curl makeWrapper;
           inherit (pkgs.buildPackages) rustc;
           pkgsTargetTarget = pkgs.targetPackages;
         };


### PR DESCRIPTION
Added makeWrapper to the imported components in mkAggregated.

fixes #2556