### PR TITLE
fix: distinguish AddrInUse from transient IPv6 bind failures in port checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed processes failing to start when exported bash functions are present in the environment ([#2587](https://github.com/cachix/devenv/issues/2587)).
 - Fixed eval cache storing inconsistent port allocations across different cached attributes ([#2631](https://github.com/cachix/devenv/issues/2631)).
 - Fixed stale eval cache invalidation for `devenv up` process config changes caused by overlapping evaluations clearing each other's file dependency observers ([#2632](https://github.com/cachix/devenv/pull/2632)).
+- Fixed false-positive `--strict-ports` failures on macOS when IPv6 loopback binding returns a benign error after a clean shutdown and cache invalidation ([#2640](https://github.com/cachix/devenv/pull/2640)).
 - Fixed child processes being left running on shutdown when using non-native process managers like process-compose ([#2586](https://github.com/cachix/devenv/issues/2586)).
 - Fixed `devenv update` resolving stale revisions when Nix's fetcher cache contains outdated entries by setting `tarball-ttl` to 0 during update, equivalent to `nix --refresh` ([#2616](https://github.com/cachix/devenv/issues/2616)).
 - Fixed Nix backend initialization crash when `impure: true` by removing use of nonexistent `impure` Nix setting; impure mode now works by skipping `pure-eval` (which defaults to false).

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -449,19 +449,6 @@ in
         '';
       }];
 
-      changelogs = [
-        {
-          date = "2026-03-19";
-          title = "Strict port checks no longer fail on benign IPv6 loopback errors";
-          when = lib.any (process: process.ports != { }) (lib.attrValues config.processes);
-          description = ''
-            Port allocation with `--strict-ports` now ignores benign IPv6 loopback bind failures while still rejecting real port conflicts.
-
-            This fixes false-positive "Port X is already in use" errors that could happen on macOS after a clean shutdown when the evaluation cache was invalidated.
-          '';
-        }
-      ];
-
       process.managers.${implementation}.enable = lib.mkDefault true;
     }
 


### PR DESCRIPTION
## Summary

Fixes false-positive "Port X is already in use" errors when `--strict-ports` is enabled and the nix evaluation cache is invalidated.

- `bind_no_reuse` now returns the actual `io::Error` instead of discarding it as `()`
- `reserve_port` only treats `AddrInUse` errors from the IPv6 bind as genuine port conflicts
- Non-conflict IPv6 failures (transient OS state on macOS, permission errors) fall through to IPv4-only mode instead of failing the entire port check

## Problem

On macOS, after a clean `devenv up` shutdown (all processes confirmed dead, `lsof` shows no listeners), restarting immediately can fail with "Port 6380 is already in use" but only when:
1. The nix eval cache is invalidated (e.g. a file changed)
2. `--strict-ports` is enabled

The port is not actually in use. `lsof` confirms nothing is listening and `get_process_using_port` finds no PID. The issue is that `bind_no_reuse` on `[::1]:port` can fail for non-`AddrInUse` reasons on macOS, and the previous code assumed any IPv6 bind failure meant the port was occupied.

## Test plan

- Added `test_bind_no_reuse_returns_addr_in_use_error` to verify error kind propagation
- Added `test_reserve_port_succeeds_when_ipv4_free` to verify strict mode works on free ports
- Added `test_strict_mode_fails_only_on_genuine_conflict` to verify real conflicts are still detected
- All existing port allocator tests should continue to pass