### PR TITLE
processes.watch: Drain queued watch events before restarting processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fixed `processes.<name>.watch` restarting processes multiple times for a single burst of queued file watcher events by draining the watch queue before restart.
+- Fixed `processes.<name>.watch` restarting processes multiple times for a single burst of queued file watcher events by draining the watch queue before restart ([#2735](https://github.com/cachix/devenv/pull/2735)).
 - Fixed `imports` overriding the base project's `inputs` (e.g. `inputs.nixpkgs.url`) instead of the base config taking precedence ([#2728](https://github.com/cachix/devenv/issues/2728)).
 - Fixed Boehm GC "Repeated allocation of very large block" warnings being printed to stderr during `devenv shell`.
 - Fixed `devenv hook` not changing directory when `cd`ing out of a devenv project. The shell would deactivate but remain in the project directory instead of following the user to the target directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `processes.<name>.watch` restarting processes multiple times for a single burst of queued file watcher events by draining the watch queue before restart.
 - Fixed `imports` overriding the base project's `inputs` (e.g. `inputs.nixpkgs.url`) instead of the base config taking precedence ([#2728](https://github.com/cachix/devenv/issues/2728)).
 - Fixed Boehm GC "Repeated allocation of very large block" warnings being printed to stderr during `devenv shell`.
 - Fixed `devenv hook` not changing directory when `cd`ing out of a devenv project. The shell would deactivate but remain in the project directory instead of following the user to the target directory.

--- a/devenv-event-sources/src/fs.rs
+++ b/devenv-event-sources/src/fs.rs
@@ -347,6 +347,10 @@ impl FileWatcher {
     pub async fn recv(&mut self) -> Option<FileChangeEvent> {
         self.rx.recv().await
     }
+
+    pub fn try_recv(&mut self) -> Result<FileChangeEvent, tokio::sync::mpsc::error::TryRecvError> {
+        self.rx.try_recv()
+    }
 }
 
 #[cfg(test)]

--- a/devenv-processes/src/supervisor.rs
+++ b/devenv-processes/src/supervisor.rs
@@ -239,8 +239,19 @@ pub fn spawn_supervisor(
                     // The biased select catches it next iteration, but we skip
                     // expensive restart work below.
                     if shutdown.is_cancelled() { break 'supervisor; }
+                    let mut drained = 0usize;
+                    while file_watcher.try_recv().is_ok() {
+                        drained += 1;
+                    }
                     info!("File change detected for {}, restarting", name);
-                    activity.log("File change detected, restarting");
+                    if drained == 0 {
+                        activity.log("File change detected, restarting");
+                    } else {
+                        activity.log(format!(
+                            "File change detected, drained {} queued watch event(s), restarting",
+                            drained
+                        ));
+                    }
                     match state.on_event(Event::FileChange, Instant::now()) {
                         Action::Restart => {
                             job.stop_with_signal(Signal::Terminate, Duration::from_secs(2)).await;


### PR DESCRIPTION
DISCLAIMER: Both bug triage, fix and most of this summary is AI Generated (Codex 5.4).

## Summary

This fixes a restart storm issue in the native process manager where a single file-save burst could cause multiple back-to-back process restarts.

Before this change, the supervisor restarted as soon as it received one watch event, but it did not drain additional already-queued file watcher events first. In practice, one logical change could generate several filesystem events, so the process could restart repeatedly for what was really just one edit.

No cooldown or arbitrary sleep-based debounce was added. The fix is purely queue draining.

## User impact

Users could see:

- repeated restarts after saving a file once (> 1000 for me).
- unstable `devenv up` behavior when editors emitted multiple filesystem events
- restart loops that felt random, especially when watching directories instead of single files

## Root cause

The file watcher debounced raw events into batches, but it still forwarded matching paths one-by-one. The supervisor treated every received watch event as an independent restart trigger.

That meant a single save operation could look like:

- first event arrives -> restart
- queued sibling events still pending -> restart again

## Fix

When the supervisor receives a file watcher event, it now:

1. consumes the triggering event
2. drains all already-queued watch events
3. performs a single restart

This keeps behavior deterministic without introducing timing hacks.

## Tests

Relevant watcher and supervisor test suites pass after this change:

- `cargo test -p devenv-event-sources fs::tests:: -- --nocapture`
- `cargo test -p devenv-processes supervisor -- --nocapture`
