### PR TITLE
languages: replace nix-hash with a faster checksum check

### DIFF
--- a/src/modules/languages/javascript.nix
+++ b/src/modules/languages/javascript.nix
@@ -11,15 +11,15 @@ let
     lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
   }node_modules";
 
+  dirPrefix = lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"'';
+
   initNpmScript = pkgs.writeShellScript "init-npm.sh" ''
     function _devenv-npm-install()
     {
       # Avoid running "npm install" for every shell.
       # Only run it when the "package-lock.json" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "package-lock.json" in node_modules.
-      local ACTUAL_NPM_CHECKSUM="${cfg.npm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
-        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
-      }package-lock.json)"
+      local ACTUAL_NPM_CHECKSUM="${cfg.npm.package.version}:${config.lib._fileChecksum "${dirPrefix}package-lock.json"}"
       local NPM_CHECKSUM_FILE="${nodeModulesPath}/package-lock.json.checksum"
       if [ -f "$NPM_CHECKSUM_FILE" ]
         then
@@ -61,9 +61,7 @@ let
       # Avoid running "pnpm install" for every shell.
       # Only run it when the "package-lock.json" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "package-lock.json" in node_modules.
-      local ACTUAL_PNPM_CHECKSUM="${cfg.pnpm.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
-        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
-      }pnpm-lock.yaml)"
+      local ACTUAL_PNPM_CHECKSUM="${cfg.pnpm.package.version}:${config.lib._fileChecksum "${dirPrefix}pnpm-lock.yaml"}"
       local PNPM_CHECKSUM_FILE="${nodeModulesPath}/pnpm-lock.yaml.checksum"
       if [ -f "$PNPM_CHECKSUM_FILE" ]
         then
@@ -105,9 +103,7 @@ let
       # Avoid running "yarn install" for every shell.
       # Only run it when the "yarn.lock" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "yarn.lock" in node_modules.
-      local ACTUAL_YARN_CHECKSUM="${cfg.yarn.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
-        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
-      }yarn.lock)"
+      local ACTUAL_YARN_CHECKSUM="${cfg.yarn.package.version}:${config.lib._fileChecksum "${dirPrefix}yarn.lock"}"
       local YARN_CHECKSUM_FILE="${nodeModulesPath}/yarn.lock.checksum"
       if [ -f "$YARN_CHECKSUM_FILE" ]
         then
@@ -150,9 +146,7 @@ let
       # Avoid running "bun install" for every shell.
       # Only run it when the "bun.lock" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "bun.lock" in node_modules.
-      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
-        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
-      }bun.lock)"
+      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:${config.lib._fileChecksum "${dirPrefix}bun.lock"}"
       local BUN_CHECKSUM_FILE="${nodeModulesPath}/bun.lock.checksum"
       if [ -f "$BUN_CHECKSUM_FILE" ]
         then
@@ -187,9 +181,7 @@ let
       # Avoid running "bun install --yarn" for every shell.
       # Only run it when the "yarn.lock" file or nodejs version has changed.
       # We do this by storing the nodejs version and a hash of "yarn.lock" in node_modules.
-      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:$(${pkgs.nix}/bin/nix-hash --type sha256 ${
-        lib.optionalString (cfg.directory != config.devenv.root) ''"${cfg.directory}/"''
-      }yarn.lock)"
+      local ACTUAL_BUN_CHECKSUM="${cfg.bun.package.version}:${config.lib._fileChecksum "${dirPrefix}yarn.lock"}"
       local BUN_CHECKSUM_FILE="${nodeModulesPath}/yarn.lock.checksum"
       if [ -f "$BUN_CHECKSUM_FILE" ]
         then

--- a/src/modules/languages/python/default.nix
+++ b/src/modules/languages/python/default.nix
@@ -190,7 +190,7 @@ let
 
       # Avoid running "uv sync" for every shell.
       # Only run it when the "pyproject.toml" file or Python interpreter has changed.
-      local ACTUAL_UV_CHECKSUM="${cfg.package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 pyproject.toml):''${UV_SYNC_COMMAND[@]}"
+      local ACTUAL_UV_CHECKSUM="${cfg.package.interpreter}:${config.lib._fileChecksum "pyproject.toml"}:''${UV_SYNC_COMMAND[@]}"
       local UV_CHECKSUM_FILE="$VENV_PATH/uv.sync.checksum"
       if [ -f "$UV_CHECKSUM_FILE" ]
       then
@@ -250,7 +250,7 @@ let
       # Avoid running "poetry install" for every shell.
       # Only run it when the "poetry.lock" file or Python interpreter has changed.
       # We do this by storing the interpreter path and a hash of "poetry.lock" in venv.
-      local ACTUAL_POETRY_CHECKSUM="${cfg.package.interpreter}:$(${pkgs.nix}/bin/nix-hash --type sha256 pyproject.toml):$(${pkgs.nix}/bin/nix-hash --type sha256 poetry.lock):''${POETRY_INSTALL_COMMAND[@]}"
+      local ACTUAL_POETRY_CHECKSUM="${cfg.package.interpreter}:${config.lib._fileChecksum "pyproject.toml"}:${config.lib._fileChecksum "poetry.lock"}:''${POETRY_INSTALL_COMMAND[@]}"
       local POETRY_CHECKSUM_FILE=".venv/poetry.lock.checksum"
       if [ -f "$POETRY_CHECKSUM_FILE" ]
       then

--- a/src/modules/lib.nix
+++ b/src/modules/lib.nix
@@ -1,4 +1,4 @@
-{ lib, config, inputs, ... }:
+{ pkgs, lib, config, inputs, ... }:
 
 {
   # freestyle
@@ -75,6 +75,10 @@
           value = if r.value != null then r.value else builtins.seq check null;
         })
         results);
+
+    # Generate a shell expression that checksums a file for change detection.
+    # Returns only the checksum value (no filename).
+    _fileChecksum = path: "$(${pkgs.coreutils}/bin/cksum ${lib.escapeShellArg path} | ${pkgs.coreutils}/bin/cut -f1 -d' ')";
 
     mkTests = folder:
       let


### PR DESCRIPTION
nix-hash creates and hashes a NAR, which we don't need at any of the call sites. There is significant overhead to running this command (100+ms if not more sometimes, daemon xpc?).