### PR TITLE
feat: add devenv.preFlight for pre-init env injection

### DIFF
--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -1,6 +1,7 @@
 mod cachix;
 mod container;
 mod gc;
+mod preflight;
 mod search;
 
 use super::{processes, tasks, util};
@@ -663,6 +664,7 @@ impl Devenv {
                 let Some(cnix) = self.cnix() else {
                     return Ok(None);
                 };
+                preflight::run(cnix).await?;
                 cachix::CachixIntegration::init(
                     cnix,
                     &self.cachix_manager,

--- a/devenv/src/devenv/preflight.rs
+++ b/devenv/src/devenv/preflight.rs
@@ -1,0 +1,70 @@
+//! Pre-flight commands.
+//!
+//! Runs user-defined commands during devenv startup, before subsystems
+//! that read `env::var()` (cachix, substituter netrc, …) initialize.
+//! Stdout in `KEY=value` form is merged into the process environment.
+
+use std::collections::BTreeMap;
+
+use devenv_activity::{Activity, ActivityLevel, start};
+use devenv_nix_backend::NixCBackend;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use tracing::{debug, warn};
+
+#[derive(serde::Deserialize)]
+struct PreFlight {
+    command: String,
+}
+
+pub async fn run(cnix: &NixCBackend) -> Result<()> {
+    let activity =
+        start!(Activity::evaluate("Reading config.devenv.preFlight").level(ActivityLevel::Debug));
+    let json = match cnix.eval_attr("config.devenv.preFlight", &activity).await {
+        Ok(j) => j,
+        Err(_) => return Ok(()),
+    };
+    let entries: BTreeMap<String, PreFlight> = serde_json::from_str(&json)
+        .into_diagnostic()
+        .wrap_err("Failed to deserialize config.devenv.preFlight")?;
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    for (name, pf) in &entries {
+        debug!(name = %name, "running preFlight command");
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&pf.command)
+            .output()
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("preFlight `{name}` failed to spawn"))?;
+
+        if !output.status.success() {
+            warn!(
+                name = %name,
+                status = %output.status,
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "preFlight command failed",
+            );
+            continue;
+        }
+
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let Some((key, val)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            let val = val.trim();
+            if key.is_empty() {
+                continue;
+            }
+            // SAFETY: pre-flight runs before subsystems that read env::var().
+            // The point of this hook is to mutate process env.
+            unsafe { std::env::set_var(key, val) };
+        }
+    }
+
+    Ok(())
+}

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -3585,6 +3585,64 @@ string
 
 
 
+## devenv.preFlight
+
+
+
+Pre-flight commands run during devenv startup, before its
+internal subsystems initialize. Useful for fetching tokens or
+other values that devenv-core itself reads from the environment
+early. Commands run in dependency-key alphabetical order.
+
+
+
+*Type:*
+attribute set of (submodule)
+
+
+
+*Default:*
+
+```nix
+{ }
+```
+
+
+
+*Example:*
+
+```nix
+{
+  cachix-auth.command = "echo CACHIX_AUTH_TOKEN=$(get-token-somehow)";
+}
+
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)
+
+
+
+## devenv.preFlight.\<name>.command
+
+
+
+Shell command run during devenv startup, before its internal
+subsystems (cachix, substituter netrc, etc.) initialize.
+Lines of ` KEY=value ` written to stdout are merged into
+devenv’s process environment and become visible to those
+subsystems.
+
+
+
+*Type:*
+string
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)
+
+
+
 ## devenv.warnOnNewVersion
 
 
@@ -5971,8 +6029,6 @@ submodule
 
 ## git-hooks.hooks.biome.enable
 
-
-
 Whether to enable this pre-commit hook.
 
 
@@ -6030,6 +6086,8 @@ null or string or absolute path
 
 
 ## git-hooks.hooks.biome.settings.configPath
+
+
 
 Path to the configuration JSON file
 
@@ -8244,8 +8302,6 @@ false
 
 ## git-hooks.hooks.isort.settings.flags
 
-
-
 Flags passed to isort. See all available [here](https://pycqa.github.io/isort/docs/configuration/options.html).
 
 
@@ -8291,6 +8347,8 @@ one of “”, “black”, “django”, “pycharm”, “google”, “open_s
 
 
 ## git-hooks.hooks.lacheck
+
+
 
 lacheck hook
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -225,6 +225,33 @@ in
     };
 
     devenv = {
+      preFlight = lib.mkOption {
+        type = types.attrsOf (types.submodule {
+          options.command = lib.mkOption {
+            type = types.str;
+            description = ''
+              Shell command run during devenv startup, before its internal
+              subsystems (cachix, substituter netrc, etc.) initialize.
+              Lines of `KEY=value` written to stdout are merged into
+              devenv's process environment and become visible to those
+              subsystems.
+            '';
+          };
+        });
+        default = { };
+        description = ''
+          Pre-flight commands run during devenv startup, before its
+          internal subsystems initialize. Useful for fetching tokens or
+          other values that devenv-core itself reads from the environment
+          early. Commands run in dependency-key alphabetical order.
+        '';
+        example = lib.literalExpression ''
+          {
+            cachix-auth.command = "echo CACHIX_AUTH_TOKEN=$(get-token-somehow)";
+          }
+        '';
+      };
+
       root = lib.mkOption {
         type = types.str;
         internal = true;


### PR DESCRIPTION
A few of devenv's own subsystems (cachix push auth, substituter netrc) read environment variables at process startup, before any module-declared `env.X` is exported into the resulting shell. Values fetched at module-evaluation time can't reach those subsystems.

For organizations that store `CACHIX_AUTH_TOKEN` in a secret manager (Vault, OpenBao, 1Password, secretspec), this means there's no way to feed the token into devenv-core's cachix init without each developer running `cachix authtoken <token>` manually first. The cachix daemon spawns with whatever env devenv was launched with, which doesn't include anything modules declare.

This PR adds a new `devenv.preFlight` option (`attrsOf submodule { command = str; }`). Each command is run, in alphabetical key order, before subsystem initialization. Lines of `KEY=value` written to stdout are merged into devenv's process environment, so the subsequent `env::var()` reads in `devenv-core` (cachix, etc.) see them.

```nix
devenv.preFlight.cachix-auth.command = ''
  echo "CACHIX_AUTH_TOKEN=$(${pkgs.openbao}/bin/bao kv get \
    -address=https://vault.example.com \
    -field=CACHIX_AUTH_TOKEN secret/cachix)"
'';
```