### PR TITLE
fix: Ctrl-C handling during Nix fetch and devenv allow retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `devenv --version` and `devenv -V` failing with `'devenv' requires a subcommand but one was not provided`. The flags now print the version and exit, matching the behavior of `devenv --help` ([#2791](https://github.com/cachix/devenv/issues/2791)).
 - Fixed `devenv hook fish` not activating when starting a new fish shell directly inside a project directory. The initial activation now runs on the first `fish_prompt` event instead of inline during `source`, so the spawned `devenv shell` inherits the real terminal as stdin instead of the closed pipe from `devenv hook fish | source` ([#2798](https://github.com/cachix/devenv/issues/2798)).
 - Fixed `devenv shell` skipping the user's `.zshenv` when launching zsh, which could mangle prompts and break `.zshrc` configurations that depend on env vars defined in `.zshenv`. The user's `.zshenv` is now sourced before `.zshrc` during shell init, matching zsh's documented startup order ([#2802](https://github.com/cachix/devenv/pull/2802)).
+- Fixed in-flight Nix evaluation not aborting on Ctrl-C in `devenv shell`. The shutdown signal now flips Nix's process-global interrupt flag so the evaluator stops at its next check, instead of running to completion inside `spawn_blocking` regardless of the cancellation token.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `devenv shell` skipping the user's `.zshenv` when launching zsh, which could mangle prompts and break `.zshrc` configurations that depend on env vars defined in `.zshenv`. The user's `.zshenv` is now sourced before `.zshrc` during shell init, matching zsh's documented startup order ([#2802](https://github.com/cachix/devenv/pull/2802)).
 - Fixed in-flight Nix evaluation not aborting on Ctrl-C in `devenv shell`. The shutdown signal now flips Nix's process-global interrupt flag so the evaluator stops at its next check, instead of running to completion inside `spawn_blocking` regardless of the cancellation token.
 - Fixed `devenv hook` not retrying auto-activation when the inner `devenv shell` fails on first allow (e.g. unauthenticated secretspec provider). The bash/zsh/fish/nu hooks now wrap `devenv` so that re-running `devenv allow` after fixing the underlying issue re-triggers activation, instead of requiring the user to `cd` out and back in.
+- Fixed `devenv shell` being killed by `SIGUSR1` (and the terminal being left in Kitty keyboard protocol mode) when Ctrl-C is pressed during a flake fetch. Nix uses `pthread_kill(thread, SIGUSR1)` to interrupt blocking download syscalls; without a no-op handler that the Nix CLI installs in `initNix()`, SIGUSR1 hits its default disposition and terminates the process before the TUI can restore the terminal. devenv now installs the same dummy handler during Nix init.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `devenv hook fish` not activating when starting a new fish shell directly inside a project directory. The initial activation now runs on the first `fish_prompt` event instead of inline during `source`, so the spawned `devenv shell` inherits the real terminal as stdin instead of the closed pipe from `devenv hook fish | source` ([#2798](https://github.com/cachix/devenv/issues/2798)).
 - Fixed `devenv shell` skipping the user's `.zshenv` when launching zsh, which could mangle prompts and break `.zshrc` configurations that depend on env vars defined in `.zshenv`. The user's `.zshenv` is now sourced before `.zshrc` during shell init, matching zsh's documented startup order ([#2802](https://github.com/cachix/devenv/pull/2802)).
 - Fixed in-flight Nix evaluation not aborting on Ctrl-C in `devenv shell`. The shutdown signal now flips Nix's process-global interrupt flag so the evaluator stops at its next check, instead of running to completion inside `spawn_blocking` regardless of the cancellation token.
+- Fixed `devenv hook` not retrying auto-activation when the inner `devenv shell` fails on first allow (e.g. unauthenticated secretspec provider). The bash/zsh/fish/nu hooks now wrap `devenv` so that re-running `devenv allow` after fixing the underlying issue re-triggers activation, instead of requiring the user to `cd` out and back in.
 
 ### Improvements
 

--- a/devenv-nix-backend/src/lib.rs
+++ b/devenv-nix-backend/src/lib.rs
@@ -40,6 +40,36 @@ pub fn trigger_interrupt() {
     nix_bindings_util::trigger_interrupt();
 }
 
+/// No-op SIGUSR1 handler.
+///
+/// Nix uses `pthread_kill(thread, SIGUSR1)` to abort blocking syscalls in
+/// worker threads (e.g. curl downloads, `ReceiveInterrupts` in
+/// libutil/signals.hh). The signal's only purpose is to make the syscall
+/// return `EINTR`, so the body is intentionally empty.
+extern "C" fn nix_sigusr1_handler(_: nix::libc::c_int) {}
+
+/// Install Nix's libmain signal handlers so Nix's internal interrupt mechanism
+/// behaves the same when Nix is linked as a library as it does in the Nix CLI.
+///
+/// Without this, a Ctrl-C during an in-flight flake fetch terminates devenv
+/// outright: Nix calls `pthread_kill(thread, SIGUSR1)` on the curl thread to
+/// interrupt the download, and SIGUSR1's default disposition is process
+/// termination. Mirrors `initNix()` in Nix's `libmain/shared.cc`.
+fn install_nix_signal_handlers() {
+    use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
+
+    // Empty SaFlags (no SA_RESTART) so blocking syscalls exit with EINTR.
+    let action = SigAction::new(
+        SigHandler::Handler(nix_sigusr1_handler),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+    // SAFETY: called once during single-threaded init, after Nix/GC is up.
+    unsafe {
+        let _ = sigaction(Signal::SIGUSR1, &action);
+    }
+}
+
 /// Initialize the Nix expression library and Boehm GC.
 ///
 /// This is safe to call multiple times - initialization only happens once.
@@ -55,6 +85,9 @@ pub fn nix_init() {
             unsafe { std::env::set_var("GC_LARGE_ALLOC_WARN_INTERVAL", "1000000") };
         }
         nix_bindings_expr::eval_state::init().expect("Failed to initialize Nix expression library");
+        // Install after Nix init so Boehm GC's stop-the-world handlers (set up
+        // during Nix init) aren't clobbered. SIGUSR1 isn't used by GC.
+        install_nix_signal_handlers();
     });
 }
 

--- a/devenv/hook-fish.fish
+++ b/devenv/hook-fish.fish
@@ -17,7 +17,7 @@ function _devenv_hook --on-variable PWD
     end
 
     # stderr flows through so user sees the "not allowed" message
-    set -l project_dir (devenv hook-should-activate)
+    set -l project_dir (command devenv hook-should-activate)
     set -l exit_code $status
 
     if test $exit_code -eq 0 -a -n "$project_dir"
@@ -51,7 +51,7 @@ function _devenv_hook_prompt --on-event fish_prompt
         return
     end
 
-    set -l project_dir (devenv hook-should-activate 2>/dev/null)
+    set -l project_dir (command devenv hook-should-activate 2>/dev/null)
     if test $status -eq 0 -a -n "$project_dir"
         set -lx _DEVENV_HOOK_DIR $project_dir
         fish --no-config -c 'cd -- $_DEVENV_HOOK_DIR; and devenv shell'
@@ -81,4 +81,17 @@ end
 function _devenv_hook_init --on-event fish_prompt
     functions -e _devenv_hook_init
     _devenv_hook
+end
+
+# Re-trigger activation after `devenv allow` succeeds, so a failed shell
+# startup (e.g. secretspec auth error) can be retried by re-running
+# `devenv allow` once the underlying issue is fixed, without having to
+# cd out and back in.
+function devenv
+    command devenv $argv
+    set -l devenv_status $status
+    if test $devenv_status -eq 0; and test "$argv[1]" = allow; and not set -q DEVENV_ROOT
+        _devenv_hook
+    end
+    return $devenv_status
 end

--- a/devenv/hook-nu.nu
+++ b/devenv/hook-nu.nu
@@ -6,6 +6,41 @@
 
 $env._DEVENV_HOOK_UNTRUSTED = ""
 
+# Shared activation logic. Returns silently when no project exists or the
+# user is already inside a devenv shell.
+def --env _devenv_activate [show_stderr: bool] {
+    if ("DEVENV_ROOT" in $env) {
+        return
+    }
+
+    let result = (^devenv hook-should-activate | complete)
+
+    if $show_stderr and ($result.stderr | str trim) != "" {
+        print -e $result.stderr
+    }
+
+    if $result.exit_code == 0 {
+        let dir = ($result.stdout | str trim)
+        if $dir != "" {
+            do { cd $dir; ^devenv shell }
+            $env._DEVENV_HOOK_UNTRUSTED = ""
+            # If the devenv shell exited due to cd outside the project, follow the user there
+            let exit_dir_file = ($dir + "/.devenv/exit-dir")
+            if ($exit_dir_file | path exists) {
+                let target_dir = (open $exit_dir_file | str trim)
+                rm -f $exit_dir_file
+                if ($target_dir | path exists) {
+                    cd $target_dir
+                }
+            }
+        } else {
+            $env._DEVENV_HOOK_UNTRUSTED = ""
+        }
+    } else {
+        $env._DEVENV_HOOK_UNTRUSTED = $env.PWD
+    }
+}
+
 $env.config = ($env.config | upsert hooks.env_change.PWD (
     ($env.config | get -o hooks.env_change.PWD | default []) | append {||
         # Inside devenv shell: exit when leaving the project directory
@@ -18,32 +53,7 @@ $env.config = ($env.config | upsert hooks.env_change.PWD (
             return
         }
 
-        let result = (^devenv hook-should-activate | complete)
-
-        if ($result.stderr | str trim) != "" {
-            print -e $result.stderr
-        }
-
-        if $result.exit_code == 0 {
-            let dir = ($result.stdout | str trim)
-            if $dir != "" {
-                do { cd $dir; ^devenv shell }
-                $env._DEVENV_HOOK_UNTRUSTED = ""
-                # If the devenv shell exited due to cd outside the project, follow the user there
-                let exit_dir_file = ($dir + "/.devenv/exit-dir")
-                if ($exit_dir_file | path exists) {
-                    let target_dir = (open $exit_dir_file | str trim)
-                    rm -f $exit_dir_file
-                    if ($target_dir | path exists) {
-                        cd $target_dir
-                    }
-                }
-            } else {
-                $env._DEVENV_HOOK_UNTRUSTED = ""
-            }
-        } else {
-            $env._DEVENV_HOOK_UNTRUSTED = $env.PWD
-        }
+        _devenv_activate true
     }
 ))
 
@@ -58,23 +68,19 @@ $env.config = ($env.config | upsert hooks.pre_prompt (
             return
         }
 
-        let result = (^devenv hook-should-activate | complete)
-
-        if $result.exit_code == 0 {
-            let dir = ($result.stdout | str trim)
-            if $dir != "" {
-                do { cd $dir; ^devenv shell }
-                $env._DEVENV_HOOK_UNTRUSTED = ""
-                # If the devenv shell exited due to cd outside the project, follow the user there
-                let exit_dir_file = ($dir + "/.devenv/exit-dir")
-                if ($exit_dir_file | path exists) {
-                    let target_dir = (open $exit_dir_file | str trim)
-                    rm -f $exit_dir_file
-                    if ($target_dir | path exists) {
-                        cd $target_dir
-                    }
-                }
-            }
-        }
+        _devenv_activate false
     }
 ))
+
+# Re-trigger activation after `devenv allow` succeeds, so a failed shell
+# startup (e.g. secretspec auth error) can be retried by re-running
+# `devenv allow` once the underlying issue is fixed, without having to
+# cd out and back in.
+def --env devenv [...args] {
+    ^devenv ...$args
+    let devenv_status = $env.LAST_EXIT_CODE
+    let first_arg = ($args | get -o 0 | default "")
+    if $devenv_status == 0 and $first_arg == "allow" and ("DEVENV_ROOT" not-in $env) {
+        _devenv_activate false
+    }
+}

--- a/devenv/hook-posix.sh
+++ b/devenv/hook-posix.sh
@@ -24,15 +24,15 @@ _devenv_hook() {
     # Suppress stderr when retrying the same untrusted PWD (message was already shown)
     local project_dir exit_code
     if [[ "$_DEVENV_HOOK_UNTRUSTED" == "$PWD" ]]; then
-        project_dir=$(devenv hook-should-activate 2>/dev/null)
+        project_dir=$(command devenv hook-should-activate 2>/dev/null)
     else
-        project_dir=$(devenv hook-should-activate)
+        project_dir=$(command devenv hook-should-activate)
     fi
     exit_code=$?
 
     if [[ $exit_code -eq 0 && -n "$project_dir" ]]; then
         _DEVENV_HOOK_UNTRUSTED=""
-        (cd "$project_dir" && devenv shell)
+        (cd "$project_dir" && command devenv shell)
         # If the devenv shell exited due to cd outside the project, follow the user there
         local exit_dir_file="$project_dir/.devenv/exit-dir"
         if [[ -f "$exit_dir_file" ]]; then
@@ -54,4 +54,18 @@ _devenv_hook() {
         _DEVENV_HOOK_UNTRUSTED="$PWD"
     fi
     return $previous_exit_status
+}
+
+# Re-trigger activation after `devenv allow` succeeds, so a failed shell
+# startup (e.g. secretspec auth error) can be retried by re-running
+# `devenv allow` once the underlying issue is fixed, without having to
+# cd out and back in.
+devenv() {
+    command devenv "$@"
+    local devenv_status=$?
+    if [[ $devenv_status -eq 0 && "${1:-}" == "allow" && -z "${DEVENV_ROOT:-}" ]]; then
+        _DEVENV_HOOK_PWD=""
+        _devenv_hook
+    fi
+    return $devenv_status
 }

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -401,6 +401,16 @@ fn run(ctx: RunContext) -> Result<()> {
             build_gc_runtime().block_on(async {
                 shutdown_clone.install_signals().await;
 
+                // Abort in-flight Nix evaluation when shutdown is triggered.
+                // The Nix C++ evaluator polls a process-global interrupt flag
+                // between evaluation steps; without this, eval running inside
+                // spawn_blocking ignores Ctrl-C until it returns naturally.
+                let nix_interrupt_token = shutdown_clone.cancellation_token();
+                tokio::spawn(async move {
+                    nix_interrupt_token.cancelled().await;
+                    devenv_nix_backend::trigger_interrupt();
+                });
+
                 let output = run_backend(
                     ctx,
                     shutdown_clone.clone(),


### PR DESCRIPTION
## Summary

Three related fixes around Ctrl-C handling and hook activation retry:

- **`fix(shell): abort in-flight Nix eval on Ctrl-C`** — shutdown signal now flips Nix's process-global interrupt flag so the evaluator stops at its next check, instead of running to completion inside `spawn_blocking`.
- **`fix(shell): install dummy SIGUSR1 handler so Ctrl-C during fetch does not kill devenv`** — when the interrupt flag flips during a flake fetch, Nix `pthread_kill`s the curl thread with SIGUSR1 to wake the blocking syscall. Without a handler, SIGUSR1's default disposition terminated devenv before the TUI's `Drop` could restore the terminal (leaving Kitty keyboard protocol mode active). Mirrors `initNix()` in `libmain/shared.cc`.
- **`hook: re-trigger activation after devenv allow succeeds`** — wraps `devenv` in the bash/zsh/fish/nu hooks so a successful `devenv allow` re-invokes activation. Previously, a failed inner `devenv shell` (e.g. unauthenticated secretspec provider) cleared the retry state, forcing the user to `cd` out and back in.

## Test plan

- [ ] Press Ctrl-C during a flake input fetch — devenv exits cleanly, terminal state intact (test in Kitty)
- [ ] Press Ctrl-C during long Nix evaluation — eval aborts promptly instead of running to completion
- [ ] Trigger a `devenv shell` failure via misconfigured secretspec, run `devenv allow` after fixing, verify activation re-triggers without `cd` round-trip (bash, zsh, fish, nu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)