### PR TITLE
docs(rust): fix crate2nix references in `rust.import` docs

### DIFF
--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -317,10 +317,10 @@ false
 
 
 
-Import a Cargo project using cargo2nix\.
+Import a Cargo project using crate2nix\.
 
 This function takes a path to a directory containing a Cargo\.toml file
-and returns a derivation that builds the Rust project using cargo2nix\.
+and returns a derivation that builds the Rust project using crate2nix\.
 
 Example usage:
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -21372,10 +21372,10 @@ false
 
 
 
-Import a Cargo project using cargo2nix.
+Import a Cargo project using crate2nix.
 
 This function takes a path to a directory containing a Cargo.toml file
-and returns a derivation that builds the Rust project using cargo2nix.
+and returns a derivation that builds the Rust project using crate2nix.
 
 Example usage:
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -205,10 +205,10 @@ in
     import = lib.mkOption {
       type = lib.types.functionTo (lib.types.functionTo lib.types.package);
       description = ''
-        Import a Cargo project using cargo2nix.
+        Import a Cargo project using crate2nix.
 
         This function takes a path to a directory containing a Cargo.toml file
-        and returns a derivation that builds the Rust project using cargo2nix.
+        and returns a derivation that builds the Rust project using crate2nix.
 
         Example usage:
         ```nix


### PR DESCRIPTION
A simple documentation tweak that fixes old and misleading documentation. `rust.nix` now correctly references `crate2nix` instead of the legacy usage of `cargo2nix`.

Made this change because an LLM was misled to think that `cargo2nix` was in use for `languages.rust.import`.