### PR TITLE
feat(devenv-tasks): support dependency pruning with execIf and execIfModified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Improvements
 
+- Added `execIf` task option for pre-flight skip checks evaluated before dependencies run. Non-zero exit skips the task and prunes unneeded dependencies.
+- `execIfModified` checks now run in the pre-flight pass and participate in dependency pruning.
 - Always enable Nix's `show-trace` setting so full evaluation stack traces are shown on error, instead of a truncated trace suggesting the nonexistent `--show-trace` flag ([#2725](https://github.com/cachix/devenv/issues/2725)).
 - Upgraded Nix to 2.34, bringing multithreaded tarball unpacking, evaluator performance improvements, and REPL enhancements.
 - Added Ctrl+X keybinding to stop individual processes from the TUI while keeping them visible and restartable.

--- a/devenv-tasks/src/config.rs
+++ b/devenv-tasks/src/config.rs
@@ -18,6 +18,8 @@ pub struct TaskConfig {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub exec_if: Option<String>,
+    #[serde(default)]
     pub exec_if_modified: Vec<String>,
     #[serde(default)]
     pub input: Option<serde_json::Value>,

--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -10,7 +10,7 @@ use base64::Engine;
 use devenv_activity::{Activity, ActivityInstrument, ActivityLevel};
 use devenv_processes::{NativeProcessManager, ProcessConfig};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -247,6 +247,31 @@ impl TaskState {
         Ok(env)
     }
 
+    /// Environment for pre-flight commands (`exec_if`): no dependency outputs
+    /// (`DEVENV_TASKS_OUTPUTS`), so the check can run before upstream tasks complete.
+    fn prepare_preflight_env(
+        &self,
+        shell_env: &std::collections::HashMap<String, String>,
+    ) -> Result<BTreeMap<String, String>> {
+        let mut env: BTreeMap<String, String> = shell_env
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        if let Some(input) = &self.task.input {
+            let input_json = serde_json::to_string(input)
+                .into_diagnostic()
+                .wrap_err("Failed to serialize task input to JSON")?;
+            env.insert("DEVENV_TASK_INPUT".to_string(), input_json);
+        }
+
+        for (key, value) in &self.task.env {
+            env.insert(key.clone(), value.clone());
+        }
+
+        Ok(env)
+    }
+
     /// Create a temporary file for task I/O.
     fn create_tempfile(prefix: &str, suffix: &str) -> Result<tempfile::NamedTempFile> {
         tempfile::Builder::new()
@@ -429,6 +454,107 @@ impl TaskState {
         })
     }
 
+    /// If this oneshot task should skip based on `exec_if` / `exec_if_modified`,
+    /// returns [`TaskCompleted::Skipped`] with merged cached output.
+    ///
+    /// `exec_if` runs with [`Self::prepare_preflight_env`] (no `DEVENV_TASKS_OUTPUTS`).
+    /// Exit 0 means "run the task" (condition met), non-0 means "skip".
+    /// On errors or when the task should run, returns `None` (conservative).
+    pub async fn check_will_skip(
+        &self,
+        cache: &TaskCache,
+        shell_env: &HashMap<String, String>,
+    ) -> Option<TaskCompleted> {
+        if self.task.r#type != TaskType::Oneshot {
+            return None;
+        }
+
+        if let Some(cmd) = &self.task.exec_if {
+            if self.validate_cwd().is_err() {
+                return None;
+            }
+            let cached_output = self.get_cached_output(cache).await;
+            let env = match self.prepare_preflight_env(shell_env) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!(
+                        "Pre-flight exec_if check: failed to prepare env for task {}: {e}",
+                        self.task.name
+                    );
+                    return None;
+                }
+            };
+            let exports_file = match Self::create_tempfile("devenv_task_exports", "") {
+                Ok(f) => f,
+                Err(e) => {
+                    tracing::warn!(
+                        "Pre-flight exec_if check: failed to create tempfile for task {}: {e}",
+                        self.task.name
+                    );
+                    return None;
+                }
+            };
+            let ctx = ExecutionContext {
+                command: cmd,
+                cwd: self.task.cwd.as_deref(),
+                env,
+                use_sudo: self.sudo_context.is_some(),
+                output_file_path: std::path::Path::new("/dev/null"),
+                exports_file_path: exports_file.path(),
+            };
+            let mut command = ctx.build_command();
+            match command.output().await {
+                Ok(output) if output.status.success() => {
+                    // Exit 0: condition met, task should run
+                    None
+                }
+                Ok(_) => {
+                    // Non-zero exit: condition not met, skip the task
+                    let mut result = cached_output.unwrap_or_else(|| serde_json::json!({}));
+                    if let Ok(data) = tokio::fs::read(exports_file.path()).await {
+                        let exports = Self::parse_exports(&data);
+                        if let (false, Some(env_obj)) = (
+                            exports.is_empty(),
+                            get_or_create_devenv_env_mut(&mut result),
+                        ) {
+                            for (k, v) in exports {
+                                env_obj.insert(k, serde_json::Value::String(v));
+                            }
+                        }
+                    }
+                    let output = Output(Some(result));
+                    Some(TaskCompleted::Skipped(Skipped::Cached(output)))
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Pre-flight exec_if check: command failed for task {}: {e}",
+                        self.task.name
+                    );
+                    None
+                }
+            }
+        } else if self.task.status.is_none() && !self.task.exec_if_modified.is_empty() {
+            let files_modified = match self.check_files_modified(cache).await {
+                Ok(modified) => modified,
+                Err(e) => {
+                    tracing::warn!(
+                        task.name = %self.task.name,
+                        error = %e,
+                        "Failed to check modified files in pre-flight, assuming modified",
+                    );
+                    return None;
+                }
+            };
+            if files_modified {
+                return None;
+            }
+            let task_output = self.get_cached_output(cache).await;
+            Some(TaskCompleted::Skipped(Skipped::Cached(Output(task_output))))
+        } else {
+            None
+        }
+    }
+
     /// Run this task with a pre-assigned activity ID.
     /// The Task::Hierarchy event has already been emitted; this emits Task::Start.
     pub async fn run(
@@ -475,7 +601,7 @@ impl TaskState {
             self.task.status.is_some()
         );
 
-        // Check if we should skip based on cache (status command or exec_if_modified)
+        // Check if we should skip based on cache (status command)
         if !refresh_task_cache {
             if let Some(cmd) = &self.task.status {
                 // First check if we have cached output from a previous run
@@ -543,35 +669,6 @@ impl TaskState {
                             },
                         ));
                     }
-                }
-            } else if !self.task.exec_if_modified.is_empty() {
-                let files_modified = match self.check_files_modified(cache).await {
-                    Ok(modified) => modified,
-                    Err(e) => {
-                        tracing::warn!(
-                            task.name = %self.task.name,
-                            error = %e,
-                            "Failed to check modified files, assuming modified",
-                        );
-                        true
-                    }
-                };
-
-                if !files_modified {
-                    // First check if we have outputs in the current run's outputs map,
-                    // then fall back to the cache
-                    let task_output = match outputs.get(&self.task.name).cloned() {
-                        Some(output) => Some(output),
-                        None => self.get_cached_output(cache).await,
-                    };
-
-                    tracing::debug!(
-                        "Skipping task {} due to unmodified files, output: {:?}",
-                        self.task.name,
-                        task_output
-                    );
-                    task_activity.cached();
-                    return Ok(TaskCompleted::Skipped(Skipped::Cached(Output(task_output))));
                 }
             }
         }

--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -95,6 +95,9 @@ impl TasksBuilder {
             if task.status.is_some() && task.command.is_none() {
                 return Err(Error::MissingCommand(name));
             }
+            if task.exec_if.is_some() && task.command.is_none() {
+                return Err(Error::MissingCommand(name));
+            }
             let index = graph.add_node(Arc::new(RwLock::new(TaskState::new(
                 task,
                 self.verbosity,
@@ -653,6 +656,42 @@ impl Tasks {
             .collect()
     }
 
+    /// Single reverse-topological pass: prune tasks whose dependents all skip, then run at most
+    /// one exec_if/exec_if_modified check per remaining oneshot task.
+    async fn compute_skip_sets(&self) -> (HashMap<NodeIndex, TaskCompleted>, HashSet<NodeIndex>) {
+        let root_set: HashSet<NodeIndex> = self.roots.iter().cloned().collect();
+        let cache = &self.cache;
+        let shell_env = &self.env;
+
+        let mut will_skip: HashMap<NodeIndex, TaskCompleted> = HashMap::new();
+        let mut pruned: HashSet<NodeIndex> = HashSet::new();
+
+        for &index in self.tasks_order.iter().rev() {
+            if !root_set.contains(&index) {
+                let dependents: Vec<NodeIndex> = self
+                    .graph
+                    .neighbors_directed(index, petgraph::Direction::Outgoing)
+                    .collect();
+                if !dependents.is_empty() {
+                    let all_dependents_skip = dependents
+                        .iter()
+                        .all(|d| will_skip.contains_key(d) || pruned.contains(d));
+                    if all_dependents_skip {
+                        pruned.insert(index);
+                        continue;
+                    }
+                }
+            }
+
+            let ts = self.graph[index].read().await;
+            if let Some(completed) = ts.check_will_skip(cache, shell_env).await {
+                will_skip.insert(index, completed);
+            }
+        }
+
+        (will_skip, pruned)
+    }
+
     /// Wait for task dependencies to be satisfied in the background.
     /// Returns `(cancelled, dependency_failed)`.
     async fn wait_for_task_deps(
@@ -741,6 +780,12 @@ impl Tasks {
         let outputs = Arc::new(Mutex::new(Outputs::new()));
         let mut running_tasks = self.shutdown.join_set();
 
+        let (mut will_skip, pruned) = if self.refresh_task_cache {
+            (HashMap::new(), HashSet::new())
+        } else {
+            self.compute_skip_sets().await
+        };
+
         // Pre-register all process tasks with the process manager so they
         // appear in the TUI immediately, regardless of topological sort order.
         // Also register dependency edges so that when an auto start off process is
@@ -749,6 +794,9 @@ impl Tasks {
         for &index in &self.tasks_order {
             if self.shutdown.is_cancelled() {
                 break;
+            }
+            if pruned.contains(&index) || will_skip.contains_key(&index) {
+                continue;
             }
             let ts = self.graph[index].read().await;
             if ts.task.r#type != TaskType::Process || ts.task.command.is_none() {
@@ -791,6 +839,84 @@ impl Tasks {
         for index in &self.tasks_order {
             let task_state = &self.graph[*index];
             let task_activity_id = task_ids[index];
+
+            if pruned.contains(index) {
+                let skip_activity = Activity::task_with_id(task_activity_id);
+                skip_activity.skipped();
+                {
+                    let mut ts = task_state.write().await;
+                    ts.status = TaskStatus::Completed(TaskCompleted::Skipped(
+                        Skipped::AllDependentsSkipped,
+                    ));
+                }
+                Self::signal_task_done(
+                    &completed_tasks,
+                    total_tasks,
+                    &orchestration_activity,
+                    &self.notify_finished,
+                    &self.notify_ui,
+                );
+                continue;
+            }
+
+            if let Some(completed) = will_skip.remove(index) {
+                let skip_activity = Activity::task_with_id(task_activity_id);
+                skip_activity.cached();
+                {
+                    let mut ts = task_state.write().await;
+                    match &completed {
+                        TaskCompleted::Skipped(Skipped::Cached(Output(Some(output)))) => {
+                            outputs
+                                .lock()
+                                .await
+                                .insert(ts.task.name.clone(), output.clone());
+
+                            if (ts.task.status.is_some()
+                                || ts.task.exec_if.is_some()
+                                || !ts.task.exec_if_modified.is_empty())
+                                && let Some(output_value) = output.as_object()
+                            {
+                                let task_name = &ts.task.name;
+                                if let Err(e) = self
+                                    .cache
+                                    .store_task_output(
+                                        task_name,
+                                        &serde_json::Value::Object(output_value.clone()),
+                                    )
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "Failed to store task output for {}: {}",
+                                        task_name,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        TaskCompleted::Skipped(Skipped::Cached(Output(None))) => {
+                            if ts.task.status.is_some()
+                                || ts.task.exec_if.is_some()
+                                || !ts.task.exec_if_modified.is_empty()
+                            {
+                                tracing::debug!(
+                                    "Skipped task {} has no cached output to store",
+                                    ts.task.name
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
+                    ts.status = TaskStatus::Completed(completed);
+                }
+                Self::signal_task_done(
+                    &completed_tasks,
+                    total_tasks,
+                    &orchestration_activity,
+                    &self.notify_finished,
+                    &self.notify_ui,
+                );
+                continue;
+            }
 
             // Check if this is a process task early so we can handle it differently.
             // Process tasks are pre-registered and spawned with background dep checking
@@ -1117,8 +1243,9 @@ impl Tasks {
                                     // TODO: fix clone
                                     .insert(task_state.task.name.clone(), output.clone());
 
-                                // Store task output if we're having status or exec_if_modified
+                                // Store task output if we're having status, exec_if, or exec_if_modified
                                 if (task_state.task.status.is_some()
+                                    || task_state.task.exec_if.is_some()
                                     || !task_state.task.exec_if_modified.is_empty())
                                     && let Some(output_value) = output.as_object()
                                 {

--- a/devenv-tasks/src/tests/mod.rs
+++ b/devenv-tasks/src/tests/mod.rs
@@ -6,6 +6,7 @@ use crate::types::{Skipped, TaskCompleted, TaskStatus, VerbosityLevel};
 use pretty_assertions::assert_matches;
 use serde_json::json;
 use sqlx::Row;
+use std::collections::HashMap;
 use std::fs::Permissions;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
@@ -1715,6 +1716,1153 @@ async fn test_status_without_command() -> Result<(), Error> {
     .await;
 
     assert!(matches!(result, Err(Error::MissingCommand(_))));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exec_if_without_command() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let exec_if_script = create_script("#!/bin/sh\nexit 0")?;
+
+    let result = Tasks::builder(
+        Config::try_from(json!({
+            "roots": ["myapp:task_1"],
+            "run_mode": "all",
+            "tasks": [
+                {
+                    "name": "myapp:task_1",
+                    "exec_if": exec_if_script.to_str().unwrap()
+                }
+            ]
+        }))
+        .unwrap(),
+        VerbosityLevel::Verbose,
+        Shutdown::new(),
+    )
+    .with_db_path(db_path)
+    .build()
+    .await;
+
+    assert!(matches!(result, Err(Error::MissingCommand(_))));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_basic() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let expensive_script = create_script("#!/bin/sh\necho expensive")?;
+    let exec_if_script = create_script("#!/bin/sh\nexit 1")?;
+    let child_script = create_script("#!/bin/sh\necho child")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:expensive",
+                "command": expensive_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:conditional",
+                "after": ["myapp:expensive"],
+                "command": child_script.to_str().unwrap(),
+                "exec_if": exec_if_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:conditional"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:expensive"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:conditional"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_partial_dependents() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let script_a = create_script("#!/bin/sh\necho a")?;
+    let script_b = create_script("#!/bin/sh\necho b")?;
+    let script_c = create_script("#!/bin/sh\necho c")?;
+    let script_d = create_script("#!/bin/sh\necho d")?;
+    let exec_if_skip = create_script("#!/bin/sh\nexit 1")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:d"],
+        "run_mode": "all",
+        "tasks": [
+            { "name": "myapp:a", "command": script_a.to_str().unwrap() },
+            {
+                "name": "myapp:b",
+                "after": ["myapp:a"],
+                "command": script_b.to_str().unwrap(),
+                "exec_if": exec_if_skip.to_str().unwrap()
+            },
+            {
+                "name": "myapp:c",
+                "after": ["myapp:a"],
+                "command": script_c.to_str().unwrap()
+            },
+            {
+                "name": "myapp:d",
+                "after": ["myapp:b", "myapp:c"],
+                "command": script_d.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:a"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:b"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:c"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:d"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_chain() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let script_a = create_script("#!/bin/sh\necho a")?;
+    let script_b = create_script("#!/bin/sh\necho b")?;
+    let script_c = create_script("#!/bin/sh\necho c")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+    let exec_if_skip = create_script("#!/bin/sh\nexit 1")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            { "name": "myapp:a", "command": script_a.to_str().unwrap() },
+            {
+                "name": "myapp:b",
+                "after": ["myapp:a"],
+                "command": script_b.to_str().unwrap()
+            },
+            {
+                "name": "myapp:c",
+                "after": ["myapp:b"],
+                "command": script_c.to_str().unwrap(),
+                "exec_if": exec_if_skip.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:c"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:a"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:b"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:c"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_root_not_pruned() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let root_script = create_script("#!/bin/sh\necho root")?;
+    let child_script = create_script("#!/bin/sh\necho child")?;
+    let exec_if_skip = create_script("#!/bin/sh\nexit 1")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:root",
+                "command": root_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:root"],
+                "command": child_script.to_str().unwrap(),
+                "exec_if": exec_if_skip.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:child"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_exec_if_modified() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let test_file = tempfile::NamedTempFile::new_in(temp_dir.path())?;
+    let test_file_path = test_file.path().to_str().unwrap().to_string();
+    fs::write(&test_file_path, "initial").await?;
+
+    let dep_script = create_script("#!/bin/sh\necho dep")?;
+    let child_script = create_script(
+        r#"#!/bin/sh
+echo '{"result": "child"}' > $DEVENV_TASK_OUTPUT_FILE
+echo child
+"#,
+    )?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config1 = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            { "name": "myapp:dep", "command": dep_script.to_str().unwrap() },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": child_script.to_str().unwrap(),
+                "exec_if_modified": [test_file_path.clone()]
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks1 = Tasks::builder(config1, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path.clone())
+        .build()
+        .await?;
+    tasks1.run(false).await;
+
+    let config2 = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            { "name": "myapp:dep", "command": dep_script.to_str().unwrap() },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": child_script.to_str().unwrap(),
+                "exec_if_modified": [test_file_path]
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks2 = Tasks::builder(config2, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks2.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks2).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:dep"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:child"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_propagation_disabled_by_refresh() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let expensive_script = create_script("#!/bin/sh\necho expensive")?;
+    let exec_if_script = create_script("#!/bin/sh\nexit 1")?;
+    let child_script = create_script("#!/bin/sh\necho child")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:expensive",
+                "command": expensive_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:conditional",
+                "after": ["myapp:expensive"],
+                "command": child_script.to_str().unwrap(),
+                "exec_if": exec_if_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:conditional"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .with_refresh_task_cache(true)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:expensive"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:conditional"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exec_if_check_runs_at_most_once() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("exec_if_invocations");
+
+    let counter = counter_path.to_str().unwrap();
+    let exec_if_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+exit 0
+"#,
+        counter
+    ))?;
+    let main_script = create_script("#!/bin/sh\necho main")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:task",
+                "command": main_script.to_str().unwrap(),
+                "exec_if": exec_if_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:task"],
+                "command": create_script("#!/bin/sh\necho root")?.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    let n = lines.lines().filter(|l| !l.is_empty()).count();
+    assert_eq!(
+        n, 1,
+        "exec_if command should run exactly once, got {} lines",
+        n
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exec_if_no_devenv_tasks_outputs() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    // Exit 0 (run) if DEVENV_TASKS_OUTPUTS is set, exit 1 (skip) if not set.
+    // Since exec_if runs pre-flight without DEVENV_TASKS_OUTPUTS, this skips.
+    let exec_if_script = create_script(
+        r#"#!/bin/sh
+case ${DEVENV_TASKS_OUTPUTS+x} in x) exit 0 ;; esac
+exit 1
+"#,
+    )?;
+    let main_script = create_script("#!/bin/sh\necho should-not-run")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:task",
+                "command": main_script.to_str().unwrap(),
+                "exec_if": exec_if_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:task"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:task"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_skip() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("main_invocations");
+    let counter = counter_path.to_str().unwrap();
+
+    let dep_script = create_script(
+        r#"#!/bin/sh
+echo '{"result": "from_dep"}' > $DEVENV_TASK_OUTPUT_FILE
+"#,
+    )?;
+    let main_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+"#,
+        counter
+    ))?;
+    let status_script = create_script("#!/bin/sh\nexit 0")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:dep",
+                "command": dep_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": main_script.to_str().unwrap(),
+                "status": status_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        0,
+        "main exec should be skipped when status exits 0"
+    );
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:child"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert!(statuses.contains_key("myapp:dep"));
+    assert!(statuses.contains_key("myapp:root"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_run() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("main_invocations_status_run");
+    let counter = counter_path.to_str().unwrap();
+
+    let dep_script = create_script(
+        r#"#!/bin/sh
+echo '{"result": "from_dep"}' > $DEVENV_TASK_OUTPUT_FILE
+"#,
+    )?;
+    let main_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+"#,
+        counter
+    ))?;
+    let status_script = create_script("#!/bin/sh\nexit 1")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:dep",
+                "command": dep_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": main_script.to_str().unwrap(),
+                "status": status_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        1,
+        "main exec should run when status exits non-zero"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_receives_outputs() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let dep_script = create_script(
+        r#"#!/bin/sh
+echo '{"k":1}' > $DEVENV_TASK_OUTPUT_FILE
+"#,
+    )?;
+    // Exit 0 (skip) only if DEVENV_TASKS_OUTPUTS mentions the dependency task name
+    let status_script = create_script(
+        r#"#!/bin/sh
+case ${DEVENV_TASKS_OUTPUTS+x} in
+  '') exit 1 ;;
+esac
+echo "$DEVENV_TASKS_OUTPUTS" | grep -q 'myapp:dep' || exit 1
+exit 0
+"#,
+    )?;
+    let main_script = create_script("#!/bin/sh\necho should-not-run")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:dep",
+                "command": dep_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": main_script.to_str().unwrap(),
+                "status": status_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:child"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_with_exec_if() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("status_invocations");
+    let counter = counter_path.to_str().unwrap();
+
+    let exec_if_skip = create_script("#!/bin/sh\nexit 1")?;
+    let status_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+exit 0
+"#,
+        counter
+    ))?;
+    let main_script = create_script("#!/bin/sh\necho main")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:task",
+                "command": main_script.to_str().unwrap(),
+                "exec_if": exec_if_skip.to_str().unwrap(),
+                "status": status_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:task"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        0,
+        "status must not run when pre-flight exec_if already skipped the task"
+    );
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:task"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exec_if_no_skip_status_skip() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir
+        .path()
+        .join("main_invocations_exec_if_pass_status_skip");
+    let counter = counter_path.to_str().unwrap();
+
+    let exec_if_run = create_script("#!/bin/sh\nexit 0")?;
+    let status_skip = create_script("#!/bin/sh\nexit 0")?;
+    let main_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+"#,
+        counter
+    ))?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:task",
+                "command": main_script.to_str().unwrap(),
+                "exec_if": exec_if_run.to_str().unwrap(),
+                "status": status_skip.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:task"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        0,
+        "main command should not run when exec_if allows but status skips"
+    );
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:task"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_exec_if_no_skip_status_no_skip() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("main_invocations_both_pass");
+    let counter = counter_path.to_str().unwrap();
+
+    let exec_if_run = create_script("#!/bin/sh\nexit 0")?;
+    let status_run = create_script("#!/bin/sh\nexit 1")?;
+    let main_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+"#,
+        counter
+    ))?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:task",
+                "command": main_script.to_str().unwrap(),
+                "exec_if": exec_if_run.to_str().unwrap(),
+                "status": status_run.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:task"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        1,
+        "main command should run when both exec_if and status indicate no skip"
+    );
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:task"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_disabled_by_refresh() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("main_invocations_refresh");
+    let counter = counter_path.to_str().unwrap();
+
+    let dep_script = create_script(
+        r#"#!/bin/sh
+echo '{"result": "from_dep"}' > $DEVENV_TASK_OUTPUT_FILE
+"#,
+    )?;
+    let main_script = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+"#,
+        counter
+    ))?;
+    let status_script = create_script("#!/bin/sh\nexit 0")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:dep",
+                "command": dep_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": main_script.to_str().unwrap(),
+                "status": status_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .with_refresh_task_cache(true)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    assert_eq!(
+        lines.lines().filter(|l| !l.is_empty()).count(),
+        1,
+        "refresh_task_cache should bypass status so main exec runs"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_short_circuits_exec_if_check() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+    let counter_path = temp_dir.path().join("b_exec_if_invocations");
+    let counter = counter_path.to_str().unwrap();
+
+    let exec_if_b = create_script(&format!(
+        r#"#!/bin/sh
+printf 'x\n' >> "{}"
+exit 1
+"#,
+        counter
+    ))?;
+    let exec_if_c = create_script("#!/bin/sh\nexit 1")?;
+    let cmd = create_script("#!/bin/sh\necho run")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            { "name": "myapp:a", "command": cmd.to_str().unwrap() },
+            {
+                "name": "myapp:b",
+                "after": ["myapp:a"],
+                "command": cmd.to_str().unwrap(),
+                "exec_if": exec_if_b.to_str().unwrap()
+            },
+            {
+                "name": "myapp:c",
+                "after": ["myapp:b"],
+                "command": cmd.to_str().unwrap(),
+                "exec_if": exec_if_c.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:c"],
+                "command": cmd.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let lines = fs::read_to_string(&counter_path).await.unwrap_or_default();
+    let n = lines.lines().filter(|l| !l.is_empty()).count();
+    assert_eq!(
+        n, 0,
+        "B's exec_if should be short-circuited by pruning; got {} invocations",
+        n
+    );
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+    assert_matches!(
+        statuses.remove("myapp:a"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:b"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::AllDependentsSkipped
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:c"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_status_does_not_cause_pruning() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let dep_script = create_script("#!/bin/sh\necho dep")?;
+    let main_script = create_script("#!/bin/sh\necho main")?;
+    let status_skip = create_script("#!/bin/sh\nexit 0")?;
+    let root_script = create_script("#!/bin/sh\necho root")?;
+
+    let config = Config::try_from(json!({
+        "roots": ["myapp:root"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "myapp:dep",
+                "command": dep_script.to_str().unwrap()
+            },
+            {
+                "name": "myapp:child",
+                "after": ["myapp:dep"],
+                "command": main_script.to_str().unwrap(),
+                "status": status_skip.to_str().unwrap()
+            },
+            {
+                "name": "myapp:root",
+                "after": ["myapp:child"],
+                "command": root_script.to_str().unwrap()
+            }
+        ]
+    }))
+    .unwrap();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+
+    tasks.run(false).await;
+
+    let mut statuses: HashMap<_, _> = inspect_tasks(&tasks).await.into_iter().collect();
+
+    assert_matches!(
+        statuses.remove("myapp:dep"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _))),
+        "dep must run because status is not a preflight check and cannot cause pruning"
+    );
+    assert_matches!(
+        statuses.remove("myapp:child"),
+        Some(TaskStatus::Completed(TaskCompleted::Skipped(
+            Skipped::Cached(_)
+        )))
+    );
+    assert_matches!(
+        statuses.remove("myapp:root"),
+        Some(TaskStatus::Completed(TaskCompleted::Success(_, _)))
+    );
+    assert!(statuses.is_empty());
+
     Ok(())
 }
 

--- a/devenv-tasks/src/types.rs
+++ b/devenv-tasks/src/types.rs
@@ -272,6 +272,8 @@ pub struct TaskFailure {
 pub enum Skipped {
     Cached(Output),
     NoCommand,
+    /// Skipped because every dependent task in the scheduled graph was skipped or pruned.
+    AllDependentsSkipped,
 }
 
 #[derive(Debug, Clone)]
@@ -444,6 +446,10 @@ mod tests {
         TaskCompleted::Skipped(Skipped::NoCommand)
     }
 
+    fn make_skipped_all_dependents() -> TaskCompleted {
+        TaskCompleted::Skipped(Skipped::AllDependentsSkipped)
+    }
+
     fn make_failed() -> TaskCompleted {
         TaskCompleted::Failed(
             Duration::from_secs(0),
@@ -609,6 +615,11 @@ mod tests {
             (make_skipped_no_command(), Ready, Satisfied),
             (make_skipped_no_command(), Succeeded, Satisfied),
             (make_skipped_no_command(), Completed, Satisfied),
+            // Skipped (AllDependentsSkipped)
+            (make_skipped_all_dependents(), Started, Satisfied),
+            (make_skipped_all_dependents(), Ready, Satisfied),
+            (make_skipped_all_dependents(), Succeeded, Satisfied),
+            (make_skipped_all_dependents(), Completed, Satisfied),
             // Failed
             (make_failed(), Started, Satisfied),
             (make_failed(), Ready, NeverSatisfiable),
@@ -732,6 +743,7 @@ mod tests {
             make_success(),
             make_skipped_cached(),
             make_skipped_no_command(),
+            make_skipped_all_dependents(),
             make_failed(),
             make_dependency_failed(),
             make_cancelled_running(),

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -36806,6 +36806,30 @@ null
 
 
 
+## tasks.\<name>.execIf
+
+
+
+Condition to evaluate before dependency tasks run. If it exits non-zero, the task (and its unneeded dependencies) are skipped.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/tasks.nix](https://github.com/cachix/devenv/blob/main/src/modules/tasks.nix)
+
+
+
 ## tasks.\<name>.execIfModified
 
 

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -119,6 +119,34 @@ If you define a `status` command, it will be executed first and if it returns `0
 
 Tasks using the `status` attribute will also cache their outputs. When a task is skipped because its status command returns success, the output from the most recent successful run will be restored and passed to dependent tasks.
 
+## Avoiding expensive dependencies via `execIf` check
+
+!!! tip "New in version 2.0"
+
+If you define an `execIf` command, it is evaluated **before** dependency tasks run. If it exits with a non-zero code, the task is skipped and its unneeded dependencies are pruned automatically.
+
+```nix title="devenv.nix"
+{ pkgs, lib, config, ... }:
+
+{
+  tasks = {
+    "myapp:expensive-dependency".exec = "sleep 10";  # pruned unless it's Monday or Wednesday
+    "myapp:monday" = {
+      after = [ "myapp:expensive-dependency" ];
+      exec = "echo 'Happy Monday!'";
+      execIf = "[ `date +%u` -eq 1 ]";
+    };
+    "myapp:monday" = {
+      after = [ "myapp:expensive-dependency" ];
+      exec = "echo 'Happy Wednesday!'";
+      execIf = "[ `date +%u` -eq 3 ]";
+    };
+  };
+}
+```
+
+`execIf` does **not** receive `$DEVENV_TASKS_OUTPUTS` since dependencies have not yet executed. It can be combined with `status` on the same task: `execIf` acts as an early gate, while `status` is evaluated after dependencies complete.
+
 ## Executing tasks only when files have been modified
 
 You can specify a list of files to monitor with `execIfModified`. The task will only run if any of these files have been modified since the last successful run. This attribute supports glob patterns, allowing you to monitor multiple files matching specific patterns.
@@ -154,7 +182,7 @@ When a task is skipped due to no file changes, any previous outputs from that ta
 Tasks support passing inputs and produce outputs, both as JSON objects:
 
 - `$DEVENV_TASK_INPUT`: JSON object of `tasks."myapp:mytask".input`.
-- `$DEVENV_TASKS_OUTPUTS`: JSON object with dependent tasks as keys and their outputs as values.
+- `$DEVENV_TASKS_OUTPUTS`: JSON object with dependent tasks as keys and their outputs as values. Not set for `execIf` commands; set for `exec` and `status` commands.
 - `$DEVENV_TASK_OUTPUT_FILE`: a writable file with tasks' outputs in JSON.
 - `$DEVENV_TASK_EXPORTS_FILE`: a writable file where tasks can export environment variables. Write `name\0base64(value)\0` pairs to this file and they will be set in the environment of dependent tasks.
 

--- a/src/modules/tasks.nix
+++ b/src/modules/tasks.nix
@@ -143,6 +143,17 @@ let
             default = mkCommand config.status true;
             description = "Path to the script to run.";
           };
+          execIf = lib.mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            description = "Condition to evaluate before dependency tasks run. If it exits non-zero, the task (and its unneeded dependencies) are skipped.";
+          };
+          execIfCommand = lib.mkOption {
+            type = types.nullOr types.package;
+            internal = true;
+            default = mkCommand config.execIf true;
+            description = "Path to the script to run.";
+          };
           execIfModified = lib.mkOption {
             type = types.listOf types.str;
             default = [ ];
@@ -156,6 +167,7 @@ let
               type = config.type;
               description = config.description;
               status = config.statusCommand;
+              exec_if = config.execIfCommand;
               after = config.after;
               before = config.before;
               command = config.command;
@@ -409,6 +421,10 @@ in
       {
         assertion = lib.all (task: task.status == null || task.execIfModified == [ ]) (lib.attrValues config.tasks);
         message = "The 'status' and 'execIfModified' options cannot be used together. Use only one of them to determine whether a task should run.";
+      }
+      {
+        assertion = lib.all (task: task.execIf == null || task.execIfModified == [ ]) (lib.attrValues config.tasks);
+        message = "The 'execIf' and 'execIfModified' options cannot be used together. Use only one of them to determine whether a task should run.";
       }
     ];
 


### PR DESCRIPTION
This change extracts task `status` and `exec-if-modified` checks into a first pass that runs in reverse-topological order, from dependents to dependencies. Tasks whose dependents are all skipped are pruned from the DAG. Tasks whose dependents are all skipped short-circuiting evaluation of their checks.

**Breaking change**: Status checks no longer receive `DEVENV_TASKS_OUTPUTS`. This allows them to run before their task's dependencies. They still receive `DEVENV_TASK_INPUT`, shell env, and per-task env vars.

# Motivating Example

```nix
{
  tasks = {
    "demo:expensive-task".exec = "sleep 10; echo 'Expensive Done'";
    "demo:conditional-task" = {
      exec = "echo 'Done'";
      status = "true";  # skip unconditionally for demo purposes
      after = ["demo:expensive-task"];
      before = ["devenv:enterShell"];
    };
  };
}
```

# Before

```shell
$ devenv shell
✓ Configuring shell                                              32ms
  └ ✓ Evaluating shell cached                                    25ms
✓ Loading tasks                                                   2ms
  └ ✓ Evaluating devenv.config.task.config cached                 1ms
✓ Running tasks                                                 10.1s
  └ ✓ devenv:enterShell                                          50ms
    └ ✓ devenv:files:cleanup                                     24ms
    └ ✓ demo:conditional-task skipped                            34ms
      └ ✓ demo:expensive-task 1 lines → Expensive Done          10.0s
  └ ✓ devenv:enterTest skipped                                    0ms
  ```

# After

```shell
devenv shell
✓ Configuring shell                                              42ms
  └ ✓ Evaluating shell cached                                    33ms
✓ Loading tasks                                                   3ms
  └ ✓ Evaluating devenv.config.task.config cached                 0ms
✓ Running tasks                                                  74ms
  └ ✓ devenv:enterShell                                          21ms
    └ ✓ devenv:files:cleanup                                     20ms
    └ ✓ demo:conditional-task skipped                             0ms
      └ ✓ demo:expensive-task skipped                             0ms
  └ ✓ devenv:enterTest skipped                                    0ms
  ```