### PR TITLE
eval-cache: skip cache write when input files change during eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed `devenv shell` and `devenv build` failing with `path '...drv' is required, but there is no substituter that can build it` after the cached derivation was garbage-collected. The stale eval-cache entry is now invalidated when its referenced store paths no longer exist, forcing a re-evaluation that re-materializes the `.drv` on disk.
+- Fixed stale eval cache when `devenv.nix` (or another tracked input) was rewritten while evaluation was still running. The eval cache no longer persists a result whose recorded file fingerprints don't match what Nix actually read, so the next run re-evaluates against the current disk state ([#2745](https://github.com/cachix/devenv/issues/2745)).
 - Fixed MCP server segfault on exit by waiting for the cache init thread to finish before exiting ([#2699](https://github.com/cachix/devenv/issues/2699)).
 - Fixed independent oneshot tasks (e.g. `devenv:files` and `devenv:python:virtualenv`) running sequentially instead of in parallel, causing unnecessary waterfall delays during `devenv shell` startup.
 - Fixed `processes.<name>.watch` restarting processes multiple times for a single burst of queued file watcher events by draining the watch queue before restart ([#2735](https://github.com/cachix/devenv/pull/2735)).

--- a/devenv-eval-cache/DESIGN.md
+++ b/devenv-eval-cache/DESIGN.md
@@ -192,10 +192,14 @@ During evaluation, `EvalInputCollector` observes operations via `NixLogBridge`:
 let collector = EvalInputCollector::start();
 log_bridge.add_observer(collector.clone());
 
+let eval_started_at = std::time::SystemTime::now();
 // ... evaluation runs, collector receives EvalOp events ...
 
 log_bridge.clear_observers();
-let inputs = collector.into_inputs(&config);
+let OpsToInputs { inputs, race_detected } =
+    collector.into_inputs(&config, eval_started_at);
+// If race_detected, do not persist inputs: a tracked file was modified
+// during evaluation and the fingerprint no longer matches what Nix read.
 ```
 
 ### Observed Operations

--- a/devenv-eval-cache/src/caching_eval.rs
+++ b/devenv-eval-cache/src/caching_eval.rs
@@ -28,7 +28,9 @@ use crate::db::{self, EnvInputRow, EvalRow, FileInputRow, empty_to_none};
 use crate::eval_inputs::{
     EnvInputDesc, FileInputDesc, FileState, Input, check_env_state, check_file_state,
 };
-use crate::ffi_cache::{CachingConfig, EvalCacheKey, EvalInputCollector, ops_to_inputs};
+use crate::ffi_cache::{
+    CachingConfig, EvalCacheKey, EvalInputCollector, OpsToInputs, ops_to_inputs,
+};
 use crate::resource_manager::{ResourceManager, ResourceSpec};
 use devenv_activity::Activity;
 use devenv_core::nix_log_bridge::NixLogBridge;
@@ -512,6 +514,36 @@ impl CachedEval {
             .map_err(|e| CacheError::Eval(format!("Resource replay failed: {}", e)))
     }
 
+    /// Persist an eval result and its inputs, or skip when a race was detected.
+    ///
+    /// When `race_detected`, a tracked input was rewritten during evaluation,
+    /// so the recorded fingerprint no longer matches what Nix actually read.
+    /// Persisting would poison the cache — the next run would find a matching
+    /// fingerprint on disk and serve the stale result.
+    async fn persist_eval(
+        &self,
+        service: &CachingEvalService,
+        key: &EvalCacheKey,
+        json_output: &str,
+        inputs: Vec<Input>,
+        race_detected: bool,
+    ) {
+        if race_detected {
+            warn!("eval cache write skipped: an input file was modified during evaluation");
+            return;
+        }
+        match service.store(key, json_output, inputs).await {
+            Ok(eval_id) => {
+                if let Some(ref rm) = self.resource_manager {
+                    self.store_resources(service, rm, eval_id).await;
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to store result in cache");
+            }
+        }
+    }
+
     /// Snapshot and store resource allocations after a cache miss evaluation.
     async fn store_resources(
         &self,
@@ -600,26 +632,19 @@ impl CachedEval {
         self.log_bridge.add_observer(observer.clone());
         let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone(), observer);
 
+        let eval_started_at = SystemTime::now();
         let result = eval_fn().await;
         drop(_observer_guard);
         let result = result.map_err(|e| CacheError::Eval(format!("{e:#}")))?;
 
-        // Stop collecting and store result
         let ops = collector.take_ops();
-        let inputs = ops_to_inputs(ops, &self.config);
+        let OpsToInputs {
+            inputs,
+            race_detected,
+        } = ops_to_inputs(ops, &self.config, eval_started_at);
 
-        match service.store(key, &result, inputs).await {
-            Ok(eval_id) => {
-                // Store resource specs alongside the cache entry
-                if let Some(ref rm) = self.resource_manager {
-                    self.store_resources(service, rm, eval_id).await;
-                }
-            }
-            Err(e) => {
-                // Log but don't fail - result is still valid
-                warn!(error = %e, "Failed to store result in cache");
-            }
-        }
+        self.persist_eval(service, key, &result, inputs, race_detected)
+            .await;
 
         Ok((result, false))
     }
@@ -695,27 +720,20 @@ impl CachedEval {
         self.log_bridge.add_observer(observer.clone());
         let _observer_guard = ObserverClearGuard::new(self.log_bridge.clone(), observer);
 
+        let eval_started_at = SystemTime::now();
         let result = eval_fn().await;
         drop(_observer_guard);
         let result = result.map_err(|e| CacheError::Eval(format!("{e:#}")))?;
 
-        // Stop collecting and store result
         let ops = collector.take_ops();
-        let inputs = ops_to_inputs(ops, &self.config);
+        let OpsToInputs {
+            inputs,
+            race_detected,
+        } = ops_to_inputs(ops, &self.config, eval_started_at);
 
         let json = serde_json::to_string(&result)?;
-        match service.store(key, &json, inputs).await {
-            Ok(eval_id) => {
-                // Store resource specs alongside the cache entry
-                if let Some(ref rm) = self.resource_manager {
-                    self.store_resources(service, rm, eval_id).await;
-                }
-            }
-            Err(e) => {
-                // Log but don't fail - result is still valid
-                warn!(error = %e, "Failed to store result in cache");
-            }
-        }
+        self.persist_eval(service, key, &json, inputs, race_detected)
+            .await;
 
         Ok((result, false))
     }

--- a/devenv-eval-cache/src/eval_inputs.rs
+++ b/devenv-eval-cache/src/eval_inputs.rs
@@ -95,7 +95,24 @@ impl FileInputDesc {
     ///
     /// All timestamps are truncated to second precision.
     pub fn new(path: PathBuf, fallback_system_time: SystemTime) -> Result<Self, io::Error> {
-        let is_directory = path.is_dir();
+        Self::new_with_raw_mtime(path, fallback_system_time).map(|(desc, _)| desc)
+    }
+
+    /// Like [`new`], but also returns the untruncated mtime read from disk.
+    ///
+    /// The raw mtime is used for detecting races where an input file was
+    /// written during evaluation. Truncated mtimes lose sub-second precision
+    /// and would miss fast races. `None` means the mtime could not be read
+    /// (missing file, unsupported platform) and the fallback was used — race
+    /// detection must skip such entries, since the fallback is captured after
+    /// evaluation ended and would always compare as "after eval started".
+    pub fn new_with_raw_mtime(
+        path: PathBuf,
+        fallback_system_time: SystemTime,
+    ) -> Result<(Self, Option<SystemTime>), io::Error> {
+        let metadata = path.metadata().ok();
+        let is_directory = metadata.as_ref().is_some_and(|m| m.is_dir());
+        let raw_mtime = metadata.as_ref().and_then(|m| m.modified().ok());
         let content_hash = if is_directory {
             let mut paths: Vec<String> = std::fs::read_dir(&path)?
                 .filter_map(Result::ok)
@@ -108,17 +125,16 @@ impl FileInputDesc {
                 .map_err(|e| std::io::Error::other(format!("Failed to compute file hash: {e}")))
                 .ok()
         };
-        let modified_at = truncate_to_seconds(
-            path.metadata()
-                .and_then(|p| p.modified())
-                .unwrap_or(fallback_system_time),
-        )?;
-        Ok(Self {
-            path,
-            is_directory,
-            content_hash,
-            modified_at,
-        })
+        let modified_at = truncate_to_seconds(raw_mtime.unwrap_or(fallback_system_time))?;
+        Ok((
+            Self {
+                path,
+                is_directory,
+                content_hash,
+                modified_at,
+            },
+            raw_mtime,
+        ))
     }
 }
 

--- a/devenv-eval-cache/src/ffi_cache.rs
+++ b/devenv-eval-cache/src/ffi_cache.rs
@@ -85,11 +85,13 @@ pub struct CachingConfig {
 /// ```ignore
 /// let collector = EvalInputCollector::start();
 /// log_bridge.add_observer(collector.clone());
+/// let eval_started_at = std::time::SystemTime::now();
 ///
 /// // ... perform evaluation ...
 ///
 /// log_bridge.clear_observers();
-/// let inputs = collector.into_inputs(&config);
+/// let OpsToInputs { inputs, race_detected } =
+///     collector.into_inputs(&config, eval_started_at);
 /// ```
 pub struct EvalInputCollector {
     ops: Arc<Mutex<Vec<EvalOp>>>,
@@ -149,9 +151,16 @@ impl EvalInputCollector {
     ///
     /// And adds:
     /// - Paths from `config.extra_watch_paths`
-    pub fn into_inputs(self: Arc<Self>, config: &CachingConfig) -> Vec<Input> {
+    ///
+    /// `eval_started_at` is forwarded to [`ops_to_inputs`] for race detection
+    /// against files modified during evaluation.
+    pub fn into_inputs(
+        self: Arc<Self>,
+        config: &CachingConfig,
+        eval_started_at: SystemTime,
+    ) -> OpsToInputs {
         let ops = self.take_ops();
-        ops_to_inputs(ops, config)
+        ops_to_inputs(ops, config, eval_started_at)
     }
 }
 
@@ -169,6 +178,18 @@ impl OpObserver for EvalInputCollector {
     }
 }
 
+/// Result of converting evaluation ops into cacheable inputs.
+#[derive(Debug)]
+pub struct OpsToInputs {
+    pub inputs: Vec<Input>,
+    /// Set if any tracked file was modified after `eval_started_at`. When
+    /// true, the caller must not persist the eval result: the recorded
+    /// fingerprint reflects the post-modification file, but the result was
+    /// derived from whatever Nix happened to read. Next run will re-evaluate
+    /// against the actual disk state.
+    pub race_detected: bool,
+}
+
 /// Convert a list of operations to Input descriptors.
 ///
 /// This is the core conversion logic that:
@@ -177,9 +198,27 @@ impl OpObserver for EvalInputCollector {
 /// 3. Creates `EnvInputDesc` for environment variable access
 /// 4. Adds extra watch paths
 /// 5. Deduplicates the result
-pub fn ops_to_inputs(ops: Vec<EvalOp>, config: &CachingConfig) -> Vec<Input> {
+///
+/// `eval_started_at` is the wall-clock moment just before evaluation began.
+/// If any tracked file's untruncated mtime is strictly later than that, the
+/// file was rewritten during eval and `race_detected` is set.
+pub fn ops_to_inputs(
+    ops: Vec<EvalOp>,
+    config: &CachingConfig,
+    eval_started_at: SystemTime,
+) -> OpsToInputs {
     let fallback_time = SystemTime::now();
     let mut inputs: Vec<Input> = Vec::new();
+    let mut race_detected = false;
+
+    let push_file = |source: PathBuf, inputs: &mut Vec<Input>, race: &mut bool| {
+        if let Ok((desc, raw_mtime)) = FileInputDesc::new_with_raw_mtime(source, fallback_time) {
+            if raw_mtime.is_some_and(|m| m > eval_started_at) {
+                *race = true;
+            }
+            inputs.push(Input::File(desc));
+        }
+    };
 
     for op in ops {
         match op {
@@ -208,10 +247,7 @@ pub fn ops_to_inputs(ops: Vec<EvalOp>, config: &CachingConfig) -> Vec<Input> {
                     continue;
                 }
 
-                // Create file input descriptor
-                if let Ok(desc) = FileInputDesc::new(source, fallback_time) {
-                    inputs.push(Input::File(desc));
-                }
+                push_file(source, &mut inputs, &mut race_detected);
             }
             EvalOp::GetEnv { name } => {
                 // Skip excluded env vars (already tracked elsewhere, e.g., via NixArgs)
@@ -228,16 +264,17 @@ pub fn ops_to_inputs(ops: Vec<EvalOp>, config: &CachingConfig) -> Vec<Input> {
 
     // Add extra watch paths
     for path in &config.extra_watch_paths {
-        if let Ok(desc) = FileInputDesc::new(path.clone(), fallback_time) {
-            inputs.push(Input::File(desc));
-        }
+        push_file(path.clone(), &mut inputs, &mut race_detected);
     }
 
     // Sort and deduplicate
     inputs.sort();
     inputs.dedup_by(Input::dedup);
 
-    inputs
+    OpsToInputs {
+        inputs,
+        race_detected,
+    }
 }
 
 #[cfg(test)]
@@ -286,8 +323,9 @@ mod tests {
         let ops = vec![EvalOp::ReadFile {
             source: PathBuf::from("/nix/store/abc123-foo/bar.txt"),
         }];
-        let inputs = ops_to_inputs(ops, &CachingConfig::default());
-        assert!(inputs.is_empty());
+        let result = ops_to_inputs(ops, &CachingConfig::default(), SystemTime::now());
+        assert!(result.inputs.is_empty());
+        assert!(!result.race_detected);
     }
 
     #[test]
@@ -295,8 +333,9 @@ mod tests {
         let ops = vec![EvalOp::ReadFile {
             source: PathBuf::from("relative/path.txt"),
         }];
-        let inputs = ops_to_inputs(ops, &CachingConfig::default());
-        assert!(inputs.is_empty());
+        let result = ops_to_inputs(ops, &CachingConfig::default(), SystemTime::now());
+        assert!(result.inputs.is_empty());
+        assert!(!result.race_detected);
     }
 
     #[test]
@@ -308,8 +347,9 @@ mod tests {
         let ops = vec![EvalOp::ReadFile {
             source: PathBuf::from("/excluded/file.txt"),
         }];
-        let inputs = ops_to_inputs(ops, &config);
-        assert!(inputs.is_empty());
+        let result = ops_to_inputs(ops, &config, SystemTime::now());
+        assert!(result.inputs.is_empty());
+        assert!(!result.race_detected);
     }
 
     #[test]
@@ -326,10 +366,10 @@ mod tests {
                 name: "OTHER_VAR".to_string(),
             },
         ];
-        let inputs = ops_to_inputs(ops, &config);
+        let result = ops_to_inputs(ops, &config, SystemTime::now());
         // NIXPKGS_CONFIG should be filtered out, only OTHER_VAR remains
-        assert_eq!(inputs.len(), 1);
-        assert!(matches!(inputs[0], Input::Env(ref e) if e.name == "OTHER_VAR"));
+        assert_eq!(result.inputs.len(), 1);
+        assert!(matches!(result.inputs[0], Input::Env(ref e) if e.name == "OTHER_VAR"));
     }
 
     #[test]
@@ -337,8 +377,98 @@ mod tests {
         let ops = vec![EvalOp::GetEnv {
             name: "MY_VAR".to_string(),
         }];
-        let inputs = ops_to_inputs(ops, &CachingConfig::default());
-        assert_eq!(inputs.len(), 1);
-        assert!(matches!(inputs[0], Input::Env(ref e) if e.name == "MY_VAR"));
+        let result = ops_to_inputs(ops, &CachingConfig::default(), SystemTime::now());
+        assert_eq!(result.inputs.len(), 1);
+        assert!(matches!(result.inputs[0], Input::Env(ref e) if e.name == "MY_VAR"));
+    }
+
+    /// Regression test for issue #2745.
+    ///
+    /// A file written after `eval_started_at` must trigger `race_detected`,
+    /// so the caller skips persisting a cache entry whose fingerprint would
+    /// not correspond to the result that was actually computed.
+    #[test]
+    fn test_ops_to_inputs_detects_race_when_file_modified_during_eval() {
+        use std::fs::File;
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::with_prefix("test_race_detection").unwrap();
+        let file_path = temp_dir.path().join("devenv.nix");
+
+        // Pretend eval started at a fixed instant.
+        let eval_started_at = SystemTime::now();
+
+        // Write the file and set its mtime AFTER eval_started_at: this
+        // simulates a user rewriting the file while eval was still running.
+        let mut f = File::create(&file_path).unwrap();
+        f.write_all(b"{ ... }: { tasks.demo-show.exec = \"echo\"; }")
+            .unwrap();
+        let post_eval = eval_started_at + std::time::Duration::from_secs(2);
+        f.set_modified(post_eval).unwrap();
+        drop(f);
+
+        let ops = vec![EvalOp::ReadFile {
+            source: file_path.clone(),
+        }];
+        let result = ops_to_inputs(ops, &CachingConfig::default(), eval_started_at);
+        assert_eq!(result.inputs.len(), 1);
+        assert!(
+            result.race_detected,
+            "file modified after eval_started_at must set race_detected"
+        );
+    }
+
+    #[test]
+    fn test_ops_to_inputs_no_race_when_file_stable() {
+        use std::fs::File;
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::with_prefix("test_no_race").unwrap();
+        let file_path = temp_dir.path().join("devenv.nix");
+
+        // Write the file and set its mtime to the distant past.
+        let mut f = File::create(&file_path).unwrap();
+        f.write_all(b"{ ... }: { }").unwrap();
+        let pre_eval = SystemTime::now() - std::time::Duration::from_secs(60);
+        f.set_modified(pre_eval).unwrap();
+        drop(f);
+
+        // eval_started_at is AFTER the file's last modification.
+        let eval_started_at = SystemTime::now();
+
+        let ops = vec![EvalOp::ReadFile {
+            source: file_path.clone(),
+        }];
+        let result = ops_to_inputs(ops, &CachingConfig::default(), eval_started_at);
+        assert_eq!(result.inputs.len(), 1);
+        assert!(!result.race_detected);
+    }
+
+    #[test]
+    fn test_ops_to_inputs_detects_race_on_extra_watch_path() {
+        use std::fs::File;
+        use std::io::Write;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::with_prefix("test_race_watch_path").unwrap();
+        let file_path = temp_dir.path().join("flake.lock");
+
+        let eval_started_at = SystemTime::now();
+
+        let mut f = File::create(&file_path).unwrap();
+        f.write_all(b"{}").unwrap();
+        let post_eval = eval_started_at + std::time::Duration::from_secs(2);
+        f.set_modified(post_eval).unwrap();
+        drop(f);
+
+        let config = CachingConfig {
+            extra_watch_paths: vec![file_path],
+            ..Default::default()
+        };
+        let result = ops_to_inputs(vec![], &config, eval_started_at);
+        assert_eq!(result.inputs.len(), 1);
+        assert!(result.race_detected);
     }
 }

--- a/devenv-eval-cache/src/lib.rs
+++ b/devenv-eval-cache/src/lib.rs
@@ -16,7 +16,7 @@ pub use caching_eval::{
     CacheError, CachedEval, CachedEvalResult, CachingEvalService, CachingEvalState,
     UncachedEvalState, UncachedReason,
 };
-pub use ffi_cache::{CachingConfig, EvalCacheKey, EvalInputCollector, ops_to_inputs};
+pub use ffi_cache::{CachingConfig, EvalCacheKey, EvalInputCollector, OpsToInputs, ops_to_inputs};
 pub use resource_manager::{ResourceManager, ResourceSpec};
 
 // Re-export database query functions for file tracking


### PR DESCRIPTION
## Summary

- Detect when a tracked input (e.g. `devenv.nix`) is rewritten while Nix is still evaluating, and skip persisting the cache entry in that case.
- Capture `eval_started_at` before evaluation; in `ops_to_inputs`, flag any tracked file whose untruncated mtime exceeds it. On `race_detected`, the eval result is still returned but nothing stale gets stored — next run re-evaluates against current disk state.
- Fixes #2745.

## Test plan

- [x] `cargo nextest run -p devenv-eval-cache` — 43 tests pass, including 3 new race-detection tests covering the read path, the stable-file case, and `extra_watch_paths`.
- [x] `cargo clippy -p devenv-eval-cache --tests` — clean.
- [ ] Reproduce locally: start `devenv shell`, edit `devenv.nix` while evaluation is in flight, and confirm the next run re-evaluates instead of serving a stale result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)