### PR TITLE
Fix: graceful process shutdown on Ctrl+C

### DIFF
--- a/devenv-tasks/src/main.rs
+++ b/devenv-tasks/src/main.rs
@@ -105,10 +105,7 @@ async fn main() -> Result<()> {
     let shutdown = Shutdown::new();
     shutdown.install_signals().await;
 
-    tokio::select! {
-        result = run_tasks(shutdown.clone()) => result?,
-        _ = shutdown.wait_for_shutdown() => {}
-    };
+    run_tasks(shutdown).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Removes `tokio::select!` race in `main()` that dropped the `run_tasks` future on SIGTERM/SIGINT, preventing graceful child process shutdown
- Child processes like PostgreSQL were left running as orphans because the cleanup path (`stop_all` → `Signal::Terminate`) never executed
- Fix: await `run_tasks` directly and let signals propagate through the internal cancellation chain

Fixes https://github.com/digitallyinduced/ihp/issues/2481

## Root Cause

```rust
// BEFORE (bug)
tokio::select! {
    result = run_tasks(shutdown.clone()) => result?,
    _ = shutdown.wait_for_shutdown() => {}  // wins the race, drops run_tasks
};
```

When SIGTERM/SIGINT arrives, `shutdown.wait_for_shutdown()` resolves immediately and `tokio::select!` drops the `run_tasks` future — cancelling all cleanup before `stop_all()` can send `Signal::Terminate` to child processes.

```rust
// AFTER (fix)
run_tasks(shutdown).await?;
```

The shutdown path inside `run_tasks` already handles this correctly:
1. `tokio-shutdown` triggers the `CancellationToken`
2. `join_set.wait_all()` aborts task futures → `Tasks::run` returns
3. `TasksUi::run` enters Phase 2 → calls `pm.run_foreground(cancel, None)`
4. `run_foreground` detects cancellation → `stop_all()` → `stop_with_signal(Terminate, 5s)` per process

## Test plan

- [x] `devenv up` → wait for postgres to start → Ctrl+C → postgres actually stops
- [x] No orphaned postgres processes (`ps aux | grep postgres`)
- [x] `devenv up` again starts cleanly without "postmaster.pid already exists"

🤖 Generated with [Claude Code](https://claude.com/claude-code)