### PR TITLE
Fix stale eval-cache invalidation for devenv up process config changes

### DIFF
--- a/devenv-eval-cache/src/caching_eval.rs
+++ b/devenv-eval-cache/src/caching_eval.rs
@@ -57,17 +57,18 @@ pub enum CacheError {
 
 struct ObserverClearGuard {
     bridge: Arc<NixLogBridge>,
+    observer: Arc<dyn devenv_core::eval_op::OpObserver>,
 }
 
 impl ObserverClearGuard {
-    fn new(bridge: Arc<NixLogBridge>) -> Self {
-        Self { bridge }
+    fn new(bridge: Arc<NixLogBridge>, observer: Arc<dyn devenv_core::eval_op::OpObserver>) -> Self {
+        Self { bridge, observer }
     }
 }
 
 impl Drop for ObserverClearGuard {
     fn drop(&mut self) {
-        self.bridge.clear_observers();
+        self.bridge.remove_observer(&self.observer);
     }
 }
 
@@ -547,8 +548,9 @@ impl CachedEval {
 
         // Cache miss (or resource replay failed) - collect inputs during evaluation
         let collector = EvalInputCollector::start();
-        self.log_bridge.add_observer(collector.clone());
-        let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone());
+        let observer: Arc<dyn devenv_core::eval_op::OpObserver> = collector.clone();
+        self.log_bridge.add_observer(observer.clone());
+        let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone(), observer);
 
         let result = eval_fn().await;
         drop(_observer_guard);
@@ -643,8 +645,9 @@ impl CachedEval {
 
         // Cache miss (or resource replay failed) - collect inputs during evaluation
         let collector = EvalInputCollector::start();
-        self.log_bridge.add_observer(collector.clone());
-        let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone());
+        let observer: Arc<dyn devenv_core::eval_op::OpObserver> = collector.clone();
+        self.log_bridge.add_observer(observer.clone());
+        let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone(), observer);
 
         let result = eval_fn().await;
         drop(_observer_guard);


### PR DESCRIPTION
### **DISCLAIMER: Both bug triage, fix and this summary is AI Generated (Codex 5.4).**

(However, a human experienced the bug and validated the fix.)
 
This fixes a cache invalidation bug that could cause devenv up to keep using an old processes configuration even after devenv.nix changed.

In the failing case, devenv up would still rebuild the procfile-related attribute path, but the evaluation could hit a stale cached result because not all file dependencies from nested evaluations were preserved. The visible symptom was that changes under processes were not reflected unless the user manually forced --refresh-eval-cache.

**Root Cause**

The eval-cache layer registers an observer to collect file and environment inputs during cache misses. That observer is used to determine when a cached evaluation should be invalidated.

On drop, the observer guard called clear_observers(), which removed every active observer from NixLogBridge, not just the collector created for that specific evaluation. In nested or overlapping evaluation paths, this could accidentally remove other collectors that were still needed.

As a result, some cached entries could be stored with incomplete dependency sets. When devenv.nix or related imported files later changed, those cache entries could still validate as fresh and return stale results.

**Fix**

The observer guard now removes only the observer it owns, using remove_observer(...), instead of clearing the full observer list.

This keeps dependency collection isolated per evaluation and preserves the complete input set needed for correct eval-cache invalidation.

**User Impact**

Before this change:

  - edits to processes in devenv.nix could be ignored by devenv up
  - devenv processes down && devenv up might still reuse stale cached evaluation results
  - --refresh-eval-cache would work around the issue

  After this change:

  - changes to devenv.nix and related inputs are tracked correctly
  - devenv up picks up updated process definitions without requiring manual cache refresh