### PR TITLE
feat(clickhouse):  adding user creation support

### DIFF
--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -27290,6 +27290,78 @@ Which http port to run clickhouse on.
 
 
 
+## services.clickhouse.keeper.enable
+
+
+
+Whether to enable keeper_server in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.keeperPort
+
+
+
+Which port to run clickhouse keeper service on.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9181
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.macros.enable
+
+
+
+Whether to enable macros in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ## services.clickhouse.port
 
 
@@ -27308,6 +27380,122 @@ Which port to run clickhouse on.
 ```nix
 9000
 ```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.raftPort
+
+
+
+Which http port to use clickhouse keeper for raft consensus.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.remoteServers.enable
+
+
+
+Whether to enable remote_servers in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.timezone
+
+
+
+Which timezone to use for ClickHouse.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.usersConfig
+
+
+
+Your ` users.yaml ` as a Nix attribute set.
+Check the [documentation](https://clickhouse.com/docs/operations/configuration-files\#user-settings)
+for possible options.
+
+
+
+*Type:*
+YAML 1.1 value
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+````nix
+{
+  profiles = {};
+
+  users = {
+    default = {
+      profile = "default";
+      password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+    };
+  };
+}
+
+````
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -27266,6 +27266,50 @@ Which port to run clickhouse on.
 
 
 
+## services.clickhouse.usersConfig
+
+
+
+Your ` users.yaml ` as a Nix attribute set.
+Check the [documentation](https://clickhouse.com/docs/operations/configuration-files\#user-settings)
+for possible options.
+
+
+
+*Type:*
+YAML 1.1 value
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+````nix
+{
+  profiles = {};
+
+  users = {
+    default = {
+      profile = "default";
+      password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+    };
+  };
+}
+
+````
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ## services.cockroachdb.enable
 
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -27178,6 +27178,78 @@ true
 
 
 
+## services.clickhouse.enableKeeper
+
+
+
+Whether to enable keeper_server in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.enableMacros
+
+
+
+Whether to enable macros in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.enableRemoteServers
+
+
+
+Whether to enable remote_servers in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ## services.clickhouse.package
 
 
@@ -27242,6 +27314,30 @@ Which http port to run clickhouse on.
 
 
 
+## services.clickhouse.keeperPort
+
+
+
+Which port to run clickhouse keeper service on.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9181
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ## services.clickhouse.port
 
 
@@ -27259,6 +27355,54 @@ Which port to run clickhouse on.
 
 ```nix
 9000
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.raftPort
+
+
+
+Which http port to use clickhouse keeper for raft consensus.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.timezone
+
+
+
+Which timezone to use for ClickHouse.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
 ```
 
 *Declared by:*

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -27178,78 +27178,6 @@ true
 
 
 
-## services.clickhouse.enableKeeper
-
-
-
-Whether to enable keeper_server in ClickHouse.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-## services.clickhouse.enableMacros
-
-
-
-Whether to enable macros in ClickHouse.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-## services.clickhouse.enableRemoteServers
-
-
-
-Whether to enable remote_servers in ClickHouse.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
 ## services.clickhouse.package
 
 
@@ -27314,6 +27242,30 @@ Which http port to run clickhouse on.
 
 
 
+## services.clickhouse.keeper.enable
+
+
+
+Whether to enable keeper_server in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ## services.clickhouse.keeperPort
 
 
@@ -27331,6 +27283,30 @@ Which port to run clickhouse keeper service on.
 
 ```nix
 9181
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.macros.enable
+
+
+
+Whether to enable macros in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
 ```
 
 *Declared by:*
@@ -27379,6 +27355,30 @@ Which http port to use clickhouse keeper for raft consensus.
 
 ```nix
 9234
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.remoteServers.enable
+
+
+
+Whether to enable remote_servers in ClickHouse.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
 ```
 
 *Declared by:*

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -27314,7 +27314,7 @@ false
 
 
 
-## services.clickhouse.keeperPort
+## services.clickhouse.keeper.port
 
 
 
@@ -27331,6 +27331,30 @@ Which port to run clickhouse keeper service on.
 
 ```nix
 9181
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+## services.clickhouse.keeper.raft.port
+
+
+
+Which http port to use clickhouse keeper for raft consensus.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
 ```
 
 *Declared by:*
@@ -27379,30 +27403,6 @@ Which port to run clickhouse on.
 
 ```nix
 9000
-```
-
-*Declared by:*
- - [https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-## services.clickhouse.raftPort
-
-
-
-Which http port to use clickhouse keeper for raft consensus.
-
-
-
-*Type:*
-16 bit unsigned integer; between 0 and 65535 (both inclusive)
-
-
-
-*Default:*
-
-```nix
-9234
 ```
 
 *Declared by:*

--- a/docs/src/services/clickhouse.md
+++ b/docs/src/services/clickhouse.md
@@ -99,6 +99,78 @@ Which http port to run clickhouse on\.
 
 
 
+### services\.clickhouse\.keeper\.enable
+
+
+
+Whether to enable keeper_server in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.keeperPort
+
+
+
+Which port to run clickhouse keeper service on\.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9181
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.macros\.enable
+
+
+
+Whether to enable macros in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ### services\.clickhouse\.port
 
 
@@ -117,6 +189,122 @@ Which port to run clickhouse on\.
 ```nix
 9000
 ```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.raftPort
+
+
+
+Which http port to use clickhouse keeper for raft consensus\.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.remoteServers\.enable
+
+
+
+Whether to enable remote_servers in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.timezone
+
+
+
+Which timezone to use for ClickHouse\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.usersConfig
+
+
+
+Your ` users.yaml ` as a Nix attribute set\.
+Check the [documentation](https://clickhouse\.com/docs/operations/configuration-files\#user-settings)
+for possible options\.
+
+
+
+*Type:*
+YAML 1\.1 value
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+````nix
+{
+  profiles = {};
+
+  users = {
+    default = {
+      profile = "default";
+      password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+    };
+  };
+}
+
+````
 
 *Declared by:*
  - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)

--- a/docs/src/services/clickhouse.md
+++ b/docs/src/services/clickhouse.md
@@ -37,78 +37,6 @@ true
 
 
 
-### services\.clickhouse\.enableKeeper
-
-
-
-Whether to enable keeper_server in ClickHouse\.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-### services\.clickhouse\.enableMacros
-
-
-
-Whether to enable macros in ClickHouse\.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-### services\.clickhouse\.enableRemoteServers
-
-
-
-Whether to enable remote_servers in ClickHouse\.
-
-
-
-*Type:*
-boolean
-
-
-
-*Default:*
-
-```nix
-false
-```
-
-*Declared by:*
- - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
 ### services\.clickhouse\.package
 
 
@@ -171,6 +99,30 @@ Which http port to run clickhouse on\.
 
 
 
+### services\.clickhouse\.keeper\.enable
+
+
+
+Whether to enable keeper_server in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ### services\.clickhouse\.keeperPort
 
 
@@ -188,6 +140,30 @@ Which port to run clickhouse keeper service on\.
 
 ```nix
 9181
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.macros\.enable
+
+
+
+Whether to enable macros in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
 ```
 
 *Declared by:*
@@ -236,6 +212,30 @@ Which http port to use clickhouse keeper for raft consensus\.
 
 ```nix
 9234
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.remoteServers\.enable
+
+
+
+Whether to enable remote_servers in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
 ```
 
 *Declared by:*

--- a/docs/src/services/clickhouse.md
+++ b/docs/src/services/clickhouse.md
@@ -37,6 +37,78 @@ true
 
 
 
+### services\.clickhouse\.enableKeeper
+
+
+
+Whether to enable keeper_server in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.enableMacros
+
+
+
+Whether to enable macros in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.enableRemoteServers
+
+
+
+Whether to enable remote_servers in ClickHouse\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+
+```nix
+false
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ### services\.clickhouse\.package
 
 
@@ -99,6 +171,30 @@ Which http port to run clickhouse on\.
 
 
 
+### services\.clickhouse\.keeperPort
+
+
+
+Which port to run clickhouse keeper service on\.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9181
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
 ### services\.clickhouse\.port
 
 
@@ -116,6 +212,54 @@ Which port to run clickhouse on\.
 
 ```nix
 9000
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.raftPort
+
+
+
+Which http port to use clickhouse keeper for raft consensus\.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.timezone
+
+
+
+Which timezone to use for ClickHouse\.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
 ```
 
 *Declared by:*

--- a/docs/src/services/clickhouse.md
+++ b/docs/src/services/clickhouse.md
@@ -120,3 +120,47 @@ Which port to run clickhouse on\.
 
 *Declared by:*
  - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.usersConfig
+
+
+
+Your ` users.yaml ` as a Nix attribute set\.
+Check the [documentation](https://clickhouse\.com/docs/operations/configuration-files\#user-settings)
+for possible options\.
+
+
+
+*Type:*
+YAML 1\.1 value
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+````nix
+{
+  profiles = {};
+
+  users = {
+    default = {
+      profile = "default";
+      password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+    };
+  };
+}
+
+````
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)

--- a/docs/src/services/clickhouse.md
+++ b/docs/src/services/clickhouse.md
@@ -123,7 +123,7 @@ false
 
 
 
-### services\.clickhouse\.keeperPort
+### services\.clickhouse\.keeper\.port
 
 
 
@@ -140,6 +140,30 @@ Which port to run clickhouse keeper service on\.
 
 ```nix
 9181
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
+
+
+
+### services\.clickhouse\.keeper\.raft\.port
+
+
+
+Which http port to use clickhouse keeper for raft consensus\.
+
+
+
+*Type:*
+16 bit unsigned integer; between 0 and 65535 (both inclusive)
+
+
+
+*Default:*
+
+```nix
+9234
 ```
 
 *Declared by:*
@@ -188,30 +212,6 @@ Which port to run clickhouse on\.
 
 ```nix
 9000
-```
-
-*Declared by:*
- - [https://github\.com/cachix/devenv/blob/main/src/modules/services/clickhouse\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/clickhouse.nix)
-
-
-
-### services\.clickhouse\.raftPort
-
-
-
-Which http port to use clickhouse keeper for raft consensus\.
-
-
-
-*Type:*
-16 bit unsigned integer; between 0 and 65535 (both inclusive)
-
-
-
-*Default:*
-
-```nix
-9234
 ```
 
 *Declared by:*

--- a/src/modules/services/clickhouse.nix
+++ b/src/modules/services/clickhouse.nix
@@ -62,19 +62,19 @@ in
       description = "Which timezone to use for ClickHouse.";
     };
 
-    enableMacros = lib.mkOption {
+    macros.enable = lib.mkOption {
       type = types.bool;
       default = false;
       description = "Whether to enable macros in ClickHouse.";
     };
 
-    enableRemoteServers = lib.mkOption {
+    remoteServers.enable = lib.mkOption {
       type = types.bool;
       default = false;
       description = "Whether to enable remote_servers in ClickHouse.";
     };
 
-    enableKeeper = lib.mkOption {
+    keeper.enable = lib.mkOption {
       type = types.bool;
       default = false;
       description = "Whether to enable keeper_server in ClickHouse.";
@@ -131,13 +131,13 @@ in
         local_directory:
           path: ${config.env.DEVENV_STATE}/clickhouse/access
 
-      ${lib.optionalString cfg.enableMacros ''
+      ${lib.optionalString cfg.macros.enable ''
         macros:
           shard: 1
           replica: localhost
       ''}
 
-      ${lib.optionalString cfg.enableRemoteServers ''
+      ${lib.optionalString cfg.remoteServers.enable ''
         remote_servers:
           default:
             shard:
@@ -146,7 +146,7 @@ in
                 port: ${toString allocatedPort}
       ''}
 
-      ${lib.optionalString cfg.enableKeeper ''
+      ${lib.optionalString cfg.keeper.enable ''
         keeper_server:
           tcp_port: ${toString allocatedKeeperPort}
           server_id: 1

--- a/src/modules/services/clickhouse.nix
+++ b/src/modules/services/clickhouse.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, config, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
 
 let
   cfg = config.services.clickhouse;
@@ -7,8 +12,13 @@ let
   # Port allocation
   basePort = cfg.port;
   baseHttpPort = cfg.httpPort;
+  baseKeeperPort = cfg.keeperPort;
+  baseRaftPort = cfg.raftPort;
   allocatedPort = config.processes.clickhouse-server.ports.main.value;
   allocatedHttpPort = config.processes.clickhouse-server.ports.http.value;
+  allocatedKeeperPort = config.processes.clickhouse-server.ports.keeper.value;
+  allocatedRaftPort = config.processes.clickhouse-server.ports.raft.value;
+
   format = pkgs.formats.yaml { };
 in
 {
@@ -32,6 +42,42 @@ in
       type = types.port;
       description = "Which http port to run clickhouse on.";
       default = 8123;
+    };
+
+    keeperPort = lib.mkOption {
+      type = types.port;
+      description = "Which port to run clickhouse keeper service on.";
+      default = 9181;
+    };
+
+    raftPort = lib.mkOption {
+      type = types.port;
+      description = "Which http port to use clickhouse keeper for raft consensus.";
+      default = 9234;
+    };
+
+    timezone = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Which timezone to use for ClickHouse.";
+    };
+
+    enableMacros = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable macros in ClickHouse.";
+    };
+
+    enableRemoteServers = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable remote_servers in ClickHouse.";
+    };
+
+    enableKeeper = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable keeper_server in ClickHouse.";
     };
 
     config = lib.mkOption {
@@ -68,10 +114,9 @@ in
       logger:
         level: warning
         console: 1
+      ${lib.optionalString (cfg.timezone != null) "timezone: ${cfg.timezone}"}
       tcp_port: ${toString allocatedPort}
       http_port: ${toString allocatedHttpPort}
-      mysql_port: 0
-      postgresql_port: 0
       default_profile: default
       default_database: default
       path: ${config.env.DEVENV_STATE}/clickhouse
@@ -86,43 +131,60 @@ in
         local_directory:
           path: ${config.env.DEVENV_STATE}/clickhouse/access
 
-      macros:
-        shard: 1
-        replica: localhost
+      ${lib.optionalString cfg.enableMacros ''
+        macros:
+          shard: 1
+          replica: localhost
+      ''}
 
-      remote_servers:
-        default:
-          shard:
-            replica:
-              host: localhost
-              port: ${toString allocatedPort}
+      ${lib.optionalString cfg.enableRemoteServers ''
+        remote_servers:
+          default:
+            shard:
+              replica:
+                host: localhost
+                port: ${toString allocatedPort}
+      ''}
 
-      keeper_server:
-        tcp_port: 9181
-        server_id: 1
-        log_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/log
-        snapshot_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/snapshots
-        raft_configuration:
-          server:
-            id: 1
-            hostname: localhost
-            port: 9234
+      ${lib.optionalString cfg.enableKeeper ''
+        keeper_server:
+          tcp_port: ${toString allocatedKeeperPort}
+          server_id: 1
+          log_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/log
+          snapshot_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/snapshots
+          raft_configuration:
+            server:
+              id: 1
+              hostname: localhost
+              port: ${toString allocatedRaftPort}
+      ''}
     '';
 
-    processes.clickhouse-server = {
-      ports.main.allocate = basePort;
-      ports.http.allocate = baseHttpPort;
+    tasks."devenv:clickhouse:setup" = {
+      description = "Setup ClickHouse";
       exec = ''
         mkdir -p ${config.env.DEVENV_STATE}/clickhouse/{server/config.d,server/users.d,tmp,user_files,format_schemas,access,caches,coordination/snapshots,coordination/log}
         install -m 644 ${cfg.package}/etc/clickhouse-server/users.xml ${config.env.DEVENV_STATE}/clickhouse/server/users.xml
         install -m 644 ${cfg.package}/etc/clickhouse-server/config.xml ${config.env.DEVENV_STATE}/clickhouse/server/config.xml
         install -m 644 ${pkgs.writeText "clickhouse-config.yaml" cfg.config} ${config.env.DEVENV_STATE}/clickhouse/server/config.d/clickhouse-config.yaml
         install -m 644 ${format.generate "users.yaml" cfg.usersConfig} ${config.env.DEVENV_STATE}/clickhouse/server/users.d/users.yaml
-        exec clickhouse-server --config-file=${config.env.DEVENV_STATE}/clickhouse/server/config.xml
       '';
+      before = [ "devenv:processes:clickhouse-server" ];
+    };
+
+    processes.clickhouse-server = {
+      ports.main.allocate = basePort;
+      ports.http.allocate = baseHttpPort;
+      ports.keeper.allocate = baseKeeperPort;
+      ports.raft.allocate = baseRaftPort;
+      exec = "exec clickhouse-server --config-file=${config.env.DEVENV_STATE}/clickhouse/server/config.xml";
 
       ready = {
-        exec = "${cfg.package}/bin/clickhouse-client --port ${toString allocatedPort} -q 'SELECT 1'";
+        exec = "${cfg.package}/bin/clickhouse-client --port ${toString allocatedPort} --user default ${
+          lib.optionalString (
+            config.services.clickhouse.usersConfig.users.default ? password
+          ) "--password ${config.services.clickhouse.usersConfig.users.default.password}"
+        } -q 'SELECT 1'";
         initial_delay = 2;
         probe_timeout = 4;
         failure_threshold = 5;

--- a/src/modules/services/clickhouse.nix
+++ b/src/modules/services/clickhouse.nix
@@ -9,6 +9,7 @@ let
   baseHttpPort = cfg.httpPort;
   allocatedPort = config.processes.clickhouse-server.ports.main.value;
   allocatedHttpPort = config.processes.clickhouse-server.ports.http.value;
+  format = pkgs.formats.yaml { };
 in
 {
   options.services.clickhouse = {
@@ -37,6 +38,28 @@ in
       type = types.lines;
       description = "ClickHouse configuration in YAML.";
     };
+
+    usersConfig = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          profiles = {};
+
+          users = {
+            default = {
+              profile = "default";
+              password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+            };
+          };
+        }
+      '';
+      description = ''
+        Your `users.yaml` as a Nix attribute set.
+        Check the [documentation](https://clickhouse.com/docs/operations/configuration-files#user-settings)
+        for possible options.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -47,20 +70,56 @@ in
         console: 1
       tcp_port: ${toString allocatedPort}
       http_port: ${toString allocatedHttpPort}
+      mysql_port: 0
+      postgresql_port: 0
       default_profile: default
       default_database: default
       path: ${config.env.DEVENV_STATE}/clickhouse
       tmp_path: ${config.env.DEVENV_STATE}/clickhouse/tmp
       user_files_path: ${config.env.DEVENV_STATE}/clickhouse/user_files
       format_schema_path: ${config.env.DEVENV_STATE}/clickhouse/format_schemas
+      access_control_path: ${config.env.DEVENV_STATE}/clickhouse/access
+      custom_cached_disks_base_directory: ${config.env.DEVENV_STATE}/clickhouse/caches
       user_directories:
         users_xml:
-          path: ${cfg.package}/etc//clickhouse-server/users.xml
+          path: ${config.env.DEVENV_STATE}/clickhouse/server/users.xml
+        local_directory:
+          path: ${config.env.DEVENV_STATE}/clickhouse/access
+
+      macros:
+        shard: 1
+        replica: localhost
+
+      remote_servers:
+        default:
+          shard:
+            replica:
+              host: localhost
+              port: ${toString allocatedPort}
+
+      keeper_server:
+        tcp_port: 9181
+        server_id: 1
+        log_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/log
+        snapshot_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/snapshots
+        raft_configuration:
+          server:
+            id: 1
+            hostname: localhost
+            port: 9234
     '';
+
     processes.clickhouse-server = {
       ports.main.allocate = basePort;
       ports.http.allocate = baseHttpPort;
-      exec = "exec clickhouse-server --config-file=${pkgs.writeText "clickhouse-config.yaml" cfg.config}";
+      exec = ''
+        mkdir -p ${config.env.DEVENV_STATE}/clickhouse/{server/config.d,server/users.d,tmp,user_files,format_schemas,access,caches,coordination/snapshots,coordination/log}
+        install -m 644 ${cfg.package}/etc/clickhouse-server/users.xml ${config.env.DEVENV_STATE}/clickhouse/server/users.xml
+        install -m 644 ${cfg.package}/etc/clickhouse-server/config.xml ${config.env.DEVENV_STATE}/clickhouse/server/config.xml
+        install -m 644 ${pkgs.writeText "clickhouse-config.yaml" cfg.config} ${config.env.DEVENV_STATE}/clickhouse/server/config.d/clickhouse-config.yaml
+        install -m 644 ${format.generate "users.yaml" cfg.usersConfig} ${config.env.DEVENV_STATE}/clickhouse/server/users.d/users.yaml
+        exec clickhouse-server --config-file=${config.env.DEVENV_STATE}/clickhouse/server/config.xml
+      '';
 
       ready = {
         exec = "${cfg.package}/bin/clickhouse-client --port ${toString allocatedPort} -q 'SELECT 1'";

--- a/src/modules/services/clickhouse.nix
+++ b/src/modules/services/clickhouse.nix
@@ -1,4 +1,8 @@
-{ pkgs, lib, config, ... }:
+{ pkgs
+, lib
+, config
+, ...
+}:
 
 let
   cfg = config.services.clickhouse;
@@ -7,8 +11,14 @@ let
   # Port allocation
   basePort = cfg.port;
   baseHttpPort = cfg.httpPort;
+  baseKeeperPort = cfg.keeper.port;
+  baseRaftPort = cfg.keeper.raft.port;
   allocatedPort = config.processes.clickhouse-server.ports.main.value;
   allocatedHttpPort = config.processes.clickhouse-server.ports.http.value;
+  allocatedKeeperPort = config.processes.clickhouse-server.ports.keeper.value;
+  allocatedRaftPort = config.processes.clickhouse-server.ports.raft.value;
+
+  format = pkgs.formats.yaml { };
 in
 {
   options.services.clickhouse = {
@@ -33,9 +43,67 @@ in
       default = 8123;
     };
 
+    keeper.port = lib.mkOption {
+      type = types.port;
+      description = "Which port to run clickhouse keeper service on.";
+      default = 9181;
+    };
+
+    keeper.raft.port = lib.mkOption {
+      type = types.port;
+      description = "Which http port to use clickhouse keeper for raft consensus.";
+      default = 9234;
+    };
+
+    timezone = lib.mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Which timezone to use for ClickHouse.";
+    };
+
+    macros.enable = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable macros in ClickHouse.";
+    };
+
+    remoteServers.enable = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable remote_servers in ClickHouse.";
+    };
+
+    keeper.enable = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to enable keeper_server in ClickHouse.";
+    };
+
     config = lib.mkOption {
       type = types.lines;
       description = "ClickHouse configuration in YAML.";
+    };
+
+    usersConfig = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          profiles = {};
+
+          users = {
+            default = {
+              profile = "default";
+              password_sha256_hex = "36dd292533174299fb0c34665df468bb881756ca9eaf9757d0cfde38f9ededa1";  # `echo -n verysecret | sha256sum`
+            };
+          };
+        }
+      '';
+      description = ''
+        Your `users.yaml` as a Nix attribute set.
+        Check the [documentation](https://clickhouse.com/docs/operations/configuration-files#user-settings)
+        for possible options.
+      '';
     };
   };
 
@@ -45,6 +113,7 @@ in
       logger:
         level: warning
         console: 1
+      ${lib.optionalString (cfg.timezone != null) "timezone: ${cfg.timezone}"}
       tcp_port: ${toString allocatedPort}
       http_port: ${toString allocatedHttpPort}
       default_profile: default
@@ -53,17 +122,68 @@ in
       tmp_path: ${config.env.DEVENV_STATE}/clickhouse/tmp
       user_files_path: ${config.env.DEVENV_STATE}/clickhouse/user_files
       format_schema_path: ${config.env.DEVENV_STATE}/clickhouse/format_schemas
+      access_control_path: ${config.env.DEVENV_STATE}/clickhouse/access
+      custom_cached_disks_base_directory: ${config.env.DEVENV_STATE}/clickhouse/caches
       user_directories:
         users_xml:
-          path: ${cfg.package}/etc//clickhouse-server/users.xml
+          path: ${config.env.DEVENV_STATE}/clickhouse/server/users.xml
+        local_directory:
+          path: ${config.env.DEVENV_STATE}/clickhouse/access
+
+      ${lib.optionalString cfg.macros.enable ''
+        macros:
+          shard: 1
+          replica: localhost
+      ''}
+
+      ${lib.optionalString cfg.remoteServers.enable ''
+        remote_servers:
+          default:
+            shard:
+              replica:
+                host: localhost
+                port: ${toString allocatedPort}
+      ''}
+
+      ${lib.optionalString cfg.keeper.enable ''
+        keeper_server:
+          tcp_port: ${toString allocatedKeeperPort}
+          server_id: 1
+          log_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/log
+          snapshot_storage_path: ${config.env.DEVENV_STATE}/clickhouse/coordination/snapshots
+          raft_configuration:
+            server:
+              id: 1
+              hostname: localhost
+              port: ${toString allocatedRaftPort}
+      ''}
     '';
+
+    tasks."devenv:clickhouse:setup" = {
+      description = "Setup ClickHouse";
+      exec = ''
+        mkdir -p ${config.env.DEVENV_STATE}/clickhouse/{server/config.d,server/users.d,tmp,user_files,format_schemas,access,caches,coordination/snapshots,coordination/log}
+        install -m 644 ${cfg.package}/etc/clickhouse-server/users.xml ${config.env.DEVENV_STATE}/clickhouse/server/users.xml
+        install -m 644 ${cfg.package}/etc/clickhouse-server/config.xml ${config.env.DEVENV_STATE}/clickhouse/server/config.xml
+        install -m 644 ${pkgs.writeText "clickhouse-config.yaml" cfg.config} ${config.env.DEVENV_STATE}/clickhouse/server/config.d/clickhouse-config.yaml
+        install -m 644 ${format.generate "users.yaml" cfg.usersConfig} ${config.env.DEVENV_STATE}/clickhouse/server/users.d/users.yaml
+      '';
+      before = [ "devenv:processes:clickhouse-server" ];
+    };
+
     processes.clickhouse-server = {
       ports.main.allocate = basePort;
       ports.http.allocate = baseHttpPort;
-      exec = "exec clickhouse-server --config-file=${pkgs.writeText "clickhouse-config.yaml" cfg.config}";
+      ports.keeper.allocate = baseKeeperPort;
+      ports.raft.allocate = baseRaftPort;
+      exec = "exec clickhouse-server --config-file=${config.env.DEVENV_STATE}/clickhouse/server/config.xml";
 
       ready = {
-        exec = "${cfg.package}/bin/clickhouse-client --port ${toString allocatedPort} -q 'SELECT 1'";
+        exec = "${cfg.package}/bin/clickhouse-client --port ${toString allocatedPort} --user default ${
+          lib.optionalString (
+            config.services.clickhouse.usersConfig.users.default ? password
+          ) "--password ${config.services.clickhouse.usersConfig.users.default.password}"
+        } -q 'SELECT 1'";
         initial_delay = 2;
         probe_timeout = 4;
         failure_threshold = 5;


### PR DESCRIPTION
Current Clickhouse implementation doesn't allow to create a user or modify any behavior.
Additionally I run into issues when try to run migration scripts due to lacking keeper integration and configuration for it.
Also macro support wasn't enabled.