### PR TITLE
Fix adding new input updating all existing inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed `devenv test` leaving orphaned processes after test failures by ensuring processes are always stopped before propagating errors.
+- Fixed adding a new input to `devenv.yaml` causing all existing inputs to be re-fetched instead of only resolving the new one ([#2688](https://github.com/cachix/devenv/issues/2688)).
 - Fixed cursor shape escape sequences (DECSCUSR) not being forwarded to the terminal in `devenv shell`, which caused programs like neovim to not change cursor shape between modes (e.g. block in normal mode, bar in insert mode).
 - Fixed shift+mouse configuration (XTSHIFTESCAPE) not being forwarded to the terminal in `devenv shell`.
 - Fixed `devenv shell` hanging indefinitely when exiting the shell during a hot-reload build by interrupting the lingering Nix evaluation on shutdown.

--- a/devenv-nix-backend/src/nix_backend.rs
+++ b/devenv-nix-backend/src/nix_backend.rs
@@ -924,7 +924,7 @@ in cfg // {{
     ///
     /// This matches the behavior of flakes - locks are automatically created/updated as needed.
     async fn validate_lock_file(&self, inputs: &BTreeMap<String, Input>) -> Result<()> {
-        use crate::{create_flake_inputs, load_lock_file};
+        use crate::{create_flake_inputs, load_lock_file, write_lock_file};
 
         let fetch_settings = &self.fetchers_settings;
         let flake_settings = &self.flake_settings;
@@ -983,8 +983,14 @@ in cfg // {{
         match lock_result {
             Ok(new_lock) => {
                 if new_lock.has_changes(&old_lock).to_miette()? {
-                    tracing::debug!("Lock validation found changes, updating lock");
-                    return self.update(&None, inputs, &[]).await;
+                    tracing::debug!("Lock validation found changes, writing updated lock");
+                    // Write the new lock directly instead of calling update(), which
+                    // would call update_all() and re-fetch every input. The new_lock
+                    // was computed with the old lock as a base, so unchanged inputs
+                    // are preserved and only new/changed inputs are resolved.
+                    write_lock_file(&new_lock, &lock_file_path)
+                        .to_miette()
+                        .wrap_err("Failed to write lock file")?;
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

- When `validate_lock_file` detected changes (e.g. a new input added to `devenv.yaml`), it called `update(&None, ...)` which triggered `update_all()`, re-fetching every input from upstream. Instead, write the already-computed `new_lock` directly, which preserves existing locked inputs and only resolves new/changed ones.

Fixes #2688

## Test plan

- [ ] Add a new input to `devenv.yaml` in an existing project and run `devenv shell`; verify only the new input is fetched
- [ ] Run `devenv update` and verify it still updates all inputs as expected
- [ ] Run `devenv update <input>` and verify selective update still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)