### PR TITLE
fix(shell): nushell hot-reload parser corrupts env vars

### DIFF
--- a/devenv-shell/src/dialect/nushell.rs
+++ b/devenv-shell/src/dialect/nushell.rs
@@ -234,8 +234,10 @@ def --env __devenv_reload_apply [] {{
                         }} else {{
                             $raw_value
                         }}
-                        # Skip shell internal variables
-                        if $var_name not-in ["BASH" "BASHOPTS" "BASH_ARGC" "BASH_ARGV" "BASH_LINENO" "BASH_SOURCE" "BASH_VERSINFO" "BASH_VERSION" "SHELLOPTS" "SHLVL" "OLDPWD" "_" "_DEVENV_PATH"] {{
+                        # Skip shell internal variables and nushell-auto-managed vars
+                        # (PWD/FILE_PWD/CURRENT_FILE are set automatically by nushell and
+                        # reject manual assignment via load-env).
+                        if $var_name not-in ["BASH" "BASHOPTS" "BASH_ARGC" "BASH_ARGV" "BASH_LINENO" "BASH_SOURCE" "BASH_VERSINFO" "BASH_VERSION" "SHELLOPTS" "SHLVL" "PWD" "OLDPWD" "FILE_PWD" "CURRENT_FILE" "_" "_DEVENV_PATH"] {{
                             # PATH is a list in nushell; split colon-separated values
                             if $var_name == "PATH" {{
                                 $env.PATH = ($value | split row ":")

--- a/devenv-shell/src/dialect/nushell.rs
+++ b/devenv-shell/src/dialect/nushell.rs
@@ -225,7 +225,7 @@ def --env __devenv_reload_apply [] {{
                     let vardef = ($trimmed | str substring 11..)
                     let eq_pos = ($vardef | str index-of "=")
                     if $eq_pos >= 0 {{
-                        let var_name = ($vardef | str substring ..$eq_pos)
+                        let var_name = ($vardef | str substring ..<$eq_pos)
                         let raw_value = ($vardef | str substring ($eq_pos + 1)..)
                         # Strip exactly one pair of surrounding double quotes,
                         # then unescape bash declare -x output (\" -> " and \\ -> \)

--- a/devenv/hook-nu.nu
+++ b/devenv/hook-nu.nu
@@ -7,7 +7,7 @@
 $env._DEVENV_HOOK_UNTRUSTED = ""
 
 $env.config = ($env.config | upsert hooks.env_change.PWD (
-    ($env.config | get -i hooks.env_change.PWD | default []) | append {||
+    ($env.config | get -o hooks.env_change.PWD | default []) | append {||
         # Inside devenv shell: exit when leaving the project directory
         if ("DEVENV_ROOT" in $env) {
             if not ($env.PWD == $env.DEVENV_ROOT or ($env.PWD | str starts-with ($env.DEVENV_ROOT + "/"))) {
@@ -18,7 +18,7 @@ $env.config = ($env.config | upsert hooks.env_change.PWD (
             return
         }
 
-        let last = ($env | get -i _DEVENV_HOOK_LAST_PROJECT | default "")
+        let last = ($env | get -o _DEVENV_HOOK_LAST_PROJECT | default "")
         let result = (^devenv hook-should-activate --last $last | complete)
 
         if ($result.stderr | str trim) != "" {
@@ -53,8 +53,8 @@ $env.config = ($env.config | upsert hooks.env_change.PWD (
 
 # Retry activation on each prompt for untrusted directories (after 'devenv allow')
 $env.config = ($env.config | upsert hooks.pre_prompt (
-    ($env.config | get -i hooks.pre_prompt | default []) | append {||
-        let untrusted = ($env | get -i _DEVENV_HOOK_UNTRUSTED | default "")
+    ($env.config | get -o hooks.pre_prompt | default []) | append {||
+        let untrusted = ($env | get -o _DEVENV_HOOK_UNTRUSTED | default "")
         if $untrusted == "" {
             return
         }
@@ -62,7 +62,7 @@ $env.config = ($env.config | upsert hooks.pre_prompt (
             return
         }
 
-        let last = ($env | get -i _DEVENV_HOOK_LAST_PROJECT | default "")
+        let last = ($env | get -o _DEVENV_HOOK_LAST_PROJECT | default "")
         let result = (^devenv hook-should-activate --last $last | complete)
 
         if $result.exit_code == 0 {


### PR DESCRIPTION
## Summary

Three nushell-only fixes for the new interactive `devenv shell --shell nu` path (the libghostty-vt-wrapped interactive shell from #2718).

### 1. Reload parser strips trailing `=` from var name

`devenv-shell/src/dialect/nushell.rs` — the embedded reload parser uses `str substring ..$eq_pos` to extract the variable name from a `declare -x KEY="value"` line. In nushell, `..$eq_pos` is **inclusive at both ends**, so the extracted name kept the `=` separator: `XDG_CONFIG_HOME=` instead of `XDG_CONFIG_HOME`.

`load-env` then created a junk env entry whose key literally contained `=`. When nu spawned a child, it serialized envp as `KEY=VALUE` per entry, so the dup serialized as bytes `XDG_CONFIG_HOME==/Users/seb/.config`. Child libc parses environ at first `=`: `key=XDG_CONFIG_HOME, value==/Users/seb/.config`. The reload helper's bash subprocess inherits this corrupted value, runs `export -p`, and round-trips it back through the buggy parser. Each reload prepends another `=`.

Fix: `..$eq_pos` → `..<$eq_pos` (exclusive end).

### 2. Skip nushell auto-managed vars

`devenv-shell/src/dialect/nushell.rs` — with the parser fix, `var_name` is now correctly `PWD` instead of `PWD=`. Nushell auto-manages `PWD`, `FILE_PWD`, and `CURRENT_FILE` and rejects `load-env` for them with `nu::shell::automatic_env_var_set_manually`.

The bash-side `__devenv_ignored_var` already filters `PWD` from the diff, but the reload helper's final `export -p` output emits every exported variable regardless of the diff. Extending the nushell-side skip list is the last line of defense.

This bug was masked by the previous parser bug — corrupted keys like `PWD=` didn't collide with the auto-managed `PWD` so `load-env` silently created junk dups instead of erroring. Both fixes are needed for nushell hot-reload to actually work.

### 3. Hook deprecation cleanup

`devenv/hook-nu.nu` — `get -i` (`--ignore-errors`) was deprecated in nushell 0.106.0 in favor of `get -o` (`--optional`). Same semantics. Five occurrences updated. Each shell startup currently prints five deprecation warnings until the user runs `devenv allow` and clears them.

## Reproduction

Before:
```nu
devenv shell --shell nu
^bash -c 'env | grep "^XDG_CONFIG_HOME" | cat -A'
# XDG_CONFIG_HOME=/Users/seb/.config$
# (edit devenv.nix to trigger reload, e.g. tweak a script's description)
^bash -c 'env | grep "^XDG_CONFIG_HOME" | cat -A'
# XDG_CONFIG_HOME==/Users/seb/.config$   <-- one = prefix
# (reload again)
^bash -c 'env | grep "^XDG_CONFIG_HOME" | cat -A'
# XDG_CONFIG_HOME===/Users/seb/.config$  <-- two = prefixes
```

After 2+ reloads, `zed .` and other XDG-aware tools fail with `nu::shell::xdg_config_home_invalid`.

After:
```nu
# Same flow, XDG stays clean across any number of reloads.
^bash -c 'env | grep "^XDG_CONFIG_HOME" | cat -A'
# XDG_CONFIG_HOME=/Users/seb/.config$
```

## Test plan

- [x] Parser-level unit test: input `declare -x KEY="val"`, observe `var_name` is `KEY` (no trailing `=`)
- [x] End-to-end: triggered N reloads, verified XDG_CONFIG_HOME byte-identical to original after each
- [x] Regression: no `nu::shell::automatic_env_var_set_manually` after reload
- [x] Hook deprecation: fresh `nu -c 'source <(devenv hook nu)'` emits no parser warnings on nu 0.110

## Notes / non-goals

- `hook-bash.sh`/`hook-fish.fish`/`hook-zsh` have similar `_DEVENV_HOOK_LAST_PROJECT` patterns I haven't touched — scoping this PR to nushell only.
- I noticed an unrelated re-entry bug (`cd /project → cd .. → cd /project` silently no-ops the second activation) but couldn't pin down its root cause from my testing harness; leaving for a separate PR with a proper instrumented repro.
- No tests added — the dialect modules don't currently have a test harness for the embedded nushell template. Happy to add one in a follow-up if reviewers want it.
