### PR TITLE
Source .zshenv before .zshrc from user's profile

### DIFF
--- a/devenv-shell/src/dialect/zsh.rs
+++ b/devenv-shell/src/dialect/zsh.rs
@@ -181,9 +181,11 @@ bindkey "${{DEVENV_RELOAD_KEYBIND:-\\e\\C-r}}" __devenv_reload_widget
 if [ -n "$_DEVENV_REAL_ZDOTDIR" ]; then
     ZDOTDIR="$_DEVENV_REAL_ZDOTDIR"
     unset _DEVENV_REAL_ZDOTDIR
+    [ -f "$ZDOTDIR/.zshenv" ] && source "$ZDOTDIR/.zshenv"
     [ -f "$ZDOTDIR/.zshrc" ] && source "$ZDOTDIR/.zshrc"
 else
     unset ZDOTDIR
+    [ -f "$HOME/.zshenv" ] && source "$HOME/.zshenv"
     [ -f "$HOME/.zshrc" ] && source "$HOME/.zshrc"
 fi
 


### PR DESCRIPTION
I just tried out devenv 2.1.0 with my zsh shell and it unfortunately mangled my prompt. I tracked the issue down to it loading my `.zshrc` file, but not loading the `.zshenv` file first, which had some env var defined that `.zshrc` used.

My zsh shell is set up via home-manager and has oh-my-zsh enabled through that (which is where the custom prompt comes from), so I don't think I have anything too unusual/crazy configured.

From [what I read](https://zsh.sourceforge.io/Intro/intro_3.html), it seems like `.zshenv` should (almost) always be loaded before `.zshrc`, so I've made a change to the code to do this. It certainly fixed my shell and prompt.

Happy to make further changes or test things on my setup if you need! 🙂