### PR TITLE
fix(rust): pass -Z unstable-options to wild on aarch64-linux

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -373,7 +373,12 @@ in
             # TODO: Work around rustc's default lld selection and missing native GCC Wild support;
             # use `-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin` for now, then switch to
             # `-C link-arg=-fuse-ld=wild` once a released GCC supports it.
-            wildFlags = lib.optionalString cfg.wild.enable "-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin";
+            # `-C linker-features` is stable on x86_64-linux but gated behind `-Z unstable-options`
+            # on aarch64-linux, so add the flag there (requires nightly on that target).
+            wildFlags = lib.optionalString cfg.wild.enable (
+              "-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin"
+              + lib.optionalString pkgs.stdenv.isAarch64 " -Z unstable-options"
+            );
             linkerFlags = lib.concatStringsSep " " (lib.filter (x: x != "") [ moldFlags lldFlags wildFlags ]);
             optionalEnv = cond: str: if cond then str else null;
           in


### PR DESCRIPTION
## Summary

`languages.rust.wild.enable` produces `-C linker-features=-lld` to defeat rustc's default lld selection. That flag is stable on `x86_64-unknown-linux-gnu` but gated behind `-Z unstable-options` on `aarch64-unknown-linux-gnu`, so even nightly users on aarch64-linux hit:

```
error: `-C linker-features=-lld` is unstable on the `aarch64-unknown-linux-gnu` target. The `-Z unstable-options` flag must also be passed to use it on this target
```

This appends `-Z unstable-options` to the wild flags when the host is aarch64, so the same option works on both architectures (still nightly-only on aarch64-linux, which is unavoidable until the underlying `-C linker-features` flag stabilizes there).

## Test plan

- [x] x86_64-linux: `languages.rust.wild.enable = true` continues to build and link via wild with no behavior change.
- [x] aarch64-linux (nightly): `languages.rust.wild.enable = true` no longer errors with the unstable-on-target message; `cargo build` succeeds and links via wild.
- [x] darwin: unaffected (wild already gated to Linux by the existing assertion at `cfg.wild.enable -> pkgs.stdenv.isLinux`).