### PR TITLE
Revert "switching nix profile add to install"

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -40,7 +40,7 @@
     === "Nix profiles (requires experimental flags)"
 
         ```
-        nix profile install nixpkgs#bashInteractive
+        nix profile add nixpkgs#bashInteractive
         ```
 
 === "Windows (WSL2)"
@@ -68,7 +68,7 @@
 === "Nix profiles (requires experimental flags)"
 
     ```
-    nix profile install nixpkgs#devenv
+    nix profile add nixpkgs#devenv
     ```
 
 === "NixOS/nix-darwin"


### PR DESCRIPTION
This reverts commit 7754bb69390738dc0464592b6fd3ec93174c3a03.

Context:

This is not the correct fix. @Triscal needs to update their Nix installation. The `install` command is deprecated in favor of `add`.

```
% nix profile install --help
warning: 'install' is a deprecated alias for 'add'
```

https://github.com/NixOS/nix/pull/13224

_Originally posted by @euphemism in https://github.com/cachix/devenv/issues/2678#issuecomment-4374294006_
            