### PR TITLE
process.watch: Ignore read/access and metadata-only file watcher events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `processes.<name>.watch` restarting processes on read-only access, directory listing, and metadata-only file events ([#2734](https://github.com/cachix/devenv/pull/2734)).
 - Fixed `imports` overriding the base project's `inputs` (e.g. `inputs.nixpkgs.url`) instead of the base config taking precedence ([#2728](https://github.com/cachix/devenv/issues/2728)).
 - Fixed Boehm GC "Repeated allocation of very large block" warnings being printed to stderr during `devenv shell`.
 - Fixed `devenv hook` not changing directory when `cd`ing out of a devenv project. The shell would deactivate but remain in the project directory instead of following the user to the target directory.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1935,6 +1935,7 @@ dependencies = [
  "tokio",
  "tracing",
  "watchexec",
+ "watchexec-events",
  "watchexec-filterer-globset",
 ]
 

--- a/devenv-event-sources/Cargo.toml
+++ b/devenv-event-sources/Cargo.toml
@@ -17,6 +17,7 @@ reqwest.workspace = true
 tokio = { workspace = true, features = ["net", "process"] }
 tracing.workspace = true
 watchexec.workspace = true
+watchexec-events = "6.1"
 watchexec-filterer-globset.workspace = true
 
 [dev-dependencies]

--- a/devenv-event-sources/src/fs.rs
+++ b/devenv-event-sources/src/fs.rs
@@ -352,12 +352,22 @@ impl FileWatcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::fs::File;
-    use std::io::Write;
+    use std::io::{Read, Write};
     use std::time::Duration;
     use tempfile::TempDir;
 
     const WATCH_TIMEOUT: Duration = Duration::from_secs(30);
+    const NO_EVENT_TIMEOUT: Duration = Duration::from_millis(500);
+
+    async fn assert_no_event(watcher: &mut FileWatcher, context: &str) {
+        let result = tokio::time::timeout(NO_EVENT_TIMEOUT, watcher.recv()).await;
+        assert!(
+            result.is_err(),
+            "unexpected file watcher event for {context}"
+        );
+    }
 
     #[tokio::test]
     async fn test_detects_file_modification() {
@@ -638,5 +648,97 @@ mod tests {
             .expect("event");
 
         assert_eq!(event.path, file1);
+    }
+
+    #[tokio::test]
+    async fn test_read_only_access_does_not_emit_change_event() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let base = temp_dir.path().canonicalize().expect("canonicalize");
+        let file_path = base.join("artifact.jar");
+
+        fs::write(&file_path, b"pretend jar bytes").expect("write file");
+
+        let paths = vec![file_path.clone()];
+        let mut watcher = FileWatcher::new(
+            FileWatcherConfig {
+                paths: &paths,
+                recursive: false,
+                ..Default::default()
+            },
+            "read-only-access",
+        )
+        .await;
+
+        let mut contents = Vec::new();
+        File::open(&file_path)
+            .expect("open file")
+            .read_to_end(&mut contents)
+            .expect("read file");
+        assert_eq!(contents, b"pretend jar bytes");
+
+        assert_no_event(&mut watcher, "read-only file access").await;
+    }
+
+    #[tokio::test]
+    async fn test_directory_listing_does_not_emit_change_event_for_children() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let watch_dir = temp_dir.path().canonicalize().expect("canonicalize");
+        let jar1 = watch_dir.join("app.jar");
+        let jar2 = watch_dir.join("lib.jar");
+
+        fs::write(&jar1, b"jar one").expect("write jar1");
+        fs::write(&jar2, b"jar two").expect("write jar2");
+
+        let paths = vec![watch_dir.clone()];
+        let mut watcher = FileWatcher::new(
+            FileWatcherConfig {
+                paths: &paths,
+                recursive: true,
+                ..Default::default()
+            },
+            "directory-listing",
+        )
+        .await;
+
+        let entries: Vec<_> = fs::read_dir(&watch_dir)
+            .expect("read dir")
+            .map(|entry| entry.expect("dir entry").file_name())
+            .collect();
+        assert_eq!(entries.len(), 2);
+
+        assert_no_event(&mut watcher, "directory listing").await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_metadata_only_chmod_does_not_emit_change_event() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let base = temp_dir.path().canonicalize().expect("canonicalize");
+        let file_path = base.join("artifact.jar");
+
+        fs::write(&file_path, b"pretend jar bytes").expect("write file");
+
+        let paths = vec![file_path.clone()];
+        let mut watcher = FileWatcher::new(
+            FileWatcherConfig {
+                paths: &paths,
+                recursive: false,
+                ..Default::default()
+            },
+            "chmod-only",
+        )
+        .await;
+
+        let mut perms = fs::metadata(&file_path).expect("metadata").permissions();
+        perms.set_mode(0o600);
+        fs::set_permissions(&file_path, perms).expect("set perms 600");
+
+        let mut perms = fs::metadata(&file_path).expect("metadata").permissions();
+        perms.set_mode(0o644);
+        fs::set_permissions(&file_path, perms).expect("set perms 644");
+
+        assert_no_event(&mut watcher, "metadata-only chmod").await;
     }
 }

--- a/devenv-event-sources/src/fs.rs
+++ b/devenv-event-sources/src/fs.rs
@@ -8,6 +8,10 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 use watchexec::{Config, WatchedPath};
+use watchexec_events::{
+    Tag,
+    filekind::{FileEventKind, ModifyKind},
+};
 use watchexec_filterer_globset::GlobsetFilterer;
 
 #[derive(Debug, Clone)]
@@ -311,6 +315,9 @@ impl FileWatcher {
                     if !filterer.check_event(event, *priority).unwrap_or(true) {
                         continue;
                     }
+                    if !is_restart_worthy_event(event) {
+                        continue;
+                    }
                     for (path, _) in event.paths() {
                         let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
                         // Use send().await instead of try_send to apply backpressure
@@ -349,6 +356,24 @@ impl FileWatcher {
     }
 }
 
+fn is_restart_worthy_event(event: &watchexec_events::Event) -> bool {
+    event.tags.iter().any(|tag| match tag {
+        Tag::FileEventKind(kind) => is_restart_worthy_kind(kind),
+        _ => false,
+    })
+}
+
+fn is_restart_worthy_kind(kind: &FileEventKind) -> bool {
+    match kind {
+        FileEventKind::Create(_)
+        | FileEventKind::Remove(_)
+        | FileEventKind::Any
+        | FileEventKind::Other => true,
+        FileEventKind::Modify(ModifyKind::Any | ModifyKind::Data(_) | ModifyKind::Name(_)) => true,
+        FileEventKind::Access(_) | FileEventKind::Modify(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -367,6 +392,38 @@ mod tests {
             result.is_err(),
             "unexpected file watcher event for {context}"
         );
+    }
+
+    #[test]
+    fn test_restart_worthy_kind_filter() {
+        use watchexec_events::filekind::{
+            AccessKind, AccessMode, CreateKind, DataChange, MetadataKind, RemoveKind, RenameMode,
+        };
+
+        assert!(is_restart_worthy_kind(&FileEventKind::Create(
+            CreateKind::File
+        )));
+        assert!(is_restart_worthy_kind(&FileEventKind::Remove(
+            RemoveKind::File
+        )));
+        assert!(is_restart_worthy_kind(&FileEventKind::Modify(
+            ModifyKind::Data(DataChange::Any,)
+        )));
+        assert!(is_restart_worthy_kind(&FileEventKind::Modify(
+            ModifyKind::Name(RenameMode::Any,)
+        )));
+        assert!(is_restart_worthy_kind(&FileEventKind::Modify(
+            ModifyKind::Any
+        )));
+        assert!(is_restart_worthy_kind(&FileEventKind::Any));
+        assert!(is_restart_worthy_kind(&FileEventKind::Other));
+
+        assert!(!is_restart_worthy_kind(&FileEventKind::Access(
+            AccessKind::Open(AccessMode::Read,)
+        )));
+        assert!(!is_restart_worthy_kind(&FileEventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Any),
+        )));
     }
 
     #[tokio::test]


### PR DESCRIPTION
DISCLAIMER: Both bug triage, fix and most of this summary is AI Generated (Codex 5.4).

## Summary

This fixes a bug in devenv's native process file watcher where processes could restart even when no meaningful file *change* happened.

Before this change, the watcher treated filesystem noise such as:

- read-only file access
- directory listing
- metadata-only changes like `chmod`

as restart-worthy changes.

In practice, this could make `devenv up` processes restart constantly when watching build artifact directories, especially for apps that read JARs at startup.

This change filters watcher events so only real change signals trigger restarts:

- create
- remove
- rename
- data/content modification

and ignores access and metadata-only events.

## User impact

This bug makes `processes.<name>.watch` unreliable for real projects.

For users, it shows up as:

- processes restarting for no obvious reason
- `devenv up` becoming unstable or unusable
- artifact directories being effectively impossible to watch safely
- confusion, because "nothing changed" but the process still restarts

This is especially painful for:

- Java/JVM apps that read JARs at startup
- projects watching generated output directories
- workflows that expect restart-on-write, not restart-on-read

## Root cause

The file watcher forwarded matching paths without checking whether the underlying filesystem event actually represented a meaningful content change.

That meant access events and metadata-only events were treated the same as writes, creates, removes, and renames.

## Fix

The watcher now inspects the watchexec file event kind and only emits restart-worthy events for:

- create
- remove
- rename
- data/content modification
- generic catch-all change events (`Any` / `Other`)

It ignores:

- access events
- metadata-only modification events

## Tests

This PR adds tests that expose the original bug and verify the fix:

- read-only access to a watched `.jar` does not emit a change event
- listing a watched directory does not emit a change event
- metadata-only `chmod` does not emit a change event
- restart-worthy event kind filtering is covered directly by a unit test

These tests failed before the fix and now pass.
