### PR TITLE
feat: add version constraint field to devenv.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Auto-detect AI coding agents (via `CLAUDECODE`, `OPENCODE_CLIENT`, and `AI_AGENT` environment variables) and enable quiet mode to avoid wasting LLM tokens on TUI progress output. Override with `--verbose` or `--tui` ([#2723](https://github.com/cachix/devenv/issues/2723)).
 - Always enable Nix's `show-trace` setting so full evaluation stack traces are shown on error, instead of a truncated trace suggesting the nonexistent `--show-trace` flag ([#2725](https://github.com/cachix/devenv/issues/2725)).
 - Upgraded Nix to 2.34, bringing multithreaded tarball unpacking, evaluator performance improvements, and REPL enhancements.
+- Added `require_version` field to `devenv.yaml` to enforce a devenv CLI version. Set to `true` to match the modules version, or use a constraint string like `">=2.1"` ([#2391](https://github.com/cachix/devenv/issues/2391)).
 - Added Ctrl-X keybinding to stop individual processes from the TUI while keeping them visible and restartable.
 - Tasks can now display messages when entering the shell by writing `{"devenv":{"messages":["..."]}}` to `$DEVENV_TASK_OUTPUT_FILE` ([#2500](https://github.com/cachix/devenv/issues/2500)).
 - Added `devenv hook <shell>` for native directory based auto-activation without direnv. Supports bash, zsh, fish, and nushell. Automatically deactivates when you leave the project directory. Add `eval "$(devenv hook bash)"` to your shell config to activate. Use `devenv allow` and `devenv revoke` to manage trust ([#2488](https://github.com/cachix/devenv/issues/2488)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "regex",
  "schemars 1.2.1",
  "schematic",
+ "semver",
  "ser_nix",
  "serde",
  "serde_json",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6564,6 +6564,10 @@ rec {
             features = [ "schema" "yaml" "renderer_template" "renderer_json_schema" ];
           }
           {
+            name = "semver";
+            packageId = "semver";
+          }
+          {
             name = "ser_nix";
             packageId = "ser_nix";
           }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ secretspec = { git = "https://github.com/cachix/secretspec", tag = "v0.8.0", fea
   "awssm",
   "vault",
 ] }
+semver = "1"
 serde = { version = "1.0.226", features = ["derive"] }
 serde_json = "1.0.145"
 serde_repr = "0.1.20"

--- a/devenv-core/Cargo.toml
+++ b/devenv-core/Cargo.toml
@@ -24,6 +24,7 @@ netstat2.workspace = true
 once_cell.workspace = true
 socket2.workspace = true
 schemars.workspace = true
+semver.workspace = true
 schematic.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -2,6 +2,7 @@ use miette::{IntoDiagnostic, Result, WrapErr, bail};
 use pathdiff;
 use schemars::{JsonSchema, schema_for};
 use schematic::ConfigLoader;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -11,6 +12,19 @@ use std::{
 
 const YAML_CONFIG: &str = "devenv.yaml";
 const YAML_LOCAL_CONFIG: &str = "devenv.local.yaml";
+
+/// Version requirement for the devenv CLI.
+///
+/// - `true`: CLI version must match the modules version (checked during Nix evaluation)
+/// - A constraint string like `">=2.0.0"`: checked before Nix evaluation
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema, schematic::Schematic)]
+#[serde(untagged)]
+pub enum RequireVersion {
+    /// When true, CLI version must match the modules version
+    Match(bool),
+    /// Version constraint string (e.g., ">=2.0.0", "2.0.7")
+    Constraint(String),
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema, schematic::Schematic)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -246,6 +260,12 @@ pub struct Nixpkgs {
 #[config(rename_all = "camelCase", allow_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 pub struct Config {
+    /// Version requirement for the devenv CLI.
+    /// Set to `true` to enforce CLI matches the modules version,
+    /// or a constraint string like `">=2.0.0"`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[setting(merge = schematic::merge::replace)]
+    pub require_version: Option<RequireVersion>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     #[setting(nested, merge = schematic::merge::merge_btreemap)]
     pub inputs: BTreeMap<String, Input>,
@@ -613,6 +633,62 @@ impl Config {
         config.git_root = git_root;
 
         Ok(config)
+    }
+
+    /// Check that `current` (e.g. "2.0.7") satisfies the version requirement in
+    /// `devenv.yaml`. No-op when no requirement is set or when `require_version: true`
+    /// (deferred to Nix evaluation where the modules version is available).
+    pub fn check_version(&self, current: &str) -> Result<()> {
+        let constraint = match &self.require_version {
+            // Match(_) is either disabled (false) or deferred to Nix eval (true)
+            None | Some(RequireVersion::Match(_)) => return Ok(()),
+            Some(RequireVersion::Constraint(c)) => c,
+        };
+
+        // Bare version "2.0.7" means exact match; semver crate treats it as "^2.0.7"
+        let req_str = if constraint.starts_with('>')
+            || constraint.starts_with('<')
+            || constraint.starts_with('=')
+        {
+            constraint.clone()
+        } else {
+            format!("={constraint}")
+        };
+
+        let cur = Self::parse_version(current)
+            .wrap_err_with(|| format!("Failed to parse current devenv version '{current}'"))?;
+        let req = VersionReq::parse(&req_str)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("Failed to parse version constraint '{constraint}' in devenv.yaml")
+            })?;
+
+        if !req.matches(&cur) {
+            bail!(
+                "devenv version {current} does not satisfy the constraint '{constraint}' in devenv.yaml"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns true when `require_version: true` is set, meaning the Nix modules
+    /// should assert that CLI version matches the modules version.
+    pub fn requires_version_match(&self) -> bool {
+        matches!(&self.require_version, Some(RequireVersion::Match(true)))
+    }
+
+    /// Parse a version string, accepting "X.Y" (appending ".0") and "X.Y.Z".
+    fn parse_version(s: &str) -> Result<Version> {
+        // semver crate requires X.Y.Z; support X.Y by appending .0
+        let normalized = if s.matches('.').count() == 1 {
+            format!("{s}.0")
+        } else {
+            s.to_string()
+        };
+        Version::parse(&normalized)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("expected version format X.Y or X.Y.Z, got '{s}'"))
     }
 
     /// Detects the git repository root starting from the given path.
@@ -1413,5 +1489,108 @@ imports:
             Some("github:NixOS/nixpkgs/nixos-25.11".to_string()),
             "Base config's nixpkgs URL should take precedence over imported config's URL"
         );
+    }
+
+    #[test]
+    fn check_version_none_always_passes() {
+        let config = Config::default();
+        assert!(config.check_version("2.0.7").is_ok());
+    }
+
+    #[test]
+    fn check_version_false_always_passes() {
+        let config = Config {
+            require_version: Some(RequireVersion::Match(false)),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.0.7").is_ok());
+    }
+
+    #[test]
+    fn check_version_true_deferred_to_nix() {
+        let config = Config {
+            require_version: Some(RequireVersion::Match(true)),
+            ..Default::default()
+        };
+        // `true` is checked during Nix evaluation, so Rust check always passes
+        assert!(config.check_version("2.0.7").is_ok());
+        assert!(config.requires_version_match());
+    }
+
+    #[test]
+    fn check_version_exact_match() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint("2.0.7".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.0.7").is_ok());
+        assert!(config.check_version("2.0.8").is_err());
+    }
+
+    #[test]
+    fn check_version_gte() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint(">=2.0.0".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.0.0").is_ok());
+        assert!(config.check_version("2.0.7").is_ok());
+        assert!(config.check_version("3.0.0").is_ok());
+        assert!(config.check_version("1.9.9").is_err());
+    }
+
+    #[test]
+    fn check_version_lt() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint("<3.0.0".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.0.7").is_ok());
+        assert!(config.check_version("3.0.0").is_err());
+    }
+
+    #[test]
+    fn check_version_two_component() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint(">=2.1".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.1.0").is_ok());
+        assert!(config.check_version("2.1.5").is_ok());
+        assert!(config.check_version("2.0.9").is_err());
+    }
+
+    #[test]
+    fn check_version_invalid_constraint() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint(">=abc".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("2.0.7").is_err());
+    }
+
+    #[test]
+    fn check_version_invalid_current() {
+        let config = Config {
+            require_version: Some(RequireVersion::Constraint(">=2.0.0".to_string())),
+            ..Default::default()
+        };
+        assert!(config.check_version("not-a-version").is_err());
+    }
+
+    #[test]
+    fn require_version_yaml_bool() {
+        let yaml = "require_version: true\n";
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let rv: RequireVersion = serde_yaml::from_value(parsed["require_version"].clone()).unwrap();
+        assert_eq!(rv, RequireVersion::Match(true));
+    }
+
+    #[test]
+    fn require_version_yaml_string() {
+        let yaml = "require_version: \">=2.0.0\"\n";
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        let rv: RequireVersion = serde_yaml::from_value(parsed["require_version"].clone()).unwrap();
+        assert_eq!(rv, RequireVersion::Constraint(">=2.0.0".to_string()));
     }
 }

--- a/devenv-core/src/nix_args.rs
+++ b/devenv-core/src/nix_args.rs
@@ -322,6 +322,9 @@ pub struct NixArgs<'a> {
     /// Whether this is a development build (not from a release tag)
     pub is_development_version: bool,
 
+    /// Whether `require_version: true` is set, meaning CLI must match modules version
+    pub require_version_match: bool,
+
     /// The system string (e.g., "x86_64-linux", "aarch64-darwin")
     pub system: &'a str,
 
@@ -443,6 +446,7 @@ mod tests {
         let args = NixArgs {
             version,
             is_development_version: false,
+            require_version_match: false,
             system,
             devenv_root: &root,
             skip_local_src: false,
@@ -551,6 +555,7 @@ mod tests {
         let args = NixArgs {
             version,
             is_development_version: false,
+            require_version_match: false,
             system,
             devenv_root: &root,
             skip_local_src: false,

--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -24,6 +24,7 @@ rec {
   mkDevenvForSystem =
     { version
     , is_development_version ? false
+    , require_version_match ? false
     , system
     , devenv_root
     , git_root ? null
@@ -158,6 +159,7 @@ rec {
                     {
                       cli.version = version;
                       cli.isDevelopment = is_development_version;
+                      cli.requireVersionMatch = require_version_match;
                     }
                   else
                     {

--- a/devenv-nix-backend/tests/test_flake_lock.rs
+++ b/devenv-nix-backend/tests/test_flake_lock.rs
@@ -44,6 +44,7 @@ impl TestNixArgs {
         NixArgs {
             version: "1.0.0",
             is_development_version: false,
+            require_version_match: false,
             system: get_current_system(),
             devenv_root: &paths.root,
             skip_local_src: false,

--- a/devenv-nix-backend/tests/test_nix_backend.rs
+++ b/devenv-nix-backend/tests/test_nix_backend.rs
@@ -96,6 +96,7 @@ impl TestNixArgs {
         NixArgs {
             version: "1.0.0",
             is_development_version: false,
+            require_version_match: false,
             system: get_current_system(),
             devenv_root: &paths.root,
             skip_local_src: false,

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -79,6 +79,7 @@ pub struct DevenvOptions {
     pub secret_settings: SecretSettings,
     pub input_overrides: InputOverrides,
     pub from_external: bool,
+    pub require_version_match: bool,
     pub devenv_root: Option<PathBuf>,
     pub devenv_dotfile: Option<PathBuf>,
     pub devenv_state: Option<PathBuf>,
@@ -99,6 +100,7 @@ impl DevenvOptions {
             secret_settings: SecretSettings::default(),
             input_overrides: InputOverrides::default(),
             from_external: false,
+            require_version_match: false,
             devenv_root: None,
             devenv_dotfile: None,
             devenv_state: None,
@@ -213,6 +215,7 @@ pub struct Devenv {
     pub secret_settings: SecretSettings,
     pub input_overrides: InputOverrides,
     pub from_external: bool,
+    require_version_match: bool,
     is_testing: bool,
 
     pub nix: Arc<Box<dyn NixBackend>>,
@@ -398,6 +401,7 @@ impl Devenv {
             secret_settings,
             input_overrides: options.input_overrides,
             from_external: options.from_external,
+            require_version_match: options.require_version_match,
             is_testing: options.is_testing,
             devenv_root,
             devenv_dotfile,
@@ -2063,6 +2067,7 @@ impl Devenv {
         let args = NixArgs {
             version: crate_version!(),
             is_development_version: crate::is_development_version(),
+            require_version_match: self.require_version_match,
             system: &self.nix_settings.system,
             devenv_root: &self.devenv_root,
             skip_local_src: self.from_external

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -204,6 +204,7 @@ fn prepare_launch_config(mut cli: Cli) -> Result<LaunchConfig> {
     let tracing_output = cli.tracing_args.trace_output;
 
     let mut config = Config::load()?;
+    config.check_version(crate_version!())?;
 
     let input_overrides = InputOverrides::from(cli.input_overrides);
 
@@ -574,6 +575,8 @@ async fn run_backend(
 
     let config_strict_ports = config.strict_ports.unwrap_or(false);
 
+    let require_version_match = config.requires_version_match();
+
     let mut options = devenv::DevenvOptions {
         inputs: config.inputs,
         imports: config.imports,
@@ -585,6 +588,7 @@ async fn run_backend(
         secret_settings,
         input_overrides,
         from_external,
+        require_version_match,
         devenv_root: None,
         devenv_dotfile: None,
         devenv_state: None,

--- a/docs/src/files-and-variables.md
+++ b/docs/src/files-and-variables.md
@@ -23,6 +23,18 @@ that developers can override some things for their local use case.
 Configuration for [inputs](inputs.md) and [imports](composing-using-imports.md),
 allowing you to specify dependencies and how to compose them.
 
+You can require a specific devenv version to make sure all developers use a compatible version:
+
+```yaml title="devenv.yaml"
+# Enforce CLI matches the modules version
+require_version: true
+
+# Or use an explicit constraint
+require_version: ">=2.1"
+```
+
+See [devenv.yaml reference](reference/yaml-options.md#require_version) for details.
+
 ### devenv.lock
 
 Pinned [inputs](inputs.md), making sure your developer environment is reproducible.

--- a/docs/src/reference/yaml-options.md
+++ b/docs/src/reference/yaml-options.md
@@ -189,3 +189,26 @@ Error if a port is already in use instead of auto-allocating the next available 
 Can be overridden by `--strict-ports` or `--no-strict-ports` CLI flags.
 
 *Type:* `boolean` · *Default:* `false`
+
+## require_version
+
+Require a specific devenv CLI version. Set to `true` to enforce that the CLI version matches
+the modules version (from the `devenv` input), or use a constraint string with operators.
+
+```yaml
+# Enforce CLI matches modules version (recommended for teams)
+require_version: true
+
+# Or use an explicit constraint
+require_version: ">=2.1"
+```
+
+Supported constraint operators: `>=`, `<=`, `>`, `<`, `=`, or a bare version for exact match.
+
+When set to `true`, the check happens during Nix evaluation and compares the CLI version
+against the version embedded in the `devenv` input. This keeps versions in sync automatically
+after running `devenv update`.
+
+*Type:* `boolean | string` · *Default:* not set
+
+!!! tip "New in version 2.1"

--- a/src/modules/update-check.nix
+++ b/src/modules/update-check.nix
@@ -2,6 +2,10 @@
 
 let
   cfg = config.devenv;
+  # Strip trailing .0 segments so that e.g. "2.1.0" compares equal to "2.1".
+  normalizeVersion = v:
+    let stripped = lib.removeSuffix ".0" v;
+    in if stripped != v then normalizeVersion stripped else v;
 in
 {
   imports = [
@@ -38,6 +42,15 @@ in
           Whether the CLI was built from a development (non-release) version.
         '';
       };
+      requireVersionMatch = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        internal = true;
+        description = ''
+          Whether require_version: true is set in devenv.yaml,
+          meaning the CLI version must match the modules version.
+        '';
+      };
     };
     latestVersion = lib.mkOption {
       type = lib.types.str;
@@ -56,8 +69,23 @@ in
     };
   };
 
-  config = lib.mkIf cfg.warnOnNewVersion {
-    enterShell =
+  config = {
+    assertions = lib.mkIf cfg.cli.requireVersionMatch [
+      {
+        assertion =
+          cfg.cli.version == null
+          || cfg.cli.isDevelopment
+          || normalizeVersion cfg.cli.version == normalizeVersion cfg.latestVersion;
+        message = ''
+          devenv CLI version ${cfg.cli.version} does not match the modules version ${cfg.latestVersion}.
+
+          require_version: true is set in devenv.yaml, which requires the CLI and modules versions to match.
+          Run 'devenv update' to sync the modules, or update your CLI to version ${cfg.latestVersion}.
+        '';
+      }
+    ];
+
+    enterShell = lib.mkIf cfg.warnOnNewVersion (
       let
         versionWarning =
           if cfg.cli.version == null then ""
@@ -74,12 +102,6 @@ in
                   echo "✨ devenv ${cfg.cli.version} is out of date. Please update to ${cfg.latestVersion}: https://devenv.sh/getting-started/#installation" >&2
                 '';
               };
-              # Normalize versions by stripping trailing .0 to make X.x.0 equivalent to X.X
-              normalizeVersion = v:
-                let
-                  stripped = builtins.replaceStrings [ ".0" ] [ "" ] v;
-                in
-                if stripped != v then normalizeVersion stripped else v;
               normalizedCliVersion = normalizeVersion cfg.cli.version;
               normalizedLatestVersion = normalizeVersion cfg.latestVersion;
               versionComparison = builtins.compareVersions normalizedCliVersion normalizedLatestVersion;
@@ -129,6 +151,7 @@ in
             fi
           fi
         } >&2
-      '';
+      ''
+    );
   };
 }


### PR DESCRIPTION
## Summary

- Add `version` field to `devenv.yaml` that checks the running devenv version against a constraint (e.g. `>=2.1`, `<3.0.0`, `2.0.7`)
- Errors early (before Nix evaluation) if the constraint is not satisfied
- Supports `X.Y` and `X.Y.Z` version formats with `>=`, `<=`, `>`, `<`, `=` operators or bare version for exact match

Closes #2391.

## Test plan

- [x] Unit tests for all operators, two-component versions, exact match, no constraint, invalid inputs
- [ ] Manual: add `version: ">=99.0.0"` to a devenv.yaml, confirm error
- [ ] Manual: add `version: ">=2.0.0"` to a devenv.yaml, confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)