### PR TITLE
rust: disable default lld selection and use `-B` for Wild linker support

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -370,7 +370,10 @@ in
           let
             moldFlags = lib.optionalString cfg.mold.enable "-C link-arg=-fuse-ld=mold";
             lldFlags = lib.optionalString cfg.lld.enable "-C link-arg=-fuse-ld=lld";
-            wildFlags = lib.optionalString cfg.wild.enable "-C link-arg=-fuse-ld=wild";
+            # TODO: Work around rustc's default lld selection and missing native GCC Wild support;
+            # use `-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin` for now, then switch to
+            # `-C link-arg=-fuse-ld=wild` once a released GCC supports it.
+            wildFlags = lib.optionalString cfg.wild.enable "-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin";
             linkerFlags = lib.concatStringsSep " " (lib.filter (x: x != "") [ moldFlags lldFlags wildFlags ]);
             optionalEnv = cond: str: if cond then str else null;
           in


### PR DESCRIPTION
## Summary

Use `-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin` for `languages.rust.wild.enable` instead of `-C link-arg=-fuse-ld=wild`.

This fixes Wild support on current stable Rust and released GCC. Rust now prefers `lld` by default on `x86_64-unknown-linux-gnu`, and `-B${pkgs.wild}/bin` alone is not enough to override that. Disabling Rust's `lld` linker feature lets the existing GCC `-B` mechanism select Wild through the `ld` entry in `${pkgs.wild}/bin`.

## Why

`rustc` passes `-C link-arg=...` to the linker driver. With GCC, `-fuse-ld=wild` is not available in released versions yet[^1], so the previous flag does not work. Using `-B${pkgs.wild}/bin` is the correct current GCC workaround for Wild[^2], but on recent Rust that still is not sufficient by itself, because `rustc` prefers `lld` on this target. Adding `-C linker-features=-lld` disables that default so GCC can resolve `ld` from `${pkgs.wild}/bin` and invoke Wild.

## Follow-up

Once a released GCC supports `-fuse-ld=wild`, this can be simplified to the narrower flag again.

## Testing

- Enabled `languages.rust.wild.enable`
- Confirmed that `-C link-arg=-B${pkgs.wild}/bin` alone still produced binaries linked with LLD
- Confirmed that `-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin` produced binaries linked with Wild
- Verified the result with `readelf --string-dump .comment ...`

[^1]: https://sourceware.org/pipermail/binutils/2025-November/145870.html
[^2]: https://github.com/wild-linker/wild?tab=readme-ov-file#using-as-your-default-linker