### PR TITLE
Emit typed exec_if_modified OTEL attrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
+ "which 8.0.0",
 ]
 
 [[package]]

--- a/devenv-tasks/Cargo.toml
+++ b/devenv-tasks/Cargo.toml
@@ -27,6 +27,7 @@ blake3.workspace = true
 shell-escape.workspace = true
 base64.workspace = true
 ignore.workspace = true
+rand.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true, features = ["user", "signal"] }

--- a/devenv-tasks/src/task_cache.rs
+++ b/devenv-tasks/src/task_cache.rs
@@ -17,6 +17,15 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use tracing::{debug, warn};
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModifiedFilesCheck {
+    pub modified: bool,
+    pub pattern_count: usize,
+    pub include_pattern_count: usize,
+    pub exclude_pattern_count: usize,
+    pub matched_file_count: usize,
+}
+
 fn normalize_pattern_for_base_dir(pattern: &str, base_dir: &Path) -> String {
     let (negated, raw_pattern) = match pattern.strip_prefix('!') {
         Some(rest) => (true, rest),
@@ -282,9 +291,34 @@ impl TaskCache {
         task_name: &str,
         files: &[String],
     ) -> CacheResult<bool> {
+        Ok(self
+            .check_modified_files_with_stats(task_name, files)
+            .await?
+            .modified)
+    }
+
+    /// Check if any files have been modified for a given task and return counters
+    /// about the matched pattern set for observability.
+    pub async fn check_modified_files_with_stats(
+        &self,
+        task_name: &str,
+        files: &[String],
+    ) -> CacheResult<ModifiedFilesCheck> {
         if files.is_empty() {
-            return Ok(false);
+            return Ok(ModifiedFilesCheck {
+                modified: false,
+                pattern_count: 0,
+                include_pattern_count: 0,
+                exclude_pattern_count: 0,
+                matched_file_count: 0,
+            });
         }
+
+        let include_pattern_count = files
+            .iter()
+            .filter(|pattern| !pattern.starts_with('!'))
+            .count();
+        let exclude_pattern_count = files.len() - include_pattern_count;
 
         // Expand all patterns and collect results
         let expanded_paths = expand_glob_patterns(files);
@@ -301,7 +335,13 @@ impl TaskCache {
             }
         }
 
-        Ok(any_modified)
+        Ok(ModifiedFilesCheck {
+            modified: any_modified,
+            pattern_count: files.len(),
+            include_pattern_count,
+            exclude_pattern_count,
+            matched_file_count: expanded_paths.len(),
+        })
     }
 
     /// Get current Unix timestamp
@@ -719,6 +759,69 @@ mod tests {
                 .check_modified_files(task_name, &patterns)
                 .await
                 .unwrap()
+        );
+    }
+
+    #[sqlx::test]
+    async fn test_check_modified_files_with_stats() {
+        let db_temp_dir = TempDir::new().unwrap();
+        let db_path = db_temp_dir.path().join("tasks-glob-stats.db");
+
+        let cache = TaskCache::with_db_path(db_path).await.unwrap();
+        let test_temp_dir = TempDir::new().unwrap();
+        let src_dir = test_temp_dir.path().join("src");
+        let node_modules_dir = test_temp_dir.path().join("node_modules");
+        tokio::fs::create_dir_all(&src_dir).await.unwrap();
+        tokio::fs::create_dir_all(&node_modules_dir).await.unwrap();
+
+        let included_file = src_dir.join("main.ts");
+        let excluded_file = node_modules_dir.join("ignored.ts");
+        tokio::fs::write(&included_file, "export const value = 1;\n")
+            .await
+            .unwrap();
+        tokio::fs::write(&excluded_file, "export const ignored = true;\n")
+            .await
+            .unwrap();
+
+        let task_name = "test_glob_stats_task";
+        let patterns = vec![
+            format!("{}/**/*.ts", test_temp_dir.path().to_string_lossy()),
+            "!**/node_modules/**".to_string(),
+        ];
+
+        let first = cache
+            .check_modified_files_with_stats(task_name, &patterns)
+            .await
+            .unwrap();
+        assert_eq!(
+            first,
+            ModifiedFilesCheck {
+                modified: true,
+                pattern_count: 2,
+                include_pattern_count: 1,
+                exclude_pattern_count: 1,
+                matched_file_count: 1,
+            }
+        );
+
+        cache
+            .update_file_state(task_name, included_file.to_str().unwrap())
+            .await
+            .unwrap();
+
+        let second = cache
+            .check_modified_files_with_stats(task_name, &patterns)
+            .await
+            .unwrap();
+        assert_eq!(
+            second,
+            ModifiedFilesCheck {
+                modified: false,
+                pattern_count: 2,
+                include_pattern_count: 1,
+                exclude_pattern_count: 1,
+                matched_file_count: 1,
+            }
         );
     }
 

--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -1,16 +1,19 @@
 use crate::SudoContext;
 use crate::config::TaskConfig;
 use crate::executor::{ExecutionContext, OutputCallback, SubprocessExecutor};
-use crate::task_cache::{TaskCache, expand_glob_patterns};
+use crate::task_cache::{ModifiedFilesCheck, TaskCache, expand_glob_patterns};
 use crate::types::{Output, Skipped, TaskCompleted, TaskFailure, TaskStatus, VerbosityLevel};
 use devenv_activity::{Activity, ActivityInstrument, ActivityLevel};
 use devenv_processes::{ListenKind, NativeProcessManager, ProcessConfig};
 use miette::{IntoDiagnostic, Result, WrapErr};
+use rand::RngCore;
+use serde_json::json;
 use std::collections::BTreeMap;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::fs::File;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -53,6 +56,13 @@ pub struct TaskState {
     pub sudo_context: Option<SudoContext>,
 }
 
+#[derive(Clone, Debug)]
+struct ExecIfModifiedCheckResult {
+    modified: bool,
+    patterns: ModifiedFilesCheck,
+    command_path: Option<ModifiedFilesCheck>,
+}
+
 impl TaskState {
     pub fn new(
         task: TaskConfig,
@@ -72,34 +82,67 @@ impl TaskState {
     async fn check_files_modified_result(
         &self,
         cache: &TaskCache,
-    ) -> Result<bool, devenv_cache_core::error::CacheError> {
+    ) -> Result<ExecIfModifiedCheckResult, devenv_cache_core::error::CacheError> {
         if self.task.exec_if_modified.is_empty() {
-            return Ok(false);
+            return Ok(ExecIfModifiedCheckResult {
+                modified: false,
+                patterns: ModifiedFilesCheck {
+                    modified: false,
+                    pattern_count: 0,
+                    include_pattern_count: 0,
+                    exclude_pattern_count: 0,
+                    matched_file_count: 0,
+                },
+                command_path: None,
+            });
         }
 
-        let patterns_modified = cache
-            .check_modified_files(&self.task.name, &self.task.exec_if_modified)
+        let patterns = cache
+            .check_modified_files_with_stats(&self.task.name, &self.task.exec_if_modified)
             .await?;
-        if patterns_modified {
-            return Ok(true);
+        if patterns.modified {
+            return Ok(ExecIfModifiedCheckResult {
+                modified: true,
+                patterns,
+                command_path: None,
+            });
         }
 
         // Track command path changes separately so negation patterns in exec_if_modified
         // don't suppress cache invalidation for the task script itself.
         if let Some(cmd) = &self.task.command {
-            return cache
-                .check_modified_files(&self.task.name, std::slice::from_ref(cmd))
-                .await;
+            let command_path = cache
+                .check_modified_files_with_stats(&self.task.name, std::slice::from_ref(cmd))
+                .await?;
+            return Ok(ExecIfModifiedCheckResult {
+                modified: command_path.modified,
+                patterns,
+                command_path: Some(command_path),
+            });
         }
 
-        Ok(false)
+        Ok(ExecIfModifiedCheckResult {
+            modified: false,
+            patterns,
+            command_path: None,
+        })
     }
 
     /// Check if any files specified in exec_if_modified have been modified.
     /// Returns true if any files have been modified or if there was an error checking.
     async fn check_modified_files(&self, cache: &TaskCache) -> bool {
+        let started_at = SystemTime::now();
+        let started_monotonic = Instant::now();
         match self.check_files_modified_result(cache).await {
-            Ok(modified) => modified,
+            Ok(result) => {
+                self.emit_exec_if_modified_status_span(
+                    &result,
+                    started_at,
+                    started_monotonic.elapsed().as_millis(),
+                )
+                .await;
+                result.modified
+            }
             Err(e) => {
                 // Log the error and default to running the task if there's an error
                 tracing::warn!(
@@ -109,6 +152,129 @@ impl TaskState {
                 );
                 true
             }
+        }
+    }
+
+    async fn emit_exec_if_modified_status_span(
+        &self,
+        result: &ExecIfModifiedCheckResult,
+        started_at: SystemTime,
+        eval_ms: u128,
+    ) {
+        if self.task.exec_if_modified.is_empty() {
+            return;
+        }
+
+        if std::env::var_os("OTEL_EXPORTER_OTLP_ENDPOINT").is_none()
+            && std::env::var_os("OTEL_SPAN_SPOOL_DIR").is_none()
+        {
+            return;
+        }
+
+        let end_at = SystemTime::now();
+        let start_ns = match started_at.duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_nanos().to_string(),
+            Err(_) => return,
+        };
+        let end_ns = match end_at.duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_nanos().to_string(),
+            Err(_) => return,
+        };
+
+        let mut trace_id = random_hex(16);
+        let mut parent_span_id = None;
+        if let Some(traceparent) =
+            std::env::var_os("OTEL_TASK_TRACEPARENT").or_else(|| std::env::var_os("TRACEPARENT"))
+            && let Some(parsed) = parse_traceparent(&traceparent.to_string_lossy())
+        {
+            trace_id = parsed.trace_id;
+            parent_span_id = Some(parsed.parent_span_id);
+        }
+
+        let exit_code = if result.modified { 1 } else { 0 };
+        let mut attributes = vec![
+            json!({"key": "service.name", "value": {"stringValue": "dt-task"}}),
+            json!({"key": "exit.code", "value": {"intValue": exit_code.to_string()}}),
+            json!({"key": "task.phase", "value": {"stringValue": "status"}}),
+            json!({"key": "status.method", "value": {"stringValue": "exec_if_modified"}}),
+            json!({"key": "task.exec_if_modified.pattern_count", "value": {"intValue": result.patterns.pattern_count.to_string()}}),
+            json!({"key": "task.exec_if_modified.include_pattern_count", "value": {"intValue": result.patterns.include_pattern_count.to_string()}}),
+            json!({"key": "task.exec_if_modified.exclude_pattern_count", "value": {"intValue": result.patterns.exclude_pattern_count.to_string()}}),
+            json!({"key": "task.exec_if_modified.matched_file_count", "value": {"intValue": result.patterns.matched_file_count.to_string()}}),
+            json!({"key": "task.exec_if_modified.modified", "value": {"boolValue": result.modified}}),
+            json!({"key": "task.exec_if_modified.eval_ms", "value": {"intValue": eval_ms.to_string()}}),
+            json!({"key": "task.cached", "value": {"boolValue": !result.modified}}),
+        ];
+
+        if let Ok(devenv_root) = std::env::var("DEVENV_ROOT") {
+            attributes.push(json!({"key": "devenv.root", "value": {"stringValue": devenv_root}}));
+        }
+
+        if let Some(command_path) = &result.command_path {
+            attributes.push(
+                json!({"key": "task.exec_if_modified.command_path_checked", "value": {"boolValue": true}}),
+            );
+            attributes.push(json!({
+                "key": "task.exec_if_modified.command_path_matched_file_count",
+                "value": {"intValue": command_path.matched_file_count.to_string()}
+            }));
+            attributes.push(json!({
+                "key": "task.exec_if_modified.command_path_modified",
+                "value": {"boolValue": command_path.modified}
+            }));
+        }
+
+        let mut span = json!({
+            "traceId": trace_id,
+            "spanId": random_hex(8),
+            "name": format!("{}:status", self.task.name),
+            "kind": 1,
+            "startTimeUnixNano": start_ns,
+            "endTimeUnixNano": end_ns,
+            "attributes": attributes,
+            "status": {"code": 1},
+        });
+        if let Some(parent_span_id) = parent_span_id {
+            span["parentSpanId"] = json!(parent_span_id);
+        }
+
+        let payload = json!({
+            "resourceSpans": [{
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "dt-task"}}
+                    ]
+                },
+                "scopeSpans": [{
+                    "scope": {"name": "devenv-tasks"},
+                    "spans": [span]
+                }]
+            }]
+        });
+
+        let mut command = Command::new("otel-span");
+        command
+            .arg("emit")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let Ok(mut child) = command.spawn() else {
+            return;
+        };
+
+        if let Some(mut stdin) = child.stdin.take()
+            && let Ok(payload) = serde_json::to_vec(&payload)
+        {
+            let _ = stdin.write_all(&payload).await;
+        }
+
+        if let Err(error) = child.wait().await {
+            tracing::debug!(
+                "Failed to emit exec_if_modified status span for task {}: {}",
+                self.task.name,
+                error
+            );
         }
     }
 
@@ -654,4 +820,32 @@ impl TaskState {
             ))
         }
     }
+}
+
+struct TraceparentContext {
+    trace_id: String,
+    parent_span_id: String,
+}
+
+fn parse_traceparent(traceparent: &str) -> Option<TraceparentContext> {
+    let mut parts = traceparent.split('-');
+    let _version = parts.next()?;
+    let trace_id = parts.next()?;
+    let parent_span_id = parts.next()?;
+    let _flags = parts.next()?;
+
+    if trace_id.len() != 32 || parent_span_id.len() != 16 {
+        return None;
+    }
+
+    Some(TraceparentContext {
+        trace_id: trace_id.to_string(),
+        parent_span_id: parent_span_id.to_string(),
+    })
+}
+
+fn random_hex(byte_len: usize) -> String {
+    let mut bytes = vec![0_u8; byte_len];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }


### PR DESCRIPTION
This instruments the real `exec_if_modified` cache path in `devenv-tasks` so status spans can report pattern counts, matched-file counts, command-path checks, and evaluation time. The stats are collected in `devenv-tasks/src/task_cache.rs` and the span emission lives in `devenv-tasks/src/task_state.rs`. The implementation uses `otel-span emit` with an explicit OTLP JSON payload so numeric values land as typed `intValue` fields instead of `stringValue` attrs. I validated the pre-fix failure mode locally and switched the upstream implementation to the typed payload path to address it.