### PR TITLE
fix: resolve symlinks in import path validation on Darwin

### DIFF
--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -692,19 +692,24 @@ impl Config {
         } else if canonical_import.is_none()
             && let Some(canonical_root) = canonical_root
         {
-            // Import path doesn't exist, but root does - validate lexically
-            // First make the import path absolute, then normalize
-            let abs_import = if import_path.is_absolute() {
-                Self::normalize_path_components(import_path)
-            } else {
-                // Make relative path absolute from current directory first
-                if let Ok(cwd) = std::env::current_dir() {
-                    let absolute = cwd.join(import_path);
-                    Self::normalize_path_components(&absolute)
+            // Import path doesn't exist, but root does.
+            // Canonicalize the parent directory to resolve symlinks
+            // (e.g. /tmp -> /run/user/...), falling back to lexical
+            // normalization only when the parent doesn't exist either.
+            let abs_import = if let Some(parent) = import_path.parent() {
+                if let Ok(canonical_parent) = parent.canonicalize() {
+                    canonical_parent.join(import_path.file_name().unwrap_or_default())
+                } else if import_path.is_absolute() {
+                    Self::normalize_path_components(import_path)
+                } else if let Ok(cwd) = std::env::current_dir() {
+                    Self::normalize_path_components(&cwd.join(import_path))
                 } else {
-                    // Can't get cwd, skip validation
                     return Ok(());
                 }
+            } else if import_path.is_absolute() {
+                Self::normalize_path_components(import_path)
+            } else {
+                return Ok(());
             };
 
             if !abs_import.starts_with(&canonical_root) {


### PR DESCRIPTION
## Summary

- On macOS, `/tmp` is a symlink to `/private/tmp`. When `validate_within_root` checked a non-existent import file, it compared a lexically normalized path (symlinks unresolved) against a canonicalized root (symlinks resolved), causing a false positive "resolves outside base directory" error.
- Fix by canonicalizing the parent directory of the import path (which does exist) instead of using pure lexical normalization. Path traversal security checks are preserved since `parent.canonicalize()` also resolves any symlinks in intermediate directories.

## Test plan

- [x] `test_dev_env_after_invalidate_yaml_import` passes on Linux (previously failed on Darwin)
- [x] `test_dev_env_after_invalidate_imported_file` still passes
- [x] `test_dev_env_after_invalidate` still passes
- [x] All 124 `devenv-core` unit tests pass
- [ ] CI passes on Darwin

🤖 Generated with [Claude Code](https://claude.com/claude-code)