### PR TITLE
feat: add --with-direnv to devenv init as opt-in; restore init/.envrc

### DIFF
--- a/devenv/init/.envrc
+++ b/devenv/init/.envrc
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+# `use devenv` supports the same options as the `devenv shell` command.
+#
+# To silence all output, use `--quiet`.
+#
+# Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
+use devenv

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -459,7 +459,21 @@ impl Cli {
 #[derive(Subcommand, Clone)]
 pub enum Commands {
     #[command(about = "Scaffold devenv.yaml, devenv.nix, and .gitignore.")]
-    Init { target: Option<PathBuf> },
+    Init {
+        #[arg(
+            long,
+            num_args=0..=1,
+            value_name = "ENABLE",
+            default_value = "false",
+            default_missing_value = "true",
+            env = "DEVENV_DIRENV_INIT",
+            help = "For use with direnv, additionally scaffold .envrc.",
+            long_help = "For use with direnv, additionally scaffold .envrc.\n\nhttps://devenv.sh/integrations/direnv/",
+
+        )]
+        with_direnv: Option<bool>,
+        target: Option<PathBuf>,
+    },
 
     #[command(about = "Generate devenv.yaml and devenv.nix using AI")]
     Generate,

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -49,6 +49,7 @@ const REQUIRED_FILES: [(&str, &str); 3] = [
     ("devenv.yaml", "devenv.yaml"),
     ("gitignore", ".gitignore"), // source name -> target name
 ];
+const OPTIONAL_DIRENV_REQUIRED_FILES: [(&str, &str); 1] = [(".envrc", ".envrc")];
 const EXISTING_REQUIRED_FILES: [&str; 1] = [".gitignore"];
 const PROJECT_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/init");
 pub static DIRENVRC: Lazy<String> = Lazy::new(|| {
@@ -559,7 +560,7 @@ impl Devenv {
         ))
     }
 
-    pub fn init(&self, target: &Option<PathBuf>) -> Result<()> {
+    pub fn init(&self, target: &Option<PathBuf>, with_direnv: &Option<bool>) -> Result<()> {
         let target = target.clone().unwrap_or_else(|| {
             std::fs::canonicalize(".").expect("Failed to get current directory")
         });
@@ -569,7 +570,14 @@ impl Devenv {
             std::fs::create_dir_all(&target).expect("Failed to create target directory");
         }
 
-        for (source_name, target_name) in REQUIRED_FILES {
+        for (source_name, target_name) in
+            REQUIRED_FILES
+                .iter()
+                .chain(match with_direnv.is_some_and(|x| x) {
+                    true => OPTIONAL_DIRENV_REQUIRED_FILES.iter(),
+                    false => [].iter(),
+                })
+        {
             info!(devenv.is_user_message = true, "Creating {}", target_name);
 
             let path = PROJECT_DIR

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -778,8 +778,11 @@ async fn dispatch_command(
                 Ok(CommandResult::Exec(shell_config.command))
             }
         },
-        Commands::Init { target } => {
-            devenv.init(&target)?;
+        Commands::Init {
+            target,
+            with_direnv,
+        } => {
+            devenv.init(&target, &with_direnv)?;
             Ok(CommandResult::Done)
         }
         Commands::Generate => {


### PR DESCRIPTION
Adding back (as opt-in either, via flag `--with-devenv` or env variable `DEVENV_DIRENV_USE=true`) support for `devenv init` creating `.envrc`.