### PR TITLE
feat: add strictPorts option to devenv.yaml

### DIFF
--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -1071,6 +1071,40 @@ mod tests {
     }
 
     #[test]
+    fn strict_ports_field_none_by_default() {
+        let config = Config::default();
+        assert_eq!(config.strict_ports, None);
+    }
+
+    #[test]
+    fn strict_ports_field_serializes_as_camel_case() {
+        let mut config = Config::default();
+        config.strict_ports = Some(true);
+
+        let yaml = serde_yaml::to_string(&config).expect("Failed to serialize config");
+        assert!(yaml.contains("strictPorts: true"));
+    }
+
+    #[test]
+    fn strict_ports_field_not_serialized_when_none() {
+        let config = Config::default();
+        let yaml = serde_yaml::to_string(&config).expect("Failed to serialize config");
+        assert!(!yaml.contains("strictPorts"));
+    }
+
+    #[test]
+    fn strict_ports_field_respects_replace_merge_strategy() {
+        let mut config1 = Config::default();
+        config1.strict_ports = Some(false);
+
+        let mut config2 = Config::default();
+        config2.strict_ports = Some(true);
+
+        let merged_strict_ports = config2.strict_ports.or(config1.strict_ports);
+        assert_eq!(merged_strict_ports, Some(true));
+    }
+
+    #[test]
     fn relative_path_url_resolved_from_correct_config_directory() {
         // Test that when a base config and imported config both define inputs
         // with relative path URLs like "path:.", each is resolved relative

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -497,6 +497,12 @@ pub enum Commands {
             help = "Error if a port is already in use instead of auto-allocating the next available port."
         )]
         strict_ports: bool,
+
+        #[arg(
+            long,
+            help = "Disable strict port mode, overriding strictPorts from devenv.yaml."
+        )]
+        no_strict_ports: bool,
     },
 
     Processes {
@@ -617,6 +623,12 @@ pub enum ProcessesCommand {
             help = "Error if a port is already in use instead of auto-allocating the next available port."
         )]
         strict_ports: bool,
+
+        #[arg(
+            long,
+            help = "Disable strict port mode, overriding strictPorts from devenv.yaml."
+        )]
+        no_strict_ports: bool,
     },
 
     #[command(alias = "stop", about = "Stop processes running in the background.")]
@@ -720,11 +732,49 @@ pub enum InputsCommand {
 
 #[cfg(test)]
 mod tests {
-    use super::Cli;
+    use super::{Cli, Commands, ProcessesCommand};
+    use clap::Parser;
 
     #[test]
     fn verify_cli() {
         use clap::CommandFactory;
         Cli::command().debug_assert()
+    }
+
+    #[test]
+    fn up_accepts_no_strict_ports() {
+        let cli = Cli::parse_from(["devenv", "up", "--no-strict-ports"]);
+
+        match cli.command {
+            Some(Commands::Up {
+                strict_ports,
+                no_strict_ports,
+                ..
+            }) => {
+                assert!(!strict_ports);
+                assert!(no_strict_ports);
+            }
+            _ => panic!("expected `devenv up` command"),
+        }
+    }
+
+    #[test]
+    fn processes_up_accepts_no_strict_ports() {
+        let cli = Cli::parse_from(["devenv", "processes", "up", "--no-strict-ports"]);
+
+        match cli.command {
+            Some(Commands::Processes {
+                command:
+                    ProcessesCommand::Up {
+                        strict_ports,
+                        no_strict_ports,
+                        ..
+                    },
+            }) => {
+                assert!(!strict_ports);
+                assert!(no_strict_ports);
+            }
+            _ => panic!("expected `devenv processes up` command"),
+        }
     }
 }

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -591,8 +591,15 @@ async fn run_backend(
     }
 
     // All other commands
-    let result =
-        dispatch_command(&devenv, command, verbosity, tui, command_rx, config_strict_ports).await;
+    let result = dispatch_command(
+        &devenv,
+        command,
+        verbosity,
+        tui,
+        command_rx,
+        config_strict_ports,
+    )
+    .await;
 
     // Signal TUI that backend is done
     backend_done.notify_one();
@@ -749,6 +756,7 @@ async fn dispatch_command(
             processes,
             detach,
             strict_ports,
+            no_strict_ports,
         }
         | Commands::Processes {
             command:
@@ -756,13 +764,16 @@ async fn dispatch_command(
                     processes,
                     detach,
                     strict_ports,
+                    no_strict_ports,
                 },
         } => {
+            let strict_ports = devenv_core::settings::flag(strict_ports, no_strict_ports)
+                .unwrap_or(config_strict_ports);
             let options = devenv::ProcessOptions {
                 envs: None,
                 detach,
                 log_to_file: detach,
-                strict_ports: strict_ports || config_strict_ports,
+                strict_ports,
                 command_rx,
             };
             match devenv.up(processes, options, verbosity, tui).await? {

--- a/docs/src/devenv.schema.json
+++ b/docs/src/devenv.schema.json
@@ -68,6 +68,18 @@
         "string",
         "null"
       ]
+    },
+    "reload": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "strictPorts": {
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
   "$defs": {

--- a/docs/src/processes.md
+++ b/docs/src/processes.md
@@ -302,19 +302,20 @@ This is particularly useful for:
 
 ### Strict port mode
 
-If you want devenv to fail when a port is already in use instead of automatically finding the next available port, you can set it in `devenv.yaml`:
+If you want devenv to fail when a port is already in use instead of automatically finding the next available port, you can set the default in `devenv.yaml`:
 
 ```yaml
 strictPorts: true
 ```
 
-Or use the `--strict-ports` CLI flag:
+Or override it for a single run with CLI flags:
 
 ```shell-session
 $ devenv up --strict-ports
+$ devenv up --no-strict-ports
 ```
 
-The CLI flag takes precedence over the config value.
+The CLI flags take precedence over the config value.
 
 This is useful when you need deterministic port assignments and want to be notified of conflicts rather than having them silently resolved. When a port conflict is detected in strict mode, devenv will show an error message including which process is currently using the port.
 

--- a/docs/src/reference/yaml-options.md
+++ b/docs/src/reference/yaml-options.md
@@ -29,7 +29,7 @@
 | nixpkgs.per-platform.&lt;system&gt;.permittedUnfreePackages   | (per-platform) A list of unfree packages to allow by name. Defaults to `[]`   |
 |                                                               |                                                                               |
 | profile                                                       | Default profile to activate. Can be overridden by `--profile` CLI flags.       |
-| strictPorts                                                   | Error if a port is already in use instead of auto-allocating the next available port. Defaults to `false`. Can be overridden by `--strict-ports` CLI flag. |
+| strictPorts                                                   | Error if a port is already in use instead of auto-allocating the next available port. Defaults to `false`. Can be overridden by `--strict-ports` or `--no-strict-ports` CLI flags. |
 |                                                               |                                                                               |
 | secretspec.enable                                             | Enable [secretspec integration](../integrations/secretspec.md). Defaults to `false`.                           |
 | secretspec.profile                                            | Secretspec profile name to use.                                               |


### PR DESCRIPTION
## Summary

- Adds `strictPorts` as a `devenv.yaml` option so projects can set strict port mode as the default
- Allows CLI overrides in either direction with `--strict-ports` and `--no-strict-ports`
- Updates docs, schema, and tests for the new config surface

## Motivation

Some projects cannot rely on dynamic port allocation. If a service is expected to run on a fixed port, silently moving it to the next available port can break local setups in ways that are hard to diagnose.

That shows up in cases like reverse proxies, callback URLs, frontend-to-backend assumptions, mobile clients, or external tools that expect a specific port.

Today the only way to enforce this is for every developer to remember `devenv up --strict-ports`. This change lets a project declare that behavior once in `devenv.yaml`, so fixed-port expectations are versioned with the project and shared across the team.

## Usage

```yaml
strictPorts: true
```

CLI overrides still work for one-off runs:

```sh
devenv up --strict-ports
devenv up --no-strict-ports
```

`devenv.local.yaml` can still be used for personal preference, but the main goal is to support project-level defaults.
