### PR TITLE
fix languages.rust.channel: Add pkgsHostHost to mkAggregated imports

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -319,7 +319,7 @@ in
         # Import the mkAggregated function.
         # This symlinkJoins and patches the individual components.
         mkAggregated = import (rust-overlay + "/lib/mk-aggregated.nix") {
-          inherit (pkgs) lib stdenv symlinkJoin bash curl makeWrapper;
+          inherit (pkgs) lib stdenv symlinkJoin bash curl makeWrapper pkgsHostHost;
           inherit (pkgs.buildPackages) rustc;
           pkgsTargetTarget = pkgs.targetPackages;
         };


### PR DESCRIPTION
In my previous PR #2557, I forgot pkgsHostHost from https://github.com/oxalica/rust-overlay/pull/250/changes#diff-0d213f9f63e2ace0a9e9eeed2843394ff96488a895862af6b27e59bd075db8b7R6

