### PR TITLE
tui: add Ctrl-H to toggle hiding stopped processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Upgraded Nix to 2.34, bringing multithreaded tarball unpacking, evaluator performance improvements, and REPL enhancements.
 - Added `require_version` field to `devenv.yaml` to enforce a devenv CLI version. Set to `true` to match the modules version, or use a constraint string like `">=2.1"` ([#2391](https://github.com/cachix/devenv/issues/2391)).
 - Added Ctrl-X keybinding to stop individual processes from the TUI while keeping them visible and restartable.
+- Added Ctrl-H keybinding to toggle hiding stopped processes in the TUI. Failed processes remain visible, and the process count shows how many are hidden ([#2692](https://github.com/cachix/devenv/issues/2692)).
 - Tasks can now display messages when entering the shell by writing `{"devenv":{"messages":["..."]}}` to `$DEVENV_TASK_OUTPUT_FILE` ([#2500](https://github.com/cachix/devenv/issues/2500)).
 - Added `devenv hook <shell>` for native directory based auto-activation without direnv. Supports bash, zsh, fish, and nushell. Automatically deactivates when you leave the project directory. Add `eval "$(devenv hook bash)"` to your shell config to activate. Use `devenv allow` and `devenv revoke` to manage trust ([#2488](https://github.com/cachix/devenv/issues/2488)).
 - Shell environment now auto-reloads at the next prompt when watched files change, instead of requiring a manual Ctrl-Alt-R keybind ([#2595](https://github.com/cachix/devenv/issues/2595)).

--- a/devenv-processes/src/manager.rs
+++ b/devenv-processes/src/manager.rs
@@ -892,11 +892,13 @@ impl NativeProcessManager {
         Ok(())
     }
 
-    /// Stop a process but keep it visible in the TUI and restartable via Ctrl+R.
+    /// Stop a running process but keep its entry in the process map so the TUI
+    /// continues to show it and the user can restart it with Ctrl+R.
     ///
-    /// Unlike `stop()` which removes the entry (used during full shutdown), this
-    /// transitions the entry back to `NotStarted` so the process remains in the TUI
-    /// with "stopped" status and can be restarted with `start_not_started()`.
+    /// Transitions an `Active` entry to `ProcessEntry::Stopped { .. }` — a
+    /// distinct variant from `NotStarted` so callers of [`Self::get_phase`]
+    /// can tell apart a process the user stopped from one that never started.
+    /// Errors if the process is not currently `Active`.
     pub async fn stop_and_keep(&self, name: &str) -> Result<()> {
         let handle = {
             let mut processes = self.processes.write().await;
@@ -1001,10 +1003,10 @@ impl NativeProcessManager {
             stderr_log: _,
         } = handle.resources;
 
-        self.processes.write().await.insert(
-            name.to_string(),
-            ProcessEntry::NotStarted { config, activity },
-        );
+        self.processes
+            .write()
+            .await
+            .insert(name.to_string(), ProcessEntry::Stopped { config, activity });
 
         if let Some(notify) = &self.task_notify {
             notify.notify_waiters();
@@ -2284,7 +2286,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stop_and_keep_transitions_to_not_started() {
+    async fn test_stop_and_keep_transitions_to_stopped() {
         let temp_dir = tempfile::tempdir().unwrap();
         let manager = NativeProcessManager::new(temp_dir.path().to_path_buf()).unwrap();
         let config = long_running_config("keepable");
@@ -2300,8 +2302,8 @@ mod tests {
         );
         assert_eq!(
             manager.get_phase("keepable").await,
-            Some(ProcessPhase::NotStarted),
-            "stopped process should transition to NotStarted"
+            Some(ProcessPhase::Stopped),
+            "stopped process should transition to Stopped"
         );
     }
 
@@ -2377,7 +2379,7 @@ mod tests {
         manager.stop_and_keep("restartable").await.unwrap();
         assert_eq!(
             manager.get_phase("restartable").await,
-            Some(ProcessPhase::NotStarted)
+            Some(ProcessPhase::Stopped)
         );
 
         manager.start_not_started("restartable").await.unwrap();
@@ -2404,7 +2406,7 @@ mod tests {
 
         assert_eq!(
             manager.get_phase("cmd-stop").await,
-            Some(ProcessPhase::NotStarted),
+            Some(ProcessPhase::Stopped),
             "handle_command(Stop) should call stop_and_keep"
         );
     }

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -631,23 +631,35 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             should_exit.set(true);
                         }
                     }
+                    KeyCode::Char('h') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+                        if let Ok(model) = activity_model.read()
+                            && let Ok(mut ui) = ui_state.write()
+                        {
+                            ui.toggle_hide_stopped_processes();
+                            if let Some(id) = ui.selected_activity
+                                && !model.is_selectable(id, &ui)
+                            {
+                                ui.selected_activity = None;
+                            }
+                        }
+                    }
                     KeyCode::Down | KeyCode::Up => {
-                        if let Ok(model) = activity_model.read() {
-                            let selectable = model.get_selectable_activity_ids();
-                            if let Ok(mut ui) = ui_state.write() {
-                                ui.select_activity(&selectable, key_event.code == KeyCode::Down);
-                                if let Some(selected_id) = ui.selected_activity
-                                    && *scroll_view_active.read()
-                                {
-                                    let display = model.get_display_activities();
-                                    let heights = activity_heights.read();
-                                    scroll_selected_into_view(
-                                        &mut scroll_handle.write(),
-                                        &heights,
-                                        &display,
-                                        selected_id,
-                                    );
-                                }
+                        if let Ok(model) = activity_model.read()
+                            && let Ok(mut ui) = ui_state.write()
+                        {
+                            let selectable = model.get_selectable_activity_ids(&ui);
+                            ui.select_activity(&selectable, key_event.code == KeyCode::Down);
+                            if let Some(selected_id) = ui.selected_activity
+                                && *scroll_view_active.read()
+                            {
+                                let display = model.get_display_activities(&ui);
+                                let heights = activity_heights.read();
+                                scroll_selected_into_view(
+                                    &mut scroll_handle.write(),
+                                    &heights,
+                                    &display,
+                                    selected_id,
+                                );
                             }
                         }
                     }
@@ -682,7 +694,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let ui = ui_state.read().unwrap();
     let is_shutting_down = shutdown.is_cancelled();
     let rendered = if let Ok(model_guard) = activity_model.read() {
-        let display = model_guard.get_display_activities();
+        let display = model_guard.get_display_activities(&ui);
 
         // Prune stale entries and compute total content height in a single lock
         let total_content_height: i32 = {

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -1213,6 +1213,30 @@ impl ActivityModel {
         }
     }
 
+    /// Whether `activity` is a direct child of `parent_id`, accounting for the
+    /// primary parent link and any additional parents.
+    fn is_direct_child_of(&self, activity: &Activity, parent_id: u64) -> bool {
+        activity.parent_id == Some(parent_id)
+            || self
+                .additional_parents
+                .get(&activity.id)
+                .is_some_and(|parents| parents.contains(&parent_id))
+    }
+
+    /// Count how many direct children of `parent_id` are hidden by the
+    /// `hide_stopped_processes` filter. Returns 0 when the filter is off.
+    pub fn count_hidden_process_children(&self, parent_id: u64, ui_state: &UiState) -> usize {
+        if !ui_state.hide_stopped_processes {
+            return 0;
+        }
+        self.activities
+            .values()
+            .filter(|a| {
+                self.is_direct_child_of(a, parent_id) && self.is_hidden_process(a, ui_state)
+            })
+            .count()
+    }
+
     pub fn calculate_summary(&self) -> ActivitySummary {
         let mut summary = ActivitySummary::default();
 
@@ -1259,10 +1283,12 @@ impl ActivityModel {
                 (ActivityVariant::Process(proc), state) => {
                     if proc.status.is_active() {
                         summary.running_processes += 1;
-                    } else if matches!(proc.status, ProcessStatus::Stopped)
-                        && !matches!(state, NixActivityState::Completed { success: false, .. })
-                    {
-                        summary.stopped_processes += 1;
+                        summary.total_processes += 1;
+                    } else if matches!(proc.status, ProcessStatus::Stopped) {
+                        if !matches!(state, NixActivityState::Completed { success: false, .. }) {
+                            summary.stopped_processes += 1;
+                        }
+                        summary.total_processes += 1;
                     }
                 }
                 _ => {}
@@ -1390,19 +1416,9 @@ impl ActivityModel {
             .activities
             .values()
             .filter(|a| {
-                if matches!(a.variant, ActivityVariant::UserOperation)
-                    || a.variant.is_always_top_level()
-                {
-                    return false;
-                }
-                // Check primary parent
-                if a.parent_id == Some(parent_id) {
-                    return true;
-                }
-                // Check additional parents
-                self.additional_parents
-                    .get(&a.id)
-                    .is_some_and(|parents| parents.contains(&parent_id))
+                !matches!(a.variant, ActivityVariant::UserOperation)
+                    && !a.variant.is_always_top_level()
+                    && self.is_direct_child_of(a, parent_id)
             })
             .collect();
 
@@ -1548,6 +1564,12 @@ pub struct ActivitySummary {
     pub failed_tasks: usize,
     pub running_processes: usize,
     pub stopped_processes: usize,
+    /// Process activities the summary bar tracks: active plus stopped
+    /// (including failed-stopped). Excludes `NotStarted`, so a shell that
+    /// only has disabled-autostart processes renders nothing in the bar.
+    /// `running_processes` is a live gauge (can go down); this is a
+    /// snapshot count of tracked processes, not cumulative progress.
+    pub total_processes: usize,
 }
 
 /// Format an EvalOp as a display string for logging.
@@ -1680,5 +1702,93 @@ mod tests {
             .map(|da| da.activity.name)
             .collect();
         assert!(!visible_after.contains(&"manually-stopped".to_string()));
+    }
+
+    #[test]
+    fn test_summary_total_processes_counts_running_and_stopped() {
+        let mut model = ActivityModel::default();
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        for (id, name) in [(1, "running"), (2, "also-running"), (3, "stopped")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: Some(100),
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+        model.apply_activity_event(ActivityEvent::Process(Process::Status {
+            id: 3,
+            status: ProcessStatus::Stopped,
+            timestamp: Timestamp::now(),
+        }));
+
+        let summary = model.calculate_summary();
+        assert_eq!(summary.running_processes, 2);
+        assert_eq!(summary.stopped_processes, 1);
+        assert_eq!(
+            summary.total_processes, 3,
+            "total should reflect the full count of process activities visible in the TUI"
+        );
+    }
+
+    #[test]
+    fn test_count_hidden_process_children_reports_hidden_clean_stops() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        for (id, name) in [(1, "clean-stop-1"), (2, "clean-stop-2"), (3, "running")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: Some(100),
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+        for id in [1, 2] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Status {
+                id,
+                status: ProcessStatus::Stopped,
+                timestamp: Timestamp::now(),
+            }));
+        }
+
+        assert_eq!(
+            model.count_hidden_process_children(100, &ui_state),
+            0,
+            "nothing is hidden while the filter is off"
+        );
+
+        ui_state.hide_stopped_processes = true;
+        assert_eq!(
+            model.count_hidden_process_children(100, &ui_state),
+            2,
+            "both clean stops are hidden under the Running processes parent"
+        );
     }
 }

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -169,6 +169,7 @@ pub struct Activity {
 pub struct UiState {
     pub viewport: ViewportConfig,
     pub selected_activity: Option<u64>,
+    pub hide_stopped_processes: bool,
     pub scroll: ScrollState,
     pub view_options: ViewOptions,
     pub terminal_size: TerminalSize,
@@ -188,6 +189,7 @@ impl UiState {
                 activities_visible: 5,
             },
             selected_activity: None,
+            hide_stopped_processes: false,
             scroll: ScrollState {
                 log_offset: 0,
                 activity_position: 0,
@@ -216,6 +218,15 @@ impl UiState {
 
     pub fn interrupt_prompt_active(&self) -> bool {
         self.interrupt_prompt_active
+    }
+
+    /// Toggle the `hide_stopped_processes` filter.
+    ///
+    /// Callers must then clear [`Self::selected_activity`] if the previous
+    /// selection is no longer selectable under the new filter state
+    /// (see [`ActivityModel::is_selectable`]).
+    pub fn toggle_hide_stopped_processes(&mut self) {
+        self.hide_stopped_processes = !self.hide_stopped_processes;
     }
 
     /// Select the next or previous activity from the list of selectable IDs.
@@ -1067,9 +1078,9 @@ impl ActivityModel {
             .collect()
     }
 
-    pub fn get_selectable_activity_ids(&self) -> Vec<u64> {
+    pub fn get_selectable_activity_ids(&self, ui_state: &UiState) -> Vec<u64> {
         let mut seen = HashSet::new();
-        self.get_display_activities()
+        self.get_display_activities(ui_state)
             .into_iter()
             .filter(|da| {
                 // Processes are always selectable (so disabled ones can be started)
@@ -1086,13 +1097,20 @@ impl ActivityModel {
             .collect()
     }
 
-    pub fn get_display_activities(&self) -> Vec<DisplayActivity> {
-        self.get_display_activities_with_limit(&ChildActivityLimit::default())
+    /// Returns `true` if `id` would appear in
+    /// [`Self::get_selectable_activity_ids`] for the given `ui_state`.
+    pub fn is_selectable(&self, id: u64, ui_state: &UiState) -> bool {
+        self.get_selectable_activity_ids(ui_state).contains(&id)
+    }
+
+    pub fn get_display_activities(&self, ui_state: &UiState) -> Vec<DisplayActivity> {
+        self.get_display_activities_with_limit(&ChildActivityLimit::default(), ui_state)
     }
 
     pub fn get_display_activities_with_limit(
         &self,
         limit: &ChildActivityLimit,
+        ui_state: &UiState,
     ) -> Vec<DisplayActivity> {
         let mut activities = Vec::new();
         // Track (activity_id, parent_id) pairs to allow same activity under multiple parents
@@ -1100,7 +1118,15 @@ impl ActivityModel {
             std::collections::HashSet::new();
 
         for &root_id in &self.root_activities {
-            self.add_display_activity(&mut activities, root_id, None, 0, &mut processed, limit);
+            self.add_display_activity(
+                &mut activities,
+                root_id,
+                None,
+                0,
+                &mut processed,
+                limit,
+                ui_state,
+            );
         }
 
         activities
@@ -1114,6 +1140,7 @@ impl ActivityModel {
         depth: usize,
         processed: &mut std::collections::HashSet<(u64, Option<u64>)>,
         limit: &ChildActivityLimit,
+        ui_state: &UiState,
     ) {
         // Track (activity_id, parent_id) to allow same activity under different parents
         if !processed.insert((activity_id, parent_id)) {
@@ -1122,7 +1149,9 @@ impl ActivityModel {
 
         if let Some(activity) = self.activities.get(&activity_id) {
             // Skip command activities (UserOperation) - they are internal details
-            if matches!(activity.variant, ActivityVariant::UserOperation) {
+            if matches!(activity.variant, ActivityVariant::UserOperation)
+                || self.is_hidden_process(activity, ui_state)
+            {
                 return;
             }
 
@@ -1154,8 +1183,33 @@ impl ActivityModel {
                     child_depth,
                     processed,
                     limit,
+                    ui_state,
                 );
             }
+        }
+    }
+
+    fn is_hidden_process(&self, activity: &Activity, ui_state: &UiState) -> bool {
+        if !ui_state.hide_stopped_processes {
+            return false;
+        }
+
+        match (&activity.variant, &activity.state) {
+            (
+                ActivityVariant::Process(ProcessActivity {
+                    status: ProcessStatus::Stopped,
+                    ..
+                }),
+                NixActivityState::Completed { success: false, .. },
+            ) => false,
+            (
+                ActivityVariant::Process(ProcessActivity {
+                    status: ProcessStatus::Stopped,
+                    ..
+                }),
+                _,
+            ) => true,
+            _ => false,
         }
     }
 
@@ -1202,9 +1256,13 @@ impl ActivityModel {
                         summary.failed_tasks += 1
                     }
                 },
-                (ActivityVariant::Process(proc), _) => {
+                (ActivityVariant::Process(proc), state) => {
                     if proc.status.is_active() {
                         summary.running_processes += 1;
+                    } else if matches!(proc.status, ProcessStatus::Stopped)
+                        && !matches!(state, NixActivityState::Completed { success: false, .. })
+                    {
+                        summary.stopped_processes += 1;
                     }
                 }
                 _ => {}
@@ -1294,8 +1352,8 @@ impl ActivityModel {
         Some(Instant::now().duration_since(earliest_start))
     }
 
-    pub fn get_active_display_activities(&self) -> Vec<DisplayActivity> {
-        self.get_display_activities()
+    pub fn get_active_display_activities(&self, ui_state: &UiState) -> Vec<DisplayActivity> {
+        self.get_display_activities(ui_state)
             .into_iter()
             .filter(|da| {
                 matches!(
@@ -1489,6 +1547,7 @@ pub struct ActivitySummary {
     pub completed_tasks: usize,
     pub failed_tasks: usize,
     pub running_processes: usize,
+    pub stopped_processes: usize,
 }
 
 /// Format an EvalOp as a display string for logging.
@@ -1569,5 +1628,57 @@ mod tests {
 
         ui.clear_interrupt_prompt();
         assert!(!ui.interrupt_prompt_active());
+    }
+
+    #[test]
+    fn test_hide_stopped_processes_matches_runtime_manual_stop_shape() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        model.apply_activity_event(ActivityEvent::Process(Process::Start {
+            id: 1,
+            name: "manually-stopped".to_string(),
+            parent: Some(100),
+            command: None,
+            ports: vec![],
+            ready_probe: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+        model.apply_activity_event(ActivityEvent::Process(Process::Status {
+            id: 1,
+            status: ProcessStatus::Stopping,
+            timestamp: Timestamp::now(),
+        }));
+        model.apply_activity_event(ActivityEvent::Process(Process::Status {
+            id: 1,
+            status: ProcessStatus::Stopped,
+            timestamp: Timestamp::now(),
+        }));
+
+        let visible_before: Vec<_> = model
+            .get_display_activities(&ui_state)
+            .into_iter()
+            .map(|da| da.activity.name)
+            .collect();
+        assert!(visible_before.contains(&"manually-stopped".to_string()));
+
+        ui_state.hide_stopped_processes = true;
+
+        let visible_after: Vec<_> = model
+            .get_display_activities(&ui_state)
+            .into_iter()
+            .map(|da| da.activity.name)
+            .collect();
+        assert!(!visible_after.contains(&"manually-stopped".to_string()));
     }
 }

--- a/devenv-tui/src/model_events.rs
+++ b/devenv-tui/src/model_events.rs
@@ -25,11 +25,11 @@ impl UiEvent {
                 use KeyCode::*;
                 match key_code {
                     Down => {
-                        let selectable = activity_model.get_selectable_activity_ids();
+                        let selectable = activity_model.get_selectable_activity_ids(ui_state);
                         ui_state.select_activity(&selectable, true);
                     }
                     Up => {
-                        let selectable = activity_model.get_selectable_activity_ids();
+                        let selectable = activity_model.get_selectable_activity_ids(ui_state);
                         ui_state.select_activity(&selectable, false);
                     }
                     Esc => {

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -22,7 +22,11 @@ pub const SUMMARY_BAR_HEIGHT: u16 = 2;
 /// Map from activity_id to rendered height in lines.
 pub type ActivityHeights = Ref<HashMap<u64, i32>>;
 
-/// Pre-computed state passed from the app to avoid redundant computation in `view()`.
+/// Scroll state and the display list the app already computed for this frame.
+///
+/// Passing `display_activities` through avoids re-walking the activity tree
+/// inside `view()`; the app needs the same list to measure heights before
+/// rendering.
 pub struct ScrollState {
     pub handle: Option<Ref<ScrollViewHandle>>,
     pub display_activities: Vec<DisplayActivity>,
@@ -38,14 +42,15 @@ pub fn view(
 ) -> impl Into<AnyElement<'static>> {
     let (scroll_handle, active_activities) = match scroll {
         Some(s) => (s.handle, s.display_activities),
-        None => (None, model.get_display_activities()),
+        None => (None, model.get_display_activities(ui_state)),
     };
 
     let summary = model.calculate_summary();
-    let selected_id = ui_state.selected_activity;
     let terminal_size = ui_state.terminal_size;
 
-    // Check if we have a selected activity with logs/details
+    let selected_id = ui_state
+        .selected_activity
+        .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
     let selected_activity = selected_id.and_then(|id| model.get_activity(id));
     let selected_logs = selected_activity
         .as_ref()
@@ -131,7 +136,7 @@ pub fn view(
     }
 
     // Determine if navigation is possible
-    let selectable_ids = model.get_selectable_activity_ids();
+    let selectable_ids = model.get_selectable_activity_ids(ui_state);
     let (can_go_up, can_go_down) = if let Some(current_id) = selected_id {
         if let Some(pos) = selectable_ids.iter().position(|&id| id == current_id) {
             (pos > 0, pos + 1 < selectable_ids.len())
@@ -153,6 +158,7 @@ pub fn view(
             can_go_up,
             can_go_down,
             interrupt_prompt_active: ui_state.interrupt_prompt_active(),
+            hide_stopped_processes: ui_state.hide_stopped_processes,
         })) {
             SummaryView
         }
@@ -894,6 +900,7 @@ struct SummaryViewContext {
     can_go_up: bool,
     can_go_down: bool,
     interrupt_prompt_active: bool,
+    hide_stopped_processes: bool,
 }
 
 /// Summary view component that adapts to terminal width
@@ -901,6 +908,11 @@ struct SummaryViewContext {
 fn SummaryView(hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let terminal_width = hooks.use_context::<TerminalSize>().width;
     let ctx = hooks.use_context::<SummaryViewContext>();
+    build_summary_view_impl(&ctx, terminal_width)
+}
+
+/// Build the summary view with colored counts
+fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> AnyElement<'static> {
     let SummaryViewContext {
         summary,
         selected,
@@ -908,29 +920,15 @@ fn SummaryView(hooks: Hooks) -> impl Into<AnyElement<'static>> {
         can_go_up,
         can_go_down,
         interrupt_prompt_active,
-    } = &*ctx;
+        hide_stopped_processes,
+    } = ctx;
+    let selected = selected.as_ref();
+    let showing_logs = *showing_logs;
+    let can_go_up = *can_go_up;
+    let can_go_down = *can_go_down;
+    let interrupt_prompt_active = *interrupt_prompt_active;
+    let hide_stopped_processes = *hide_stopped_processes;
 
-    build_summary_view_impl(
-        summary,
-        selected.as_ref(),
-        *showing_logs,
-        *can_go_up,
-        *can_go_down,
-        *interrupt_prompt_active,
-        terminal_width,
-    )
-}
-
-/// Build the summary view with colored counts
-fn build_summary_view_impl(
-    summary: &ActivitySummary,
-    selected: Option<&Activity>,
-    showing_logs: bool,
-    can_go_up: bool,
-    can_go_down: bool,
-    interrupt_prompt_active: bool,
-    terminal_width: u16,
-) -> AnyElement<'static> {
     if interrupt_prompt_active {
         let prompt_text = if terminal_width < 72 {
             "Quit devenv? Nothing stopped."
@@ -1153,6 +1151,7 @@ fn build_summary_view_impl(
     // Build help text - always show, adapt based on terminal width
     let mut help_children = vec![];
     let use_short_text = terminal_width < 100; // Use shorter text for narrow terminals
+    let show_hide_toggle = summary.stopped_processes > 0 || hide_stopped_processes;
 
     let up_arrow_color = if can_go_up {
         COLOR_INTERACTIVE
@@ -1203,6 +1202,10 @@ fn build_summary_view_impl(
                 help_children.push(element!(Text(content: " (re)start process • ")).into_any());
             }
         }
+        if show_hide_toggle {
+            help_children.push(element!(Text(content: if use_short_text { "^H" } else { "Ctrl-H" }, color: COLOR_INTERACTIVE)).into_any());
+            help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped • " } else { " hide stopped • " })).into_any());
+        }
         help_children.push(element!(Text(content: "Esc", color: COLOR_INTERACTIVE)).into_any());
         if showing_logs {
             if use_symbols {
@@ -1220,12 +1223,19 @@ fn build_summary_view_impl(
         // Show navigate hint only when no selection (Ctrl-E requires selection)
         help_children.push(element!(Text(content: "↑", color: up_arrow_color)).into_any());
         help_children.push(element!(Text(content: "↓", color: down_arrow_color)).into_any());
+        let trail = if show_hide_toggle { " • " } else { "" };
         if !use_symbols {
             if use_short_text {
-                help_children.push(element!(Text(content: " nav")).into_any());
+                help_children.push(element!(Text(content: format!(" nav{trail}"))).into_any());
             } else {
-                help_children.push(element!(Text(content: " navigate")).into_any());
+                help_children.push(element!(Text(content: format!(" navigate{trail}"))).into_any());
             }
+        } else if show_hide_toggle {
+            help_children.push(element!(Text(content: " • ")).into_any());
+        }
+        if show_hide_toggle {
+            help_children.push(element!(Text(content: if use_short_text { "^H" } else { "Ctrl-H" }, color: COLOR_INTERACTIVE)).into_any());
+            help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped" } else { " hide stopped" })).into_any());
         }
     }
 
@@ -1251,23 +1261,122 @@ pub fn format_duration(duration: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::ActivityModel;
+    use devenv_activity::{ActivityEvent, ActivityLevel, Operation, Process, Timestamp};
+
+    fn summary_ctx(
+        hide_stopped_processes: bool,
+        interrupt_prompt_active: bool,
+        stopped_processes: usize,
+    ) -> SummaryViewContext {
+        SummaryViewContext {
+            summary: ActivitySummary {
+                stopped_processes,
+                ..ActivitySummary::default()
+            },
+            selected: None,
+            showing_logs: false,
+            can_go_up: false,
+            can_go_down: false,
+            interrupt_prompt_active,
+            hide_stopped_processes,
+        }
+    }
 
     #[test]
     fn test_summary_interrupt_prompt_renders() {
-        let mut element = build_summary_view_impl(
-            &ActivitySummary::default(),
-            None,
-            false,
-            false,
-            false,
-            true,
-            100,
-        );
+        let mut element = build_summary_view_impl(&summary_ctx(false, true, 0), 100);
         let output = element.render(Some(100)).to_string();
 
         assert!(output.contains("Quit devenv?"));
         assert!(output.contains("stopped"));
         assert!(output.contains("keep running"));
         assert!(output.contains("quit"));
+    }
+
+    #[test]
+    fn test_summary_help_reflects_hide_stopped_processes_state() {
+        let hidden_output = build_summary_view_impl(&summary_ctx(true, false, 0), 100)
+            .render(Some(100))
+            .to_string();
+
+        assert!(hidden_output.contains("show stopped"));
+        assert!(!hidden_output.contains("hide stopped"));
+
+        let shown_output = build_summary_view_impl(&summary_ctx(false, false, 1), 100)
+            .render(Some(100))
+            .to_string();
+
+        assert!(shown_output.contains("hide stopped"));
+        assert!(!shown_output.contains("show stopped"));
+    }
+
+    #[test]
+    fn test_summary_help_omits_hide_toggle_when_no_stopped_processes() {
+        let output = build_summary_view_impl(&summary_ctx(false, false, 0), 100)
+            .render(Some(100))
+            .to_string();
+
+        assert!(!output.contains("hide stopped"));
+        assert!(!output.contains("show stopped"));
+        assert!(!output.contains("Ctrl-H"));
+    }
+
+    #[test]
+    fn test_view_uses_current_ui_state_for_process_visibility() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        model.apply_activity_event(ActivityEvent::Process(Process::Start {
+            id: 1,
+            name: "manually-stopped".to_string(),
+            parent: Some(100),
+            command: None,
+            ports: vec![],
+            ready_probe: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+        model.apply_activity_event(ActivityEvent::Process(Process::Status {
+            id: 1,
+            status: ProcessStatus::Stopped,
+            timestamp: Timestamp::now(),
+        }));
+
+        let stale_display = model.get_display_activities(&ui_state);
+        assert!(
+            stale_display
+                .iter()
+                .any(|da| da.activity.name == "manually-stopped")
+        );
+
+        ui_state.hide_stopped_processes = true;
+
+        let display_activities = model.get_display_activities(&ui_state);
+        let mut element: AnyElement<'static> = view(
+            &model,
+            &ui_state,
+            RenderContext::Normal,
+            Some(ScrollState {
+                handle: None,
+                display_activities,
+            }),
+            false,
+        )
+        .into();
+        let rendered = element
+            .render(Some(ui_state.terminal_size.width as usize))
+            .to_string();
+
+        assert!(!rendered.contains("manually-stopped"));
     }
 }

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -115,6 +115,12 @@ pub fn view(
             } => (Some(*success), *cached),
         };
 
+        let hidden_children_count = if matches!(activity.variant, ActivityVariant::Devenv) {
+            model.count_hidden_process_children(activity.id, ui_state)
+        } else {
+            0
+        };
+
         activity_elements.push(
             element! {
                 ContextProvider(value: Context::owned(ActivityRenderContext {
@@ -127,6 +133,7 @@ pub fn view(
                     cached,
                     render_context,
                     shutting_down,
+                    hidden_children_count,
                 })) {
                     ActivityItem
                 }
@@ -250,6 +257,8 @@ struct ActivityRenderContext {
     render_context: RenderContext,
     /// Whether the application is shutting down (Ctrl-C pressed)
     shutting_down: bool,
+    /// Number of direct children hidden by the `hide_stopped_processes` filter.
+    hidden_children_count: usize,
 }
 
 /// Helper to build activity prefix with hierarchy and status indicator.
@@ -297,6 +306,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         cached,
         render_context,
         shutting_down,
+        hidden_children_count,
     } = &*ctx;
 
     // Calculate elapsed time - use stored duration for completed activities, skip for queued
@@ -586,7 +596,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             let prefix = build_activity_prefix(*depth, *completed, true);
 
             // Show line count as suffix when active or failed with logs
-            let suffix = if *completed == Some(true) {
+            let base_suffix = if *completed == Some(true) {
                 // Success - no suffix needed
                 None
             } else if let Some(ref progress) = activity.progress {
@@ -610,6 +620,16 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 Some(format!("{} lines", log_line_count))
             } else {
                 None
+            };
+
+            let suffix = if *hidden_children_count > 0 {
+                let hidden_note = format!("({} hidden)", hidden_children_count);
+                Some(match base_suffix {
+                    Some(s) => format!("{} {}", s, hidden_note),
+                    None => hidden_note,
+                })
+            } else {
+                base_suffix
             };
 
             let main_line = ActivityTextComponent::name_only(
@@ -1128,21 +1148,39 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         has_content = true;
     }
 
-    // Processes - show if there are any running
-    if summary.running_processes > 0 {
+    // Processes - show if there are any tracked (running or stopped)
+    if summary.total_processes > 0 {
         if has_content {
             children.push(element!(View(margin_left: if use_symbols { 1 } else { 2 }, margin_right: if use_symbols { 1 } else { 2 }, flex_shrink: 0.0) {
                 Text(content: "│", color: COLOR_HIERARCHY)
             }).into_any());
         }
 
-        children.push(element!(View(margin_right: 1, flex_shrink: 0.0) {
-            Text(content: format!("{}", summary.running_processes), color: COLOR_COMPLETED, weight: Weight::Bold)
-        }).into_any());
+        let running_all = summary.running_processes == summary.total_processes;
+        if running_all {
+            children.push(element!(View(margin_right: 1, flex_shrink: 0.0) {
+                Text(content: format!("{}", summary.total_processes), color: COLOR_COMPLETED, weight: Weight::Bold)
+            }).into_any());
+        } else if use_symbols {
+            children.push(element!(View(margin_right: 1, flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
+                Text(content: format!("{}", summary.running_processes), color: COLOR_COMPLETED, weight: Weight::Bold)
+                Text(content: format!("/{}", summary.total_processes))
+            }).into_any());
+        } else {
+            children.push(element!(View(margin_right: 1, flex_shrink: 0.0) {
+                Text(content: format!("{}", summary.running_processes), color: COLOR_COMPLETED, weight: Weight::Bold)
+            }).into_any());
+            children.push(
+                element!(View(margin_right: 1, flex_shrink: 0.0) {
+                    Text(content: format!("of {}", summary.total_processes))
+                })
+                .into_any(),
+            );
+        }
 
         children.push(
             element!(View(flex_shrink: 0.0) {
-                Text(content: if summary.running_processes == 1 { "process" } else { "processes" })
+                Text(content: if summary.total_processes == 1 { "process" } else { "processes" })
             })
             .into_any(),
         );
@@ -1378,5 +1416,196 @@ mod tests {
             .to_string();
 
         assert!(!rendered.contains("manually-stopped"));
+    }
+
+    #[test]
+    fn test_running_processes_label_shows_hidden_count_when_filter_is_active() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        for (id, name) in [(1, "stopped-a"), (2, "stopped-b"), (3, "running")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: Some(100),
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+        for id in [1, 2] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Status {
+                id,
+                status: ProcessStatus::Stopped,
+                timestamp: Timestamp::now(),
+            }));
+        }
+
+        let render = |ui: &UiState| {
+            let display_activities = model.get_display_activities(ui);
+            let mut element: AnyElement<'static> = view(
+                &model,
+                ui,
+                RenderContext::Normal,
+                Some(ScrollState {
+                    handle: None,
+                    display_activities,
+                }),
+                false,
+            )
+            .into();
+            element
+                .render(Some(ui.terminal_size.width as usize))
+                .to_string()
+        };
+
+        let rendered_visible = render(&ui_state);
+        assert!(
+            !rendered_visible.contains("hidden)"),
+            "no hidden count is shown while the filter is off: {rendered_visible}"
+        );
+
+        ui_state.hide_stopped_processes = true;
+        let rendered_hidden = render(&ui_state);
+        assert!(
+            rendered_hidden.contains("(2 hidden)"),
+            "hidden count should appear next to the Running processes label: {rendered_hidden}"
+        );
+    }
+
+    #[test]
+    fn test_summary_bar_shows_running_of_total_when_some_are_stopped() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+        // Wide enough to fit stats + help without column truncation.
+        ui_state.set_terminal_size(120, 24);
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        for (id, name) in [(1, "stopped"), (2, "running-a"), (3, "running-b")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: Some(100),
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+        model.apply_activity_event(ActivityEvent::Process(Process::Status {
+            id: 1,
+            status: ProcessStatus::Stopped,
+            timestamp: Timestamp::now(),
+        }));
+
+        let display_activities = model.get_display_activities(&ui_state);
+        let mut element: AnyElement<'static> = view(
+            &model,
+            &ui_state,
+            RenderContext::Normal,
+            Some(ScrollState {
+                handle: None,
+                display_activities,
+            }),
+            false,
+        )
+        .into();
+        let rendered = element
+            .render(Some(ui_state.terminal_size.width as usize))
+            .to_string();
+
+        assert!(
+            rendered.contains("2 of 3"),
+            "summary bar must surface running-of-total when some are stopped: {rendered}"
+        );
+    }
+
+    #[test]
+    fn test_summary_bar_excludes_not_started_processes_from_total() {
+        let mut model = ActivityModel::default();
+        let mut ui_state = UiState::new();
+        ui_state.set_terminal_size(120, 24);
+
+        model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+            id: 100,
+            name: "Running processes".to_string(),
+            parent: None,
+            detail: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        for (id, name) in [(1, "disabled-a"), (2, "disabled-b"), (3, "running")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: Some(100),
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+        for id in [1, 2] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Status {
+                id,
+                status: ProcessStatus::NotStarted,
+                timestamp: Timestamp::now(),
+            }));
+        }
+
+        let summary = model.calculate_summary();
+        assert_eq!(summary.running_processes, 1);
+        assert_eq!(summary.stopped_processes, 0);
+        assert_eq!(
+            summary.total_processes, 1,
+            "NotStarted processes must not inflate the tracked total"
+        );
+
+        let display_activities = model.get_display_activities(&ui_state);
+        let mut element: AnyElement<'static> = view(
+            &model,
+            &ui_state,
+            RenderContext::Normal,
+            Some(ScrollState {
+                handle: None,
+                display_activities,
+            }),
+            false,
+        )
+        .into();
+        let rendered = element
+            .render(Some(ui_state.terminal_size.width as usize))
+            .to_string();
+
+        assert!(
+            !rendered.contains("of 1 processes") && !rendered.contains("0 of"),
+            "bar must render `1 process` not `0 of 1`: {rendered}"
+        );
+        assert!(
+            rendered.contains("1 process"),
+            "running count should still surface: {rendered}"
+        );
     }
 }

--- a/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
@@ -1,6 +1,5 @@
 ---
 source: devenv-tui/tests/tui_tests.rs
-assertion_line: 1830
 expression: output
 ---
 ⠋ Running processes       [TIME]

--- a/devenv-tui/tests/snapshots/tui_tests__query_activity.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__query_activity.snap
@@ -1,6 +1,5 @@
 ---
 source: devenv-tui/tests/tui_tests.rs
-assertion_line: 397
 expression: output
 ---
 ⠋ Querying  7xyndmr0mgfissin0h5ggzb0b2i5drbz-cargo-vendor-dir from some… [TIME]

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -1331,7 +1331,7 @@ fn test_selectable_ids_dedup_for_multi_parent_tasks() {
         timestamp: Timestamp::now(),
     }));
 
-    let selectable = model.get_selectable_activity_ids();
+    let selectable = model.get_selectable_activity_ids(&ui_state);
     assert_eq!(selectable, vec![1, 3]);
 
     ui_state.select_activity(&selectable, true);
@@ -1689,6 +1689,208 @@ fn test_overflow_clips_top_keeps_bottom() {
         "Last line should be summary, not empty.\nFull output (debug):\n{:?}",
         output
     );
+}
+
+#[test]
+fn test_hide_stopped_processes_filters_manually_stopped_processes_but_keeps_failures() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+        id: 100,
+        name: "Running processes".to_string(),
+        parent: None,
+        detail: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+
+    for (id, name) in [(1, "clean-stop"), (2, "failed-stop"), (3, "running")] {
+        model.apply_activity_event(ActivityEvent::Process(Process::Start {
+            id,
+            name: name.to_string(),
+            parent: Some(100),
+            command: None,
+            ports: vec![],
+            ready_probe: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+    }
+
+    model.apply_activity_event(ActivityEvent::Process(Process::Status {
+        id: 1,
+        status: devenv_activity::ProcessStatus::Running,
+        timestamp: Timestamp::now(),
+    }));
+    model.apply_activity_event(ActivityEvent::Process(Process::Status {
+        id: 1,
+        status: devenv_activity::ProcessStatus::Stopped,
+        timestamp: Timestamp::now(),
+    }));
+    model.apply_activity_event(ActivityEvent::Process(Process::Complete {
+        id: 2,
+        outcome: ActivityOutcome::Failed,
+        timestamp: Timestamp::now(),
+    }));
+
+    let visible_before: Vec<_> = model
+        .get_display_activities(&ui_state)
+        .into_iter()
+        .map(|da| da.activity.name)
+        .collect();
+    assert!(visible_before.contains(&"clean-stop".to_string()));
+    assert!(visible_before.contains(&"failed-stop".to_string()));
+    assert!(visible_before.contains(&"running".to_string()));
+
+    ui_state.hide_stopped_processes = true;
+
+    let visible_after: Vec<_> = model
+        .get_display_activities(&ui_state)
+        .into_iter()
+        .map(|da| da.activity.name)
+        .collect();
+    assert!(!visible_after.contains(&"clean-stop".to_string()));
+    assert!(visible_after.contains(&"failed-stop".to_string()));
+    assert!(visible_after.contains(&"running".to_string()));
+
+    let summary = model.calculate_summary();
+    assert_eq!(
+        summary.stopped_processes, 1,
+        "summary.stopped_processes must match filter behaviour: only counts processes \
+         the filter would actually hide (i.e. clean stops, not failures)"
+    );
+}
+
+#[test]
+fn test_previous_hide_stopped_processes_coverage_used_completed_success() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+        id: 100,
+        name: "Running processes".to_string(),
+        parent: None,
+        detail: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+
+    model.apply_activity_event(ActivityEvent::Process(Process::Start {
+        id: 1,
+        name: "clean-stop".to_string(),
+        parent: Some(100),
+        command: None,
+        ports: vec![],
+        ready_probe: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+    model.apply_activity_event(ActivityEvent::Process(Process::Complete {
+        id: 1,
+        outcome: ActivityOutcome::Success,
+        timestamp: Timestamp::now(),
+    }));
+
+    ui_state.hide_stopped_processes = true;
+
+    let visible_after: Vec<_> = model
+        .get_display_activities(&ui_state)
+        .into_iter()
+        .map(|da| da.activity.name)
+        .collect();
+    assert!(
+        !visible_after.contains(&"clean-stop".to_string()),
+        "The old test shape used Process::Complete(Success), which already matched the previous filter."
+    );
+}
+
+#[test]
+fn test_toggle_hide_stopped_processes_clears_hidden_selection() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+        id: 100,
+        name: "Running processes".to_string(),
+        parent: None,
+        detail: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+
+    model.apply_activity_event(ActivityEvent::Process(Process::Start {
+        id: 1,
+        name: "clean-stop".to_string(),
+        parent: Some(100),
+        command: None,
+        ports: vec![],
+        ready_probe: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+    model.apply_activity_event(ActivityEvent::Process(Process::Status {
+        id: 1,
+        status: devenv_activity::ProcessStatus::Stopped,
+        timestamp: Timestamp::now(),
+    }));
+
+    ui_state.selected_activity = Some(1);
+    ui_state.toggle_hide_stopped_processes();
+    if let Some(id) = ui_state.selected_activity
+        && !model.is_selectable(id, &ui_state)
+    {
+        ui_state.selected_activity = None;
+    }
+
+    assert!(ui_state.hide_stopped_processes);
+    assert_eq!(ui_state.selected_activity, None);
+}
+
+#[test]
+fn test_hide_stopped_processes_removes_hidden_processes_from_selection() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
+        id: 100,
+        name: "Running processes".to_string(),
+        parent: None,
+        detail: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+
+    model.apply_activity_event(ActivityEvent::Process(Process::Start {
+        id: 1,
+        name: "clean-stop".to_string(),
+        parent: Some(100),
+        command: None,
+        ports: vec![],
+        ready_probe: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+    model.apply_activity_event(ActivityEvent::Process(Process::Status {
+        id: 1,
+        status: devenv_activity::ProcessStatus::Stopped,
+        timestamp: Timestamp::now(),
+    }));
+
+    model.apply_activity_event(ActivityEvent::Process(Process::Start {
+        id: 2,
+        name: "running".to_string(),
+        parent: Some(100),
+        command: None,
+        ports: vec![],
+        ready_probe: None,
+        level: ActivityLevel::Info,
+        timestamp: Timestamp::now(),
+    }));
+
+    let selectable_before = model.get_selectable_activity_ids(&ui_state);
+    assert_eq!(selectable_before, vec![1, 2]);
+
+    ui_state.hide_stopped_processes = true;
+
+    let selectable_after = model.get_selectable_activity_ids(&ui_state);
+    assert_eq!(selectable_after, vec![2]);
 }
 
 /// Test cachix push operation starting shows in the TUI.


### PR DESCRIPTION
This closes: #2692

Adds a `Ctrl+H` shortcut to toggle hiding stopped processes in the TUI. Cleanly stopped processes are filtered out when the filter is active, while failed ones remain visible so users notice issues.

I added `hide_stopped_processes` to `UiState`, updated the help bar to show a "hide stopped" / "show stopped" toggle (visible when relevant), and introduced `ProcessEntry::Stopped` in `manager.rs` to distinguish manually stopped processes from never-started ones. If the selected process becomes hidden, selection is cleared automatically.

## Notes

The hidden-process check intentionally only hides clean stops:

```rust
(
    ActivityVariant::Process(ProcessActivity {
        status: ProcessStatus::Stopped,
        ..
    }),
    NixActivityState::Completed { success: false, .. },
) => false,
(
    ActivityVariant::Process(ProcessActivity {
        status: ProcessStatus::Stopped,
        ..
    }),
    _,
) => true,
```

`UiState::toggle_hide_stopped_processes()` only flips the filter state. Callers must clear `selected_activity` if the previous selection is no longer selectable:

```rust
ui.toggle_hide_stopped_processes();
if let Some(id) = ui.selected_activity && !model.is_selectable(id, &ui) {
    ui.selected_activity = None;
}
```