### PR TITLE
fix(hook): activate fish hook when fish starts inside project dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed `devenv --version` and `devenv -V` failing with `'devenv' requires a subcommand but one was not provided`. The flags now print the version and exit, matching the behavior of `devenv --help` ([#2791](https://github.com/cachix/devenv/issues/2791)).
+- Fixed `devenv hook fish` not activating when starting a new fish shell directly inside a project directory. The initial activation now runs on the first `fish_prompt` event instead of inline during `source`, so the spawned `devenv shell` inherits the real terminal as stdin instead of the closed pipe from `devenv hook fish | source` ([#2798](https://github.com/cachix/devenv/issues/2798)).
 
 ### Improvements
 

--- a/devenv/hook-fish.fish
+++ b/devenv/hook-fish.fish
@@ -68,7 +68,17 @@ function _devenv_hook_prompt --on-event fish_prompt
     end
 end
 
-# Trigger initial check
-if test -n "$PWD"
+# Trigger initial check on the first prompt rather than inline.
+#
+# The hook is typically loaded via `devenv hook fish | source`, which makes
+# `source`'s stdin a pipe. Any child shell spawned inline (i.e. during the
+# `source` itself) inherits that closed pipe as stdin, so `devenv shell`
+# detects no tty, disables the watcher UI, and the interactive fish it
+# execs into exits immediately on EOF.
+#
+# Deferring to fish_prompt runs the initial check after fish has entered
+# its main loop, where stdin is the real terminal.
+function _devenv_hook_init --on-event fish_prompt
+    functions -e _devenv_hook_init
     _devenv_hook
 end


### PR DESCRIPTION
## Summary

- Fixes #2798: opening a new fish shell directly inside a devenv project printed the activation logs but never actually entered `devenv shell` (no watcher UI, no env vars).
- Defers the initial activation to a one-shot `fish_prompt` event handler so the spawned `devenv shell` inherits the real terminal as stdin.

## Root cause

The hook is loaded via `devenv hook fish | source`. Fish's `source` reads its script from the pipe, so during `source` the script's stdin is that pipe. The script ended with an inline `_devenv_hook` call that spawned `fish --no-config -c '... devenv shell'`. The child fish (and `devenv shell`) inherited the closed pipe as stdin, so `devenv shell` saw no tty: TUI/PTY/watcher were disabled, and the interactive fish it exec'd into hit EOF on stdin and exited immediately. `cd`-ing into a subdir worked because the `--on-variable PWD` handler fires from fish's main loop, where stdin is the real tty.

## Fix

Replace the inline trigger with a `--on-event fish_prompt` handler that removes itself after firing once. By the time `fish_prompt` fires, fish is in its interactive main loop and stdin is the real terminal.

## Test plan

- [ ] In a fish shell, add `devenv hook fish | source` to `~/.config/fish/config.fish`
- [ ] Run `devenv allow` in a project
- [ ] Open a new terminal directly in the project directory and confirm the watcher UI appears and devenv env vars are set (e.g. `echo $DEVENV_ROOT`)
- [ ] Open a new terminal in the parent / unrelated dir and `cd` into the project; confirm activation still works
- [ ] `cd` out of the project; confirm the shell deactivates and follows the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)