### PR TITLE
Fix single-user Nix with permissive umask

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -142,16 +142,16 @@
         "nixpkgs-regression": []
       },
       "locked": {
-        "lastModified": 1772748357,
-        "narHash": "sha256-vtf03lfgQKNkPH9FdXdboBDS5DtFkXB8xRw5EBpuDas=",
+        "lastModified": 1773169354,
+        "narHash": "sha256-MZyvPH8XdSfYpARlTjQTSbRlZ8Dj4jUW3/oc0tdf97Y=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "41eee9d3b1f611b1b90d51caa858b6d83834c44a",
+        "rev": "3c8f32beba01be57ca02bc9d8739431590f444cd",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "devenv-2.32",
+        "ref": "fix/builder-umask",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     };
   };
   inputs.nix = {
-    url = "github:cachix/nix/devenv-2.32";
+    url = "github:cachix/nix/fix/builder-umask";
     inputs = {
       nixpkgs.follows = "nixpkgs";
       flake-compat.follows = "flake-compat";


### PR DESCRIPTION
## Summary

- Fixes "suspicious ownership or permission" errors on single-user Nix installs with permissive umask (e.g. 0002 on Ubuntu)
- Points the nix input to `fix/builder-umask` which adds `umask(0022)` in the builder child process

## Root cause

The Nix C API (`nix_string_realise`, `nix_get_dev_environment`) does not call `initNix()`, so it never sets `umask(0022)`. With the user's umask of 0002, builder outputs get group-writable permissions (664). The `registerOutputs()` check rejects these as "suspicious" before `canonicalisePathMetaData()` gets a chance to fix them to 0444.

The Nix fix: https://github.com/cachix/nix/commit/3c8f32beba01be57ca02bc9d8739431590f444cd

## Test plan

- [ ] Verify on single-user Nix with `umask 0002` that `devenv shell` works
- [ ] Verify existing builds are unaffected on multi-user Nix

Fixes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)