### PR TITLE
fix: bump nix to include temproot fix for fetchToStore

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,16 +142,16 @@
         "nixpkgs-regression": []
       },
       "locked": {
-        "lastModified": 1772748357,
-        "narHash": "sha256-vtf03lfgQKNkPH9FdXdboBDS5DtFkXB8xRw5EBpuDas=",
+        "lastModified": 1773158757,
+        "narHash": "sha256-l/UMzByfYOww3Hq8Cvyule9/S8XgOniXd2zvQFYEIq0=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "41eee9d3b1f611b1b90d51caa858b6d83834c44a",
+        "rev": "ae751039ffee783c0549ea36307b162c40bc01d5",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.32",
+        "ref": "fix/temproot-fetch-to-store",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     };
   };
   inputs.nix = {
-    url = "github:cachix/nix/devenv-2.32";
+    url = "github:cachix/nix/fix/temproot-fetch-to-store";
     inputs = {
       nixpkgs.follows = "nixpkgs";
       flake-compat.follows = "flake-compat";


### PR DESCRIPTION
## Summary

- Bumps the nix input to `cachix/nix#fix/temproot-fetch-to-store` which adds a client-side `addTempRoot()` call for the non-cached code path in `fetchToStore`
- Fixes sporadic `path '/nix/store/...' is not valid` errors during evaluation on CI

## Root cause

When `fetchToStore` returns a newly added store path (non-cached), the only temp root is held by the daemon worker that handled the `addToStore` call. If the daemon connection is recycled during a long evaluation, that temp root is lost and auto-GC can collect the path before `derivationStrict` writes the `.drv` file referencing it.

The cached code path already had `addTempRoot()` (line 40 of `fetch-to-store.cc`), but the non-cached path was missing it. This specifically affects plain file paths like patches and source files that appear as opaque context elements in `inputSrcs`.

## Test plan

- [ ] CI examples that previously failed with "is not valid" errors should pass
- [ ] Once verified, merge `fix/temproot-fetch-to-store` into `devenv-2.32` in cachix/nix and switch this input URL back

🤖 Generated with [Claude Code](https://claude.com/claude-code)