### PR TITLE
feat(containers): add fromImage option for base image support

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -99,6 +99,7 @@ let
   mkDerivation = cfg: nix2container.nix2container.buildImage {
     name = cfg.name;
     tag = cfg.version;
+    fromImage = cfg.fromImage;
     initializeNixDatabase = true;
     nixUid = lib.toInt uid;
     nixGid = lib.toInt gid;
@@ -198,6 +199,12 @@ let
         description = "Name of the container.";
         defaultText = "top-level name or containers.mycontainer.name";
         default = "${projectName name}-${name}";
+      };
+
+      fromImage = lib.mkOption {
+        type = types.nullOr types.package;
+        description = "An existing OCI base image to build on top of, built with nix2container's pullImage.";
+        default = null;
       };
 
       version = lib.mkOption {

--- a/tests/container-from-image/.test.sh
+++ b/tests/container-from-image/.test.sh
@@ -1,0 +1,5 @@
+set -xe
+
+devenv container build test
+
+echo "container-from-image: build succeeded"

--- a/tests/container-from-image/devenv.nix
+++ b/tests/container-from-image/devenv.nix
@@ -1,0 +1,17 @@
+{ pkgs, inputs, ... }:
+
+let
+  nix2container = inputs.nix2container.packages.${pkgs.stdenv.system}.nix2container;
+in
+{
+  name = "from-image-test";
+
+  containers.test = {
+    name = "from-image-test";
+    fromImage = nix2container.pullImage {
+      imageName = "docker.io/library/alpine";
+      imageDigest = "sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c";
+      sha256 = "sha256-hCgBDeQAulu/MSPPvojHcoynV1v1pjXtkir/dULO3Wk=";
+    };
+  };
+}

--- a/tests/container-from-image/devenv.yaml
+++ b/tests/container-from-image/devenv.yaml
@@ -1,0 +1,12 @@
+inputs:
+  devenv:
+    url: path:../../?dir=src/modules
+  mk-shell-bin:
+    url: github:rrbutani/nix-mk-shell-bin
+  nix2container:
+    url: github:nlewo/nix2container
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
## Summary

Add a `fromImage` option to `containers.<name>`, exposing nix2container's `fromImage` parameter. This allows building container images on top of an existing OCI base image (e.g. Ubuntu, Alpine) instead of from scratch.

## Changes

- `src/modules/containers.nix`: Add `fromImage` option and pass it through to `nix2container.buildImage`
- `tests/container-from-image/`: Test that builds a container with Alpine as base image