### PR TITLE
git-hooks: let modules override default tool entries

### DIFF
--- a/src/modules/integrations/git-hooks.nix
+++ b/src/modules/integrations/git-hooks.nix
@@ -54,7 +54,7 @@ let
             {
               rootSrc = self;
               package = lib.mkDefault pkgs.prek;
-              tools = import (git-hooks + "/nix/call-tools.nix") pkgs;
+              tools = lib.mapAttrs (_: lib.mkOptionDefault) (import (git-hooks + "/nix/call-tools.nix") pkgs);
             }
           ];
           specialArgs = { inherit pkgs; };


### PR DESCRIPTION
## Problem

`languages.rust` tries to route the `cargo`, `clippy`, and `rustfmt` hooks through `languages.rust.toolchainPackage` via `git-hooks.tools`. That currently does not work because the git-hooks integration sets `tools` as a plain module definition:

```nix
tools = import ...;
```

In the Nix module system, plain definitions win over defaults, so the upstream `tools` attrset from `git-hooks.nix` wins and the Rust module never gets to replace it.

https://github.com/cachix/devenv/blob/f30a244f8175ef14ed1a4e4dfc737d28ecc5d852/src/modules/languages/rust.nix#L395-L399

This means the shell can use one Rust toolchain while the git hooks still use another one, which can lead to version mismatch failures.

```
     = note: the following crate versions were found:
             crate `serde_json` compiled by rustc 1.94.1 (e408947bf 2026-03-25): /home/ilkecan/repos/git/github.com/ilkecan/graft/target/debug/deps/libserde_json-c5bc9e90e729f10d.rmeta
     = help: please recompile that crate using this compiler (rustc 1.93.0 (254b59607 2026-01-19) (built from a source tarball)) (consider running `cargo clean` first)
```

## Fix

This patch changes that definition to:

```nix
tools = lib.mapAttrs (_: lib.mkOptionDefault) (import ...);
```

This applies option-default priority to each tool entry individually. That allows module-provided defaults such as `languages.rust.toolchainPackage` to override only the relevant tools while preserving the rest of the default tool set. Explicit user configuration still takes precedence.

## Follow-up Note

Separately, I think `config.lib.mkOverrideDefault = lib.mkOverride 500` is probably unnecessary at the current git-hooks call sites.

Once each `git-hooks.tools` entry is an option default, plain `lib.mkDefault` should be enough for cases like the Rust module, and it is preferable because it uses the standard module API and is easier to read.

From a quick grep, the current `mkOverrideDefault` uses seem to target upstream plain definitions, so the custom helper does not appear to buy much in practice.