### PR TITLE
docs: recommend devenv-vscode extension for VS Code

### DIFF
--- a/docs/src/editor-support/vscode.md
+++ b/docs/src/editor-support/vscode.md
@@ -1,3 +1,5 @@
-It's best to use [direnv integration](../integrations/direnv.md) with [direnv extension](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv).
+Use the [devenv extension for VS Code](https://marketplace.visualstudio.com/items?itemName=datakurre.devenv).
+
+Report any issues at the [extension's issue tracker](https://github.com/datakurre/devenv-vscode/issues).
 
 


### PR DESCRIPTION
Draft until it lands in marketplace: https://github.com/datakurre/devenv-vscode/issues/16