### PR TITLE
Fix RabbitMQ dynamic allocation for distribution and EPMD ports

### DIFF
--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -146,47 +146,65 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    packages = [ cfg.package ];
+  config = mkMerge [
+    {
+      changelogs = [
+        {
+          date = "2026-04-11";
+          title = "services.rabbitmq: allocate distribution and EPMD ports dynamically";
+          when = cfg.enable;
+          description = ''
+            RabbitMQ's Erlang distribution port and EPMD port now use devenv's dynamic port allocation,
+            just like the AMQP and management listeners.
 
-    services.rabbitmq.configItems = {
-      "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString allocatedPort}";
-      "distribution.listener.interface" = mkDefault cfg.listenAddress;
-    } // optionalAttrs cfg.managementPlugin.enable {
-      "management.tcp.port" = toString allocatedManagementPort;
-      "management.tcp.ip" = cfg.listenAddress;
-    };
+            This avoids hardcoded use of ports `25672` and `4369`, which could previously cause port collisions
+            when running multiple environments.
+          '';
+        }
+      ];
+    }
+    (mkIf cfg.enable {
+      packages = [ cfg.package ];
 
-    services.rabbitmq.plugins =
-      optional cfg.managementPlugin.enable "rabbitmq_management";
-
-    env.RABBITMQ_DATA_DIR = config.env.DEVENV_STATE + "/rabbitmq";
-    env.RABBITMQ_MNESIA_BASE = config.env.RABBITMQ_DATA_DIR + "/mnesia";
-    env.RABBITMQ_LOGS = "-";
-    env.RABBITMQ_LOG_BASE = config.env.RABBITMQ_DATA_DIR + "/logs";
-    env.RABBITMQ_CONFIG_FILE = config_file;
-    env.RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
-    env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
-    env.RABBITMQ_NODENAME = cfg.nodeName;
-    env.RABBITMQ_HOST = cfg.listenAddress;
-    env.RABBITMQ_DIST_PORT = toString allocatedDistributionPort;
-    env.ERL_EPMD_ADDRESS = cfg.listenAddress;
-    env.ERL_EPMD_PORT = toString allocatedEpmdPort;
-
-    processes.rabbitmq = {
-      ports.main.allocate = basePort;
-      ports.management.allocate = baseManagementPort;
-      ports.distribution.allocate = basePort + 20000;
-      ports.epmd.allocate = 4369;
-      exec = "exec ${cfg.package}/bin/rabbitmq-server";
-
-      ready = {
-        exec = "${cfg.package}/bin/rabbitmq-diagnostics -q ping";
-        initial_delay = 10;
-        period = 3;
-        probe_timeout = 3;
-        failure_threshold = 5;
+      services.rabbitmq.configItems = {
+        "listeners.tcp.1" = mkDefault "${cfg.listenAddress}:${toString allocatedPort}";
+        "distribution.listener.interface" = mkDefault cfg.listenAddress;
+      } // optionalAttrs cfg.managementPlugin.enable {
+        "management.tcp.port" = toString allocatedManagementPort;
+        "management.tcp.ip" = cfg.listenAddress;
       };
-    };
-  };
+
+      services.rabbitmq.plugins =
+        optional cfg.managementPlugin.enable "rabbitmq_management";
+
+      env.RABBITMQ_DATA_DIR = config.env.DEVENV_STATE + "/rabbitmq";
+      env.RABBITMQ_MNESIA_BASE = config.env.RABBITMQ_DATA_DIR + "/mnesia";
+      env.RABBITMQ_LOGS = "-";
+      env.RABBITMQ_LOG_BASE = config.env.RABBITMQ_DATA_DIR + "/logs";
+      env.RABBITMQ_CONFIG_FILE = config_file;
+      env.RABBITMQ_PLUGINS_DIR = concatStringsSep ":" cfg.pluginDirs;
+      env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
+      env.RABBITMQ_NODENAME = cfg.nodeName;
+      env.RABBITMQ_HOST = cfg.listenAddress;
+      env.RABBITMQ_DIST_PORT = toString allocatedDistributionPort;
+      env.ERL_EPMD_ADDRESS = cfg.listenAddress;
+      env.ERL_EPMD_PORT = toString allocatedEpmdPort;
+
+      processes.rabbitmq = {
+        ports.main.allocate = basePort;
+        ports.management.allocate = baseManagementPort;
+        ports.distribution.allocate = basePort + 20000;
+        ports.epmd.allocate = 4369;
+        exec = "exec ${cfg.package}/bin/rabbitmq-server";
+
+        ready = {
+          exec = "${cfg.package}/bin/rabbitmq-diagnostics -q ping";
+          initial_delay = 10;
+          period = 3;
+          probe_timeout = 3;
+          failure_threshold = 5;
+        };
+      };
+    })
+  ];
 }

--- a/src/modules/services/rabbitmq.nix
+++ b/src/modules/services/rabbitmq.nix
@@ -12,6 +12,8 @@ let
   baseManagementPort = cfg.managementPlugin.port;
   allocatedPort = config.processes.rabbitmq.ports.main.value;
   allocatedManagementPort = config.processes.rabbitmq.ports.management.value;
+  allocatedDistributionPort = config.processes.rabbitmq.ports.distribution.value;
+  allocatedEpmdPort = config.processes.rabbitmq.ports.epmd.value;
 
   config_file_content = lib.generators.toKeyValue { } cfg.configItems;
   config_file = pkgs.writeText "rabbitmq.conf" config_file_content;
@@ -167,11 +169,15 @@ in
     env.RABBITMQ_ENABLED_PLUGINS_FILE = plugin_file;
     env.RABBITMQ_NODENAME = cfg.nodeName;
     env.RABBITMQ_HOST = cfg.listenAddress;
+    env.RABBITMQ_DIST_PORT = toString allocatedDistributionPort;
     env.ERL_EPMD_ADDRESS = cfg.listenAddress;
+    env.ERL_EPMD_PORT = toString allocatedEpmdPort;
 
     processes.rabbitmq = {
       ports.main.allocate = basePort;
       ports.management.allocate = baseManagementPort;
+      ports.distribution.allocate = basePort + 20000;
+      ports.epmd.allocate = 4369;
       exec = "exec ${cfg.package}/bin/rabbitmq-server";
 
       ready = {


### PR DESCRIPTION
This fixes `services.rabbitmq` so RabbitMQ's Erlang distribution port and EPMD port use devenv's dynamic port allocation, just like the existing AMQP (`5672`) and management (`15672`) listeners. Previously, RabbitMQ could still bind fixed ports `25672` and `4369`, which made parallel environments needlessly collide.

The change adds allocated `distribution` and `epmd` ports under `processes.rabbitmq.ports`, exports them through `RABBITMQ_DIST_PORT` and `ERL_EPMD_PORT`, which is what RabbitMQ picks up.