### PR TITLE
fix(devcontainer): restore `cat` command for direnv config heredoc

### DIFF
--- a/containers/devcontainer/Dockerfile
+++ b/containers/devcontainer/Dockerfile
@@ -50,7 +50,7 @@ USER vscode
 
 # Configure direnv
 RUN mkdir -p ~/.config/direnv
-RUN <<EOF > ~/.config/direnv/config.toml
+RUN cat <<EOF > ~/.config/direnv/config.toml
 [whitelist]
 prefix = [ "/workspaces" ]
 EOF


### PR DESCRIPTION
Restores the `cat` command lost during a refactor that prevented direnv config from being configured: https://github.com/cachix/devenv/commit/65364f32493ecafae89c1b0d4683cc993abe36cf#diff-a62352f72c56dc258fd5f01f4fa7301864d95b8de5cf429a9a55d4a6a9a3475bL37

This fix resolves:
```
direnv: error /workspaces/nixos-dotfiles/.envrc is blocked. Run direnv allow to approve its content
@hilorioze ➜ /workspaces/nixos-dotfiles (main) $ cat ~/.config/direnv/config.toml
@hilorioze ➜ /workspaces/nixos-dotfiles (main) $
```