### PR TITLE
fix(reload): remove startup hang and track state across reload cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed `devenv shell` and `devenv build` failing with `path '...drv' is required, but there is no substituter that can build it` after the cached derivation was garbage-collected. The stale eval-cache entry is now invalidated when its referenced store paths no longer exist, forcing a re-evaluation that re-materializes the `.drv` on disk.
+- Fixed hot reload missing file and directory changes that occurred during a build or during the brief gap between watch refreshes. The reload watcher now tracks path state (file/directory/missing) across reload cycles, queues deferred events while a build is in progress, and reconciles drift after rewatching so missed changes still trigger a follow-up rebuild.
 - Fixed MCP server segfault on exit by waiting for the cache init thread to finish before exiting ([#2699](https://github.com/cachix/devenv/issues/2699)).
 - Fixed independent oneshot tasks (e.g. `devenv:files` and `devenv:python:virtualenv`) running sequentially instead of in parallel, causing unnecessary waterfall delays during `devenv shell` startup.
 - Fixed `processes.<name>.watch` restarting processes multiple times for a single burst of queued file watcher events by draining the watch queue before restart ([#2735](https://github.com/cachix/devenv/pull/2735)).
@@ -31,6 +32,7 @@
 
 ### Improvements
 
+- Sped up `devenv shell` startup on projects with many cached input paths by batching file watcher registration into a single pathset update and readiness wait, instead of reconciling the pathset once per path. This removes long hangs before `enterShell` on large inputs.
 - Fixed port allocation values (`config.processes.<name>.ports.<port>.value`) resolving to the base `allocate` port in `devenv shell`, `devenv tasks run`, and other commands. When the native process manager is running, port values now match the ports allocated by `devenv up` ([#2710](https://github.com/cachix/devenv/issues/2710)).
 - Standardized keyboard shortcut notation across `devenv up` TUI and `devenv shell` to use consistent `Ctrl-E` format instead of mixed `^e`/`Ctrl-Alt-E` styles. macOS now shows `Opt` instead of `Alt` ([#2736](https://github.com/cachix/devenv/issues/2736)).
 - Auto-detect AI coding agents (via `CLAUDECODE`, `OPENCODE_CLIENT`, and `AI_AGENT` environment variables) and enable quiet mode to avoid wasting LLM tokens on TUI progress output. Override with `--verbose` or `--tui` ([#2723](https://github.com/cachix/devenv/issues/2723)).

--- a/devenv-cache-core/src/file.rs
+++ b/devenv-cache-core/src/file.rs
@@ -143,8 +143,10 @@ pub fn compute_file_hash<P: AsRef<Path>>(path: P) -> CacheResult<String> {
     Ok(hasher.finalize().to_hex().to_string())
 }
 
-/// Compute a hash of a directory's contents
-fn compute_directory_hash<P: AsRef<Path>>(path: P) -> CacheResult<Option<String>> {
+/// Compute a hash of a directory's contents.
+///
+/// Returns `Ok(None)` for an empty directory.
+pub fn compute_directory_hash<P: AsRef<Path>>(path: P) -> CacheResult<Option<String>> {
     let path = path.as_ref();
     let mut entries = Vec::new();
 

--- a/devenv-event-sources/src/fs.rs
+++ b/devenv-event-sources/src/fs.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 use watchexec::{Config, WatchedPath};
@@ -52,6 +52,7 @@ impl Default for FileWatcherConfig<'_> {
 #[derive(Clone)]
 pub struct WatcherHandle {
     watched_paths: Arc<Mutex<HashSet<PathBuf>>>,
+    operation_lock: Arc<AsyncMutex<()>>,
     config: Option<Arc<Config>>,
 }
 
@@ -62,6 +63,7 @@ impl WatcherHandle {
     /// Redundant pathset updates signal the fs worker to reconcile its inotify
     /// watches, which can break existing watches.
     pub async fn watch(&self, path: &Path) {
+        let _op = self.operation_lock.lock().await;
         let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
 
         // Subscribe BEFORE updating pathset so we don't miss the ready signal.
@@ -87,6 +89,57 @@ impl WatcherHandle {
         }
     }
 
+    /// Adds many paths to watch in a single reconciliation and waits for the
+    /// OS watches to be registered.
+    ///
+    /// Equivalent to calling `watch()` for each path but without the O(n^2)
+    /// cost: `watch()` re-sends the entire growing pathset to watchexec per
+    /// call and awaits the fs worker's ready signal each time. For large
+    /// input sets (e.g. thousands of cached eval inputs) that serialisation
+    /// dominates shell startup time. This method locks the pathset once,
+    /// inserts all new paths, calls `config.pathset(...)` once, and awaits
+    /// a single ready signal.
+    pub async fn watch_many<I, P>(&self, paths: I)
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let _op = self.operation_lock.lock().await;
+        // Subscribe BEFORE updating pathset so we don't miss the ready signal.
+        let mut ready = self.config.as_ref().map(|c| c.fs_ready());
+
+        let changed = {
+            let mut watched = self.watched_paths.lock().unwrap();
+            let before = watched.len();
+            for p in paths {
+                let path = p.as_ref();
+                let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+                watched.insert(canonical);
+            }
+            let changed = watched.len() != before;
+
+            if changed {
+                if let Some(ref config) = self.config {
+                    config.pathset(
+                        watched
+                            .iter()
+                            .map(|p| WatchedPath::non_recursive(p.as_path())),
+                    );
+                }
+            }
+
+            changed
+        };
+
+        if !changed {
+            return;
+        }
+
+        if let Some(ref mut rx) = ready {
+            let _ = rx.changed().await;
+        }
+    }
+
     /// Force all watched paths to be re-registered with the OS.
     ///
     /// On Linux, inotify watches track file inodes. When an editor does an
@@ -98,6 +151,7 @@ impl WatcherHandle {
     /// (causing the fs worker to drop all watches) and then re-setting it
     /// (causing fresh watches to be created on current inodes).
     pub async fn rewatch_all(&self) {
+        let _op = self.operation_lock.lock().await;
         let mut ready = self.config.as_ref().map(|c| c.fs_ready());
 
         {
@@ -172,6 +226,7 @@ impl FileWatcher {
         let (tx, rx) = mpsc::channel::<FileChangeEvent>(100);
 
         let watched_paths = Arc::new(Mutex::new(HashSet::new()));
+        let operation_lock = Arc::new(AsyncMutex::new(()));
 
         macro_rules! empty_watcher {
             () => {
@@ -180,6 +235,7 @@ impl FileWatcher {
                     _tx: tx,
                     handle: WatcherHandle {
                         watched_paths,
+                        operation_lock,
                         config: None,
                     },
                     tasks: Vec::new(),
@@ -257,6 +313,7 @@ impl FileWatcher {
 
         let handle = WatcherHandle {
             watched_paths,
+            operation_lock,
             config: Some(wx_config.clone()),
         };
 
@@ -659,6 +716,60 @@ mod tests {
                 Ok(Some(_)) => continue,
                 Ok(None) => panic!("watcher channel closed before runtime file event"),
                 Err(_) => panic!("timeout waiting for runtime file change event"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_watch_many_batches_paths() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let base = temp_dir.path().canonicalize().expect("canonicalize");
+
+        let files: Vec<PathBuf> = (0..5)
+            .map(|i| {
+                let p = base.join(format!("f{i}.nix"));
+                File::create(&p)
+                    .expect("create")
+                    .write_all(b"x")
+                    .expect("write");
+                p
+            })
+            .collect();
+
+        let mut watcher = FileWatcher::new(
+            FileWatcherConfig {
+                paths: &[],
+                recursive: false,
+                ..Default::default()
+            },
+            "test-watch-many",
+        )
+        .await;
+
+        let handle = watcher.handle();
+        handle.watch_many(files.iter()).await;
+
+        let watched = handle.watched_paths();
+        for f in &files {
+            assert!(
+                watched.contains(f),
+                "expected {f:?} in watched set, got {watched:?}"
+            );
+        }
+
+        File::create(&files[2])
+            .expect("open")
+            .write_all(b"changed")
+            .expect("write");
+
+        let deadline = tokio::time::Instant::now() + WATCH_TIMEOUT;
+        loop {
+            let remaining = deadline - tokio::time::Instant::now();
+            match tokio::time::timeout(remaining, watcher.recv()).await {
+                Ok(Some(e)) if e.path == files[2] => break,
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("watcher channel closed"),
+                Err(_) => panic!("timeout waiting for change event after watch_many"),
             }
         }
     }

--- a/devenv-reload/src/coordinator.rs
+++ b/devenv-reload/src/coordinator.rs
@@ -7,7 +7,8 @@ use crate::builder::{BuildContext, BuildTrigger, ShellBuilder};
 use crate::config::Config;
 use devenv_activity::Activity;
 use devenv_event_sources::{FileWatcher, FileWatcherConfig};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use thiserror::Error;
@@ -44,6 +45,101 @@ enum Event {
 /// Coordinates shell builds and file watching, but does not own the PTY.
 /// The TUI is responsible for PTY management and terminal I/O.
 pub struct ShellCoordinator;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WatchedPathState {
+    File(String),
+    Directory(String),
+    Missing,
+    Unreadable,
+}
+
+fn hash_directory_listing(path: &Path) -> std::io::Result<String> {
+    devenv_cache_core::file::compute_directory_hash(path)
+        .map(|hash| hash.unwrap_or_default())
+        .map_err(std::io::Error::other)
+}
+
+fn capture_watched_path_state(path: &Path) -> WatchedPathState {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return WatchedPathState::Missing,
+        Err(_) => return WatchedPathState::Unreadable,
+    };
+
+    if metadata.is_dir() {
+        match hash_directory_listing(path) {
+            Ok(hash) => WatchedPathState::Directory(hash),
+            Err(_) => WatchedPathState::Unreadable,
+        }
+    } else {
+        match devenv_cache_core::compute_file_hash(path) {
+            Ok(hash) => WatchedPathState::File(hash),
+            Err(_) => WatchedPathState::Unreadable,
+        }
+    }
+}
+
+fn snapshot_watched_path_states(
+    watcher_handle: &devenv_event_sources::WatcherHandle,
+) -> HashMap<PathBuf, WatchedPathState> {
+    watcher_handle
+        .watched_paths()
+        .into_iter()
+        .map(|path| {
+            let state = capture_watched_path_state(&path);
+            (path, state)
+        })
+        .collect()
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: &Path) {
+    if !paths.iter().any(|p| p == path) {
+        paths.push(path.to_path_buf());
+    }
+}
+
+fn reconcile_post_rewatch_drift(
+    before_rewatch: &HashMap<PathBuf, WatchedPathState>,
+    after_rewatch: &HashMap<PathBuf, WatchedPathState>,
+    deferred_changes: &mut Vec<PathBuf>,
+) -> usize {
+    let mut drift_count = 0;
+
+    for (path, before_state) in before_rewatch {
+        if let Some(after_state) = after_rewatch.get(path)
+            && before_state != after_state
+        {
+            drift_count += 1;
+            push_unique_path(deferred_changes, path);
+        }
+    }
+
+    drift_count
+}
+
+fn launch_reload_build<B: ShellBuilder + 'static>(
+    builder: Arc<B>,
+    event_tx: mpsc::Sender<Event>,
+    ctx: BuildContext,
+    activity: Activity,
+) -> tokio::task::AbortHandle {
+    let handle = tokio::spawn(async move {
+        let result = tokio::task::spawn_blocking(move || builder.build_reload_env(&ctx))
+            .await
+            .unwrap_or_else(|e| {
+                Err(crate::builder::BuildError::new(format!(
+                    "build task panicked: {}",
+                    e
+                )))
+            });
+        let _ = event_tx
+            .send(Event::ReloadBuildComplete { result, activity })
+            .await;
+    });
+
+    handle.abort_handle()
+}
 
 impl ShellCoordinator {
     /// Run the shell coordinator.
@@ -138,8 +234,10 @@ impl ShellCoordinator {
         let mut current_build: Option<tokio::task::AbortHandle> = None;
         // Track files that changed and triggered rebuilds
         let mut pending_changes: Vec<PathBuf> = Vec::new();
-        // Track file content hashes to detect actual changes
-        let mut file_hashes: HashMap<PathBuf, String> = HashMap::new();
+        // Track watched path state (kind + content hash) to detect real changes.
+        let mut path_states = snapshot_watched_path_states(&watcher_handle);
+        // Track changes that arrive while a build is running.
+        let mut deferred_changes: Vec<PathBuf> = Vec::new();
         // Track if reload is ready (waiting for user to apply)
         let mut reload_ready = false;
         // Track if file watching is paused
@@ -175,20 +273,22 @@ impl ShellCoordinator {
                         tracing::debug!("File watching paused, ignoring change: {:?}", path);
                         continue;
                     }
-                    // Check if file content actually changed by comparing hashes
-                    let new_hash = match devenv_cache_core::compute_file_hash(&path) {
-                        Ok(h) => h,
-                        Err(_) => {
-                            tracing::debug!("Could not read file: {:?}", path);
-                            continue;
-                        }
-                    };
-
-                    if let Some(old_hash) = file_hashes.get(&path)
-                        && *old_hash == new_hash
+                    let new_state = capture_watched_path_state(&path);
+                    if let Some(old_state) = path_states.get(&path)
+                        && *old_state == new_state
                     {
-                        tracing::debug!("File unchanged (same hash): {:?}", path);
+                        tracing::debug!("Watched path unchanged: {:?}", path);
                         continue;
+                    }
+
+                    if matches!(
+                        new_state,
+                        WatchedPathState::Missing | WatchedPathState::Unreadable
+                    ) {
+                        tracing::warn!(
+                            "Watched path became unavailable, forcing reload: {:?}",
+                            path
+                        );
                     }
 
                     // Content actually changed: no longer in ready state.
@@ -197,8 +297,8 @@ impl ShellCoordinator {
                     // otherwise the status line gets stuck on "Reload ready".
                     reload_ready = false;
 
-                    // Update stored hash
-                    file_hashes.insert(path.clone(), new_hash);
+                    // Update stored path state
+                    path_states.insert(path.clone(), new_state);
 
                     tracing::debug!("File content changed: {:?}", path);
 
@@ -207,7 +307,8 @@ impl ShellCoordinator {
                     // aborting and restarting would accumulate zombie builds
                     // that can cascade into more file changes (fork bomb).
                     if current_build.is_some() {
-                        tracing::debug!("Build in progress, ignoring file change: {:?}", path);
+                        push_unique_path(&mut deferred_changes, &path);
+                        tracing::debug!("Build in progress, deferring file change: {:?}", path);
                         continue;
                     }
 
@@ -246,28 +347,18 @@ impl ShellCoordinator {
                         reload_file: Some(reload_file.clone()),
                     };
 
-                    // Spawn build in background task - use build_reload_env for hot-reload
-                    let builder = builder.clone();
-                    let build_tx = event_tx.clone();
-                    let handle = tokio::spawn(async move {
-                        let result =
-                            tokio::task::spawn_blocking(move || builder.build_reload_env(&ctx))
-                                .await
-                                .unwrap_or_else(|e| {
-                                    Err(crate::builder::BuildError::new(format!(
-                                        "build task panicked: {}",
-                                        e
-                                    )))
-                                });
-                        let _ = build_tx
-                            .send(Event::ReloadBuildComplete { result, activity })
-                            .await;
-                    });
-                    current_build = Some(handle.abort_handle());
+                    current_build = Some(launch_reload_build(
+                        builder.clone(),
+                        event_tx.clone(),
+                        ctx,
+                        activity,
+                    ));
                 }
 
                 Event::ReloadBuildComplete { result, activity } => {
                     current_build = None;
+
+                    let before_rewatch = snapshot_watched_path_states(&watcher_handle);
 
                     // Refresh all inotify watches. Editors using atomic save
                     // (write temp + rename) replace the file inode, which
@@ -275,6 +366,23 @@ impl ShellCoordinator {
                     // The watchexec diff logic won't re-watch paths it thinks
                     // are already watched, so we force a full refresh.
                     watcher_handle.rewatch_all().await;
+
+                    let after_rewatch = snapshot_watched_path_states(&watcher_handle);
+                    let rewatch_drift_count = reconcile_post_rewatch_drift(
+                        &before_rewatch,
+                        &after_rewatch,
+                        &mut deferred_changes,
+                    );
+                    if rewatch_drift_count > 0 {
+                        tracing::warn!(
+                            "Detected {} watched-path changes during rewatch gap; scheduling catch-up rebuild",
+                            rewatch_drift_count
+                        );
+                    }
+                    path_states = after_rewatch;
+
+                    let watched_set: HashSet<PathBuf> = path_states.keys().cloned().collect();
+                    deferred_changes.retain(|p| watched_set.contains(p));
 
                     // Collect changed files as relative paths
                     let files: Vec<PathBuf> = pending_changes
@@ -304,6 +412,55 @@ impl ShellCoordinator {
                         // TUI disconnected
                         break;
                     }
+
+                    if paused || deferred_changes.is_empty() {
+                        continue;
+                    }
+
+                    let mut changed_files = Vec::new();
+                    std::mem::swap(&mut changed_files, &mut deferred_changes);
+
+                    // Use first deferred path as trigger; include all deferred
+                    // paths in UI reporting for this catch-up rebuild.
+                    let trigger = changed_files[0].clone();
+                    pending_changes.extend(changed_files);
+
+                    let relative_files: Vec<PathBuf> = pending_changes
+                        .iter()
+                        .map(|p| {
+                            p.strip_prefix(&cwd)
+                                .map(|p| p.to_path_buf())
+                                .unwrap_or(p.clone())
+                        })
+                        .collect();
+                    let _ = command_tx
+                        .send(ShellCommand::Building {
+                            changed_files: relative_files.clone(),
+                        })
+                        .await;
+
+                    let files_display: Vec<String> = relative_files
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect();
+                    let activity = devenv_activity::start!(
+                        Activity::operation("Reloading shell").detail(files_display.join(", "))
+                    );
+
+                    let ctx = BuildContext {
+                        cwd: cwd.clone(),
+                        env: std::env::vars().collect(),
+                        trigger: BuildTrigger::FileChanged(trigger),
+                        watcher: watcher_handle.clone(),
+                        reload_file: Some(reload_file.clone()),
+                    };
+
+                    current_build = Some(launch_reload_build(
+                        builder.clone(),
+                        event_tx.clone(),
+                        ctx,
+                        activity,
+                    ));
                 }
 
                 Event::ReloadFileDeleted => {
@@ -364,10 +521,90 @@ impl ShellCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_coordinator_error_display() {
         let err = CoordinatorError::ChannelClosed;
         assert_eq!(format!("{}", err), "channel closed");
+    }
+
+    #[test]
+    fn test_capture_watched_path_state_detects_dir_to_file_transition() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("watched");
+
+        std::fs::create_dir(&path).expect("create dir");
+        let before = capture_watched_path_state(&path);
+        assert!(matches!(before, WatchedPathState::Directory(_)));
+
+        std::fs::remove_dir(&path).expect("remove dir");
+        std::fs::write(&path, "now a file").expect("write file");
+        let after = capture_watched_path_state(&path);
+        assert!(matches!(after, WatchedPathState::File(_)));
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_capture_watched_path_state_detects_directory_removal() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("watched-dir");
+
+        std::fs::create_dir(&path).expect("create dir");
+        assert!(matches!(
+            capture_watched_path_state(&path),
+            WatchedPathState::Directory(_)
+        ));
+
+        std::fs::remove_dir(&path).expect("remove dir");
+        assert!(matches!(
+            capture_watched_path_state(&path),
+            WatchedPathState::Missing
+        ));
+    }
+
+    #[test]
+    fn test_capture_watched_path_state_detects_directory_child_content_change() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("watched-dir");
+        std::fs::create_dir(&path).expect("create dir");
+
+        let child = path.join("child.nix");
+        std::fs::write(&child, "before").expect("write initial child content");
+
+        let before = capture_watched_path_state(&path);
+        assert!(matches!(before, WatchedPathState::Directory(_)));
+
+        std::fs::write(&child, "after").expect("overwrite child content");
+
+        let after = capture_watched_path_state(&path);
+        assert!(matches!(after, WatchedPathState::Directory(_)));
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn test_reconcile_post_rewatch_drift_enqueues_changed_paths() {
+        let mut before = HashMap::new();
+        let mut after = HashMap::new();
+
+        let a = PathBuf::from("/tmp/a");
+        let b = PathBuf::from("/tmp/b");
+        let c = PathBuf::from("/tmp/c");
+
+        before.insert(a.clone(), WatchedPathState::File("h1".to_string()));
+        before.insert(b.clone(), WatchedPathState::Directory("d1".to_string()));
+        before.insert(c.clone(), WatchedPathState::Missing);
+
+        after.insert(a.clone(), WatchedPathState::File("h2".to_string()));
+        after.insert(b.clone(), WatchedPathState::Directory("d1".to_string()));
+        after.insert(c.clone(), WatchedPathState::File("h3".to_string()));
+
+        let mut deferred_changes = vec![a.clone()];
+        let drift = reconcile_post_rewatch_drift(&before, &after, &mut deferred_changes);
+
+        assert_eq!(drift, 2);
+        assert_eq!(deferred_changes.len(), 2);
+        assert!(deferred_changes.contains(&a));
+        assert!(deferred_changes.contains(&c));
     }
 }

--- a/devenv/src/reload.rs
+++ b/devenv/src/reload.rs
@@ -267,11 +267,12 @@ impl ShellBuilder for DevenvShellBuilder {
                     .await
                 {
                     Ok(inputs) => {
-                        for input in inputs {
-                            if input.path.exists() && !input.path.starts_with("/nix/store") {
-                                watcher.watch(&input.path).await;
-                            }
-                        }
+                        let paths: Vec<_> = inputs
+                            .into_iter()
+                            .filter(|i| i.path.exists() && !i.path.starts_with("/nix/store"))
+                            .map(|i| i.path)
+                            .collect();
+                        watcher.watch_many(paths).await;
                     }
                     Err(e) => {
                         tracing::warn!("Failed to query eval cache for shell inputs: {}", e);
@@ -307,11 +308,12 @@ impl DevenvShellBuilder {
             match devenv_eval_cache::get_file_inputs_by_key_hash(pool, &cache_key.key_hash).await {
                 Ok(inputs) if !inputs.is_empty() => {
                     tracing::debug!("Found {} file inputs for shell key", inputs.len());
-                    for input in inputs {
-                        if input.path.exists() && !input.path.starts_with("/nix/store") {
-                            ctx.watcher.watch(&input.path).await;
-                        }
-                    }
+                    let paths: Vec<_> = inputs
+                        .into_iter()
+                        .filter(|i| i.path.exists() && !i.path.starts_with("/nix/store"))
+                        .map(|i| i.path)
+                        .collect();
+                    ctx.watcher.watch_many(paths).await;
                     return;
                 }
                 Ok(_) => {
@@ -327,11 +329,11 @@ impl DevenvShellBuilder {
         match devenv_eval_cache::get_all_tracked_file_paths(pool).await {
             Ok(paths) => {
                 tracing::debug!("Found {} total tracked files in eval cache", paths.len());
-                for path in paths {
-                    if path.exists() && !path.starts_with("/nix/store") {
-                        ctx.watcher.watch(&path).await;
-                    }
-                }
+                let filtered: Vec<_> = paths
+                    .into_iter()
+                    .filter(|p| p.exists() && !p.starts_with("/nix/store"))
+                    .collect();
+                ctx.watcher.watch_many(filtered).await;
             }
             Err(e) => {
                 tracing::warn!("Failed to query all tracked files: {}", e);


### PR DESCRIPTION
  ## Summary                         

This originated because we observed extremely long devshell load times when running `devenv shell` (after the shell finished building).
Running `devenv shell --no-reload` lead to significantly faster load times.

Investigation of the root cause and implementation of the fixes done with Claude Code. Validated that with the patches in this PR, `devenv shell` does not hang.

## Changes                                                                                                                                                         
                                                                                                                                                                                              
  - Batch watcher path registration via new `WatcherHandle::watch_many` — single lock, one pathset update, one fs-readiness wait. Replaces per-path `watcher.watch` calls in reload cache hydration that caused long hangs before `enterShell` on large cached input sets.                                                                                                            
  - Track path state (file/dir/missing) across reload cycles, hash watched directories by sorted listings, and queue deferred changes while a build is in flight. Reconcile drift after the
  rewatch gap so changes during watch refresh still trigger a follow-up rebuild.     

## Validation

Ran the following commands successfully:
```
devenv shell -- cargo fmt --check
devenv shell -- cargo clippy --all-targets -- -D warnings                                                                                                                                   
devenv shell -- cargo nextest run -p devenv-reload -p devenv-event-sources -p devenv-cache-core -p devenv
devenv shell -- cargo nextest run --features devenv/test-all
devenv shell -- devenv-run-tests run tests
```

> [!note]
>
> Pre-existing warnings surfaced with `-D warnings` ignored