### PR TITLE
Add task messages for post-init shell output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Added Ctrl+X keybinding to stop individual processes from the TUI while keeping them visible and restartable.
+- Tasks can now display messages when entering the shell by writing `{"devenv":{"messages":["..."]}}` to `$DEVENV_TASK_OUTPUT_FILE` ([#2500](https://github.com/cachix/devenv/issues/2500)).
 - Added `nixpkgs.rocmSupport` option to enable ROCm support in nixpkgs configuration.
 
 ## 2.0.6 (2026-03-22)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "iocraft",
  "libc",
  "portable-pty",
+ "shell-escape",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7182,6 +7182,10 @@ rec {
             packageId = "portable-pty";
           }
           {
+            name = "shell-escape";
+            packageId = "shell-escape";
+          }
+          {
             name = "thiserror";
             packageId = "thiserror 2.0.18";
           }

--- a/devenv-shell/Cargo.toml
+++ b/devenv-shell/Cargo.toml
@@ -21,6 +21,9 @@ avt = { workspace = true }
 # Async runtime
 tokio = { workspace = true, features = ["sync", "rt", "signal", "io-util"] }
 
+# Shell escaping
+shell-escape = { workspace = true }
+
 # Error handling
 thiserror = { workspace = true }
 

--- a/devenv-shell/src/dialect/bash.rs
+++ b/devenv-shell/src/dialect/bash.rs
@@ -1,4 +1,6 @@
 use super::{InteractiveArgs, RcfileContext, ShellDialect};
+use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Bash shell dialect implementation.
@@ -247,5 +249,27 @@ fi
 
     fn prompt_prefix(&self) -> &str {
         r#"PS1="(devenv) ${PS1:-}"#
+    }
+
+    fn format_task_exports(&self, exports: &BTreeMap<String, String>) -> String {
+        let mut result = String::with_capacity(exports.len() * 50);
+        for (key, value) in exports {
+            result.push_str("export ");
+            result.push_str(&shell_escape::escape(Cow::Borrowed(key)));
+            result.push('=');
+            result.push_str(&shell_escape::escape(Cow::Borrowed(value)));
+            result.push('\n');
+        }
+        result
+    }
+
+    fn format_task_messages(&self, messages: &[String]) -> String {
+        let mut result = String::with_capacity(messages.len() * 40);
+        for msg in messages {
+            result.push_str("printf '%s\\n' ");
+            result.push_str(&shell_escape::escape(Cow::Borrowed(msg)));
+            result.push('\n');
+        }
+        result
     }
 }

--- a/devenv-shell/src/dialect/mod.rs
+++ b/devenv-shell/src/dialect/mod.rs
@@ -8,6 +8,7 @@ mod bash;
 
 pub use bash::BashDialect;
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Shell-specific behavior for interactive sessions.
@@ -34,6 +35,14 @@ pub trait ShellDialect: Send + Sync {
 
     /// Generate a shell-specific PS1/prompt prefix for "(devenv)".
     fn prompt_prefix(&self) -> &str;
+
+    /// Format task exports as shell export statements.
+    ///
+    /// Keys are already sorted (BTreeMap), giving deterministic output (important for direnv diffing).
+    fn format_task_exports(&self, exports: &BTreeMap<String, String>) -> String;
+
+    /// Format task messages as shell print statements.
+    fn format_task_messages(&self, messages: &[String]) -> String;
 }
 
 /// Arguments for launching an interactive shell with a custom init script.

--- a/devenv-tasks/src/types.rs
+++ b/devenv-tasks/src/types.rs
@@ -121,14 +121,28 @@ impl TasksStatus {
 /// Output data from tasks
 pub type TaskOutputs = serde_json::Value;
 
+/// Navigate to `value["devenv"][field]`.
+fn get_devenv_field<'a>(
+    value: &'a serde_json::Value,
+    field: &str,
+) -> Option<&'a serde_json::Value> {
+    value.get("devenv").and_then(|d| d.get(field))
+}
+
 /// Read the `devenv.env` object from a task output JSON value.
 pub fn get_devenv_env(
     value: &serde_json::Value,
 ) -> Option<&serde_json::Map<String, serde_json::Value>> {
-    value
-        .get("devenv")
-        .and_then(|d| d.get("env"))
-        .and_then(|e| e.as_object())
+    get_devenv_field(value, "env").and_then(|e| e.as_object())
+}
+
+/// Iterate over the `devenv.messages` strings in a task output JSON value.
+fn iter_devenv_messages(value: &serde_json::Value) -> impl Iterator<Item = &str> {
+    get_devenv_field(value, "messages")
+        .and_then(|m| m.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|v| v.as_str())
 }
 
 /// Get or create the mutable `devenv.env` object in a task output JSON value.
@@ -209,6 +223,19 @@ impl Outputs {
             }
         }
         envs
+    }
+
+    /// Extract all `devenv.messages` strings from task outputs.
+    ///
+    /// Each task's JSON output may contain `{"devenv": {"messages": ["msg1", "msg2"]}}`.
+    /// Messages are collected in task name order (BTreeMap iteration), preserving
+    /// array order within each task.
+    pub fn collect_messages(&self) -> Vec<String> {
+        self.0
+            .values()
+            .flat_map(|v| iter_devenv_messages(v))
+            .map(String::from)
+            .collect()
     }
 }
 

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -232,6 +232,10 @@ pub struct Devenv {
     // run_enter_shell_tasks(). Injected into the bash script by prepare_shell()
     // so they take effect AFTER the Nix shell env is applied.
     task_exports: std::sync::Mutex<BTreeMap<String, String>>,
+
+    // Task messages to display when entering the shell, set by
+    // run_enter_shell_tasks(). Injected as echo statements into the bash script.
+    task_messages: std::sync::Mutex<Vec<String>>,
 }
 
 /// Sanitize profile name to be filesystem-safe
@@ -415,6 +419,7 @@ impl Devenv {
             native_process_manager: Arc::new(OnceCell::new()),
             shutdown: options.shutdown,
             task_exports: std::sync::Mutex::new(BTreeMap::new()),
+            task_messages: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -665,9 +670,17 @@ impl Devenv {
 
         // Inject task-exported env vars (e.g., PATH with venv/bin, VIRTUAL_ENV)
         // after the Nix shell env is applied so they aren't overridden.
+        let dialect = BashDialect;
         {
             let exports = self.task_exports.lock().unwrap();
-            script.push_str(&Self::format_task_exports_bash(&exports));
+            script.push_str(&dialect.format_task_exports(&exports));
+        }
+
+        // Print task messages only in interactive mode to avoid corrupting stdout
+        // when running `devenv shell -- some-command` where output may be piped.
+        if cmd.is_none() {
+            let messages = self.task_messages.lock().unwrap();
+            script.push_str(&dialect.format_task_messages(&messages));
         }
 
         // Add command for non-interactive mode
@@ -699,7 +712,6 @@ impl Devenv {
                 shell_cmd.arg(&script_path);
             }
             None => {
-                let dialect = BashDialect;
                 let interactive_args = dialect.interactive_args();
                 shell_cmd.args(&interactive_args.prefix);
                 shell_cmd.arg(&script_path);
@@ -986,7 +998,7 @@ impl Devenv {
         pre_captured_envs: Option<HashMap<String, String>>,
         verbosity: tasks::VerbosityLevel,
         tui: bool,
-    ) -> Result<BTreeMap<String, String>> {
+    ) -> Result<(BTreeMap<String, String>, Vec<String>)> {
         self.assemble().await?;
 
         let envs = match pre_captured_envs {
@@ -997,7 +1009,7 @@ impl Devenv {
         let task_configs = self.load_tasks().await?;
         // Shell entry proceeds even if some tasks fail (matches interactive reload behavior).
         // Task failures are shown in the TUI/UI output, no need to bail here.
-        let (_status, exports) = self
+        let (_status, exports, messages) = self
             .run_tasks_with_roots(
                 vec!["devenv:enterShell".to_string()],
                 task_configs,
@@ -1006,7 +1018,7 @@ impl Devenv {
                 tui,
             )
             .await?;
-        Ok(exports)
+        Ok((exports, messages))
     }
 
     /// Run tasks with the given roots, storing exports on self for prepare_shell().
@@ -1017,7 +1029,7 @@ impl Devenv {
         envs: HashMap<String, String>,
         verbosity: tasks::VerbosityLevel,
         tui: bool,
-    ) -> Result<(tasks::TasksStatus, BTreeMap<String, String>)> {
+    ) -> Result<(tasks::TasksStatus, BTreeMap<String, String>, Vec<String>)> {
         let config = tasks::Config {
             roots,
             tasks: task_configs,
@@ -1037,9 +1049,13 @@ impl Devenv {
         let (status, outputs) = run_tasks_with_ui(tasks, verbosity, tui).await?;
 
         let exports = outputs.collect_env_exports();
-        // Store on self so prepare_shell() can inject them into the bash script
-        *self.task_exports.lock().unwrap() = exports.clone();
-        Ok((status, exports))
+        let messages = outputs.collect_messages();
+        // Store on self so prepare_shell() can inject them into the bash script.
+        // Clone for return value, move originals into Mutex.
+        let ret = (status, exports.clone(), messages.clone());
+        *self.task_exports.lock().unwrap() = exports;
+        *self.task_messages.lock().unwrap() = messages;
+        Ok(ret)
     }
 
     /// Get the path to bash.
@@ -1146,22 +1162,6 @@ impl Devenv {
         Ok(envs)
     }
 
-    /// Format a map of task exports as bash `export KEY=VALUE` lines.
-    ///
-    /// Keys are already sorted (BTreeMap), giving deterministic output (important for direnv diffing).
-    pub fn format_task_exports_bash(exports: &BTreeMap<String, String>) -> String {
-        use std::borrow::Cow;
-        let mut result = String::with_capacity(exports.len() * 50);
-        for (key, value) in exports {
-            result.push_str("export ");
-            result.push_str(&shell_escape::escape(Cow::Borrowed(key)));
-            result.push('=');
-            result.push_str(&shell_escape::escape(Cow::Borrowed(value)));
-            result.push('\n');
-        }
-        result
-    }
-
     /// Assemble, build dev environment, cache it, and capture shell env vars.
     async fn configure_shell(&self) -> Result<HashMap<String, String>> {
         let phase1 = Activity::operation("Configuring shell")
@@ -1194,7 +1194,7 @@ impl Devenv {
         let mut envs = envs;
         {
             let task_configs = self.load_tasks().await?;
-            let (status, exports) = self
+            let (status, exports, _messages) = self
                 .run_tasks_with_roots(
                     vec!["devenv:enterTest".to_string()],
                     task_configs,
@@ -1395,7 +1395,7 @@ impl Devenv {
 
         // ── Phase 2: Loading and running enterShell tasks ─────────────
         let task_configs = self.load_tasks().await?;
-        let (_status, exports) = self
+        let (_status, exports, _messages) = self
             .run_tasks_with_roots(
                 vec!["devenv:enterShell".to_string()],
                 task_configs,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -15,6 +15,7 @@ use devenv_core::{
     CacheSettings, InputOverrides, NixSettings, SecretSettings, ShellSettings,
     config::{self, Config, NixpkgsConfig},
 };
+use devenv_shell::dialect::ShellDialect;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -705,6 +706,7 @@ async fn dispatch_command(
     match command {
         Commands::Shell { cmd, ref args } => {
             // Non-PTY shell path (PTY is handled as early return in run_backend)
+            // Messages are injected into the shell script by prepare_shell() via self.task_messages.
             devenv.run_enter_shell_tasks(None, verbosity, tui).await?;
 
             let shell_config = match cmd {
@@ -864,14 +866,17 @@ async fn dispatch_command(
         }
         Commands::DirenvExport => {
             let mut output = devenv.print_dev_env(false).await?;
+            // Discard messages: direnv captures stdout as env var definitions,
+            // so echo statements would corrupt the output.
             let task_exports = match devenv.run_enter_shell_tasks(None, verbosity, tui).await {
-                Ok(exports) => exports,
+                Ok((exports, _messages)) => exports,
                 Err(e) => {
                     tracing::warn!("enterShell tasks failed, skipping exports: {e}");
                     BTreeMap::new()
                 }
             };
-            output.push_str(&Devenv::format_task_exports_bash(&task_exports));
+            let dialect = devenv_shell::dialect::BashDialect;
+            output.push_str(&dialect.format_task_exports(&task_exports));
             Ok(CommandResult::Print(output))
         }
         Commands::GenerateJSONSchema => {
@@ -959,9 +964,9 @@ async fn run_reload_shell(
     );
 
     // Run enterShell tasks with subprocess executor before spawning PTY.
-    // Task exports are stored in devenv.task_exports and injected into the
-    // shell script by prepare_shell().
-    let task_exports = devenv_guard
+    // Task exports and messages are stored in devenv.task_exports / task_messages
+    // and injected into the bash script by prepare_shell().
+    let (task_exports, task_messages) = devenv_guard
         .run_enter_shell_tasks(None, verbosity, tui)
         .await?;
 
@@ -989,6 +994,7 @@ async fn run_reload_shell(
         eval_cache_pool,
         shell_cache_key,
         task_exports,
+        task_messages,
     );
 
     // Set up communication channels between coordinator and shell runner

--- a/devenv/src/reload.rs
+++ b/devenv/src/reload.rs
@@ -40,6 +40,8 @@ pub struct DevenvShellBuilder {
     shell_cache_key: Option<devenv_eval_cache::EvalCacheKey>,
     /// Environment variables exported by enterShell tasks (e.g. VIRTUAL_ENV, PATH from venv)
     task_exports: BTreeMap<String, String>,
+    /// Messages from enterShell tasks to display when entering the shell
+    task_messages: Vec<String>,
 }
 
 impl DevenvShellBuilder {
@@ -63,6 +65,7 @@ impl DevenvShellBuilder {
         eval_cache_pool: Option<sqlx::SqlitePool>,
         shell_cache_key: Option<devenv_eval_cache::EvalCacheKey>,
         task_exports: BTreeMap<String, String>,
+        task_messages: Vec<String>,
     ) -> Self {
         Self {
             handle,
@@ -76,6 +79,7 @@ impl DevenvShellBuilder {
             eval_cache_pool,
             shell_cache_key,
             task_exports,
+            task_messages,
         }
     }
 }
@@ -93,7 +97,9 @@ impl ShellBuilder for DevenvShellBuilder {
             // (e.g. VIRTUAL_ENV, PATH with venv) after the Nix shell env so they take precedence.
             let env_script_path = self.dotfile.join("shell-env.sh");
             let mut env_script = self.initial_env_script.clone();
-            env_script.push_str(&Devenv::format_task_exports_bash(&self.task_exports));
+            let dialect = BashDialect;
+            env_script.push_str(&dialect.format_task_exports(&self.task_exports));
+            env_script.push_str(&dialect.format_task_messages(&self.task_messages));
             std::fs::write(&env_script_path, &env_script)
                 .map_err(|e| BuildError::new(format!("Failed to write env script: {}", e)))?;
 

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -177,6 +177,29 @@ Tasks support passing inputs and produce outputs, both as JSON objects:
 }
 ```
 
+### Shell messages
+
+!!! tip "New in version 2.1"
+
+Tasks can display messages to the user when entering the shell by writing a `devenv.messages` array to `$DEVENV_TASK_OUTPUT_FILE`. This is useful for showing informational output like trace URLs or setup status after initialization.
+
+```nix title="devenv.nix"
+{ pkgs, lib, config, ... }:
+
+{
+  tasks = {
+    "myapp:info" = {
+      exec = ''
+        echo '{"devenv":{"messages":["Setup complete. Dashboard: http://localhost:3000"]}}' > "$DEVENV_TASK_OUTPUT_FILE"
+      '';
+      before = [ "devenv:enterShell" ];
+    };
+  };
+}
+```
+
+Messages are printed after the shell environment is loaded, so they remain visible in the interactive session.
+
 ### Passing inputs from the CLI
 
 !!! tip "New in version 2.0"

--- a/tests/tasks/.test.sh
+++ b/tests/tasks/.test.sh
@@ -171,5 +171,19 @@ if ! echo "$INPUT" | grep -q '"added":true'; then
 fi
 echo "✓ --input-json flag works"
 
+# Test: Task messages displayed when entering the shell
+OUTPUT=$(echo "exit" | devenv shell 2>&1)
+if ! echo "$OUTPUT" | grep -q "msg-one"; then
+  echo "FAIL: msg-one not displayed when entering shell"
+  echo "Got: $OUTPUT"
+  exit 1
+fi
+if ! echo "$OUTPUT" | grep -q "msg-two"; then
+  echo "FAIL: msg-two not displayed when entering shell"
+  echo "Got: $OUTPUT"
+  exit 1
+fi
+echo "✓ Task messages work"
+
 echo ""
 echo "All task tests passed!"

--- a/tests/tasks/devenv.nix
+++ b/tests/tasks/devenv.nix
@@ -120,5 +120,13 @@
       '';
       showOutput = false;
     };
+
+    # Test: Task messages displayed when entering the shell
+    "test:messages" = {
+      exec = ''
+        echo '{"devenv":{"messages":["msg-one","msg-two"]}}' > "$DEVENV_TASK_OUTPUT_FILE"
+      '';
+      before = [ "devenv:enterShell" ];
+    };
   };
 }


### PR DESCRIPTION
## Summary

- Tasks can now display messages when entering the shell by writing `{"devenv":{"messages":["..."]}}` to `$DEVENV_TASK_OUTPUT_FILE`
- Follows the same pattern as task exports (`devenv.env`): collected from task outputs, stored on the Devenv struct, injected as `printf` statements into the shell script
- Messages are excluded from `direnv export` to avoid corrupting env var output

Closes #2500

## Test plan

- [ ] Create a task with `before = [ "devenv:enterShell" ]` that writes messages to `$DEVENV_TASK_OUTPUT_FILE` and verify they appear after `devenv shell` init
- [ ] Verify `devenv shell -- echo test` (non PTY path) also prints messages
- [ ] Verify `direnv export` does not include message output
- [ ] Verify cached/skipped tasks still produce their messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)