### PR TITLE
fix: permittedInsecurePackages not working due to getName version stripping

### DIFF
--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -61,16 +61,19 @@ rec {
         import nixpkgs {
           system = evalSystem;
           config = nixpkgs_config // {
+            # nixpkgs' check-meta.nix natively handles permittedInsecurePackages
+            # via allowInsecureDefaultPredicate using the full derivation name.
+            # We must NOT override allowInsecurePredicate here, as lib.getName
+            # strips the version, causing mismatches with user-provided entries
+            # like "openssl-1.1.1w".
+            #
+            # For unfree packages, nixpkgs does not natively support
+            # permittedUnfreePackages, so we provide a custom predicate.
             allowUnfreePredicate =
               if nixpkgs_config.allowUnfree or false then
                 (_: true)
               else if (nixpkgs_config.permittedUnfreePackages or [ ]) != [ ] then
                 (pkg: builtins.elem (lib.getName pkg) (nixpkgs_config.permittedUnfreePackages or [ ]))
-              else
-                (_: false);
-            allowInsecurePredicate =
-              if (nixpkgs_config.permittedInsecurePackages or [ ]) != [ ] then
-                (pkg: builtins.elem (lib.getName pkg) (nixpkgs_config.permittedInsecurePackages or [ ]))
               else
                 (_: false);
           } // lib.optionalAttrs ((nixpkgs_config.allowlistedLicenses or [ ]) != [ ]) {

--- a/devenv-nix-backend/src/nix_backend.rs
+++ b/devenv-nix-backend/src/nix_backend.rs
@@ -323,8 +323,14 @@ impl NixRustBackend {
             .wrap_err("Failed to create fetchers settings")?;
 
         // Write pre-computed nixpkgs config to temp file for NIXPKGS_CONFIG env var
-        // Wrap in a let expression that adds predicate functions and license references
-        // Note: NIXPKGS_CONFIG expects a file path, not inline Nix content
+        // Wrap in a let expression that adds predicate functions.
+        // Note: NIXPKGS_CONFIG expects a file path, not inline Nix content.
+        // We do NOT override allowInsecurePredicate: nixpkgs' check-meta.nix
+        // natively creates it from permittedInsecurePackages using the full
+        // derivation name (with version). Our old getName via parseDrvName
+        // stripped the version, causing mismatches.
+        // For unfree packages, nixpkgs does not natively support
+        // permittedUnfreePackages, so we provide a custom predicate.
         let nixpkgs_config_base = ser_nix::to_string(&nixpkgs_config)
             .map_err(|e| miette::miette!("Failed to serialize nixpkgs config: {}", e))?;
         let nixpkgs_config_nix = format!(
@@ -337,11 +343,6 @@ in cfg // {{
       (_: true)
     else if (cfg.permittedUnfreePackages or []) != [] then
       (pkg: builtins.elem (getName pkg) (cfg.permittedUnfreePackages or []))
-    else
-      (_: false);
-  allowInsecurePredicate =
-    if (cfg.permittedInsecurePackages or []) != [] then
-      (pkg: builtins.elem (getName pkg) (cfg.permittedInsecurePackages or []))
     else
       (_: false);
 }}"#,


### PR DESCRIPTION
## Summary

- **Bug**: devenv's custom `allowInsecurePredicate` used `lib.getName` / `builtins.parseDrvName` which strips the version from package names (e.g. `"openssl-1.1.1w"` -> `"openssl"`), so `permittedInsecurePackages` entries never matched.
- **Fix**: Remove the custom `allowInsecurePredicate` and let nixpkgs handle it natively via its own `allowInsecureDefaultPredicate` in `check-meta.nix`, which uses the full derivation name.
- The custom `allowUnfreePredicate` is kept because nixpkgs does not natively support `permittedUnfreePackages`.

Fixes #1090

## Test plan

- [ ] Add `permittedInsecurePackages = [ "openssl-1.1.1w" ];` to `nixpkgs.config` in a `devenv.nix` and confirm the build succeeds
- [ ] Verify unfree packages still work with `permittedUnfreePackages`
- [ ] Verify `allowInsecure = true` still works as a blanket override

🤖 Generated with [Claude Code](https://claude.com/claude-code)