### PR TITLE
fix: stop child processes on shutdown with non-native process managers

### DIFF
--- a/devenv-tasks/src/main.rs
+++ b/devenv-tasks/src/main.rs
@@ -101,10 +101,7 @@ async fn main() -> Result<()> {
     let shutdown = Shutdown::new();
     shutdown.install_signals().await;
 
-    tokio::select! {
-        result = run_tasks(shutdown.clone()) => result?,
-        _ = shutdown.wait_for_shutdown() => {}
-    };
+    run_tasks(shutdown.clone()).await?;
 
     Ok(())
 }
@@ -205,6 +202,7 @@ async fn run_tasks(shutdown: Arc<Shutdown>) -> Result<()> {
             let (status, _) = ui.run(run_handle).await?;
 
             if shutdown.last_signal().is_some() {
+                let _ = tasks.process_manager.stop_all().await;
                 shutdown.exit_process();
             }
 


### PR DESCRIPTION
Fixes #2586

When using process-compose, each service runs as a devenv-tasks run subprocess. On Ctrl+C, main() had a tokio::select! racing run_tasks against the shutdown signal. When shutdown wins, the run_tasks future is dropped immediately, skipping any cleanup. Child processes like postgres or redis are left orphaned.
The fix:
- Await run_tasks directly instead of racing it
- Call process_manager.stop_all() before exit_process() so children get SIGTERM

The native process manager is unaffected since it handles shutdown via its own CancellationToken.
Tested by building devenv-tasks locally, overriding task.package in a project with process-compose + PostgreSQL and confirming postgres is properly stopped on Ctrl+C.

Note: This removes the select! that, as I understand it, acted as a force-exit safety net. If run_tasks ever hangs on shutdown, the process will now hang too. In practice ShutdownJoinSet handles cancellation, so this shouldn't happen.