### PR TITLE
feat(tasks): default --mode to before so dependencies run by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 - Shell environment now auto-reloads at the next prompt when watched files change, instead of requiring a manual Ctrl-Alt-R keybind ([#2595](https://github.com/cachix/devenv/issues/2595)).
 - Added `nixpkgs.rocmSupport` option to enable ROCm support in nixpkgs configuration.
 - Added process management subcommands and MCP tools: `devenv processes list`, `status`, `logs`, `restart`, `start`, `stop` for interacting with running native processes ([#2621](https://github.com/cachix/devenv/issues/2621)).
+
+### Breaking Changes
+
+- **`devenv tasks run`**: The default execution mode is now `before` instead of `single`, so task dependencies declared via `before`/`after` are respected by default. Running `devenv tasks run admin:deploy` now also runs any tasks that `admin:deploy` depends on. Use `--mode single` to restore the previous behavior of running only the specified task ([#2551](https://github.com/cachix/devenv/issues/2551)).
+
 ## 2.0.6 (2026-03-22)
 
 ### Bug Fixes

--- a/devenv-tasks/src/main.rs
+++ b/devenv-tasks/src/main.rs
@@ -20,7 +20,7 @@ enum Command {
         #[clap()]
         roots: Vec<String>,
 
-        #[clap(long, value_enum, default_value_t = RunMode::Single, help = "The execution mode for tasks (affects dependency resolution)")]
+        #[clap(long, value_enum, default_value_t = RunMode::Before, help = "The execution mode for tasks (affects dependency resolution)")]
         mode: RunMode,
 
         #[clap(

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -735,7 +735,7 @@ pub enum TasksCommand {
             long,
             help = "The execution mode for tasks (affects dependency resolution)",
             value_enum,
-            default_value_t = RunMode::Single
+            default_value_t = RunMode::Before
         )]
         mode: RunMode,
 


### PR DESCRIPTION
## Summary
- Change the default execution mode of `devenv tasks run` from `single` to `before` so that task dependencies declared via `before`/`after` are respected out of the box.
- Running `devenv tasks run admin:deploy` now runs any tasks that `admin:deploy` depends on (e.g. via `after = [ \"admin:build\" ]`), instead of silently skipping them.
- Use `--mode single` to restore the previous behavior of running only the specified task.

Fixes #2551

## Test plan
- [ ] `devenv-run-tests run tests --only tasks` still passes (the existing suite explicitly uses `--mode all` where needed, and the remaining task invocations have no dependencies)
- [ ] `cargo nextest run -p devenv-tasks` still passes
- [ ] Manually verify a task with `after = [ \"...\" ]` now pulls in its upstream dependency by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)