### PR TITLE
fix: address services.garage CLI access and silent token failure

### DIFF
--- a/src/modules/services/garage.nix
+++ b/src/modules/services/garage.nix
@@ -166,6 +166,7 @@ in
       GARAGE_S3_PORT = toString allocatedS3Port;
       GARAGE_ADMIN_PORT = toString allocatedAdminPort;
       GARAGE_S3_ENDPOINT = "http://${s3Host}:${toString allocatedS3Port}";
+      GARAGE_CONFIG_FILE = "${configFile}";
     };
 
     tasks."devenv:garage:setup" = {

--- a/src/modules/services/garage.nix
+++ b/src/modules/services/garage.nix
@@ -147,6 +147,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.adminToken != "";
+        message = "services.garage.adminToken is empty; the admin API ready probe will fail silently.";
+      }
+      {
+        assertion = cfg.rpcSecret != "";
+        message = "services.garage.rpcSecret is empty.";
+      }
+    ];
+
     packages = [ cfg.package ];
 
     processes.garage = {


### PR DESCRIPTION
Closes #2786.

1. The module starts the daemon with `-c ${configFile}` internally but doesn't expose that path. Users can't run `garage status` (or any other garage CLI) from the dev shell because the CLI doesn't know which config the daemon is using. Fixed by exporting `GARAGE_CONFIG_FILE = "${configFile}"`.

2. Setting `adminToken` (or `rpcSecret`) to an empty string silently breaks the admin API ready probe. The probe fails forever, the `devenv:garage:configure` task never runs, and `afterStart` never executes. Fixed by adding eval-time assertions that fail loud when these values are empty.