### PR TITLE
feat: add a lot more tui functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ version = "2.0.7"
 dependencies = [
  "async-priority-channel",
  "miette",
+ "nix 0.31.2",
  "notify",
  "reqwest 0.13.2",
  "tempfile",
@@ -1987,6 +1988,7 @@ version = "2.0.7"
 dependencies = [
  "async-trait",
  "caps",
+ "crossterm",
  "devenv-activity",
  "devenv-event-sources",
  "futures",
@@ -2117,6 +2119,7 @@ version = "2.0.7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "avt",
  "base64",
  "chrono",
  "clap",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6710,6 +6710,11 @@ rec {
             features = [ "fancy" ];
           }
           {
+            name = "nix";
+            packageId = "nix 0.31.2";
+            features = [ "fs" "process" "signal" ];
+          }
+          {
             name = "notify";
             packageId = "notify";
             optional = true;
@@ -6933,6 +6938,10 @@ rec {
             name = "caps";
             packageId = "caps";
             target = { target, features }: ("linux" == target."os" or null);
+          }
+          {
+            name = "crossterm";
+            packageId = "crossterm";
           }
           {
             name = "devenv-activity";
@@ -7445,6 +7454,10 @@ rec {
           {
             name = "async-trait";
             packageId = "async-trait";
+          }
+          {
+            name = "avt";
+            packageId = "avt";
           }
           {
             name = "base64";

--- a/devenv-activity/src/activity.rs
+++ b/devenv-activity/src/activity.rs
@@ -423,6 +423,17 @@ impl Activity {
         }
     }
 
+    pub fn raw_log(&self, data: Vec<u8>) {
+        let _guard = self.span.enter();
+        if matches!(self.activity_type, ActivityType::Process) {
+            send_activity_event(ActivityEvent::Process(Process::RawLog {
+                id: self.id,
+                data,
+                timestamp: Timestamp::now(),
+            }));
+        }
+    }
+
     /// Set process status (for Process activities only)
     pub fn set_status(&self, status: ProcessStatus) {
         let _guard = self.span.enter();
@@ -494,6 +505,17 @@ impl ActivityRef {
         }
         if let Some(event) = make_log_event(self.id, self.activity_type, line_str, true) {
             send_activity_event(event);
+        }
+    }
+
+    pub fn raw_log(&self, data: Vec<u8>) {
+        let _guard = self.span.enter();
+        if matches!(self.activity_type, ActivityType::Process) {
+            send_activity_event(ActivityEvent::Process(Process::RawLog {
+                id: self.id,
+                data,
+                timestamp: Timestamp::now(),
+            }));
         }
     }
 

--- a/devenv-activity/src/events.rs
+++ b/devenv-activity/src/events.rs
@@ -327,6 +327,12 @@ pub enum Process {
         is_error: bool,
         timestamp: Timestamp,
     },
+    RawLog {
+        #[serde(alias = "activity_id")]
+        id: u64,
+        data: Vec<u8>,
+        timestamp: Timestamp,
+    },
     Status {
         #[serde(alias = "activity_id")]
         id: u64,

--- a/devenv-event-sources/Cargo.toml
+++ b/devenv-event-sources/Cargo.toml
@@ -12,6 +12,7 @@ macos-kqueue = ["notify/macos_kqueue"]
 [dependencies]
 async-priority-channel.workspace = true
 miette.workspace = true
+nix.workspace = true
 notify = { workspace = true, optional = true }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["net", "process"] }

--- a/devenv-event-sources/src/exec_probe.rs
+++ b/devenv-event-sources/src/exec_probe.rs
@@ -36,17 +36,28 @@ impl ExecProbe {
             }
 
             loop {
-                let result = tokio::time::timeout(
-                    timeout,
-                    tokio::process::Command::new(&bash)
-                        .arg("-c")
-                        .arg(&command)
-                        .envs(&env)
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status(),
-                )
-                .await;
+                let mut cmd = tokio::process::Command::new(&bash);
+                cmd.arg("-c")
+                    .arg(&command)
+                    .envs(&env)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null());
+
+                #[cfg(unix)]
+                {
+                    cmd.process_group(0);
+                }
+
+                let mut child = match cmd.spawn() {
+                    Ok(child) => child,
+                    Err(e) => {
+                        warn!("Exec probe for {} failed to run: {}", name, e);
+                        tokio::time::sleep(period).await;
+                        continue;
+                    }
+                };
+
+                let result = tokio::time::timeout(timeout, child.wait()).await;
 
                 match result {
                     Ok(Ok(status)) if status.success() => {
@@ -58,10 +69,20 @@ impl ExecProbe {
                         debug!("Exec probe for {} exited with {}", name, status);
                     }
                     Ok(Err(e)) => {
-                        warn!("Exec probe for {} failed to run: {}", name, e);
+                        warn!("Exec probe for {} failed to wait: {}", name, e);
                     }
                     Err(_) => {
-                        debug!("Exec probe for {} timed out", name);
+                        debug!("Exec probe for {} timed out, killing process group", name);
+                        #[cfg(unix)]
+                        {
+                            if let Some(pid) = child.id() {
+                                use nix::sys::signal::{Signal, kill};
+                                use nix::unistd::Pid;
+
+                                let _ = kill(Pid::from_raw(-(pid as i32)), Signal::SIGKILL);
+                            }
+                        }
+                        let _ = child.kill().await;
                     }
                 }
 

--- a/devenv-processes/Cargo.toml
+++ b/devenv-processes/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 devenv-activity.workspace = true
 devenv-event-sources.workspace = true
 futures.workspace = true
+crossterm.workspace = true
 miette.workspace = true
 netstat2.workspace = true
 nix.workspace = true

--- a/devenv-processes/src/config.rs
+++ b/devenv-processes/src/config.rs
@@ -231,6 +231,8 @@ pub struct ProcessConfig {
     pub exec: String,
     #[serde(default)]
     pub args: Vec<String>,
+    #[serde(default = "default_true")]
+    pub use_pty: bool,
     #[serde(default)]
     pub cwd: Option<PathBuf>,
     #[serde(default)]
@@ -274,6 +276,7 @@ impl Default for ProcessConfig {
             process_type: ProcessType::default(),
             exec: String::new(),
             args: Vec::new(),
+            use_pty: true,
             cwd: None,
             env: HashMap::new(),
             listen: Vec::new(),

--- a/devenv-processes/src/manager.rs
+++ b/devenv-processes/src/manager.rs
@@ -23,6 +23,10 @@ pub enum ProcessCommand {
     Restart(String),
     /// Stop a running process but keep it visible and restartable
     Stop(String),
+    /// Resize all PTY-backed processes to match the terminal
+    Resize { cols: u16, rows: u16 },
+    /// Send raw input bytes to a PTY-backed process activity
+    SendInput { activity_id: u64, data: Vec<u8> },
 }
 
 /// Request sent by a client to the native manager API socket.
@@ -53,6 +57,7 @@ use watchexec_supervisor::{
 
 use crate::config::ProcessConfig;
 use crate::pid::{self, PidStatus};
+use crate::pty::PtyProcess;
 use crate::socket_activation::{ProcessSetupWrapper, activation_from_listen};
 use crate::{ProcessManager, StartOptions};
 use devenv_event_sources::NotifySocket;
@@ -74,11 +79,20 @@ pub struct ProcessState {
 /// Per-process handles shared between `JobHandle` and the supervision task.
 pub struct ProcessResources {
     pub config: ProcessConfig,
-    pub job: Arc<Job>,
+    pub backend: ProcessBackend,
     pub activity: Activity,
     pub notify_socket: Option<Arc<NotifySocket>>,
     pub status_tx: tokio::sync::watch::Sender<crate::supervisor_state::JobStatus>,
+    pub spawn_env: HashMap<String, String>,
+    pub cwd: Option<PathBuf>,
+    pub stdout_log: PathBuf,
     pub stderr_log: PathBuf,
+}
+
+#[derive(Clone)]
+pub enum ProcessBackend {
+    Job(Arc<Job>),
+    Pty(Arc<RwLock<Option<PtyProcess>>>),
 }
 
 /// Handle to a managed process job
@@ -485,7 +499,7 @@ impl NativeProcessManager {
     /// Removes the `Waiting` entry, transitions the activity to `Running`
     /// status, and launches the process. The TUI elapsed time includes the
     /// waiting period since the activity was created at registration time.
-    pub async fn launch_waiting(&self, name: &str) -> Result<Option<Arc<Job>>> {
+    pub async fn launch_waiting(&self, name: &str) -> Result<bool> {
         let mut processes = self.processes.write().await;
         let (config, activity) = match processes.remove(name) {
             Some(ProcessEntry::Waiting { config, activity }) => (config, activity),
@@ -515,7 +529,7 @@ impl NativeProcessManager {
         &self,
         config: &ProcessConfig,
         parent_id: Option<u64>,
-    ) -> Result<Option<Arc<Job>>> {
+    ) -> Result<bool> {
         debug!("Starting command '{}': {}", config.name, config.exec);
 
         let activity = self.create_process_activity(config, parent_id);
@@ -526,12 +540,12 @@ impl NativeProcessManager {
 
     /// Launch a process if enabled, or register as not started if auto start is off.
     ///
-    /// Returns `Ok(None)` for auto start off processes, `Ok(Some(job))` for launched ones.
+    /// Returns `Ok(false)` for auto start off processes, `Ok(true)` for launched ones.
     async fn launch_or_register_not_started(
         &self,
         config: ProcessConfig,
         activity: Activity,
-    ) -> Result<Option<Arc<Job>>> {
+    ) -> Result<bool> {
         if !config.start.enable {
             activity.set_status(ProcessStatus::NotStarted);
             info!("Registered auto start off process: {}", config.name);
@@ -539,14 +553,15 @@ impl NativeProcessManager {
                 config.name.clone(),
                 ProcessEntry::NotStarted { config, activity },
             );
-            return Ok(None);
+            return Ok(false);
         }
 
-        self.launch(&config, activity).await.map(Some)
+        self.launch(&config, activity).await?;
+        Ok(true)
     }
 
     /// Launch a process: sets up probes, sockets, supervisor, and log tailers.
-    async fn launch(&self, config: &ProcessConfig, activity: Activity) -> Result<Arc<Job>> {
+    async fn launch(&self, config: &ProcessConfig, activity: Activity) -> Result<()> {
         activity.set_status(ProcessStatus::Running);
 
         // Create notify socket if configured via ready.notify
@@ -578,10 +593,6 @@ impl NativeProcessManager {
         let _ = std::fs::write(&proc_cmd.stdout_log, "");
         let _ = std::fs::write(&proc_cmd.stderr_log, "");
 
-        let (job, _task) = start_job(proc_cmd.command);
-        let job = Arc::new(job);
-
-        // Setup socket activation and/or capabilities if configured
         let has_sockets = !config.listen.is_empty();
         let has_caps = !config.linux.capabilities.is_empty();
 
@@ -613,45 +624,71 @@ impl NativeProcessManager {
             None
         };
 
-        // Set spawn hook to configure env, cwd, and stdio on the TokioCommand
-        // directly instead of baking them into the bash wrapper script. This
-        // avoids hitting the kernel ARG_MAX limit with large environments.
-        let spawn_env = proc_cmd.env;
-        let spawn_cwd = proc_cmd.cwd;
-        let spawn_stdout = proc_cmd.stdout_log.clone();
-        let spawn_stderr = proc_cmd.stderr_log.clone();
-
-        job.set_spawn_hook(move |command_wrap, _ctx| {
-            let cmd = command_wrap.command_mut();
-            cmd.envs(&spawn_env);
-            if let Some(ref cwd) = spawn_cwd {
-                cmd.current_dir(cwd);
+        let backend = if config.use_pty {
+            if has_sockets || has_caps {
+                warn!(
+                    "Socket activation and Linux capabilities are not supported with use_pty for {}",
+                    config.name
+                );
             }
-            cmd.stdin(std::process::Stdio::null());
-            cmd.stdout(
-                crate::command::open_log_file(&spawn_stdout)
-                    .map(std::process::Stdio::from)
-                    .unwrap_or_else(std::process::Stdio::null),
-            );
-            cmd.stderr(
-                crate::command::open_log_file(&spawn_stderr)
-                    .map(std::process::Stdio::from)
-                    .unwrap_or_else(std::process::Stdio::null),
-            );
 
-            if let Some((ref fds, ref capabilities)) = process_setup {
-                command_wrap.wrap(ProcessSetupWrapper::new(fds.clone(), capabilities.clone()));
-            }
-        });
+            let pty = PtyProcess::spawn(
+                &config.bash,
+                &config.exec,
+                &config.args,
+                proc_cmd.cwd.as_ref(),
+                &proc_cmd.env,
+                &proc_cmd.stdout_log,
+                Some(activity.ref_handle()),
+            )?;
+            ProcessBackend::Pty(Arc::new(RwLock::new(Some(pty))))
+        } else {
+            let (job, _task) = start_job(proc_cmd.command);
+            let job = Arc::new(job);
 
-        job.start().await;
+            // Set spawn hook to configure env, cwd, and stdio on the TokioCommand
+            // directly instead of baking them into the bash wrapper script. This
+            // avoids hitting the kernel ARG_MAX limit with large environments.
+            let spawn_env = proc_cmd.env.clone();
+            let spawn_cwd = proc_cmd.cwd.clone();
+            let spawn_stdout = proc_cmd.stdout_log.clone();
+            let spawn_stderr = proc_cmd.stderr_log.clone();
+            let process_setup = process_setup.clone();
+
+            job.set_spawn_hook(move |command_wrap, _ctx| {
+                let cmd = command_wrap.command_mut();
+                cmd.envs(&spawn_env);
+                if let Some(ref cwd) = spawn_cwd {
+                    cmd.current_dir(cwd);
+                }
+                cmd.stdin(std::process::Stdio::null());
+                cmd.stdout(
+                    crate::command::open_log_file(&spawn_stdout)
+                        .map(std::process::Stdio::from)
+                        .unwrap_or_else(std::process::Stdio::null),
+                );
+                cmd.stderr(
+                    crate::command::open_log_file(&spawn_stderr)
+                        .map(std::process::Stdio::from)
+                        .unwrap_or_else(std::process::Stdio::null),
+                );
+
+                if let Some((ref fds, ref capabilities)) = process_setup {
+                    command_wrap.wrap(ProcessSetupWrapper::new(fds.clone(), capabilities.clone()));
+                }
+            });
+
+            job.start().await;
+            ProcessBackend::Job(job)
+        };
 
         // Spawn file tailers to emit output to activity
+        let stdout_log = proc_cmd.stdout_log.clone();
         let stderr_log = proc_cmd.stderr_log.clone();
         let stdout_tailer =
-            crate::log_tailer::spawn_file_tailer(proc_cmd.stdout_log, activity.ref_handle(), false);
+            crate::log_tailer::spawn_file_tailer(stdout_log.clone(), activity.ref_handle(), false);
         let stderr_tailer =
-            crate::log_tailer::spawn_file_tailer(proc_cmd.stderr_log, activity.ref_handle(), true);
+            crate::log_tailer::spawn_file_tailer(stderr_log.clone(), activity.ref_handle(), true);
 
         // Create status channel for supervisor state observation
         let initial_status = crate::supervisor_state::JobStatus {
@@ -673,10 +710,13 @@ impl NativeProcessManager {
 
         let resources = ProcessResources {
             config: config.clone(),
-            job: job.clone(),
+            backend,
             activity,
             notify_socket,
             status_tx,
+            spawn_env: proc_cmd.env.clone(),
+            cwd: proc_cmd.cwd.clone(),
+            stdout_log,
             stderr_log,
         };
 
@@ -697,7 +737,7 @@ impl NativeProcessManager {
         );
 
         info!("Command '{}' started", config.name);
-        Ok(job)
+        Ok(())
     }
 
     /// Stop a process by name
@@ -739,11 +779,20 @@ impl NativeProcessManager {
         }
 
         // Send terminate signal with grace period
-        handle
-            .resources
-            .job
-            .stop_with_signal(Signal::Terminate, grace_period)
-            .await;
+        match &handle.resources.backend {
+            ProcessBackend::Job(job) => {
+                job.stop_with_signal(Signal::Terminate, grace_period).await;
+            }
+            ProcessBackend::Pty(pty) => {
+                let pty = {
+                    let mut guard = pty.write().await;
+                    guard.take()
+                };
+                if let Some(mut pty) = pty {
+                    pty.kill().await?;
+                }
+            }
+        }
 
         if !ports.is_empty() {
             let release_status =
@@ -840,11 +889,20 @@ impl NativeProcessManager {
             stderr_reader.abort();
         }
 
-        handle
-            .resources
-            .job
-            .stop_with_signal(Signal::Terminate, grace_period)
-            .await;
+        match &handle.resources.backend {
+            ProcessBackend::Job(job) => {
+                job.stop_with_signal(Signal::Terminate, grace_period).await;
+            }
+            ProcessBackend::Pty(pty) => {
+                let pty = {
+                    let mut guard = pty.write().await;
+                    guard.take()
+                };
+                if let Some(mut pty) = pty {
+                    pty.kill().await?;
+                }
+            }
+        }
 
         if !ports.is_empty() {
             let release_status =
@@ -899,9 +957,12 @@ impl NativeProcessManager {
         let ProcessResources {
             config,
             activity,
-            job: _,
+            backend: _,
             notify_socket: _,
             status_tx: _,
+            spawn_env: _,
+            cwd: _,
+            stdout_log: _,
             stderr_log: _,
         } = handle.resources;
 
@@ -957,77 +1018,25 @@ impl NativeProcessManager {
     /// This resets the restart count and activity state, respawns the supervision
     /// task if it exited (e.g., due to max restarts), and restarts the underlying job.
     pub async fn restart(&self, name: &str) -> Result<()> {
-        let mut processes = self.processes.write().await;
-        let handle = match processes.get_mut(name) {
-            Some(ProcessEntry::Active(h)) => h,
-            Some(_) => {
-                debug!("restart: process {} is not active, ignoring", name);
-                return Ok(());
-            }
-            None => bail!("Process {} not running", name),
+        let is_active = {
+            let processes = self.processes.read().await;
+            matches!(processes.get(name), Some(ProcessEntry::Active(_)))
         };
 
-        // Reset activity state (unfail it) and set status to restarting
-        handle.resources.activity.reset();
-        handle
-            .resources
-            .activity
-            .set_status(ProcessStatus::Restarting);
-
-        // Truncate log files and restart output tailers
-        let (stdout_log, stderr_log) = crate::command::log_paths(&self.state_dir, name);
-        let _ = std::fs::write(&stdout_log, "");
-        let _ = std::fs::write(&stderr_log, "");
-
-        if let Some((stdout_reader, stderr_reader)) = handle.output_readers.take() {
-            stdout_reader.abort();
-            stderr_reader.abort();
-        }
-        handle.output_readers = Some((
-            crate::log_tailer::spawn_file_tailer(
-                stdout_log,
-                handle.resources.activity.ref_handle(),
-                false,
-            ),
-            crate::log_tailer::spawn_file_tailer(
-                stderr_log,
-                handle.resources.activity.ref_handle(),
-                true,
-            ),
-        ));
-
-        // Check if supervisor task has exited (e.g., due to max restarts)
-        if handle.supervisor_task.is_finished() {
-            // Supervisor has exited — start fresh with new supervision.
-            // Order matters: start job first, then spawn supervisor (like start_command does).
-            // This gives the process a fresh restart quota (restart_count = 0).
-            info!(
-                "Supervisor for {} has exited, starting fresh with new supervision",
-                name
-            );
-            handle.resources.job.start().await;
-            handle.supervisor_task =
-                crate::supervisor::spawn_supervisor(&handle.resources, self.shutdown.clone());
-        } else {
-            // Supervisor is still running — just restart the job.
-            // The existing supervisor will continue monitoring with its current restart_count.
-            handle
-                .resources
-                .job
-                .restart_with_signal(Signal::Terminate, Duration::from_secs(2))
-                .await;
+        if !is_active {
+            debug!("restart: process {} is not active, ignoring", name);
+            return Ok(());
         }
 
-        // The supervisor will update the status via status_tx once the
-        // process is actually ready.
-        handle.resources.activity.set_status(ProcessStatus::Running);
+        self.stop_and_keep(name).await?;
+        self.start_not_started(name).await?;
 
         info!("Process {} restarted", name);
         Ok(())
     }
 
     /// Start a previously not-started process, reusing its existing TUI activity.
-    pub async fn start_not_started(&self, name: &str) -> Result<Arc<Job>> {
+    pub async fn start_not_started(&self, name: &str) -> Result<()> {
         let (config, activity) = {
             let mut processes = self.processes.write().await;
             match processes.get(name) {
@@ -1049,7 +1058,7 @@ impl NativeProcessManager {
         // Move the activity into launch (not clone) so the original is not
         // dropped — Activity::drop sends Process::Complete which would
         // immediately mark the process as stopped in the TUI.
-        let job = self.launch(&config, activity).await?;
+        self.launch(&config, activity).await?;
 
         // Notify the task system so it re-checks dependencies.
         // Dependent processes will be launched by the task scheduler once
@@ -1058,7 +1067,7 @@ impl NativeProcessManager {
             notify.notify_waiters();
         }
 
-        Ok(job)
+        Ok(())
     }
 
     /// Get list of running processes
@@ -1352,6 +1361,44 @@ impl NativeProcessManager {
                 info!("Stopping process: {}", name);
                 if let Err(e) = self.stop_and_keep(&name).await {
                     warn!("Failed to stop process {}: {}", name, e);
+                }
+            }
+            ProcessCommand::Resize { cols, rows } => {
+                let processes = self.processes.read().await;
+                for entry in processes.values() {
+                    let ProcessEntry::Active(handle) = entry else {
+                        continue;
+                    };
+                    let ProcessBackend::Pty(pty) = &handle.resources.backend else {
+                        continue;
+                    };
+                    let guard = pty.read().await;
+                    if let Some(pty) = guard.as_ref()
+                        && let Err(e) = pty.resize(cols, rows)
+                    {
+                        warn!("Failed to resize PTY: {}", e);
+                    }
+                }
+            }
+            ProcessCommand::SendInput { activity_id, data } => {
+                let processes = self.processes.read().await;
+                for entry in processes.values() {
+                    let ProcessEntry::Active(handle) = entry else {
+                        continue;
+                    };
+                    if handle.resources.activity.id() != activity_id {
+                        continue;
+                    }
+                    let ProcessBackend::Pty(pty) = &handle.resources.backend else {
+                        continue;
+                    };
+                    let guard = pty.read().await;
+                    if let Some(pty) = guard.as_ref()
+                        && let Err(e) = pty.send_input(&data)
+                    {
+                        warn!("Failed to send PTY input: {}", e);
+                    }
+                    break;
                 }
             }
         }
@@ -1783,7 +1830,7 @@ mod tests {
         let result = manager.launch_waiting("auto-start-off-proc").await;
 
         assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        assert!(!result.unwrap());
         assert_eq!(
             manager.get_phase("auto-start-off-proc").await,
             Some(ProcessPhase::NotStarted)
@@ -1830,8 +1877,8 @@ mod tests {
         let result = manager.launch_waiting("long-runner").await;
 
         assert!(result.is_ok());
-        let job = result.unwrap();
-        assert!(job.is_some(), "Expected Some(job) for an enabled process");
+        let started = result.unwrap();
+        assert!(started, "Expected launched=true for an enabled process");
 
         let phase = manager.get_phase("long-runner").await;
         assert_ne!(phase, Some(ProcessPhase::Waiting));

--- a/devenv-processes/src/pty.rs
+++ b/devenv-processes/src/pty.rs
@@ -1,48 +1,61 @@
-use miette::{IntoDiagnostic, Result, miette};
-use portable_pty::{Child, CommandBuilder, PtySize, native_pty_system};
+use crossterm::terminal;
+use devenv_activity::ActivityRef;
+use miette::{IntoDiagnostic, Result, WrapErr, miette};
+use nix::sys::signal::{Signal, kill};
+use nix::unistd::Pid;
+use portable_pty::{Child, CommandBuilder, MasterPty, PtySize, native_pty_system};
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 use tracing::{debug, error};
 
-/// PTY process wrapper
+const EXPANDED_LOG_GUTTER_WIDTH: u16 = 8;
+
+fn current_pty_size() -> PtySize {
+    let (cols, rows) = terminal::size().unwrap_or((80, 24));
+    PtySize {
+        rows,
+        cols: cols.saturating_sub(EXPANDED_LOG_GUTTER_WIDTH).max(1),
+        pixel_width: 0,
+        pixel_height: 0,
+    }
+}
+
 pub struct PtyProcess {
-    child: Box<dyn Child + Send>,
+    master: Arc<Mutex<Box<dyn MasterPty + Send>>>,
+    child: Arc<Mutex<Box<dyn Child + Send + Sync>>>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    pid: Option<u32>,
+    exit_rx: tokio::sync::watch::Receiver<Option<i32>>,
     reader_thread: Option<thread::JoinHandle<()>>,
-    running: Arc<Mutex<bool>>,
+    waiter_thread: Option<thread::JoinHandle<()>>,
 }
 
 impl PtyProcess {
-    /// Spawn a new process with a pseudo-terminal
     pub fn spawn(
+        bash: &str,
         exec: &str,
         args: &[String],
         cwd: Option<&PathBuf>,
         env: &HashMap<String, String>,
+        log_path: &Path,
+        activity: Option<ActivityRef>,
     ) -> Result<Self> {
-        debug!("Spawning PTY process: {} {:?}", exec, args);
+        debug!("Spawning PTY process via {} -c ...", bash);
 
-        // Get the native PTY system
         let pty_system = native_pty_system();
-
-        // Create a new PTY
         let pair = pty_system
-            .openpty(PtySize {
-                rows: 24,
-                cols: 80,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
+            .openpty(current_pty_size())
             .map_err(|e| miette!("Failed to open PTY: {}", e))?;
 
-        // Build the command
-        let mut cmd = CommandBuilder::new(exec);
+        let mut cmd = CommandBuilder::new(bash);
+        cmd.arg("-c");
+        cmd.arg(exec);
         cmd.args(args);
 
-        // Set working directory - fall back to current dir if not specified
-        // (portable_pty falls back to HOME which may not exist in sandboxes)
         if let Some(dir) = cwd {
             cmd.cwd(dir);
         } else if let Ok(current) = std::env::current_dir() {
@@ -53,107 +66,176 @@ impl PtyProcess {
             cmd.env(key, value);
         }
 
-        // Spawn the child process
         let child = pair
             .slave
             .spawn_command(cmd)
-            .map_err(|e| miette!("Failed to spawn command: {}", e))?;
-        debug!("PTY process spawned successfully");
+            .map_err(|e| miette!("Failed to spawn PTY command: {}", e))?;
+        let pid = child.process_id();
 
-        // Set up a reader thread to forward PTY output to stdout
-        let mut reader = pair
+        let reader = pair
             .master
             .try_clone_reader()
             .map_err(|e| miette!("Failed to clone PTY reader: {}", e))?;
-        let running = Arc::new(Mutex::new(true));
-        let running_clone = Arc::clone(&running);
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| miette!("Failed to acquire PTY writer: {}", e))?;
+
+        let log_file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_path)
+            .into_diagnostic()
+            .wrap_err(format!(
+                "Failed to open PTY log file {}",
+                log_path.display()
+            ))?;
 
         let reader_thread = thread::Builder::new()
-            .name("pty-reader".into())
+            .name("devenv-pty-reader".into())
             .spawn(move || {
+                let mut reader = reader;
+                let mut log_file = log_file;
                 let mut buffer = [0u8; 8192];
-                loop {
-                    // Check if we should stop
-                    {
-                        let is_running = running_clone.lock().unwrap();
-                        if !*is_running {
-                            break;
-                        }
-                    }
+                let activity = activity;
 
+                loop {
                     match reader.read(&mut buffer) {
-                        Ok(0) => {
-                            // EOF reached
-                            debug!("PTY reader: EOF");
-                            break;
-                        }
+                        Ok(0) => break,
                         Ok(n) => {
-                            // Forward to stdout
-                            if let Err(e) = std::io::stdout().write_all(&buffer[..n]) {
-                                error!("PTY reader: Failed to write to stdout: {}", e);
+                            if let Some(activity) = &activity {
+                                activity.raw_log(buffer[..n].to_vec());
+                            }
+                            if let Err(err) = log_file.write_all(&buffer[..n]) {
+                                error!("PTY reader failed to append to log file: {}", err);
                                 break;
                             }
-                            let _ = std::io::stdout().flush();
+                            let _ = log_file.flush();
                         }
-                        Err(e) => {
-                            error!("PTY reader: Read error: {}", e);
+                        Err(err) => {
+                            error!("PTY reader failed: {}", err);
                             break;
                         }
                     }
                 }
-                debug!("PTY reader thread exiting");
             })
-            .expect("failed to spawn pty-reader thread");
+            .map_err(|e| miette!("Failed to spawn PTY reader thread: {}", e))?;
+
+        let child = Arc::new(Mutex::new(child));
+        let (exit_tx, exit_rx) = tokio::sync::watch::channel(None);
+        let waiter_child = Arc::clone(&child);
+        let waiter_thread = thread::Builder::new()
+            .name("devenv-pty-waiter".into())
+            .spawn(move || {
+                loop {
+                    let wait_result = {
+                        let mut child = waiter_child.lock().unwrap();
+                        child.try_wait()
+                    };
+
+                    match wait_result {
+                        Ok(Some(status)) => {
+                            let _ = exit_tx.send(Some(status.exit_code() as i32));
+                            break;
+                        }
+                        Ok(None) => thread::sleep(Duration::from_millis(100)),
+                        Err(err) => {
+                            error!("PTY waiter failed: {}", err);
+                            let _ = exit_tx.send(Some(1));
+                            break;
+                        }
+                    }
+                }
+            })
+            .map_err(|e| miette!("Failed to spawn PTY waiter thread: {}", e))?;
 
         Ok(Self {
+            master: Arc::new(Mutex::new(pair.master)),
             child,
+            writer: Arc::new(Mutex::new(writer)),
+            pid,
+            exit_rx,
             reader_thread: Some(reader_thread),
-            running,
+            waiter_thread: Some(waiter_thread),
         })
     }
 
-    /// Get the process ID
-    pub fn pid(&self) -> Option<u32> {
-        self.child.process_id()
+    pub fn exit_status(&self) -> tokio::sync::watch::Receiver<Option<i32>> {
+        self.exit_rx.clone()
     }
 
-    /// Wait for the process to exit
-    pub fn wait(&mut self) -> Result<i32> {
-        // Wait for child to exit
-        let exit_status = self.child.wait().into_diagnostic()?;
-
-        // Signal the reader thread to stop
-        {
-            let mut running = self.running.lock().unwrap();
-            *running = false;
-        }
-
-        // Wait for reader thread to finish
-        if let Some(handle) = self.reader_thread.take() {
-            let _ = handle.join();
-        }
-
-        let code = exit_status.exit_code();
-        debug!("PTY process exited with code {}", code);
-        Ok(code as i32)
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
+        let size = PtySize {
+            rows,
+            cols: cols.saturating_sub(EXPANDED_LOG_GUTTER_WIDTH).max(1),
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        self.master
+            .lock()
+            .unwrap()
+            .resize(size)
+            .map_err(|e| miette!("Failed to resize PTY: {}", e))
     }
 
-    /// Kill the process
-    pub fn kill(&mut self) -> Result<()> {
-        self.child.kill().into_diagnostic()?;
-
-        // Signal the reader thread to stop
-        {
-            let mut running = self.running.lock().unwrap();
-            *running = false;
-        }
-
-        // Wait for reader thread to finish
-        if let Some(handle) = self.reader_thread.take() {
-            let _ = handle.join();
-        }
-
+    pub fn send_input(&self, data: &[u8]) -> Result<()> {
+        let mut writer = self.writer.lock().unwrap();
+        writer.write_all(data).into_diagnostic()?;
+        writer.flush().into_diagnostic()?;
         Ok(())
+    }
+
+    pub async fn kill(&mut self) -> Result<()> {
+        if let Some(pid) = self.pid {
+            let target = Pid::from_raw(-(pid as i32));
+            match kill(target, Signal::SIGTERM) {
+                Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+                Err(e) => return Err(miette!("Failed to send SIGTERM to process group: {}", e)),
+            }
+
+            let mut exit_rx = self.exit_rx.clone();
+            let exited = tokio::time::timeout(Duration::from_secs(5), async move {
+                loop {
+                    if exit_rx.borrow().is_some() {
+                        return;
+                    }
+                    if exit_rx.changed().await.is_err() {
+                        return;
+                    }
+                }
+            })
+            .await;
+
+            if exited.is_err() {
+                match kill(target, Signal::SIGKILL) {
+                    Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+                    Err(e) => {
+                        return Err(miette!("Failed to send SIGKILL to process group: {}", e));
+                    }
+                }
+            }
+        } else {
+            let mut child = self.child.lock().unwrap();
+            child.kill().into_diagnostic()?;
+        }
+
+        self.join_threads();
+        Ok(())
+    }
+
+    fn join_threads(&mut self) {
+        if let Some(handle) = self.reader_thread.take() {
+            let _ = handle.join();
+        }
+        if let Some(handle) = self.waiter_thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for PtyProcess {
+    fn drop(&mut self) {
+        self.join_threads();
     }
 }
 
@@ -163,20 +245,34 @@ mod tests {
 
     #[test]
     fn test_pty_spawn_echo() {
-        let mut pty = PtyProcess::spawn("echo", &["hello".to_string()], None, &HashMap::new())
-            .expect("Failed to spawn PTY process");
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("echo.log");
+        let pty = PtyProcess::spawn(
+            "bash",
+            "echo hello",
+            &[],
+            None,
+            &HashMap::new(),
+            &log_path,
+            None,
+        )
+        .expect("Failed to spawn PTY process");
 
-        let exit_code = pty.wait().expect("Failed to wait for process");
-        assert_eq!(exit_code, 0);
-    }
-
-    #[test]
-    fn test_pty_get_pid() {
-        let pty = PtyProcess::spawn("sleep", &["0.1".to_string()], None, &HashMap::new())
-            .expect("Failed to spawn PTY process");
-
-        let pid = pty.pid();
-        assert!(pid.is_some());
-        assert!(pid.unwrap() > 0);
+        let mut rx = pty.exit_status();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    if rx.borrow().is_some() {
+                        break;
+                    }
+                    rx.changed()
+                        .await
+                        .expect("PTY exit watcher closed unexpectedly");
+                }
+            })
+            .await
+            .expect("PTY process did not exit");
+        });
     }
 }

--- a/devenv-processes/src/supervisor.rs
+++ b/devenv-processes/src/supervisor.rs
@@ -13,7 +13,8 @@ use watchexec_supervisor::job::CommandState;
 use watchexec_supervisor::{ProcessEnd, Signal};
 
 use crate::config::ListenKind;
-use crate::manager::ProcessResources;
+use crate::manager::{ProcessBackend, ProcessResources};
+use crate::pty::PtyProcess;
 use crate::supervisor_state::{
     Action, Event, ExitStatus, JobStatus, SupervisorPhase, SupervisorState,
 };
@@ -31,6 +32,63 @@ fn handle_probe_success(
     let _ = status_tx.send(state.status());
 }
 
+fn pty_exit_status(code: i32) -> ExitStatus {
+    if code == 0 {
+        ExitStatus::Success
+    } else {
+        ExitStatus::Failure
+    }
+}
+
+async fn restart_pty(
+    pty: &tokio::sync::RwLock<Option<PtyProcess>>,
+    config: &crate::config::ProcessConfig,
+    spawn_env: &std::collections::HashMap<String, String>,
+    cwd: Option<&std::path::PathBuf>,
+    stdout_log: &std::path::Path,
+    activity: &devenv_activity::ActivityRef,
+) -> miette::Result<()> {
+    let old = {
+        let mut guard = pty.write().await;
+        guard.take()
+    };
+
+    if let Some(mut old) = old {
+        old.kill().await?;
+    }
+
+    let new_pty = PtyProcess::spawn(
+        &config.bash,
+        &config.exec,
+        &config.args,
+        cwd,
+        spawn_env,
+        stdout_log,
+        Some(activity.clone()),
+    )?;
+
+    let mut guard = pty.write().await;
+    *guard = Some(new_pty);
+    Ok(())
+}
+
+async fn wait_for_pty_exit(pty: &tokio::sync::RwLock<Option<PtyProcess>>) -> Option<ExitStatus> {
+    let mut exit_rx = {
+        let guard = pty.read().await;
+        guard.as_ref()?.exit_status()
+    };
+
+    loop {
+        if let Some(code) = *exit_rx.borrow() {
+            return Some(pty_exit_status(code));
+        }
+
+        if exit_rx.changed().await.is_err() {
+            return None;
+        }
+    }
+}
+
 /// Spawn a supervision task that monitors a job and handles restarts.
 ///
 /// Uses `SupervisorState` for all restart/watchdog decisions.
@@ -40,10 +98,13 @@ pub fn spawn_supervisor(
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     let config = resources.config.clone();
-    let job = resources.job.clone();
+    let backend = resources.backend.clone();
     let activity = resources.activity.ref_handle();
     let notify_socket = resources.notify_socket.clone();
     let status_tx = resources.status_tx.clone();
+    let spawn_env = resources.spawn_env.clone();
+    let cwd = resources.cwd.clone();
+    let stdout_log = resources.stdout_log.clone();
     let name = config.name.clone();
 
     // Probe timing from ready config
@@ -239,13 +300,30 @@ pub fn spawn_supervisor(
                     // The biased select catches it next iteration, but we skip
                     // expensive restart work below.
                     if shutdown.is_cancelled() { break 'supervisor; }
-                    info!("File change detected for {}, restarting", name);
-                    activity.log("File change detected, restarting");
-                    match state.on_event(Event::FileChange, Instant::now()) {
-                        Action::Restart => {
-                            job.stop_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
-                            tokio::time::sleep(Duration::from_millis(100)).await;
-                            job.start().await;
+                        info!("File change detected for {}, restarting", name);
+                        activity.log("File change detected, restarting");
+                        match state.on_event(Event::FileChange, Instant::now()) {
+                            Action::Restart => {
+                            let restart_result = match &backend {
+                                ProcessBackend::Job(job) => {
+                                    job.stop_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                    job.start().await;
+                                    Ok(())
+                                }
+                                ProcessBackend::Pty(pty) => {
+                                    restart_pty(pty, &config, &spawn_env, cwd.as_ref(), &stdout_log, &activity).await
+                                }
+                                ,
+                            };
+                            if let Err(err) = restart_result {
+                                let reason = format!("Failed to restart process {}: {}", name, err);
+                                warn!("{}", reason);
+                                activity.error(&reason);
+                                activity.fail();
+                                let _ = status_tx.send(state.status());
+                                break;
+                            }
                             state.on_restart_complete(Instant::now());
                             let count = state.restart_count();
                             activity.log(format!("Restarted (attempt {})", count));
@@ -290,7 +368,24 @@ pub fn spawn_supervisor(
                                     match state.on_event(Event::WatchdogTrigger, Instant::now()) {
                                         Action::Restart => {
                                             activity.error("Watchdog trigger - process signaled failure");
-                                            job.restart_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
+                                            let restart_result = match &backend {
+                                                ProcessBackend::Job(job) => {
+                                                    job.restart_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
+                                                    Ok(())
+                                                }
+                                                ProcessBackend::Pty(pty) => {
+                                                    restart_pty(pty, &config, &spawn_env, cwd.as_ref(), &stdout_log, &activity).await
+                                                }
+                                                ,
+                                            };
+                                            if let Err(err) = restart_result {
+                                                let reason = format!("Failed to restart process {}: {}", name, err);
+                                                warn!("{}", reason);
+                                                activity.error(&reason);
+                                                activity.fail();
+                                                let _ = status_tx.send(state.status());
+                                                break 'supervisor;
+                                            }
                                             state.on_restart_complete(Instant::now());
                                             let count = state.restart_count();
                                             let msg = format!("Restarted (attempt {count})");
@@ -354,7 +449,24 @@ pub fn spawn_supervisor(
                         now,
                     ) {
                         Action::Restart => {
-                            job.restart_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
+                            let restart_result = match &backend {
+                                ProcessBackend::Job(job) => {
+                                    job.restart_with_signal(Signal::Terminate, Duration::from_secs(2)).await;
+                                    Ok(())
+                                }
+                                ProcessBackend::Pty(pty) => {
+                                    restart_pty(pty, &config, &spawn_env, cwd.as_ref(), &stdout_log, &activity).await
+                                }
+                                ,
+                            };
+                            if let Err(err) = restart_result {
+                                let reason = format!("Failed to restart process {}: {}", name, err);
+                                warn!("{}", reason);
+                                activity.error(&reason);
+                                activity.fail();
+                                let _ = status_tx.send(state.status());
+                                break;
+                            }
                             state.on_restart_complete(Instant::now());
                             let count = state.restart_count();
                             let msg = format!("Restarted (attempt {count})");
@@ -374,28 +486,39 @@ pub fn spawn_supervisor(
                     let _ = status_tx.send(state.status());
                 }
 
-                _ = job.to_wait() => {
-                    if shutdown.is_cancelled() { break 'supervisor; }
-                    // Extract exit status from the job
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    job.run_async(move |ctx| {
-                        let status = if let CommandState::Finished { status, .. } = ctx.current {
-                            Some(if matches!(status, ProcessEnd::Success) {
-                                ExitStatus::Success
-                            } else {
-                                ExitStatus::Failure
-                            })
-                        } else {
-                            None
-                        };
-                        Box::new(async move {
-                            let _ = tx.send(status);
-                        })
-                    }).await;
+                result = async {
+                    match &backend {
+                        ProcessBackend::Job(job) => {
+                            job.to_wait().await;
 
-                    let exit_status = match rx.await {
-                        Ok(Some(status)) => status,
-                        _ => {
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            job.run_async(move |ctx| {
+                                let status = if let CommandState::Finished { status, .. } = ctx.current {
+                                    Some(if matches!(status, ProcessEnd::Success) {
+                                        ExitStatus::Success
+                                    } else {
+                                        ExitStatus::Failure
+                                    })
+                                } else {
+                                    None
+                                };
+                                Box::new(async move {
+                                    let _ = tx.send(status);
+                                })
+                            }).await;
+
+                            match rx.await {
+                                Ok(Some(status)) => Some(status),
+                                _ => None,
+                            }
+                        }
+                        ProcessBackend::Pty(pty) => wait_for_pty_exit(pty).await,
+                    }
+                } => {
+                    if shutdown.is_cancelled() { break 'supervisor; }
+                    let exit_status = match result {
+                        Some(status) => status,
+                        None => {
                             debug!("Process {} exited (unknown status)", name);
                             break;
                         }
@@ -404,7 +527,24 @@ pub fn spawn_supervisor(
                     match state.on_event(Event::ProcessExit { status: exit_status }, Instant::now()) {
                         Action::Restart => {
                             activity.log(format!("Process exited ({exit_status:?}), restarting"));
-                            job.start().await;
+                            let restart_result = match &backend {
+                                ProcessBackend::Job(job) => {
+                                    job.start().await;
+                                    Ok(())
+                                }
+                                ProcessBackend::Pty(pty) => {
+                                    restart_pty(pty, &config, &spawn_env, cwd.as_ref(), &stdout_log, &activity).await
+                                }
+                                ,
+                            };
+                            if let Err(err) = restart_result {
+                                let reason = format!("Failed to restart process {}: {}", name, err);
+                                warn!("{}", reason);
+                                activity.error(&reason);
+                                activity.fail();
+                                let _ = status_tx.send(state.status());
+                                break;
+                            }
                             state.on_restart_complete(Instant::now());
                             let count = state.restart_count();
                             let msg = format!("Restarted (attempt {count})");

--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -135,6 +135,45 @@ impl TaskState {
 
     /// Handle file modification checking with centralized error handling.
     /// Returns a Result with a boolean indicating if files were modified.
+    fn resolve_path_for_cwd(&self, path: &str) -> String {
+        let path_buf = std::path::PathBuf::from(path);
+        if path_buf.is_absolute() {
+            return path.to_string();
+        }
+
+        self.task
+            .cwd
+            .as_ref()
+            .map(|cwd| {
+                std::path::Path::new(cwd)
+                    .join(&path_buf)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .unwrap_or_else(|| path.to_string())
+    }
+
+    fn resolve_exec_if_modified_patterns(&self) -> Vec<String> {
+        self.task
+            .exec_if_modified
+            .iter()
+            .map(|pattern| {
+                if let Some(rest) = pattern.strip_prefix('!') {
+                    format!("!{}", self.resolve_path_for_cwd(rest))
+                } else {
+                    self.resolve_path_for_cwd(pattern)
+                }
+            })
+            .collect()
+    }
+
+    fn resolved_command_path(&self) -> Option<String> {
+        self.task
+            .command
+            .as_ref()
+            .map(|cmd| self.resolve_path_for_cwd(cmd))
+    }
+
     async fn check_files_modified_result(
         &self,
         cache: &TaskCache,
@@ -143,8 +182,10 @@ impl TaskState {
             return Ok(false);
         }
 
+        let resolved_patterns = self.resolve_exec_if_modified_patterns();
+
         let patterns_modified = cache
-            .check_modified_files(&self.task.name, &self.task.exec_if_modified)
+            .check_modified_files(&self.task.name, &resolved_patterns)
             .await?;
         if patterns_modified {
             return Ok(true);
@@ -152,9 +193,9 @@ impl TaskState {
 
         // Track command path changes separately so negation patterns in exec_if_modified
         // don't suppress cache invalidation for the task script itself.
-        if let Some(cmd) = &self.task.command {
+        if let Some(cmd) = self.resolved_command_path() {
             let cmd_modified = cache
-                .check_modified_files(&self.task.name, std::slice::from_ref(cmd))
+                .check_modified_files(&self.task.name, std::slice::from_ref(&cmd))
                 .await?;
             if cmd_modified {
                 return Ok(true);
@@ -164,9 +205,9 @@ impl TaskState {
         // Check for files previously tracked in the DB that no longer match the globs
         // (deleted, renamed, or moved outside the pattern). Build the full set of
         // currently expected paths so we don't false-positive on command paths.
-        let mut all_current_paths = expand_glob_patterns(&self.task.exec_if_modified);
-        if let Some(cmd) = &self.task.command {
-            all_current_paths.push(cmd.clone());
+        let mut all_current_paths = expand_glob_patterns(&resolved_patterns);
+        if let Some(cmd) = self.resolved_command_path() {
+            all_current_paths.push(cmd);
         }
         cache
             .has_removed_files(&self.task.name, &all_current_paths)
@@ -409,7 +450,7 @@ impl TaskState {
         // Launch the pre-registered waiting process.
         let started = manager.launch_waiting(&config.name).await?;
 
-        let auto_start_off = started.is_none();
+        let auto_start_off = !started;
         if auto_start_off {
             tracing::info!("Process task {} has auto start off", self.task.name);
         }
@@ -610,7 +651,8 @@ impl TaskState {
 
         // Only update file states on success - failed tasks should not be cached
         if result.success {
-            let expanded_paths = expand_glob_patterns(&self.task.exec_if_modified);
+            let resolved_patterns = self.resolve_exec_if_modified_patterns();
+            let expanded_paths = expand_glob_patterns(&resolved_patterns);
             for path in &expanded_paths {
                 cache.update_file_state(&self.task.name, path).await?;
             }
@@ -618,8 +660,8 @@ impl TaskState {
                 .cleanup_stale_files(&self.task.name, &expanded_paths)
                 .await?;
 
-            if let Some(cmd) = &self.task.command {
-                cache.update_file_state(&self.task.name, cmd).await?;
+            if let Some(cmd) = self.resolved_command_path() {
+                cache.update_file_state(&self.task.name, &cmd).await?;
             }
         }
 

--- a/devenv-tui/Cargo.toml
+++ b/devenv-tui/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { workspace = true }
 # TUI library
 iocraft.workspace = true
 crossterm = { workspace = true }
+avt.workspace = true
 
 # Tracing integration
 tracing = { workspace = true }

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -1,5 +1,6 @@
 use crate::{
     expanded_view::ExpandedLogView,
+    input,
     model::{ActivityModel, RenderContext, UiState, ViewMode},
     view::{ActivityHeights, SUMMARY_BAR_HEIGHT, ScrollState, view},
 };
@@ -17,6 +18,9 @@ use std::sync::{Arc, OnceLock, RwLock};
 use tokio::sync::{Notify, mpsc};
 use tokio_shutdown::Shutdown;
 use tracing::debug;
+
+const TMUX_MAX_FPS: u64 = 12;
+const MAIN_VIEW_PAGE_SCROLL_OVERLAP: i32 = 1;
 
 /// Cooperative exit flag for TUI shutdown.
 ///
@@ -73,7 +77,11 @@ impl Default for TuiConfig {
             max_log_messages: 1000,
             max_log_lines_per_build: 1000,
             log_viewport_collapsed: 10,
-            max_fps: 30,
+            max_fps: if std::env::var_os("TMUX").is_some() {
+                TMUX_MAX_FPS
+            } else {
+                30
+            },
             filter_level: ActivityLevel::Info,
         }
     }
@@ -86,6 +94,11 @@ pub struct TuiApp {
     shutdown: Arc<Shutdown>,
     command_tx: Option<mpsc::Sender<ProcessCommand>>,
     shutdown_on_backend_done: bool,
+    fullscreen: bool,
+}
+
+fn should_present_final_snapshot(shutdown: &Shutdown) -> bool {
+    shutdown.last_signal().is_none()
 }
 
 impl TuiApp {
@@ -100,7 +113,14 @@ impl TuiApp {
             shutdown,
             command_tx: None,
             shutdown_on_backend_done: true,
+            fullscreen: false,
         }
+    }
+
+    /// Set whether the TUI should run in fullscreen mode.
+    pub fn fullscreen(mut self, enabled: bool) -> Self {
+        self.fullscreen = enabled;
+        self
     }
 
     /// Set the command sender for process control commands.
@@ -244,6 +264,9 @@ impl TuiApp {
         // The event processor only writes to ActivityModel, never UiState.
         // UiState is only modified by the UI thread.
         let ui_state = Arc::new(RwLock::new(UiState::new()));
+        if let Ok(mut ui) = ui_state.write() {
+            ui.fullscreen = self.fullscreen;
+        }
 
         // Main loop - runs until backend signals completion via exit_flag.
         // The render loop exits cooperatively: the component checks exit_flag
@@ -281,6 +304,10 @@ impl TuiApp {
         {
             let ui = ui_state.read().unwrap();
             if let Ok(model_guard) = activity_model.read() {
+                if !should_present_final_snapshot(&shutdown) {
+                    return Ok(0);
+                }
+
                 let (terminal_width, _) = crossterm::terminal::size().unwrap_or((80, 24));
 
                 // Measure the last inline render's height so we clear the right
@@ -493,6 +520,63 @@ fn activity_height(heights: &std::collections::HashMap<u64, i32>, id: u64) -> i3
     heights.get(&id).copied().unwrap_or(1)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MainViewScrollAction {
+    UpLine,
+    DownLine,
+    UpPage,
+    DownPage,
+    Top,
+    Bottom,
+}
+
+fn main_view_scroll_action_for_key(key_event: &KeyEvent) -> Option<MainViewScrollAction> {
+    if key_event.modifiers.contains(KeyModifiers::CONTROL)
+        || key_event.modifiers.contains(KeyModifiers::ALT)
+        || key_event.modifiers.contains(KeyModifiers::SUPER)
+    {
+        return None;
+    }
+
+    match key_event.code {
+        KeyCode::PageUp => Some(MainViewScrollAction::UpPage),
+        KeyCode::PageDown => Some(MainViewScrollAction::DownPage),
+        KeyCode::Home => Some(MainViewScrollAction::Top),
+        KeyCode::End => Some(MainViewScrollAction::Bottom),
+        KeyCode::Char('k') => Some(MainViewScrollAction::UpLine),
+        KeyCode::Char('j') => Some(MainViewScrollAction::DownLine),
+        _ => None,
+    }
+}
+
+fn selected_process(
+    activity_model: &Arc<RwLock<ActivityModel>>,
+    ui_state: &Arc<RwLock<UiState>>,
+) -> Option<(u64, String)> {
+    let activity_id = ui_state.read().ok()?.selected_activity?;
+    let model = activity_model.read().ok()?;
+    let activity = model.get_activity(activity_id)?;
+    matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+        .then(|| (activity.id, activity.name.clone()))
+}
+
+fn apply_main_view_scroll_action(handle: &mut ScrollViewHandle, action: MainViewScrollAction) {
+    match action {
+        MainViewScrollAction::UpLine => handle.scroll_by(-1),
+        MainViewScrollAction::DownLine => handle.scroll_by(1),
+        MainViewScrollAction::UpPage => {
+            let page = (handle.viewport_height() as i32 - MAIN_VIEW_PAGE_SCROLL_OVERLAP).max(1);
+            handle.scroll_by(-page);
+        }
+        MainViewScrollAction::DownPage => {
+            let page = (handle.viewport_height() as i32 - MAIN_VIEW_PAGE_SCROLL_OVERLAP).max(1);
+            handle.scroll_by(page);
+        }
+        MainViewScrollAction::Top => handle.scroll_to_top(),
+        MainViewScrollAction::Bottom => handle.scroll_to_bottom(),
+    }
+}
+
 /// Scroll the viewport so the selected activity is visible.
 fn scroll_selected_into_view(
     handle: &mut ScrollViewHandle,
@@ -525,13 +609,13 @@ fn scroll_selected_into_view(
 /// Main TUI component (inline mode)
 #[component]
 fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
-    let config = hooks.use_context::<Arc<TuiConfig>>();
-    let activity_model = hooks.use_context::<Arc<RwLock<ActivityModel>>>();
-    let ui_state = hooks.use_context::<Arc<RwLock<UiState>>>();
-    let notify = hooks.use_context::<Arc<Notify>>();
+    let config = hooks.use_context::<Arc<TuiConfig>>().clone();
+    let activity_model = hooks.use_context::<Arc<RwLock<ActivityModel>>>().clone();
+    let ui_state = hooks.use_context::<Arc<RwLock<UiState>>>().clone();
+    let notify = hooks.use_context::<Arc<Notify>>().clone();
     let (terminal_width, terminal_height) = hooks.use_terminal_size();
     let mut should_exit = hooks.use_state(|| false);
-    let shutdown = hooks.use_context::<Arc<Shutdown>>();
+    let shutdown = hooks.use_context::<Arc<Shutdown>>().clone();
     let mut system = hooks.use_context_mut::<SystemContext>();
 
     // ScrollView handle and per-activity height measurements
@@ -550,6 +634,11 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         }
     });
 
+    // Get optional command sender for process control
+    let command_tx = hooks
+        .use_context::<Option<mpsc::Sender<ProcessCommand>>>()
+        .clone();
+
     // Track terminal size changes (update UiState, no activity model lock needed)
     let mut prev_size = hooks.use_state(crate::TerminalSize::default);
     let current_size = crate::TerminalSize {
@@ -561,11 +650,16 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         if let Ok(mut ui) = ui_state.write() {
             ui.set_terminal_size(current_size.width, current_size.height);
         }
+        if let Ok(mut model) = activity_model.write() {
+            model.resize_vts(current_size.width, current_size.height);
+        }
+        if let Some(tx) = command_tx.as_ref() {
+            let _ = tx.try_send(ProcessCommand::Resize {
+                cols: current_size.width,
+                rows: current_size.height,
+            });
+        }
     }
-
-    // Get optional command sender for process control
-    let command_tx = hooks.use_context::<Option<mpsc::Sender<ProcessCommand>>>();
-
     // Handle keyboard events - only UI state updates, no activity model writes
     hooks.use_terminal_events({
         let activity_model = activity_model.clone();
@@ -581,6 +675,43 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             {
                 debug!("Key event: {:?}", key_event);
                 if handle_interrupt_prompt_key(&key_event, &ui_state, &shutdown) {
+                    notify.notify_waiters();
+                    return;
+                }
+
+                if shutdown.is_cancelled() {
+                    return;
+                }
+
+                let focused_activity = ui_state.read().ok().and_then(|ui| ui.focused_activity);
+
+                if let Some(activity_id) = focused_activity {
+                    if input::is_input_toggle(&key_event) {
+                        if let Ok(mut ui) = ui_state.write()
+                            && ui.focused_activity == Some(activity_id)
+                        {
+                            ui.focused_activity = None;
+                        }
+                        notify.notify_waiters();
+                        return;
+                    }
+
+                    if let Some(tx) = command_tx.as_ref()
+                        && let Some(data) = input::encode_key_event(&key_event)
+                    {
+                        let _ = tx.try_send(ProcessCommand::SendInput { activity_id, data });
+                        notify.notify_waiters();
+                    }
+                    return;
+                }
+
+                if input::is_input_toggle(&key_event) {
+                    if let Some((activity_id, _)) = selected_process(&activity_model, &ui_state) {
+                        if let Ok(mut ui) = ui_state.write() {
+                            ui.focused_activity = Some(activity_id);
+                        }
+                        notify.notify_waiters();
+                    }
                     return;
                 }
 
@@ -589,38 +720,22 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         if !request_interrupt_prompt(command_tx.as_ref(), &ui_state) {
                             shutdown.handle_interrupt();
                         }
+                        notify.notify_waiters();
                     }
                     KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Restart selected process
                         if let Some(tx) = command_tx.as_ref()
-                            && let Ok(ui) = ui_state.read()
-                            && let Some(activity_id) = ui.selected_activity
+                            && let Some((_, name)) = selected_process(&activity_model, &ui_state)
                         {
-                            if let Ok(model) = activity_model.read()
-                                && let Some(activity) = model.get_activity(activity_id)
-                                && matches!(
-                                    activity.variant,
-                                    crate::model::ActivityVariant::Process(_)
-                                )
-                            {
-                                let _ = tx.try_send(ProcessCommand::Restart(activity.name.clone()));
-                            }
+                            let _ = tx.try_send(ProcessCommand::Restart(name));
+                            notify.notify_waiters();
                         }
                     }
                     KeyCode::Char('x') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Stop selected process (only if active)
                         if let Some(tx) = command_tx.as_ref()
-                            && let Ok(ui) = ui_state.read()
-                            && let Some(activity_id) = ui.selected_activity
+                            && let Some((_, name)) = selected_process(&activity_model, &ui_state)
                         {
-                            if let Ok(model) = activity_model.read()
-                                && let Some(activity) = model.get_activity(activity_id)
-                                && let crate::model::ActivityVariant::Process(ref proc) =
-                                    activity.variant
-                                && proc.status.is_stoppable()
-                            {
-                                let _ = tx.try_send(ProcessCommand::Stop(activity.name.clone()));
-                            }
+                            let _ = tx.try_send(ProcessCommand::Stop(name));
+                            notify.notify_waiters();
                         }
                     }
                     KeyCode::Char('e') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -648,14 +763,23 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                         selected_id,
                                     );
                                 }
+                                notify.notify_waiters();
                             }
                         }
                     }
                     KeyCode::Esc => {
                         if let Ok(mut ui) = ui_state.write() {
                             ui.selected_activity = None;
+                            ui.focused_activity = None;
                         }
                         scroll_handle.write().scroll_to_bottom();
+                        notify.notify_waiters();
+                    }
+                    _ if *scroll_view_active.read() => {
+                        if let Some(action) = main_view_scroll_action_for_key(&key_event) {
+                            apply_main_view_scroll_action(&mut scroll_handle.write(), action);
+                            notify.notify_waiters();
+                        }
                     }
                     _ => {}
                 }
@@ -698,7 +822,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
         // Only enable ScrollView when content exceeds available terminal height.
         let available_height = terminal_height.saturating_sub(SUMMARY_BAR_HEIGHT) as i32;
-        let scroll_handle_opt = if total_content_height > available_height {
+        let scroll_handle_opt = if ui.fullscreen || total_content_height > available_height {
             Some(scroll_handle)
         } else {
             None
@@ -769,11 +893,13 @@ async fn run_view(
                 }
             };
 
-            element
-                .render_loop()
-                .output(Output::Stderr)
-                .ignore_ctrl_c()
-                .await
+            let fullscreen = ui_state.read().map(|ui| ui.fullscreen).unwrap_or(false);
+            let mut render_loop = element.render_loop();
+            if fullscreen {
+                render_loop = render_loop.fullscreen();
+            }
+
+            render_loop.output(Output::Stderr).ignore_ctrl_c().await
         }
         ViewMode::ExpandedLogs { activity_id } => {
             // Calculate height before switching to expanded view
@@ -848,5 +974,52 @@ mod tests {
         let quit = KeyEvent::new(KeyEventKind::Press, KeyCode::Char('q'));
         assert!(handle_interrupt_prompt_key(&quit, &ui_state, &shutdown));
         assert!(shutdown.is_cancelled());
+    }
+
+    #[test]
+    fn test_user_interrupt_does_not_leave_final_snapshot() {
+        let shutdown = tokio_shutdown::Shutdown::new();
+        assert!(should_present_final_snapshot(&shutdown));
+
+        shutdown.set_last_signal(tokio_shutdown::Signal::SIGINT);
+        assert!(!should_present_final_snapshot(&shutdown));
+    }
+
+    #[test]
+    fn test_main_view_scroll_action_for_key() {
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(KeyEventKind::Press, KeyCode::PageUp)),
+            Some(MainViewScrollAction::UpPage)
+        );
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(KeyEventKind::Press, KeyCode::PageDown)),
+            Some(MainViewScrollAction::DownPage)
+        );
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(KeyEventKind::Press, KeyCode::Home)),
+            Some(MainViewScrollAction::Top)
+        );
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(KeyEventKind::Press, KeyCode::End)),
+            Some(MainViewScrollAction::Bottom)
+        );
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(
+                KeyEventKind::Press,
+                KeyCode::Char('j')
+            )),
+            Some(MainViewScrollAction::DownLine)
+        );
+        assert_eq!(
+            main_view_scroll_action_for_key(&KeyEvent::new(
+                KeyEventKind::Press,
+                KeyCode::Char('k')
+            )),
+            Some(MainViewScrollAction::UpLine)
+        );
+
+        let mut ctrl_j = KeyEvent::new(KeyEventKind::Press, KeyCode::Char('j'));
+        ctrl_j.modifiers = KeyModifiers::CONTROL;
+        assert_eq!(main_view_scroll_action_for_key(&ctrl_j), None);
     }
 }

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -3,7 +3,10 @@
 use crate::model::{Activity, ActivityVariant, NixActivityState};
 use human_repr::{HumanCount, HumanThroughput};
 use iocraft::prelude::*;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
 
 // Import shared UI constants from devenv-shell
@@ -84,6 +87,98 @@ pub const LOG_VIEWPORT_COLLAPSED: usize = 10;
 pub const LOG_VIEWPORT_FAILED: usize = 20;
 /// Reduced viewport height for tasks with showOutput=true (expands to full when selected)
 pub const LOG_VIEWPORT_SHOW_OUTPUT: usize = 3;
+
+fn preview_panel_width(terminal_width: u16, indent: usize) -> u32 {
+    terminal_width.saturating_sub(indent as u16).max(1) as u32
+}
+
+fn truncate_preview_line(text: &str, max_width: usize) -> String {
+    if text.chars().count() > max_width {
+        let mut s: String = text.chars().take(max_width.saturating_sub(1)).collect();
+        s.push('…');
+        s
+    } else {
+        text.to_string()
+    }
+}
+
+// Broad ANSI matcher covering CSI, OSC, DCS, and single-byte ESC sequences.
+// Collapsed previews are plain-text summaries, so strip escape sequences before width math.
+static PREVIEW_ANSI_ESCAPE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(
+        r"\x1B(?:\[[0-?]*[ -/]*[@-~]|[PX^_][^\x1B]*\x1B\\|\][^\x07\x1B]*(?:\x07|\x1B\\)|[@-Z\\-_])",
+    )
+    .expect("valid ANSI escape regex")
+});
+
+// Strip remaining control bytes except tab/newline/carriage return.
+static PREVIEW_CONTROL_BYTE_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[\x00-\x08\x0B-\x1A\x1C-\x1F\x7F]").expect("valid control-byte regex")
+});
+
+fn sanitize_preview_text(text: &str) -> String {
+    let no_escapes = PREVIEW_ANSI_ESCAPE_REGEX.replace_all(text, "");
+    PREVIEW_CONTROL_BYTE_REGEX
+        .replace_all(no_escapes.as_ref(), "")
+        .to_string()
+}
+
+#[derive(Clone)]
+struct PreviewStyledCell {
+    ch: char,
+    pen: avt::Pen,
+}
+
+enum PreviewLine {
+    Plain(String),
+    Styled(Vec<PreviewStyledCell>),
+}
+
+fn preview_pen_color(color: avt::Color) -> Color {
+    match color {
+        avt::Color::Indexed(c) => Color::AnsiValue(c),
+        avt::Color::RGB(rgb) => Color::Rgb {
+            r: rgb.r,
+            g: rgb.g,
+            b: rgb.b,
+        },
+    }
+}
+
+fn build_preview_styled_segment(text: String, pen: &avt::Pen) -> AnyElement<'static> {
+    let fg = pen.foreground().map(preview_pen_color);
+    let bg = pen.background().map(preview_pen_color);
+
+    let text = element! {
+        Text(
+            content: text,
+            color: fg,
+            weight: if pen.is_bold() { Weight::Bold } else { Weight::Normal },
+            italic: pen.is_italic(),
+            decoration: if pen.is_underline() { TextDecoration::Underline } else { TextDecoration::None },
+            wrap: TextWrap::NoWrap,
+        )
+    }
+    .into_any();
+
+    if let Some(background_color) = bg {
+        element!(View(background_color: background_color) { #(vec![text]) }).into_any()
+    } else {
+        text
+    }
+}
+
+fn is_blank_vt_row(row: &[avt::Cell]) -> bool {
+    row.iter().all(|cell| cell.char() == ' ')
+}
+
+fn trim_trailing_blank_vt_rows<'a>(rows: &'a [&'a [avt::Cell]]) -> &'a [&'a [avt::Cell]] {
+    let Some(last_content_idx) = rows.iter().rposition(|row| !is_blank_vt_row(row)) else {
+        return &[];
+    };
+
+    &rows[..=last_content_idx]
+}
 
 /// Format elapsed time for display: ms -> s -> m s -> h m
 /// When `high_resolution` is true, shows ms for sub-second durations.
@@ -256,7 +351,7 @@ impl ActivityTextComponent {
 
         if let Some(bg) = bg_color {
             element! {
-                View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
+                View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
                     // Fixed left column - never truncates
                     View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                         #(final_prefix)
@@ -291,7 +386,7 @@ impl ActivityTextComponent {
             .into()
         } else {
             element! {
-                View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
+                View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1) {
                     // Fixed left column - never truncates
                     View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                         #(final_prefix)
@@ -707,6 +802,7 @@ fn shorten_store_path_aggressive(path: &str) -> String {
 /// Press 'e' to expand to fullscreen view with scrolling.
 pub struct ExpandedContentComponent<'a> {
     pub lines: Option<&'a VecDeque<String>>,
+    pub vt: Option<&'a Arc<std::sync::Mutex<avt::Vt>>>,
     pub empty_message: &'a str,
     pub max_lines: usize,
     pub depth: usize,
@@ -716,10 +812,16 @@ impl<'a> ExpandedContentComponent<'a> {
     pub fn new(lines: Option<&'a VecDeque<String>>) -> Self {
         Self {
             lines,
+            vt: None,
             empty_message: "  → no content",
             max_lines: LOG_VIEWPORT_COLLAPSED,
             depth: 0,
         }
+    }
+
+    pub fn with_vt(mut self, vt: Option<&'a Arc<std::sync::Mutex<avt::Vt>>>) -> Self {
+        self.vt = vt;
+        self
     }
 
     pub fn with_max_lines(mut self, max_lines: usize) -> Self {
@@ -737,62 +839,28 @@ impl<'a> ExpandedContentComponent<'a> {
         self
     }
 
-    pub fn render(&self) -> Vec<AnyElement<'static>> {
-        // Calculate indentation based on depth (2 base + 2 per depth level)
-        let indent = 2 + (self.depth * 2);
-
-        if let Some(lines) = &self.lines
-            && !lines.is_empty()
-        {
-            // Take the last N lines that fit in collapsed viewport
-            let visible_lines: Vec<_> = lines.iter().rev().take(self.max_lines).rev().collect();
-
-            if !visible_lines.is_empty() {
-                let actual_height = visible_lines.len();
-
-                let mut line_elements = vec![];
-                for line in visible_lines {
-                    line_elements.push(
-                        element! {
-                            View(height: 1, flex_direction: FlexDirection::Row) {
-                                Text(content: format!(" {line}"), color: Color::AnsiValue(245))
-                            }
-                        }
-                        .into_any(),
-                    );
-                }
-
-                return vec![
-                    element! {
-                        View(
-                            height: actual_height as u32,
-                            flex_direction: FlexDirection::Column,
-                            overflow: Overflow::Hidden,
-                            margin_left: indent as u32,
-                            margin_right: 1,
-                            border_style: BorderStyle::Single,
-                            border_edges: Edges::Left,
-                            border_color: Color::AnsiValue(245),
-                        ) {
-                            #(line_elements)
-                        }
-                    }
-                    .into_any(),
-                ];
-            }
+    pub fn render(&self, terminal_width: u16) -> Vec<AnyElement<'static>> {
+        let preview_lines = self.preview_lines();
+        if preview_lines.is_empty() {
+            return vec![self.render_preview_block(
+                vec![PreviewLine::Plain(self.empty_message.to_string())],
+                terminal_width,
+            )];
         }
 
-        // Fallback: show empty message with minimal height
-        vec![element! {
-            View(height: 1, flex_direction: FlexDirection::Column, padding_left: indent as u32, padding_right: 1) {
-                Text(content: self.empty_message.to_string(), color: Color::AnsiValue(245))
-            }
-        }
-        .into_any()]
+        vec![self.render_preview_block(preview_lines, terminal_width)]
     }
 
     /// Calculate the height this component will take
     pub fn calculate_height(&self) -> usize {
+        if let Some(vt) = self.vt {
+            let vt = vt.lock().unwrap();
+            let rows: Vec<&[avt::Cell]> = vt.lines().map(|row| row.cells()).collect();
+            let count = trim_trailing_blank_vt_rows(&rows).len();
+            if count > 0 {
+                return count.min(self.max_lines);
+            }
+        }
         if let Some(lines) = &self.lines
             && !lines.is_empty()
         {
@@ -806,15 +874,172 @@ impl<'a> ExpandedContentComponent<'a> {
 
     /// Render the component with a main activity line, returning a single element
     /// with proper height calculation for the combined content.
-    pub fn render_with_main_line(&self, main_line: AnyElement<'static>) -> AnyElement<'static> {
+    pub fn render_with_main_line(
+        &self,
+        main_line: AnyElement<'static>,
+        terminal_width: u16,
+    ) -> AnyElement<'static> {
         let mut elements = vec![main_line];
-        elements.extend(self.render());
+        elements.extend(self.render(terminal_width));
 
         let total_height = (1 + self.calculate_height()) as u32;
 
         element! {
-            View(height: total_height, flex_direction: FlexDirection::Column) {
+            View(height: total_height, width: 100pct, flex_direction: FlexDirection::Column) {
                 #(elements)
+            }
+        }
+        .into_any()
+    }
+
+    fn preview_lines(&self) -> Vec<PreviewLine> {
+        if let Some(vt) = self.vt {
+            let vt = vt.lock().unwrap();
+            let rows: Vec<&[avt::Cell]> = vt.lines().map(|row| row.cells()).collect();
+            let rows = trim_trailing_blank_vt_rows(&rows);
+            let mut lines = Vec::new();
+            for row in rows.iter().rev().take(self.max_lines).rev() {
+                lines.push(PreviewLine::Styled(
+                    row.iter()
+                        .map(|cell| PreviewStyledCell {
+                            ch: cell.char(),
+                            pen: cell.pen().clone(),
+                        })
+                        .collect(),
+                ));
+            }
+            if !lines.is_empty() {
+                return lines;
+            }
+        }
+
+        if let Some(lines) = &self.lines {
+            return lines
+                .iter()
+                .rev()
+                .take(self.max_lines)
+                .rev()
+                .cloned()
+                .map(PreviewLine::Plain)
+                .collect();
+        }
+
+        Vec::new()
+    }
+
+    fn render_preview_block(
+        &self,
+        lines: Vec<PreviewLine>,
+        terminal_width: u16,
+    ) -> AnyElement<'static> {
+        let indent = 2 + (self.depth * 2);
+        let panel_width = preview_panel_width(terminal_width, indent);
+        let text_width = (panel_width as usize).saturating_sub(2);
+
+        let rows: Vec<_> = lines
+            .into_iter()
+            .map(|line| {
+                let content = match line {
+                    PreviewLine::Plain(line) => {
+                        let line = sanitize_preview_text(&line);
+                        let display_text = truncate_preview_line(&line, text_width);
+                        element! {
+                            View(
+                                width: text_width as u32,
+                                flex_shrink: 0.0,
+                                flex_direction: FlexDirection::Row,
+                                overflow: Overflow::Hidden,
+                            ) {
+                                View(flex_shrink: 0.0, overflow: Overflow::Hidden) {
+                                    Text(content: display_text, color: Color::AnsiValue(245), wrap: TextWrap::NoWrap)
+                                }
+                            }
+                        }
+                        .into_any()
+                    }
+                    PreviewLine::Styled(cells) => {
+                        self.build_styled_preview_content(cells, text_width)
+                    }
+                };
+                element! {
+                    View(
+                        height: 1,
+                        width: 100pct,
+                        flex_direction: FlexDirection::Row,
+                        overflow: Overflow::Hidden,
+                    ) {
+                        View(
+                            width: 1,
+                            flex_shrink: 0.0,
+                        ) {
+                            Text(content: "│", color: Color::AnsiValue(245), wrap: TextWrap::NoWrap)
+                        }
+                        View(
+                            width: 1,
+                            flex_shrink: 0.0,
+                        ) {}
+                        #(vec![content])
+                    }
+                }
+                .into_any()
+            })
+            .collect();
+
+        let row_count = rows.len() as u32;
+
+        element! {
+            View(height: row_count, width: 100pct, flex_direction: FlexDirection::Column, overflow: Overflow::Hidden) {
+                View(width: 100pct, padding_left: indent as u32, flex_direction: FlexDirection::Column, overflow: Overflow::Hidden) {
+                    #(rows)
+                }
+            }
+        }
+        .into_any()
+    }
+
+    fn build_styled_preview_content(
+        &self,
+        cells: Vec<PreviewStyledCell>,
+        text_width: usize,
+    ) -> AnyElement<'static> {
+        let mut clipped = cells;
+        if clipped.len() > text_width {
+            clipped.truncate(text_width);
+            if let Some(last) = clipped.last_mut() {
+                last.ch = '…';
+            }
+        }
+        while clipped.len() < text_width {
+            clipped.push(PreviewStyledCell {
+                ch: ' ',
+                pen: avt::Pen::default(),
+            });
+        }
+
+        let mut runs: Vec<(String, avt::Pen)> = Vec::new();
+        for cell in clipped {
+            if let Some((text, pen)) = runs.last_mut()
+                && *pen == cell.pen
+            {
+                text.push(cell.ch);
+            } else {
+                runs.push((cell.ch.to_string(), cell.pen));
+            }
+        }
+
+        let run_elements: Vec<_> = runs
+            .into_iter()
+            .map(|(text, pen)| build_preview_styled_segment(text, &pen))
+            .collect();
+
+        element! {
+            View(
+                width: text_width as u32,
+                flex_shrink: 0.0,
+                flex_direction: FlexDirection::Row,
+                overflow: Overflow::Hidden,
+            ) {
+                #(run_elements)
             }
         }
         .into_any()
@@ -1009,5 +1234,78 @@ mod tests {
         let (name, _suffix) =
             calculate_display_info("pkg", 80, "building", Some(suffix), "1.0s", 0);
         assert_eq!(name, "pkg");
+    }
+
+    #[test]
+    fn expanded_preview_lines_do_not_render_trailing_border() {
+        let lines = VecDeque::from(["short".to_string(), "tiny".to_string()]);
+        let component = ExpandedContentComponent::new(Some(&lines));
+        let mut elements = component.render(20);
+        let output = elements.remove(0).render(Some(20)).to_string();
+
+        for line in output.lines() {
+            assert_ne!(
+                line.chars().last(),
+                Some('│'),
+                "line should not render a trailing preview border: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn nested_expanded_preview_does_not_render_trailing_border() {
+        let lines = VecDeque::from(["nested".to_string()]);
+        let component = ExpandedContentComponent::new(Some(&lines)).with_depth(2);
+        let mut elements = component.render(24);
+        let output = elements.remove(0).render(Some(24)).to_string();
+
+        for line in output.lines() {
+            assert_ne!(
+                line.chars().last(),
+                Some('│'),
+                "line should not render a trailing preview border: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_preview_text_removes_terminal_sequences() {
+        let input = "\x1b[32mgreen\x1b[0m \x1b]8;;https://example.com\x07link\x1b]8;;\x07\x07";
+        assert_eq!(sanitize_preview_text(input), "green link");
+    }
+
+    #[test]
+    fn sanitize_preview_text_removes_non_printable_controls() {
+        let input = "ab\x00\x1f\x7fcd\t";
+        assert_eq!(sanitize_preview_text(input), "abcd\t");
+    }
+
+    #[test]
+    fn preview_render_strips_ansi_before_layout() {
+        let lines = VecDeque::from(["\x1b[32mgreen\x1b[0m tail".to_string()]);
+        let component = ExpandedContentComponent::new(Some(&lines));
+        let mut elements = component.render(20);
+        let output = elements.remove(0).render(Some(20)).to_string();
+
+        assert!(output.contains("green tail"));
+        assert!(!output.contains("\x1b"));
+    }
+
+    #[test]
+    fn vt_preview_preserves_styled_text_layout() {
+        let vt = Arc::new(std::sync::Mutex::new(avt::Vt::new(20, 4)));
+        {
+            let mut vt = vt.lock().unwrap();
+            vt.feed_str("\x1b[32mgreen\x1b[0m tail\n");
+        }
+
+        let component = ExpandedContentComponent::new(None).with_vt(Some(&vt));
+        let mut elements = component.render(20);
+        let output = elements.remove(0).render(Some(20)).to_string();
+
+        assert!(output.contains("green tail"));
+        for line in output.lines() {
+            assert_ne!(line.chars().last(), Some('│'));
+        }
     }
 }

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -7,6 +7,8 @@
 
 use crate::TuiConfig;
 use crate::app::{ExitFlag, handle_interrupt_prompt_key, request_interrupt_prompt};
+use crate::components::{COLOR_HIERARCHY, COLOR_INTERACTIVE};
+use crate::input;
 use crate::model::{ActivityModel, UiState, ViewMode};
 use base64::Engine;
 use crossterm::event::MouseButton;
@@ -14,13 +16,20 @@ use devenv_processes::ProcessCommand;
 use iocraft::prelude::*;
 use iocraft::{FullscreenMouseEvent, MouseEventKind};
 use std::collections::VecDeque;
-use std::io::Write as _;
+use std::fs::OpenOptions;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{Notify, mpsc};
 use tokio_shutdown::Shutdown;
 
-/// Line number prefix width: "NNNNN | " = 8 chars
-const LINE_NUM_PREFIX_WIDTH: usize = 8;
+/// Width of the non-selectable line number gutter: "NNNNN " = 6 chars.
+const LINE_NUM_GUTTER_WIDTH: usize = 6;
+
+/// Column where log content starts: gutter + left border + padding.
+const LINE_NUM_PREFIX_WIDTH: usize = LINE_NUM_GUTTER_WIDTH + 2;
+fn content_column(col: usize) -> usize {
+    col.max(LINE_NUM_PREFIX_WIDTH)
+        .saturating_sub(LINE_NUM_PREFIX_WIDTH)
+}
 
 /// Represents a normalized text selection range.
 struct Selection {
@@ -67,6 +76,24 @@ impl Selection {
         }
         Some((start_col.min(line_len), end_col.min(line_len)))
     }
+
+    /// Returns true if the selection range contains the given (line_idx, col_idx).
+    fn contains(&self, line_idx: usize, col_idx: usize) -> bool {
+        if line_idx < self.start.0 || line_idx > self.end.0 {
+            return false;
+        }
+        let start_col = if line_idx == self.start.0 {
+            self.start.1
+        } else {
+            0
+        };
+        let end_col = if line_idx == self.end.0 {
+            self.end.1
+        } else {
+            usize::MAX
+        };
+        col_idx >= start_col && col_idx < end_col
+    }
 }
 
 /// Fullscreen component for viewing expanded logs.
@@ -83,13 +110,14 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let activity_model = hooks.use_context::<Arc<RwLock<ActivityModel>>>();
     let ui_state = hooks.use_context::<Arc<RwLock<UiState>>>();
     let activity_id = *hooks.use_context::<u64>();
-    let notify = hooks.use_context::<Arc<Notify>>();
+    let notify = hooks.use_context::<Arc<Notify>>().clone();
     let shutdown = hooks.use_context::<Arc<Shutdown>>();
     let command_tx = hooks.use_context::<Option<mpsc::Sender<ProcessCommand>>>();
     let (width, height) = hooks.use_terminal_size();
 
     // Component-local scroll state - updates are immediate, no model lock needed
     let mut scroll_offset = hooks.use_state(|| 0usize);
+    let mut follow_logs = hooks.use_state(|| true);
 
     // Selection state
     let mut selection_anchor = hooks.use_state(|| None::<(usize, usize)>);
@@ -107,6 +135,24 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         }
     });
 
+    let mut prev_size = hooks.use_state(crate::TerminalSize::default);
+    let current_size = crate::TerminalSize { width, height };
+    if current_size != prev_size.get() {
+        prev_size.set(current_size);
+        if let Ok(mut ui) = ui_state.write() {
+            ui.set_terminal_size(current_size.width, current_size.height);
+        }
+        if let Ok(mut model) = activity_model.write() {
+            model.resize_vt(activity_id, current_size.width, current_size.height);
+        }
+        if let Some(tx) = command_tx.as_ref() {
+            let _ = tx.try_send(ProcessCommand::Resize {
+                cols: current_size.width,
+                rows: current_size.height,
+            });
+        }
+    }
+
     // Extract view state from activity model (read-only, brief lock)
     let view_state = {
         let model_guard = activity_model.read().unwrap();
@@ -114,52 +160,84 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     };
 
     let Some(state) = view_state else {
-        // Activity not found, exit
         if let Ok(mut ui) = ui_state.write() {
             ui.view_mode = ViewMode::Main;
         }
-        hooks.use_context_mut::<SystemContext>().exit();
         return element!(View).into_any();
     };
 
     let viewport_height = calculate_viewport_height(height);
     let total_lines = state.total_lines;
+    let max_offset = total_lines.saturating_sub(viewport_height);
+    let effective_scroll_offset = if follow_logs.get() {
+        max_offset
+    } else {
+        state.scroll_offset.min(max_offset)
+    };
 
-    // Build current selection for use in event handlers
-    let current_selection_anchor = selection_anchor.get();
-    let current_selection_cursor = selection_cursor.get();
-    let has_selection = current_selection_anchor.is_some() && current_selection_cursor.is_some();
+    if effective_scroll_offset != scroll_offset.get() {
+        scroll_offset.set(effective_scroll_offset);
+    }
 
-    // Clone logs Arc for use in copy handler
+    let input_focused = ui_state
+        .read()
+        .map(|ui| ui.focused_activity == Some(activity_id))
+        .unwrap_or(false);
+
     let logs_for_copy = state.logs.clone();
+    let vt_for_copy = state.vt.clone();
+    let activity_name = state.activity_name.clone();
 
-    // Handle keyboard and mouse events - NO MODEL LOCK, only local state updates
     hooks.use_terminal_events({
         let ui_state = ui_state.clone();
+        let notify = notify.clone();
         let shutdown = shutdown.clone();
         let command_tx = command_tx.clone();
+        let vt_for_copy = vt_for_copy.clone();
         move |event| match event {
             TerminalEvent::Key(key_event) => {
                 if key_event.kind == KeyEventKind::Release {
                     return;
                 }
+                if !input_focused && state.supports_input && input::is_input_toggle(&key_event) {
+                    if let Ok(mut ui) = ui_state.write() {
+                        ui.focused_activity = Some(activity_id);
+                    }
+                    notify.notify_one();
+                    return;
+                }
+                if input_focused {
+                    if input::is_input_toggle(&key_event) {
+                        if let Ok(mut ui) = ui_state.write()
+                            && ui.focused_activity == Some(activity_id)
+                        {
+                            ui.focused_activity = None;
+                        }
+                        notify.notify_one();
+                        return;
+                    }
+
+                    if let Some(tx) = command_tx.as_ref()
+                        && let Some(data) = input::encode_key_event(&key_event)
+                    {
+                        let _ = tx.try_send(ProcessCommand::SendInput { activity_id, data });
+                        notify.notify_one();
+                    }
+                    return;
+                }
+
                 handle_key_event(
                     key_event,
+                    &activity_name,
+                    state.supports_input,
                     &ui_state,
+                    &notify,
                     &shutdown,
                     command_tx.as_ref(),
                     &mut scroll_offset,
+                    &mut follow_logs,
                     total_lines,
                     viewport_height,
-                    &mut SelectionState {
-                        has_selection,
-                        anchor: current_selection_anchor,
-                        cursor: current_selection_cursor,
-                        logs: &logs_for_copy,
-                        anchor_state: &mut selection_anchor,
-                        cursor_state: &mut selection_cursor,
-                        is_selecting: &mut is_selecting,
-                    },
                 );
             }
             TerminalEvent::FullscreenMouse(mouse_event) => {
@@ -171,8 +249,11 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     handle_mouse_event(
                         mouse_event,
                         &mut scroll_offset,
+                        &mut follow_logs,
                         total_lines,
                         viewport_height,
+                        &logs_for_copy,
+                        vt_for_copy.as_ref(),
                         &mut selection_anchor,
                         &mut selection_cursor,
                         &mut is_selecting,
@@ -183,7 +264,6 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         }
     });
 
-    // Check if we should exit (backend done or view mode changed)
     let exit_flag = hooks.use_context::<ExitFlag>();
     let should_exit = exit_flag.is_set()
         || ui_state
@@ -195,7 +275,6 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         return element!(View).into_any();
     }
 
-    // Build selection for rendering
     let selection =
         if let (Some(anchor), Some(cursor)) = (selection_anchor.get(), selection_cursor.get()) {
             Some(Selection::from_anchor_cursor(anchor, cursor))
@@ -208,12 +287,21 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         .map(|ui| ui.interrupt_prompt_active())
         .unwrap_or(false);
 
+    let state = ExpandedViewState {
+        scroll_offset: effective_scroll_offset,
+        ..state
+    };
+
     render_expanded_view(
         &state,
         width,
         height,
         selection.as_ref(),
         interrupt_prompt_active,
+        shutdown.is_cancelled(),
+        follow_logs.get(),
+        state.supports_input,
+        input_focused,
     )
 }
 
@@ -223,190 +311,306 @@ struct ExpandedViewState {
     scroll_offset: usize,
     logs: Arc<VecDeque<String>>,
     total_lines: usize,
+    supports_input: bool,
+    vt: Option<Arc<std::sync::Mutex<avt::Vt>>>,
 }
 
-/// Extract the view state from the activity model
+fn is_blank_vt_row(row: &[avt::Cell]) -> bool {
+    row.iter().all(|cell| cell.char() == ' ')
+}
+
+fn trim_trailing_blank_vt_rows<'a>(rows: &'a [&'a [avt::Cell]]) -> &'a [&'a [avt::Cell]] {
+    let Some(last_content_idx) = rows.iter().rposition(|row| !is_blank_vt_row(row)) else {
+        return &[];
+    };
+
+    &rows[..=last_content_idx]
+}
+
+fn trim_trailing_blank_vt_lines<'a>(lines: &'a [&'a avt::Line]) -> &'a [&'a avt::Line] {
+    let Some(last_content_idx) = lines
+        .iter()
+        .rposition(|line| !is_blank_vt_row(line.cells()))
+    else {
+        return &[];
+    };
+
+    &lines[..=last_content_idx]
+}
+
+fn vt_line_is_wrapped(line: &avt::Line) -> bool {
+    format!("{line:?}").contains('⏎')
+}
+
+fn vt_display_line_numbers(lines: &[&avt::Line]) -> Vec<usize> {
+    let mut numbers = Vec::with_capacity(lines.len());
+    let mut current = 1;
+
+    for (idx, _) in lines.iter().enumerate() {
+        if idx > 0 && !vt_line_is_wrapped(lines[idx - 1]) {
+            current += 1;
+        }
+        numbers.push(current);
+    }
+
+    numbers
+}
+
 fn extract_view_state(
     model: &ActivityModel,
     activity_id: u64,
     scroll_offset: usize,
 ) -> Option<ExpandedViewState> {
-    let activity_name = model
-        .get_activity(activity_id)
-        .map(|a| a.name.clone())
-        .unwrap_or_else(|| format!("Activity {}", activity_id));
+    let activity = model.get_activity(activity_id)?;
+    let activity_name = activity.name.clone();
+    let supports_input = matches!(activity.variant, crate::model::ActivityVariant::Process(_));
+    let vt = activity.vt.clone();
 
-    // Clone the Arc, not the data - this is cheap
     let logs = model
         .get_build_logs(activity_id)
         .cloned()
         .unwrap_or_else(|| Arc::new(VecDeque::new()));
 
-    let total_lines = logs.len();
+    let total_lines = if let Some(vt) = &vt {
+        let vt = vt.lock().unwrap();
+        let rows: Vec<&[avt::Cell]> = vt.lines().map(|row| row.cells()).collect();
+        trim_trailing_blank_vt_rows(&rows).len()
+    } else {
+        logs.len()
+    };
 
     Some(ExpandedViewState {
         activity_name,
         scroll_offset,
         logs,
         total_lines,
+        supports_input,
+        vt,
     })
 }
 
-/// Calculate the viewport height (total height minus header and footer)
 fn calculate_viewport_height(terminal_height: u16) -> usize {
-    (terminal_height as usize).saturating_sub(2) // header + footer
+    (terminal_height as usize).saturating_sub(2)
 }
 
-/// Mutable selection state passed to event handlers.
-struct SelectionState<'a> {
-    has_selection: bool,
-    anchor: Option<(usize, usize)>,
-    cursor: Option<(usize, usize)>,
-    logs: &'a Arc<VecDeque<String>>,
-    anchor_state: &'a mut State<Option<(usize, usize)>>,
-    cursor_state: &'a mut State<Option<(usize, usize)>>,
-    is_selecting: &'a mut State<bool>,
-}
-
-impl SelectionState<'_> {
-    fn clear(&mut self) {
-        self.anchor_state.set(None);
-        self.cursor_state.set(None);
-        self.is_selecting.set(false);
-    }
-}
-
-/// Handle keyboard input - updates local scroll state, no model lock needed
 #[allow(clippy::too_many_arguments)]
 fn handle_key_event(
     key_event: KeyEvent,
+    activity_name: &str,
+    supports_input: bool,
     ui_state: &Arc<RwLock<UiState>>,
+    notify: &Arc<Notify>,
     shutdown: &Arc<Shutdown>,
     command_tx: Option<&mpsc::Sender<ProcessCommand>>,
     scroll_offset: &mut State<usize>,
+    follow_logs: &mut State<bool>,
     total_lines: usize,
     viewport_height: usize,
-    sel: &mut SelectionState<'_>,
 ) {
     if handle_interrupt_prompt_key(&key_event, ui_state, shutdown) {
+        notify.notify_one();
+        return;
+    }
+
+    if shutdown.is_cancelled() {
         return;
     }
 
     let max_offset = total_lines.saturating_sub(viewport_height);
 
+    let set_scroll =
+        |scroll_offset: &mut State<usize>, follow_logs: &mut State<bool>, new_offset: usize| {
+            let clamped = new_offset.min(max_offset);
+            scroll_offset.set(clamped);
+            follow_logs.set(clamped == max_offset);
+        };
+
     match key_event.code {
-        // Esc: clear selection first, then exit
         KeyCode::Esc => {
-            if sel.has_selection {
-                sel.clear();
-            } else if let Ok(mut ui) = ui_state.write() {
+            if let Ok(mut ui) = ui_state.write() {
                 ui.view_mode = ViewMode::Main;
+                notify.notify_one();
             }
         }
-
-        // q: always exit
         KeyCode::Char('q') => {
             if let Ok(mut ui) = ui_state.write() {
                 ui.view_mode = ViewMode::Main;
+                notify.notify_one();
             }
         }
-
         KeyCode::Char('e') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
             if let Ok(mut ui) = ui_state.write() {
                 ui.view_mode = ViewMode::Main;
+                notify.notify_one();
             }
         }
-
-        // Scroll down one line
         KeyCode::Down | KeyCode::Char('j') => {
-            scroll_offset.set((scroll_offset.get() + 1).min(max_offset));
+            set_scroll(scroll_offset, follow_logs, scroll_offset.get() + 1);
         }
-
-        // Scroll up one line
         KeyCode::Up | KeyCode::Char('k') => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(1));
+            set_scroll(
+                scroll_offset,
+                follow_logs,
+                scroll_offset.get().saturating_sub(1),
+            );
         }
-
-        // Page down
         KeyCode::PageDown | KeyCode::Char(' ') => {
-            scroll_offset.set((scroll_offset.get() + viewport_height).min(max_offset));
+            set_scroll(
+                scroll_offset,
+                follow_logs,
+                scroll_offset.get() + viewport_height,
+            );
         }
-
-        // Page up
         KeyCode::PageUp => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(viewport_height));
+            set_scroll(
+                scroll_offset,
+                follow_logs,
+                scroll_offset.get().saturating_sub(viewport_height),
+            );
         }
-
-        // Go to top
         KeyCode::Home | KeyCode::Char('g') => {
-            scroll_offset.set(0);
+            set_scroll(scroll_offset, follow_logs, 0);
         }
-
-        // Go to bottom
         KeyCode::End | KeyCode::Char('G') => {
-            scroll_offset.set(max_offset);
+            set_scroll(scroll_offset, follow_logs, max_offset);
         }
-
-        // Ctrl+C: copy selection if active, otherwise open the quit prompt
         KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-            if sel.has_selection {
-                if let (Some(anchor), Some(cursor)) = (sel.anchor, sel.cursor) {
-                    let selection = Selection::from_anchor_cursor(anchor, cursor);
-                    let text = extract_selected_text(sel.logs, &selection);
-                    if !text.is_empty() {
-                        copy_to_clipboard(&text);
-                    }
-                }
-                sel.clear();
-            } else if !request_interrupt_prompt(command_tx, ui_state) {
+            if !request_interrupt_prompt(command_tx, ui_state) {
                 shutdown.handle_interrupt();
             }
+            notify.notify_one();
         }
-
+        KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            if let Some(tx) = command_tx {
+                let _ = tx.try_send(ProcessCommand::Restart(activity_name.to_string()));
+                notify.notify_one();
+            }
+        }
+        KeyCode::Char('x') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            if supports_input && let Some(tx) = command_tx {
+                let _ = tx.try_send(ProcessCommand::Stop(activity_name.to_string()));
+                notify.notify_one();
+            }
+        }
         _ => {}
     }
 }
 
-/// Handle mouse input - updates local scroll state and selection
-fn handle_mouse_event(
-    mouse_event: FullscreenMouseEvent,
-    scroll_offset: &mut State<usize>,
+fn vt_row_content_len(row: &[avt::Cell]) -> usize {
+    row.iter()
+        .rposition(|cell| cell.char() != ' ')
+        .map(|idx| idx + 1)
+        .unwrap_or(0)
+}
+
+fn line_len_at(
+    logs: &Arc<VecDeque<String>>,
+    vt: Option<&Arc<std::sync::Mutex<avt::Vt>>>,
+    line_idx: usize,
+) -> usize {
+    if let Some(vt) = vt {
+        let vt = vt.lock().unwrap();
+        let rows: Vec<&[avt::Cell]> = vt.lines().map(|row| row.cells()).collect();
+        let rows = trim_trailing_blank_vt_rows(&rows);
+        rows.get(line_idx)
+            .map(|row| vt_row_content_len(row))
+            .unwrap_or(0)
+    } else {
+        logs.get(line_idx)
+            .map(|line| line.chars().count())
+            .unwrap_or(0)
+    }
+}
+
+fn last_selectable_position(
     total_lines: usize,
-    viewport_height: usize,
+    logs: &Arc<VecDeque<String>>,
+    vt: Option<&Arc<std::sync::Mutex<avt::Vt>>>,
+) -> Option<(usize, usize)> {
+    let last_line_idx = total_lines.checked_sub(1)?;
+    Some((last_line_idx, line_len_at(logs, vt, last_line_idx)))
+}
+
+fn first_selectable_position() -> (usize, usize) {
+    (0, 0)
+}
+
+fn finalize_selection_copy(
+    logs: &Arc<VecDeque<String>>,
+    vt: Option<&Arc<std::sync::Mutex<avt::Vt>>>,
     selection_anchor: &mut State<Option<(usize, usize)>>,
     selection_cursor: &mut State<Option<(usize, usize)>>,
     is_selecting: &mut State<bool>,
 ) {
-    let scroll_lines = 3; // Lines to scroll per wheel tick
+    is_selecting.set(false);
+
+    if let (Some(anchor), Some(cursor)) = (selection_anchor.get(), selection_cursor.get())
+        && anchor != cursor
+    {
+        let selection = Selection::from_anchor_cursor(anchor, cursor);
+        let text = extract_selected_text(logs, vt, &selection);
+        copy_to_clipboard(&text);
+    }
+
+    selection_anchor.set(None);
+    selection_cursor.set(None);
+}
+
+fn handle_mouse_event(
+    mouse_event: FullscreenMouseEvent,
+    scroll_offset: &mut State<usize>,
+    follow_logs: &mut State<bool>,
+    total_lines: usize,
+    viewport_height: usize,
+    logs: &Arc<VecDeque<String>>,
+    vt: Option<&Arc<std::sync::Mutex<avt::Vt>>>,
+    selection_anchor: &mut State<Option<(usize, usize)>>,
+    selection_cursor: &mut State<Option<(usize, usize)>>,
+    is_selecting: &mut State<bool>,
+) {
+    let scroll_lines = 3;
     let max_offset = total_lines.saturating_sub(viewport_height);
+
+    let set_scroll =
+        |scroll_offset: &mut State<usize>, follow_logs: &mut State<bool>, new_offset: usize| {
+            let clamped = new_offset.min(max_offset);
+            scroll_offset.set(clamped);
+            follow_logs.set(clamped == max_offset);
+        };
 
     match mouse_event.kind {
         MouseEventKind::Down(MouseButton::Left) => {
             let row = mouse_event.row as usize;
             let col = mouse_event.column as usize;
 
-            // Row 0 is header, last row is footer - ignore those
             if row == 0 || row > viewport_height {
                 return;
             }
 
-            // Map to log line index: row 1 = first visible line
             let visible_line_idx = row - 1;
             let log_line_idx = scroll_offset.get() + visible_line_idx;
 
             if log_line_idx >= total_lines {
+                let Some(pos) = last_selectable_position(total_lines, logs, vt) else {
+                    selection_anchor.set(None);
+                    selection_cursor.set(None);
+                    is_selecting.set(true);
+                    return;
+                };
+
+                selection_anchor.set(Some(pos));
+                selection_cursor.set(Some(pos));
+                is_selecting.set(true);
                 return;
             }
 
-            // Map column to content position (subtract line number prefix)
-            let visual_col = col.saturating_sub(LINE_NUM_PREFIX_WIDTH);
+            let visual_col = content_column(col);
 
             let pos = (log_line_idx, visual_col);
             selection_anchor.set(Some(pos));
             selection_cursor.set(Some(pos));
             is_selecting.set(true);
         }
-
         MouseEventKind::Drag(MouseButton::Left) => {
             if !is_selecting.get() {
                 return;
@@ -415,129 +619,306 @@ fn handle_mouse_event(
             let row = mouse_event.row as usize;
             let col = mouse_event.column as usize;
 
-            // Clamp row to content area
-            let clamped_row = row.clamp(1, viewport_height);
-            let visible_line_idx = clamped_row - 1;
-            let log_line_idx =
-                (scroll_offset.get() + visible_line_idx).min(total_lines.saturating_sub(1));
+            if total_lines == 0 {
+                return;
+            }
 
-            let visual_col = col.saturating_sub(LINE_NUM_PREFIX_WIDTH);
+            let outside_top = row == 0;
+            let visible_line_idx = row.saturating_sub(1);
+            let raw_log_line_idx = scroll_offset.get().saturating_add(visible_line_idx);
+            let outside_bottom = row > viewport_height || raw_log_line_idx >= total_lines;
 
-            selection_cursor.set(Some((log_line_idx, visual_col)));
-        }
+            let pos = if outside_top {
+                first_selectable_position()
+            } else if outside_bottom {
+                last_selectable_position(total_lines, logs, vt)
+                    .unwrap_or_else(first_selectable_position)
+            } else {
+                (raw_log_line_idx, content_column(col))
+            };
 
-        MouseEventKind::Up(MouseButton::Left) => {
-            is_selecting.set(false);
-
-            // If anchor == cursor, it was just a click - clear selection
-            if let (Some(anchor), Some(cursor)) = (selection_anchor.get(), selection_cursor.get())
-                && anchor == cursor
-            {
-                selection_anchor.set(None);
-                selection_cursor.set(None);
+            if selection_anchor.get().is_some() {
+                selection_cursor.set(Some(pos));
             }
         }
-
+        MouseEventKind::Up(MouseButton::Left) => {
+            finalize_selection_copy(logs, vt, selection_anchor, selection_cursor, is_selecting);
+        }
+        MouseEventKind::Moved if is_selecting.get() => {
+            finalize_selection_copy(logs, vt, selection_anchor, selection_cursor, is_selecting);
+        }
         MouseEventKind::ScrollDown => {
-            scroll_offset.set((scroll_offset.get() + scroll_lines).min(max_offset));
+            set_scroll(
+                scroll_offset,
+                follow_logs,
+                scroll_offset.get() + scroll_lines,
+            );
         }
         MouseEventKind::ScrollUp => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(scroll_lines));
+            set_scroll(
+                scroll_offset,
+                follow_logs,
+                scroll_offset.get().saturating_sub(scroll_lines),
+            );
         }
         _ => {}
     }
 }
 
-/// Copy text to clipboard using OSC 52 escape sequence.
-/// This works in most modern terminals including over SSH.
 fn copy_to_clipboard(text: &str) {
+    if text.is_empty() {
+        return;
+    }
+
     let encoded = base64::engine::general_purpose::STANDARD.encode(text);
-    // Write OSC 52 sequence to stderr (matches TUI output target)
-    let _ = write!(std::io::stderr(), "\x1b]52;c;{}\x07", encoded);
-    let _ = std::io::stderr().flush();
+    if let Ok(mut tty) = OpenOptions::new().write(true).open("/dev/tty") {
+        write_osc52_sequence(&mut tty, &encoded);
+    } else {
+        let mut stdout = std::io::stdout();
+        write_osc52_sequence(&mut stdout, &encoded);
+    }
 }
 
-/// Extract selected text from log lines, stripping ANSI codes.
-fn extract_selected_text(logs: &VecDeque<String>, selection: &Selection) -> String {
+fn write_osc52_sequence<W: std::io::Write>(out: &mut W, encoded: &str) {
+    if std::env::var_os("TMUX").is_some() {
+        let _ = write!(out, "\x1bPtmux;\x1b\x1b]52;c;{}\x07\x1b\\", encoded);
+    } else {
+        let _ = write!(out, "\x1b]52;c;{}\x07", encoded);
+    }
+    let _ = out.flush();
+}
+
+fn extract_selected_text(
+    logs: &VecDeque<String>,
+    vt: Option<&Arc<std::sync::Mutex<avt::Vt>>>,
+    selection: &Selection,
+) -> String {
     let mut lines = Vec::new();
 
-    for line_idx in selection.start.0..=selection.end.0 {
-        let Some(line) = logs.get(line_idx) else {
-            continue;
-        };
+    if let Some(vt) = vt {
+        let vt = vt.lock().unwrap();
+        let rows: Vec<&[avt::Cell]> = vt.lines().map(|row| row.cells()).collect();
+        let rows = trim_trailing_blank_vt_rows(&rows);
+        for line_idx in selection.start.0..=selection.end.0 {
+            let Some(row) = rows.get(line_idx) else {
+                continue;
+            };
+            let len = row.len();
+            if let Some((start_col, end_col)) = selection.line_range(line_idx, len) {
+                let mut line_text = String::new();
+                for col in start_col..end_col {
+                    if let Some(cell) = row.get(col) {
+                        line_text.push(cell.char());
+                    }
+                }
+                lines.push(line_text);
+            }
+        }
+    } else {
+        for line_idx in selection.start.0..=selection.end.0 {
+            let Some(line) = logs.get(line_idx) else {
+                continue;
+            };
 
-        if let Some((start_col, end_col)) = selection.line_range(line_idx, line.len()) {
-            let selected: String = line
-                .chars()
-                .skip(start_col)
-                .take(end_col - start_col)
-                .collect();
-            lines.push(selected);
+            if let Some((start_col, end_col)) = selection.line_range(line_idx, line.len()) {
+                let selected: String = line
+                    .chars()
+                    .skip(start_col)
+                    .take(end_col - start_col)
+                    .collect();
+                lines.push(selected);
+            }
         }
     }
 
     lines.join("\n")
 }
 
-/// Render the expanded view UI
 fn render_expanded_view(
     state: &ExpandedViewState,
     width: u16,
     height: u16,
     selection: Option<&Selection>,
     interrupt_prompt_active: bool,
+    shutting_down: bool,
+    follow_logs: bool,
+    supports_input: bool,
+    input_focused: bool,
 ) -> AnyElement<'static> {
     let viewport_height = calculate_viewport_height(height);
+    let content_width = (width as usize).saturating_sub(LINE_NUM_PREFIX_WIDTH);
 
-    // Clamp scroll offset to valid range
-    let max_offset = state.total_lines.saturating_sub(viewport_height);
-    let clamped_offset = state.scroll_offset.min(max_offset);
+    let (gutter_elements, content_elements, progress) = if let Some(vt) = &state.vt {
+        let vt = vt.lock().unwrap();
+        let mut gutter_elements = Vec::new();
+        let mut line_elements = Vec::new();
+        let lines: Vec<&avt::Line> = vt.lines().collect();
+        let lines = trim_trailing_blank_vt_lines(&lines);
+        let display_numbers = vt_display_line_numbers(lines);
+        let visible_lines = lines.iter().skip(state.scroll_offset).take(viewport_height);
 
-    // Get visible lines
-    let visible_lines: Vec<&String> = state
-        .logs
-        .iter()
-        .skip(clamped_offset)
-        .take(viewport_height)
-        .collect();
+        for (i, line) in visible_lines.enumerate() {
+            let log_line_idx = state.scroll_offset + i;
+            let line_num = display_numbers
+                .get(log_line_idx)
+                .copied()
+                .unwrap_or(log_line_idx + 1);
+            let line_gutter = format!("{:>5} ", line_num);
 
-    // Build line elements
-    let line_elements = build_line_elements(&visible_lines, clamped_offset, width, selection);
+            gutter_elements.push(
+                element! {
+                    View(height: 1, width: LINE_NUM_GUTTER_WIDTH as u32, flex_shrink: 0.0) {
+                        Text(
+                            content: line_gutter,
+                            color: Color::AnsiValue(250),
+                            wrap: TextWrap::NoWrap
+                        )
+                    }
+                }
+                .into_any(),
+            );
 
-    // Build empty line padding
-    let padding_elements = build_padding_elements(visible_lines.len(), viewport_height);
-
-    // Combine all content elements
-    let mut content_elements = line_elements;
-    content_elements.extend(padding_elements);
-
-    // Build progress indicator
-    let progress = build_progress_indicator(clamped_offset, viewport_height, state.total_lines);
-
-    // Build footer text - show copy hint when selection is active
-    let footer_text = if interrupt_prompt_active {
-        if width < 88 {
-            format!(
-                "{} \u{2502} Quit devenv?  c:keep running  q/^C:quit",
-                progress
-            )
-        } else {
-            format!(
-                "{} \u{2502} Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  ^C:quit",
-                progress
-            )
+            line_elements.push(build_vt_line_element(
+                line.cells(),
+                log_line_idx,
+                content_width,
+                selection,
+            ));
         }
-    } else if selection.is_some() {
-        format!(
-            "{} \u{2502} j/k:line  PgUp/PgDn:page  g/G:top/bottom  Ctrl+C:copy  Esc:deselect  q:back",
-            progress
+        let total = line_elements.len();
+        let padding = build_padding_elements(total, viewport_height);
+        gutter_elements.extend(build_gutter_padding_elements(total, viewport_height));
+        line_elements.extend(padding);
+        (
+            gutter_elements,
+            line_elements,
+            build_progress_indicator(state.scroll_offset, viewport_height, lines.len()),
         )
     } else {
-        format!(
-            "{} \u{2502} j/k:line  PgUp/PgDn:page  g/G:top/bottom  q:back",
-            progress
+        let max_offset = state.total_lines.saturating_sub(viewport_height);
+        let clamped_offset = state.scroll_offset.min(max_offset);
+
+        let visible_lines: Vec<&String> = state
+            .logs
+            .iter()
+            .skip(clamped_offset)
+            .take(viewport_height)
+            .collect();
+
+        let (mut gutter_elements, mut line_elements) =
+            build_line_elements(&visible_lines, clamped_offset, width, selection);
+
+        gutter_elements.extend(build_gutter_padding_elements(
+            visible_lines.len(),
+            viewport_height,
+        ));
+        let padding_elements = build_padding_elements(visible_lines.len(), viewport_height);
+        line_elements.extend(padding_elements);
+
+        (
+            gutter_elements,
+            line_elements,
+            build_progress_indicator(clamped_offset, viewport_height, state.total_lines),
         )
     };
+
+    let mode = if follow_logs { "follow" } else { "scrolled" };
+    let use_symbols = width < 60;
+    let use_short_text = width < 100;
+
+    let interrupt_footer_text = if interrupt_prompt_active {
+        Some(if width < 88 {
+            format!("{} │ Quit devenv?  c:keep running  q/^C:quit", progress)
+        } else {
+            format!(
+                "{} │ Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  ^C:quit",
+                progress
+            )
+        })
+    } else {
+        None
+    };
+
+    let mut footer_left = vec![
+        element!(Text(content: progress, color: Color::AnsiValue(245))).into_any(),
+        element!(Text(content: " ")).into_any(),
+        element!(Text(content: "|", color: COLOR_HIERARCHY)).into_any(),
+        element!(Text(content: " ")).into_any(),
+    ];
+
+    if !interrupt_prompt_active {
+        footer_left.push(
+            element!(Text(content: mode, color: COLOR_INTERACTIVE, weight: Weight::Bold))
+                .into_any(),
+        );
+
+        if input_focused {
+            footer_left.push(element!(Text(content: " ")).into_any());
+            footer_left.push(element!(Text(content: "|", color: COLOR_HIERARCHY)).into_any());
+            footer_left.push(element!(Text(content: " ")).into_any());
+            footer_left.push(
+                element!(Text(content: "input captured", color: Color::AnsiValue(214))).into_any(),
+            );
+        }
+    }
+
+    let mut footer_right = vec![];
+    if !interrupt_prompt_active {
+        footer_right.push(element!(Text(content: "↑", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(element!(Text(content: "↓", color: COLOR_INTERACTIVE)).into_any());
+        if !use_symbols {
+            footer_right.push(
+                element!(Text(content: if use_short_text { " scroll • " } else { " scroll logs • " }))
+                    .into_any(),
+            );
+        } else {
+            footer_right.push(element!(Text(content: " • ")).into_any());
+        }
+        footer_right.push(element!(Text(content: "PgUp", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        footer_right.push(element!(Text(content: "PgDn", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(
+            element!(Text(content: if use_short_text { " page • " } else { " page jump • " }))
+                .into_any(),
+        );
+        footer_right.push(element!(Text(content: "g", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        footer_right.push(element!(Text(content: "G", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(
+            element!(Text(content: if use_short_text { " ends" } else { " top-bottom" }))
+                .into_any(),
+        );
+
+        if supports_input && !shutting_down {
+            footer_right.push(element!(Text(content: " • ")).into_any());
+            footer_right.push(element!(Text(content: "^x", color: COLOR_INTERACTIVE)).into_any());
+            footer_right.push(
+                element!(Text(content: if use_short_text { " stop" } else { " stop process" }))
+                    .into_any(),
+            );
+
+            footer_right.push(element!(Text(content: " • ")).into_any());
+            footer_right.push(element!(Text(content: "^r", color: COLOR_INTERACTIVE)).into_any());
+            footer_right.push(
+                element!(Text(content: if use_short_text { " (re)start" } else { " (re)start process" }))
+                    .into_any(),
+            );
+
+            footer_right.push(element!(Text(content: " • ")).into_any());
+            footer_right.push(
+                element!(Text(content: input::INPUT_TOGGLE_HINT, color: COLOR_INTERACTIVE))
+                    .into_any(),
+            );
+            footer_right.push(
+                element!(Text(content: if input_focused { " return" } else { " input" }))
+                    .into_any(),
+            );
+        }
+
+        footer_right.push(element!(Text(content: " • ")).into_any());
+        footer_right.push(element!(Text(content: "q", color: COLOR_INTERACTIVE)).into_any());
+        footer_right.push(element!(Text(content: " back")).into_any());
+    }
 
     element! {
         View(
@@ -545,81 +926,178 @@ fn render_expanded_view(
             height: height as u32,
             width: width as u32
         ) {
-            // Header
             View(height: 1, padding_left: 1, padding_right: 1) {
                 Text(
-                    content: format!("\u{2500}\u{2500}\u{2500} {} \u{2500}\u{2500}\u{2500}", state.activity_name),
+                    content: format!("--- {} ---", state.activity_name),
                     color: Color::Cyan,
                     weight: Weight::Bold
                 )
             }
-            // Log content
-            View(flex_grow: 1.0, flex_direction: FlexDirection::Column) {
-                #(content_elements)
+            View(flex_grow: 1.0, flex_direction: FlexDirection::Row) {
+                View(width: LINE_NUM_GUTTER_WIDTH as u32, flex_shrink: 0.0, flex_direction: FlexDirection::Column) {
+                    #(gutter_elements)
+                }
+                View(
+                    width: content_width as u32,
+                    flex_shrink: 0.0,
+                    flex_direction: FlexDirection::Column,
+                    border_style: BorderStyle::Single,
+                    border_edges: Edges::Left,
+                    border_color: Color::AnsiValue(250),
+                    padding_left: 1,
+                    overflow: Overflow::Hidden,
+                ) {
+                    #(content_elements)
+                }
             }
-            // Footer
             View(height: 1, padding_left: 1, padding_right: 1) {
-                Text(
-                    content: footer_text,
-                    color: Color::AnsiValue(245)
-                )
+                #(if let Some(interrupt_footer_text) = interrupt_footer_text {
+                    vec![element!(Text(
+                        content: interrupt_footer_text,
+                        color: Color::AnsiValue(245)
+                    )).into_any()]
+                } else {
+                    vec![element! {
+                        View(
+                            flex_direction: FlexDirection::Row,
+                            justify_content: JustifyContent::SpaceBetween,
+                            width: 100pct
+                        ) {
+                            View(flex_direction: FlexDirection::Row, flex_grow: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                                #(footer_left)
+                            }
+                            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0, margin_left: if use_symbols { 1 } else { 2 }) {
+                                #(footer_right)
+                            }
+                        }
+                    }.into_any()]
+                })
             }
         }
     }
     .into_any()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn build_vt_line_element(
+    row: &[avt::Cell],
+    log_line_idx: usize,
+    content_width: usize,
+    selection: Option<&Selection>,
+) -> AnyElement<'static> {
+    let mut runs: Vec<(String, avt::Pen, bool)> = Vec::new();
 
-    #[test]
-    fn test_render_expanded_view_interrupt_prompt_footer() {
-        let state = ExpandedViewState {
-            activity_name: "api".to_string(),
-            scroll_offset: 0,
-            logs: Arc::new(VecDeque::new()),
-            total_lines: 0,
-        };
+    for (col_idx, cell) in row.iter().take(content_width).enumerate() {
+        let is_selected = selection.is_some_and(|s| s.contains(log_line_idx, col_idx));
 
-        let mut element = render_expanded_view(&state, 100, 8, None, true);
-        let output = element.render(Some(100)).to_string();
+        if let Some((text, pen, selected)) = runs.last_mut()
+            && *selected == is_selected
+            && *pen == *cell.pen()
+        {
+            text.push(cell.char());
+        } else {
+            runs.push((cell.char().to_string(), cell.pen().clone(), is_selected));
+        }
+    }
 
-        assert!(output.contains("Quit devenv? Nothing has been stopped yet"));
-        assert!(output.contains("c:keep running"));
-        assert!(output.contains("q:quit"));
+    let run_elements = runs
+        .into_iter()
+        .map(|(text, pen, selected)| build_vt_segment_element(text, &pen, selected))
+        .collect::<Vec<_>>();
+
+    element! {
+        View(height: 1, width: content_width as u32, overflow: Overflow::Hidden, flex_direction: FlexDirection::Row) {
+            #(run_elements)
+        }
+    }
+    .into_any()
+}
+
+fn build_vt_segment_element(text: String, pen: &avt::Pen, selected: bool) -> AnyElement<'static> {
+    let fg = if selected {
+        Some(Color::AnsiValue(232))
+    } else {
+        pen.foreground().map(avt_color_to_iocraft)
+    };
+
+    let bg = if selected {
+        Some(Color::AnsiValue(250))
+    } else {
+        pen.background().map(avt_color_to_iocraft)
+    };
+
+    let text = element! {
+        Text(
+            content: text,
+            color: fg,
+            weight: if pen.is_bold() { Weight::Bold } else { Weight::Normal },
+            italic: pen.is_italic(),
+            decoration: if pen.is_underline() { TextDecoration::Underline } else { TextDecoration::None },
+            wrap: TextWrap::NoWrap
+        )
+    }
+    .into_any();
+
+    if let Some(background_color) = bg {
+        element! {
+            View(background_color: background_color) {
+                #(vec![text])
+            }
+        }
+        .into_any()
+    } else {
+        text
     }
 }
 
-/// Build elements for visible log lines
+fn avt_color_to_iocraft(color: avt::Color) -> Color {
+    match color {
+        avt::Color::Indexed(c) => Color::AnsiValue(c),
+        avt::Color::RGB(rgb) => Color::Rgb {
+            r: rgb.r,
+            g: rgb.g,
+            b: rgb.b,
+        },
+    }
+}
+
 fn build_line_elements(
     visible_lines: &[&String],
     offset: usize,
     width: u16,
     selection: Option<&Selection>,
-) -> Vec<AnyElement<'static>> {
+) -> (Vec<AnyElement<'static>>, Vec<AnyElement<'static>>) {
+    let mut gutter_elements = Vec::with_capacity(visible_lines.len());
     let mut elements = Vec::with_capacity(visible_lines.len());
-    let line_num_width = 5;
-    let content_width = (width as usize).saturating_sub(line_num_width + 3); // "NNNNN │ "
+    let content_width = (width as usize).saturating_sub(LINE_NUM_PREFIX_WIDTH);
 
     for (i, line) in visible_lines.iter().enumerate() {
         let line_num = offset + i + 1;
         let log_line_idx = offset + i;
 
-        // Truncate long lines to fit terminal width
         let display_line = if line.len() > content_width {
-            format!("{}…", &line[..content_width.saturating_sub(1)])
+            format!("{}...", &line[..content_width.saturating_sub(3)])
         } else {
             (*line).clone()
         };
 
-        let line_prefix = format!("{:>5} \u{2502} ", line_num);
+        let line_gutter = format!("{:>5} ", line_num);
+        gutter_elements.push(
+            element! {
+                View(height: 1, width: LINE_NUM_GUTTER_WIDTH as u32, flex_shrink: 0.0) {
+                    Text(
+                        content: line_gutter,
+                        color: Color::AnsiValue(250),
+                        wrap: TextWrap::NoWrap
+                    )
+                }
+            }
+            .into_any(),
+        );
 
-        // Check if this line has a selection range
         let sel_range = selection.and_then(|s| s.line_range(log_line_idx, display_line.len()));
+        let line_color = Color::AnsiValue(250);
 
         if let Some((start_col, end_col)) = sel_range {
-            // Split display_line into before/selected/after segments
             let before: String = display_line.chars().take(start_col).collect();
             let selected: String = display_line
                 .chars()
@@ -630,24 +1108,23 @@ fn build_line_elements(
 
             elements.push(
                 element! {
-                    View(height: 1, flex_direction: FlexDirection::Row) {
-                        Text(
-                            content: line_prefix,
-                            color: Color::AnsiValue(250)
-                        )
+                    View(height: 1, width: content_width as u32, overflow: Overflow::Hidden, flex_direction: FlexDirection::Row) {
                         Text(
                             content: before,
-                            color: Color::AnsiValue(250)
+                            color: line_color,
+                            wrap: TextWrap::NoWrap
                         )
                         View(background_color: Color::AnsiValue(250)) {
                             Text(
                                 content: selected,
-                                color: Color::AnsiValue(232)
+                                color: Color::AnsiValue(232),
+                                wrap: TextWrap::NoWrap
                             )
                         }
                         Text(
                             content: after,
-                            color: Color::AnsiValue(250)
+                            color: line_color,
+                            wrap: TextWrap::NoWrap
                         )
                     }
                 }
@@ -656,10 +1133,11 @@ fn build_line_elements(
         } else {
             elements.push(
                 element! {
-                    View(height: 1) {
+                    View(height: 1, width: content_width as u32, overflow: Overflow::Hidden) {
                         Text(
-                            content: format!("{}{}", line_prefix, display_line),
-                            color: Color::AnsiValue(250)
+                            content: display_line,
+                            color: line_color,
+                            wrap: TextWrap::NoWrap
                         )
                     }
                 }
@@ -668,10 +1146,30 @@ fn build_line_elements(
         }
     }
 
+    (gutter_elements, elements)
+}
+
+fn build_gutter_padding_elements(
+    filled_lines: usize,
+    viewport_height: usize,
+) -> Vec<AnyElement<'static>> {
+    let padding_count = viewport_height.saturating_sub(filled_lines);
+    let mut elements = Vec::with_capacity(padding_count);
+
+    for _ in 0..padding_count {
+        elements.push(
+            element! {
+                View(height: 1, width: LINE_NUM_GUTTER_WIDTH as u32, flex_shrink: 0.0) {
+                    Text(content: "      ".to_string(), wrap: TextWrap::NoWrap)
+                }
+            }
+            .into_any(),
+        );
+    }
+
     elements
 }
 
-/// Build empty padding elements to fill the viewport
 fn build_padding_elements(filled_lines: usize, viewport_height: usize) -> Vec<AnyElement<'static>> {
     let padding_count = viewport_height.saturating_sub(filled_lines);
     let mut elements = Vec::with_capacity(padding_count);
@@ -690,7 +1188,6 @@ fn build_padding_elements(filled_lines: usize, viewport_height: usize) -> Vec<An
     elements
 }
 
-/// Build the progress indicator string
 fn build_progress_indicator(offset: usize, viewport_height: usize, total_lines: usize) -> String {
     if total_lines == 0 {
         "Empty".to_string()
@@ -698,5 +1195,30 @@ fn build_progress_indicator(offset: usize, viewport_height: usize, total_lines: 
         let start = offset + 1;
         let end = (offset + viewport_height).min(total_lines);
         format!("{}-{}/{}", start, end, total_lines)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_expanded_view_interrupt_prompt_footer() {
+        let state = ExpandedViewState {
+            activity_name: "api".to_string(),
+            scroll_offset: 0,
+            logs: Arc::new(VecDeque::new()),
+            total_lines: 0,
+            supports_input: false,
+            vt: None,
+        };
+
+        let mut element =
+            render_expanded_view(&state, 100, 8, None, true, false, false, false, false);
+        let output = element.render(Some(100)).to_string();
+
+        assert!(output.contains("Quit devenv? Nothing has been stopped yet"));
+        assert!(output.contains("c:keep running"));
+        assert!(output.contains("q:quit"));
     }
 }

--- a/devenv-tui/src/input.rs
+++ b/devenv-tui/src/input.rs
@@ -1,0 +1,59 @@
+use iocraft::prelude::{KeyCode, KeyEvent, KeyModifiers};
+
+pub const INPUT_TOGGLE_HINT: &str = "F12";
+
+pub fn is_input_toggle(key_event: &KeyEvent) -> bool {
+    matches!(key_event.code, KeyCode::F(12))
+}
+
+pub fn encode_key_event(key_event: &KeyEvent) -> Option<Vec<u8>> {
+    let alt = key_event.modifiers.contains(KeyModifiers::ALT);
+    let ctrl = key_event.modifiers.contains(KeyModifiers::CONTROL);
+
+    let mut bytes = match key_event.code {
+        KeyCode::Char(c) => {
+            if ctrl {
+                vec![ctrl_char(c)?]
+            } else {
+                c.to_string().into_bytes()
+            }
+        }
+        KeyCode::Enter => vec![b'\r'],
+        KeyCode::Tab => vec![b'\t'],
+        KeyCode::BackTab => b"\x1b[Z".to_vec(),
+        KeyCode::Backspace => vec![0x7f],
+        KeyCode::Esc => vec![0x1b],
+        KeyCode::Left => b"\x1b[D".to_vec(),
+        KeyCode::Right => b"\x1b[C".to_vec(),
+        KeyCode::Up => b"\x1b[A".to_vec(),
+        KeyCode::Down => b"\x1b[B".to_vec(),
+        KeyCode::Home => b"\x1b[H".to_vec(),
+        KeyCode::End => b"\x1b[F".to_vec(),
+        KeyCode::PageUp => b"\x1b[5~".to_vec(),
+        KeyCode::PageDown => b"\x1b[6~".to_vec(),
+        KeyCode::Insert => b"\x1b[2~".to_vec(),
+        KeyCode::Delete => b"\x1b[3~".to_vec(),
+        _ => return None,
+    };
+
+    if alt && !matches!(key_event.code, KeyCode::Esc) {
+        bytes.insert(0, 0x1b);
+    }
+
+    Some(bytes)
+}
+
+fn ctrl_char(c: char) -> Option<u8> {
+    match c {
+        'a'..='z' => Some((c as u8) - b'a' + 1),
+        'A'..='Z' => Some((c as u8) - b'A' + 1),
+        ' ' | '@' => Some(0x00),
+        '[' => Some(0x1b),
+        '\\' => Some(0x1c),
+        ']' => Some(0x1d),
+        '^' => Some(0x1e),
+        '_' => Some(0x1f),
+        '?' => Some(0x7f),
+        _ => None,
+    }
+}

--- a/devenv-tui/src/lib.rs
+++ b/devenv-tui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod tracing_interface;
 pub mod app;
 pub mod components;
 pub mod expanded_view;
+pub mod input;
 pub mod model;
 pub mod view;
 

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -8,6 +8,20 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+const EXPANDED_LOG_GUTTER_WIDTH: u16 = 8;
+
+fn current_vt_size() -> (usize, usize) {
+    let (width, height) = crossterm::terminal::size().unwrap_or((80, 24));
+    vt_size_for_terminal(width, height)
+}
+
+fn vt_size_for_terminal(width: u16, height: u16) -> (usize, usize) {
+    (
+        width.saturating_sub(EXPANDED_LOG_GUTTER_WIDTH).max(1) as usize,
+        height.max(1) as usize,
+    )
+}
+
 /// Configuration for limiting displayed child activities
 #[derive(Debug, Clone)]
 pub struct ChildActivityLimit {
@@ -45,6 +59,7 @@ pub struct ActivityModel {
     expected_downloads: Option<u64>,
     /// Additional parents for activities (for displaying under multiple parents in TUI)
     additional_parents: HashMap<u64, Vec<u64>>,
+    last_vt_size: Option<(usize, usize)>,
 }
 
 impl Default for ActivityModel {
@@ -162,6 +177,8 @@ pub struct Activity {
     pub details: Vec<ActivityDetail>,
     /// Activity level for filtering (defaults to Info)
     pub level: ActivityLevel,
+    /// Virtual terminal state for processes and tasks
+    pub vt: Option<Arc<std::sync::Mutex<avt::Vt>>>,
 }
 
 /// UI state - lives outside the RwLock, managed by the UI thread.
@@ -169,11 +186,13 @@ pub struct Activity {
 pub struct UiState {
     pub viewport: ViewportConfig,
     pub selected_activity: Option<u64>,
+    pub focused_activity: Option<u64>,
     pub scroll: ScrollState,
     pub view_options: ViewOptions,
     pub terminal_size: TerminalSize,
     pub interrupt_prompt_active: bool,
     pub view_mode: ViewMode,
+    pub fullscreen: bool,
 }
 
 impl UiState {
@@ -188,6 +207,7 @@ impl UiState {
                 activities_visible: 5,
             },
             selected_activity: None,
+            focused_activity: None,
             scroll: ScrollState {
                 log_offset: 0,
                 activity_position: 0,
@@ -198,6 +218,7 @@ impl UiState {
             terminal_size: TerminalSize { width, height },
             interrupt_prompt_active: false,
             view_mode: ViewMode::Main,
+            fullscreen: false,
         }
     }
 
@@ -342,6 +363,33 @@ impl ActivityModel {
             expected_builds: None,
             expected_downloads: None,
             additional_parents: HashMap::new(),
+            last_vt_size: None,
+        }
+    }
+
+    pub fn resize_vts(&mut self, width: u16, height: u16) {
+        let (cols, rows) = vt_size_for_terminal(width, height);
+        if self.last_vt_size == Some((cols, rows)) {
+            return;
+        }
+        for activity in self.activities.values_mut() {
+            if let Some(vt) = &activity.vt {
+                vt.lock().unwrap().resize(cols, rows);
+            }
+        }
+        self.last_vt_size = Some((cols, rows));
+    }
+
+    pub fn resize_vt(&mut self, activity_id: u64, width: u16, height: u16) {
+        let (cols, rows) = vt_size_for_terminal(width, height);
+        if self.last_vt_size == Some((cols, rows)) {
+            return;
+        }
+        if let Some(activity) = self.activities.get_mut(&activity_id)
+            && let Some(vt) = &activity.vt
+        {
+            vt.lock().unwrap().resize(cols, rows);
+            self.last_vt_size = Some((cols, rows));
         }
     }
 
@@ -657,9 +705,27 @@ impl ActivityModel {
                 self.handle_activity_complete(id, outcome);
             }
             Process::Log {
-                id, line, is_error, ..
+                id,
+                line,
+                is_error: _,
+                ..
             } => {
-                self.handle_activity_log(id, line, is_error);
+                if is_process_status_log(&line)
+                    && let Some(activity) = self.activities.get_mut(&id)
+                    && let Some(vt) = &activity.vt
+                {
+                    let mut vt = vt.lock().unwrap();
+                    vt.feed_str(&process_status_vt_block(&line));
+                }
+                self.log_to_activity(id, line.clone());
+            }
+            Process::RawLog { id, data, .. } => {
+                if let Some(activity) = self.activities.get_mut(&id)
+                    && let Some(vt) = &activity.vt
+                {
+                    let mut vt = vt.lock().unwrap();
+                    vt.feed_str(&String::from_utf8_lossy(&data));
+                }
             }
             Process::Status { id, status, .. } => {
                 if let Some(activity) = self.activities.get_mut(&id) {
@@ -789,6 +855,20 @@ impl ActivityModel {
 
         let is_root = parent.is_none() || variant.is_always_top_level();
 
+        let vt = if matches!(
+            variant,
+            ActivityVariant::Process(_)
+                | ActivityVariant::Task(_)
+                | ActivityVariant::Build(_)
+                | ActivityVariant::Evaluating(_)
+                | ActivityVariant::Devenv
+        ) {
+            let (cols, rows) = current_vt_size();
+            Some(Arc::new(std::sync::Mutex::new(avt::Vt::new(cols, rows))))
+        } else {
+            None
+        };
+
         let activity = Activity {
             id,
             name: name.clone(),
@@ -802,6 +882,7 @@ impl ActivityModel {
             progress: None,
             details: Vec::new(),
             level: effective_level,
+            vt,
         };
 
         if is_root {
@@ -946,6 +1027,14 @@ impl ActivityModel {
     }
 
     fn handle_activity_log(&mut self, id: u64, line: String, is_error: bool) {
+        if let Some(activity) = self.activities.get_mut(&id) {
+            if let Some(vt) = &activity.vt {
+                let mut vt = vt.lock().unwrap();
+                vt.feed_str(&line);
+                vt.feed_str("\n");
+            }
+        }
+
         let logs = self
             .build_logs
             .entry(id)
@@ -1435,6 +1524,16 @@ impl ActivityModel {
             })
             .count()
     }
+}
+
+const PROCESS_STATUS_LOG_PREFIX: &str = "[devenv] ";
+
+fn is_process_status_log(line: &str) -> bool {
+    line.starts_with(PROCESS_STATUS_LOG_PREFIX)
+}
+
+fn process_status_vt_block(line: &str) -> String {
+    format!("\n\x1b[38;5;245m{line}\x1b[0m\n\n")
 }
 
 /// State of a Nix activity

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -145,6 +145,8 @@ pub fn view(
             can_go_up,
             can_go_down,
             interrupt_prompt_active: ui_state.interrupt_prompt_active(),
+            shutting_down,
+            scrollable: scroll_handle.is_some(),
         })) {
             SummaryView
         }
@@ -164,11 +166,18 @@ pub fn view(
     // Activity list: wrap in ScrollView for Normal render with scroll_handle,
     // use plain layout for Final render
     if let Some(handle) = scroll_handle {
-        let scroll_height = terminal_size.height.saturating_sub(SUMMARY_BAR_HEIGHT) as u32;
+        let scroll_height = terminal_size.height.saturating_sub(SUMMARY_BAR_HEIGHT + 1) as u32;
+        let view_width = terminal_size.width as u32;
         children.push(
             element! {
-                View(height: scroll_height) {
-                    ScrollView(auto_scroll: true, keyboard_scroll: false, handle: handle) {
+                View(height: scroll_height, width: view_width, overflow: Overflow::Hidden) {
+                        ScrollView(
+                            auto_scroll: false,
+                            keyboard_scroll: false,
+                            handle: handle,
+                            scrollbar_thumb_color: Some(COLOR_INTERACTIVE),
+                            scrollbar_track_color: Some(Color::AnsiValue(238))
+                        ) {
                         #(activity_list)
                     }
                 }
@@ -204,14 +213,21 @@ pub fn view(
         );
     }
 
+    let (root_height, padding_top) = if ui_state.fullscreen {
+        (Size::Length(terminal_size.height as u32), 1)
+    } else {
+        (Size::Auto, 0)
+    };
+
     element! {
         ContextProvider(value: Context::owned(terminal_size)) {
             View(
                 flex_direction: FlexDirection::Column,
-                max_height: terminal_size.height as u32,
-                width: 100pct,
+                height: root_height,
+                width: terminal_size.width as u32,
                 overflow: Overflow::Hidden,
-                justify_content: JustifyContent::FlexEnd,
+                justify_content: JustifyContent::FlexStart,
+                padding_top: padding_top,
             ) {
                 #(children)
             }
@@ -330,8 +346,9 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 .render(terminal_width, *depth, prefix);
 
                 return ExpandedContentComponent::new(logs.as_deref())
+                    .with_vt(activity.vt.as_ref())
                     .with_empty_message("  → no build logs yet (press '^e' to expand)")
-                    .render_with_main_line(main_line);
+                    .render_with_main_line(main_line, terminal_width);
             }
 
             // Non-selected build activities use normal rendering
@@ -400,20 +417,21 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
             // Show logs inline for tasks with show_output=true or failed tasks
             let task_failed = *completed == Some(false);
-            if (task_data.show_output || task_failed) && logs.is_some() {
+            if (task_data.show_output || task_failed) && (logs.is_some() || activity.vt.is_some()) {
                 let empty_message = if completed.is_some() {
                     "  → no output"
                 } else {
                     "  → waiting for output..."
                 };
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
+                    .with_vt(activity.vt.as_ref())
                     .with_empty_message(empty_message);
                 if task_failed {
                     component = component.with_max_lines(LOG_VIEWPORT_FAILED);
                 } else if task_data.show_output && !is_selected {
                     component = component.with_max_lines(LOG_VIEWPORT_SHOW_OUTPUT);
                 }
-                return component.render_with_main_line(main_line);
+                return component.render_with_main_line(main_line, terminal_width);
             }
 
             return main_line;
@@ -532,7 +550,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             };
 
             // For selected evaluation activities, show expandable file list
-            if *is_selected && logs.is_some() {
+            if *is_selected && (logs.is_some() || activity.vt.is_some()) {
                 let prefix = build_activity_prefix(*depth, *completed, true);
 
                 let main_line = ActivityTextComponent::name_only(
@@ -546,8 +564,9 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 .render(terminal_width, *depth, prefix);
 
                 return ExpandedContentComponent::new(logs.as_deref())
+                    .with_vt(activity.vt.as_ref())
                     .with_empty_message("  → no files evaluated yet (press '^e' to expand)")
-                    .render_with_main_line(main_line);
+                    .render_with_main_line(main_line, terminal_width);
             }
 
             let prefix = build_activity_prefix(*depth, *completed, true);
@@ -616,13 +635,14 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
             // Show logs when selected or when failed
             let failed = *completed == Some(false);
-            if (failed || *is_selected) && logs.is_some() {
+            if (failed || *is_selected) && (logs.is_some() || activity.vt.is_some()) {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
+                    .with_vt(activity.vt.as_ref())
                     .with_empty_message("  → no output yet");
                 if failed {
                     component = component.with_max_lines(LOG_VIEWPORT_FAILED);
                 }
-                return component.render_with_main_line(main_line);
+                return component.render_with_main_line(main_line, terminal_width);
             }
 
             return main_line;
@@ -645,7 +665,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 }
                 ProcessStatus::Ready => "ready".into(),
                 ProcessStatus::Restarting => "restarting".into(),
-                ProcessStatus::Stopping => "stopping".into(),
+                ProcessStatus::Stopping => "stopping...".into(),
                 ProcessStatus::Stopped if *completed == Some(false) => "failed".into(),
                 ProcessStatus::Stopped => "stopped".into(),
             };
@@ -699,8 +719,9 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // Show logs: always show LOG_VIEWPORT_SHOW_OUTPUT lines,
             // expand when selected, show more when failed
             let process_failed = *completed == Some(false);
-            if logs.is_some() {
+            if logs.is_some() || activity.vt.is_some() {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
+                    .with_vt(activity.vt.as_ref())
                     .with_depth(*depth)
                     .with_empty_message("→ no output yet (press 'e' to expand)");
                 if process_failed && *render_context == RenderContext::Final {
@@ -710,13 +731,13 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 }
 
                 let mut elements = vec![main_line];
-                let log_elements = component.render();
+                let log_elements = component.render(terminal_width);
                 elements.extend(log_elements);
 
                 let log_viewport_height = component.calculate_height();
                 let total_height = (1 + log_viewport_height).min(50) as u32;
                 return element! {
-                    View(height: total_height, flex_direction: FlexDirection::Column) {
+                    View(height: total_height, width: 100pct, flex_direction: FlexDirection::Column) {
                         #(elements)
                     }
                 }
@@ -769,9 +790,20 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         .collect();
 
                     for line in visible_lines {
+                        let prefix_len = prefix_str.chars().count() + 1;
+                        let max_text_width =
+                            (terminal_width as usize).saturating_sub(prefix_len + 4);
+                        let display_text = if line.chars().count() > max_text_width {
+                            let mut s: String = line.chars().take(max_text_width - 1).collect();
+                            s.push('…');
+                            s
+                        } else {
+                            line.clone()
+                        };
+
                         all_lines.push(
                             element! {
-                                View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
+                                View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1) {
                                     View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                                         Text(content: prefix_str.clone())
                                         View(margin_right: 1) {
@@ -779,7 +811,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                         }
                                     }
                                     View(flex_grow: 1.0, min_width: 0, overflow: Overflow::Hidden) {
-                                        Text(content: line.clone(), color: COLOR_HIERARCHY)
+                                        Text(content: display_text, color: COLOR_HIERARCHY, wrap: TextWrap::NoWrap)
                                     }
                                 }
                             }
@@ -791,8 +823,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 // Last line: icon + error summary (with inverse highlight if selected)
                 if let Some(bg) = bg_color {
                     all_lines.push(
-                        element! {
-                            View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
+                            element! {
+                                View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
                                 View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                                     Text(content: prefix_str.clone())
                                     View(margin_right: 1) {
@@ -808,8 +840,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     );
                 } else {
                     all_lines.push(
-                        element! {
-                            View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
+                            element! {
+                                View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1) {
                                 View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                                     Text(content: prefix_str.clone())
                                     View(margin_right: 1) {
@@ -827,7 +859,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
                 let total_height = all_lines.len() as u32;
                 return element! {
-                    View(height: total_height, flex_direction: FlexDirection::Column) {
+                    View(height: total_height, width: 100pct, flex_direction: FlexDirection::Column) {
                         #(all_lines)
                     }
                 }
@@ -837,7 +869,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // Simple single-line message (no details)
             if let Some(bg) = bg_color {
                 return element! {
-                    View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
+                    View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1, background_color: bg) {
                         View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                             Text(content: prefix_str)
                             View(margin_right: 1) {
@@ -852,7 +884,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 .into_any();
             } else {
                 return element! {
-                    View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
+                    View(height: 1, width: 100pct, flex_direction: FlexDirection::Row, padding_right: 1) {
                         View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
                             Text(content: prefix_str)
                             View(margin_right: 1) {
@@ -892,6 +924,8 @@ struct SummaryViewContext {
     can_go_up: bool,
     can_go_down: bool,
     interrupt_prompt_active: bool,
+    shutting_down: bool,
+    scrollable: bool,
 }
 
 /// Summary view component that adapts to terminal width
@@ -906,6 +940,8 @@ fn SummaryView(hooks: Hooks) -> impl Into<AnyElement<'static>> {
         can_go_up,
         can_go_down,
         interrupt_prompt_active,
+        shutting_down,
+        scrollable,
     } = &*ctx;
 
     build_summary_view_impl(
@@ -915,6 +951,8 @@ fn SummaryView(hooks: Hooks) -> impl Into<AnyElement<'static>> {
         *can_go_up,
         *can_go_down,
         *interrupt_prompt_active,
+        *shutting_down,
+        *scrollable,
         terminal_width,
     )
 }
@@ -927,6 +965,8 @@ fn build_summary_view_impl(
     can_go_up: bool,
     can_go_down: bool,
     interrupt_prompt_active: bool,
+    shutting_down: bool,
+    scrollable: bool,
     terminal_width: u16,
 ) -> AnyElement<'static> {
     if interrupt_prompt_active {
@@ -963,10 +1003,6 @@ fn build_summary_view_impl(
     let has_selection = selected.is_some();
     let is_process =
         matches!(selected, Some(a) if matches!(a.variant, ActivityVariant::Process(_)));
-    let is_stoppable = matches!(
-        selected,
-        Some(a) if matches!(&a.variant, ActivityVariant::Process(p) if p.status.is_stoppable())
-    );
 
     // Determine display mode based on terminal width
     let use_symbols = terminal_width < 60; // Use unicode symbols for very narrow terminals
@@ -1092,8 +1128,10 @@ fn build_summary_view_impl(
         has_content = true;
     }
 
-    // Tasks - show if there are any tasks
-    if summary.running_tasks > 0 || summary.completed_tasks > 0 || summary.failed_tasks > 0 {
+    // Tasks - keep the counter visible while work is still in progress or if any task failed.
+    // Once all tasks succeed, the task rows themselves already show the final status, so the
+    // aggregate line becomes redundant and visually duplicates that information.
+    if summary.running_tasks > 0 || summary.failed_tasks > 0 {
         if has_content {
             children.push(element!(View(margin_left: if use_symbols { 1 } else { 2 }, margin_right: if use_symbols { 1 } else { 2 }, flex_shrink: 0.0) {
                 Text(content: "│", color: COLOR_HIERARCHY)
@@ -1184,15 +1222,12 @@ fn build_summary_view_impl(
         } else {
             help_children.push(element!(Text(content: " expand logs • ")).into_any());
         }
-        if is_process {
-            if is_stoppable {
-                help_children
-                    .push(element!(Text(content: "^x", color: COLOR_INTERACTIVE)).into_any());
-                if use_short_text {
-                    help_children.push(element!(Text(content: " stop • ")).into_any());
-                } else {
-                    help_children.push(element!(Text(content: " stop process • ")).into_any());
-                }
+        if is_process && !shutting_down {
+            help_children.push(element!(Text(content: "^x", color: COLOR_INTERACTIVE)).into_any());
+            if use_short_text {
+                help_children.push(element!(Text(content: " stop • ")).into_any());
+            } else {
+                help_children.push(element!(Text(content: " stop process • ")).into_any());
             }
             help_children.push(element!(Text(content: "^r", color: COLOR_INTERACTIVE)).into_any());
             if use_short_text {
@@ -1224,6 +1259,22 @@ fn build_summary_view_impl(
             } else {
                 help_children.push(element!(Text(content: " navigate")).into_any());
             }
+        }
+    }
+
+    if scrollable {
+        if !help_children.is_empty() {
+            help_children.push(element!(Text(content: " • ")).into_any());
+        }
+        help_children
+            .push(element!(Text(content: "PgUp/PgDn", color: COLOR_INTERACTIVE)).into_any());
+        if use_short_text {
+            help_children.push(element!(Text(content: " scroll")).into_any());
+        } else {
+            help_children.push(element!(Text(content: " scroll • ")).into_any());
+            help_children
+                .push(element!(Text(content: "Home/End", color: COLOR_INTERACTIVE)).into_any());
+            help_children.push(element!(Text(content: " jump")).into_any());
         }
     }
 
@@ -1259,6 +1310,8 @@ mod tests {
             false,
             false,
             true,
+            false,
+            false,
             100,
         );
         let output = element.render(Some(100)).to_string();
@@ -1267,5 +1320,38 @@ mod tests {
         assert!(output.contains("stopped"));
         assert!(output.contains("keep running"));
         assert!(output.contains("quit"));
+    }
+
+    #[test]
+    fn test_summary_hides_task_counter_after_successful_completion() {
+        let summary = ActivitySummary {
+            completed_tasks: 3,
+            ..ActivitySummary::default()
+        };
+
+        let mut element = build_summary_view_impl(
+            &summary, None, false, false, false, false, false, false, 100,
+        );
+        let output = element.render(Some(100)).to_string();
+
+        assert!(!output.contains("tasks"));
+        assert!(!output.contains("3 of 3"));
+    }
+
+    #[test]
+    fn test_summary_keeps_task_counter_while_tasks_are_running() {
+        let summary = ActivitySummary {
+            running_tasks: 1,
+            completed_tasks: 2,
+            ..ActivitySummary::default()
+        };
+
+        let mut element = build_summary_view_impl(
+            &summary, None, false, false, false, false, false, false, 100,
+        );
+        let output = element.render(Some(100)).to_string();
+
+        assert!(output.contains("2"));
+        assert!(output.contains("of 3") || output.contains("/3"));
     }
 }

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -1235,7 +1235,7 @@ impl Devenv {
                 detach: true,
                 ..Default::default()
             };
-            self.start_processes(vec![], envs, options).await?;
+            self.start_processes(vec![], envs, options, None).await?;
         }
 
         // ── Phase 5: Running tests ──────────────────────────────────
@@ -1403,7 +1403,7 @@ impl Devenv {
         let (_status, exports, _messages) = self
             .run_tasks_with_roots(
                 vec!["devenv:enterShell".to_string()],
-                task_configs,
+                task_configs.clone(),
                 envs.clone(),
                 verbosity,
                 tui,
@@ -1412,7 +1412,8 @@ impl Devenv {
         envs.extend(exports);
 
         // ── Phase 3: Running processes ──────────────────────────────
-        self.start_processes(processes, envs, options).await
+        self.start_processes(processes, envs, options, Some(task_configs))
+            .await
     }
 
     /// Start processes after shell environment and tasks are already configured.
@@ -1421,6 +1422,7 @@ impl Devenv {
         processes: Vec<String>,
         envs: HashMap<String, String>,
         mut options: ProcessOptions,
+        task_configs: Option<Vec<tasks::TaskConfig>>,
     ) -> Result<RunMode> {
         // Release port reservations so processes can bind their allocated ports.
         // The port allocator holds TcpListeners during Nix evaluation to prevent
@@ -1445,7 +1447,10 @@ impl Devenv {
         if impl_result == "native" {
             info!("Using native process manager with task-based dependency ordering");
 
-            let task_configs = self.load_tasks().await?;
+            let task_configs = match task_configs {
+                Some(task_configs) => task_configs,
+                None => self.load_tasks().await?,
+            };
             let roots: Vec<String> = if processes.is_empty() {
                 task_configs
                     .iter()

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -283,7 +283,13 @@ fn run(launch: LaunchConfig) -> Result<()> {
     );
 
     let tui = launch.tui;
-    let use_pty = launch.use_pty;
+    let tui_fullscreen = matches!(
+        &launch.command,
+        Commands::Up { .. }
+            | Commands::Processes {
+                command: ProcessesCommand::Up { .. },
+            }
+    );
     let needs_terminal_handoff = launch.needs_terminal_handoff;
     let verbosity = launch.verbosity;
 
@@ -359,6 +365,7 @@ fn run(launch: LaunchConfig) -> Result<()> {
 
         rt.block_on(async {
             devenv_tui::TuiApp::new(activity_rx, shutdown.clone())
+                .fullscreen(tui_fullscreen)
                 .with_command_sender(command_tx)
                 .filter_level(filter_level)
                 // When a command needs terminal handoff, don't shut down on backend_done —

--- a/src/modules/process-managers/native.nix
+++ b/src/modules/process-managers/native.nix
@@ -175,6 +175,7 @@ in
           listen = pc.listen or [ ];
           watchdog = pc.watchdog or null;
           ready = process.ready;
+          use_pty = process.use_pty;
           inherit (process) watch;
         }
       )
@@ -190,6 +191,7 @@ in
           removeAttrs process [ "process-compose" "ports" "notify" "ready" "restart" "enable" "after" "before" ] // {
             inherit name;
             inherit (native) watchdog;
+            inherit (native) use_pty;
             ready = native.ready;
             restart = process.restart;
             listen = map

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -55,6 +55,14 @@ let
         description = "Auto-start configuration for this process.";
       };
 
+      use_pty = lib.mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to run this long-running process in a pseudo-terminal when using the native process manager.
+        '';
+      };
+
       exec = lib.mkOption {
         type = types.str;
         description = "Bash code to run the process.";


### PR DESCRIPTION
This PR changes the native process manager to use PTY's instead of log streaming which allows more complex UIs (qr codes, colors, etc) to be rendered properly. It properly shuts processes down instead of them surviving. Adds support for providing input into a process, such as interacting with Expo. Fixes flickering issues.

needs https://github.com/cachix/iocraft/pull/1

**Disclaimer:** this PR was entirely done by AI but I've been using it locally without issue

<details>
<summary>More in depth summary by AI:</summary>

## Summary

- Move process rendering in the TUI closer to real terminal behavior instead of treating everything as plain appended logs
- Add direct keyboard interaction with selected processes from inside the TUI
- Improve how process output is shown in both collapsed previews and expanded views
- Make stop/restart flows more explicit and reusable for manually managed processes
- Tighten PTY lifecycle handling so interactive processes behave more reliably during resize, restart, and shutdown

## Key changes

### TUI process rendering

- Process activities now maintain terminal state so output that relies on ANSI control sequences, cursor movement, and screen updates is rendered more faithfully
- Richer output handling is used across process views instead of only relying on line-buffered logs, which makes active services feel less like static log streams
- Process status banners and lifecycle updates are integrated into the rendered output more cleanly so state transitions are easier to follow

### Interactive process input

- A selected process can now be focused for input from the TUI with `F12`
- Once focused, key presses are forwarded to the underlying PTY instead of being handled only as TUI navigation
- Input forwarding includes normal character input plus control, alt, navigation, and editing keys so terminal-driven tools can be interacted with more naturally
- The same focus/input model is carried into the expanded process view so interaction is consistent between overview and detail modes

### Expanded and collapsed process views

- The expanded process view now works against terminal-backed process state instead of only a plain-text log representation
- Expanded view behavior is improved for live output by keeping a follow mode and adapting better when content is still actively changing
- Expanded view selection/copy behavior is updated to work with the richer rendered content model
- Collapsed previews now better represent ANSI-heavy process output, including styled content, while still stripping destructive control behavior that would break the layout
- Preview rendering is width-aware, making the condensed process view more readable and less noisy

### Process lifecycle and controls

- Process lifecycle handling is expanded with a reusable `Stopped` state instead of treating manually stopped processes the same as never-started ones
- Stopping a process now moves through an explicit `Stopping` state before settling into `Stopped`, which makes the UI reflect that transition more clearly
- Restart flows now account for processes that are active, never started, or manually stopped, so TUI controls behave more predictably across states
- Manual stop/restart actions also preserve and reuse process activity state more cleanly instead of forcing everything through a fresh registration path

### PTY and process supervision changes

- PTY-backed process execution is used more directly, which gives the TUI better control over process I/O and terminal behavior
- PTY instances are resized when the terminal changes size so interactive programs can adapt properly to the current viewport
- Raw process output is captured separately so terminal state can be updated without losing the existing log stream behavior used elsewhere in the UI
- Stop/restart handling is tightened so PTY-backed processes are torn down and recreated more deliberately during file-change restarts and manual control actions
- Shutdown behavior is improved so child processes are cleaned up more consistently rather than being left behind by partial teardown behavior

### UI polish and behavior

- Main-view scrolling behavior is more deliberate, including page/home/end navigation support around the activity list
- Input focus and selected activity state are tracked separately, which helps distinguish between navigating the TUI and interacting with a live process
- Exit/final-render behavior is cleaned up so the TUI leaves the terminal in a better state and presents a cleaner final snapshot when appropriate
- tmux gets a lower frame-rate cap to reduce unnecessary redraw pressure in environments where higher refresh rates are less useful

</details>