### PR TITLE
nix_backend: set umask around nix ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed "suspicious ownership" errors when using Nix installed in single-user mode. Nix requires read-only group permissions on outputs ([#2751](https://github.com/cachix/devenv/issues/2751)).
 - Fixed the root `devenv.nix` being imported twice when `devenv.yaml` imported a sub-project that also had its own `devenv.yaml` ([#2755](https://github.com/cachix/devenv/issues/2755)).
 - Fixed `devenv shell` and `devenv build` failing with `path '...drv' is required, but there is no substituter that can build it` after the cached derivation was garbage-collected. The stale eval-cache entry is now invalidated when its referenced store paths no longer exist, forcing a re-evaluation that re-materializes the `.drv` on disk.
 - Fixed hot reload missing file and directory changes that occurred during a build or during the brief gap between watch refreshes. The reload watcher now tracks path state (file/directory/missing) across reload cycles, queues deferred events while a build is in progress, and reconciles drift after rewatching so missed changes still trigger a follow-up rebuild.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,6 +1971,7 @@ dependencies = [
  "devenv-nix-backend-macros",
  "include_dir",
  "miette",
+ "nix 0.31.2",
  "nix-bindings-bindgen-raw",
  "nix-bindings-expr",
  "nix-bindings-fetchers",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6877,6 +6877,11 @@ rec {
             features = [ "fancy" ];
           }
           {
+            name = "nix";
+            packageId = "nix 0.31.2";
+            features = [ "fs" "process" "signal" ];
+          }
+          {
             name = "nix-bindings-bindgen-raw";
             packageId = "nix-bindings-bindgen-raw";
           }

--- a/devenv-nix-backend/Cargo.toml
+++ b/devenv-nix-backend/Cargo.toml
@@ -34,6 +34,7 @@ nix-bindings-util.workspace = true
 nix-bindings-fetchers.workspace = true
 nix-bindings-bindgen-raw.workspace = true
 nix-cmd.workspace = true
+nix.workspace = true
 tempfile.workspace = true
 which.workspace = true
 

--- a/devenv-nix-backend/src/lib.rs
+++ b/devenv-nix-backend/src/lib.rs
@@ -103,6 +103,9 @@ pub mod build_environment;
 // Cachix daemon client for pushing store paths
 pub mod cachix_daemon;
 
+// Scoped umask guard for Nix C API calls
+pub mod umask_guard;
+
 /// Convert devenv inputs to FlakeInputs
 ///
 /// # Arguments

--- a/devenv-nix-backend/src/nix_backend.rs
+++ b/devenv-nix-backend/src/nix_backend.rs
@@ -9,6 +9,7 @@
 
 use crate::anyhow_ext::AnyhowToMiette;
 use crate::build_environment::BuildEnvironment as RustBuildEnvironment;
+use crate::umask_guard::UmaskGuard;
 
 use async_trait::async_trait;
 use cstr::cstr;
@@ -987,6 +988,7 @@ in cfg // {{
 
         let lock_result = {
             let eval_state = self.eval_session(&activity)?;
+            let _guard = UmaskGuard::restrictive();
             locker.lock(fetch_settings, &eval_state)
         };
 
@@ -1833,10 +1835,13 @@ impl NixBackend for NixRustBackend {
         let eval_state = self.eval_session(&activity)?;
 
         // Lock the inputs - pass eval_state by reference to avoid cloning
-        let lock_file = locker
-            .lock(fetch_settings, &eval_state)
-            .to_miette()
-            .wrap_err("Failed to lock inputs")?;
+        let lock_file = {
+            let _guard = UmaskGuard::restrictive();
+            locker
+                .lock(fetch_settings, &eval_state)
+                .to_miette()
+                .wrap_err("Failed to lock inputs")?
+        };
 
         // Write the updated lock file
         write_lock_file(&lock_file, &lock_file_path)
@@ -2336,11 +2341,13 @@ impl NixRustBackend {
             "Failed to get outPath from shell derivation",
         )?;
 
-        // Build the derivation to get the output path
-        let realized = self.enriched(
-            eval_state.realise_string(&out_path_value, false),
-            "Failed to realize shell derivation",
-        )?;
+        let realized = {
+            let _guard = UmaskGuard::restrictive();
+            self.enriched(
+                eval_state.realise_string(&out_path_value, false),
+                "Failed to realize shell derivation",
+            )?
+        };
 
         let store_path = realized
             .paths
@@ -2359,10 +2366,12 @@ impl NixRustBackend {
             .parse_store_path(&drv_path)
             .to_miette()
             .wrap_err("Failed to parse derivation store path")?;
-        let (_build_env, env_store_path) =
+        let (_build_env, env_store_path) = {
+            let _guard = UmaskGuard::restrictive();
             BuildEnvironment::get_dev_environment(&self.store, &drv_store_path)
                 .to_miette()
-                .wrap_err("Failed to get dev environment")?;
+                .wrap_err("Failed to get dev environment")?
+        };
 
         // Convert the env store path to a real filesystem path for caching
         let env_path = Some(
@@ -2410,11 +2419,13 @@ impl NixRustBackend {
             )?
             .unwrap_or_else(|| value.clone());
 
-        // Realize the value, which triggers the actual build
-        let realized = self.enriched(
-            eval_state.realise_string(&build_value, false),
-            format!("Failed to build attribute: {}", attr_path),
-        )?;
+        let realized = {
+            let _guard = UmaskGuard::restrictive();
+            self.enriched(
+                eval_state.realise_string(&build_value, false),
+                format!("Failed to build attribute: {}", attr_path),
+            )?
+        };
 
         let store_path = realized
             .paths

--- a/devenv-nix-backend/src/umask_guard.rs
+++ b/devenv-nix-backend/src/umask_guard.rs
@@ -1,0 +1,25 @@
+//! Scoped umask guard for Nix C API calls.
+//!
+//! Nix's CLI sets `umask(0022)` in `initNix()` (libmain/shared.cc), but we drive libstore via the C API and never go through that entry point.
+//! On systems with a permissive default umask, parent-side build setup in `DerivationBuilderImpl::startBuild()` creates files with group-write bits, which Nix then rejects as "suspicious ownership or permission".
+//!
+//! Caveat: `umask(2)` is process-wide. This is not thread-safe.
+
+pub struct UmaskGuard {
+    previous: nix::sys::stat::Mode,
+}
+
+impl UmaskGuard {
+    pub fn restrictive() -> Self {
+        let mask = nix::sys::stat::Mode::from_bits_truncate(0o022);
+        Self {
+            previous: nix::sys::stat::umask(mask),
+        }
+    }
+}
+
+impl Drop for UmaskGuard {
+    fn drop(&mut self) {
+        nix::sys::stat::umask(self.previous);
+    }
+}


### PR DESCRIPTION
Nix expects outputs to be created with group permissions set to read. In single-user installs, it's our job to ensure this happens.

A global umask would affect the files we write.
This scoped guard is still global, but since the FFI is sync, it should be safe.

Fixes #2751.