### PR TITLE
switching nix profile add to install

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -40,7 +40,7 @@
     === "Nix profiles (requires experimental flags)"
 
         ```
-        nix profile add nixpkgs#bashInteractive
+        nix profile install nixpkgs#bashInteractive
         ```
 
 === "Windows (WSL2)"
@@ -68,7 +68,7 @@
 === "Nix profiles (requires experimental flags)"
 
     ```
-    nix profile add nixpkgs#devenv
+    nix profile install nixpkgs#devenv
     ```
 
 === "NixOS/nix-darwin"


### PR DESCRIPTION
After installing nix (I installed via lix) running `nix profile add` 

errors out with: 
```
error: 'add' is not a recognised command
Try 'nix --help' for more information.
```

But `install` works. See https://nix.dev/manual/nix/2.26/command-ref/new-cli/nix3-profile-install

I didn't check other pages, just https://devenv.sh/getting-started/