### PR TITLE
Export devenv integrations for NixOS and home-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Improvements
 
-- Added `nixosModules.default` and `homeManagerModules.default` flake outputs that expose `programs.devenv.enable` and per-shell integration toggles. The package now also installs hook scripts under `$out/share/devenv/shell-integration/<shell>/hook.<ext>` so they can be sourced directly.
+- Added `nixosModules.default`, `darwinModules.default`, and `homeManagerModules.default` flake outputs that expose `programs.devenv.enable` and per-shell integration toggles. The package now also installs hook scripts under `$out/share/devenv/shell-integration/<shell>/hook.<ext>` so they can be sourced directly.
 - `devenv shell` now registers zsh completions from packages in the devenv profile. A generated `.zshenv` prepends `$DEVENV_PROFILE/share/zsh/site-functions` to `fpath` before `/etc/zshrc` runs, so the system `compinit` picks up the new directory.
 - Bumped `secretspec` to `v0.10.1`. The new `bws` (Bitwarden Secrets Manager) feature is not enabled because its transitive `bitwarden` crate conflicts with `sqlx` 0.8 on `libsqlite3-sys` and pins `typenum` to 1.18.
 - Bumped `iocraft` to `0.8.2` and switched the `[patch.crates-io]` entry from the `cachix/iocraft` fork to upstream `ccbrown/iocraft` `main`, now that the row-level diff and stderr rendering patches are merged upstream.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Improvements
 
-`devenv shell` now registers zsh completions from packages in the devenv profile. A generated `.zshenv` prepends `$DEVENV_PROFILE/share/zsh/site-functions` to `fpath` before `/etc/zshrc` runs, so the system `compinit` picks up the new directory.
+- Added `nixosModules.default` and `homeManagerModules.default` flake outputs that expose `programs.devenv.enable` and per-shell integration toggles. The package now also installs hook scripts under `$out/share/devenv/shell-integration/<shell>/hook.<ext>` so they can be sourced directly.
+- `devenv shell` now registers zsh completions from packages in the devenv profile. A generated `.zshenv` prepends `$DEVENV_PROFILE/share/zsh/site-functions` to `fpath` before `/etc/zshrc` runs, so the system `compinit` picks up the new directory.
 - Bumped `secretspec` to `v0.10.1`. The new `bws` (Bitwarden Secrets Manager) feature is not enabled because its transitive `bitwarden` crate conflicts with `sqlx` 0.8 on `libsqlite3-sys` and pins `typenum` to 1.18.
 - Bumped `iocraft` to `0.8.2` and switched the `[patch.crates-io]` entry from the `cachix/iocraft` fork to upstream `ccbrown/iocraft` `main`, now that the row-level diff and stderr rendering patches are merged upstream.
 

--- a/docs/src/auto-activation.md
+++ b/docs/src/auto-activation.md
@@ -33,11 +33,11 @@ Add one line to your shell configuration file:
     source ~/.cache/devenv/hook.nu
     ```
 
-## Setup via the NixOS or home-manager module
+## Setup via the NixOS, nix-darwin, or home-manager module
 
 !!! tip "New in version 2.2"
 
-[NixOS](https://nixos.org/) and [home-manager](https://github.com/nix-community/home-manager) users can import the flake modules that devenv ships, which install the package and source the shell hook for every shell you have enabled — no rc-file edits required.
+[NixOS](https://nixos.org/), [nix-darwin](https://github.com/nix-darwin/nix-darwin), and [home-manager](https://github.com/nix-community/home-manager) users can import the flake modules that devenv ships, which install the package and source the shell hook for every shell you have enabled — no rc-file edits required.
 
 Add devenv as a flake input:
 
@@ -53,6 +53,17 @@ Add devenv as a flake input:
     { inputs, ... }:
     {
       imports = [ inputs.devenv.nixosModules.default ];
+
+      programs.devenv.enable = true;
+    }
+    ```
+
+=== "nix-darwin"
+
+    ```nix title="configuration.nix"
+    { inputs, ... }:
+    {
+      imports = [ inputs.devenv.darwinModules.default ];
 
       programs.devenv.enable = true;
     }

--- a/docs/src/auto-activation.md
+++ b/docs/src/auto-activation.md
@@ -33,6 +33,53 @@ Add one line to your shell configuration file:
     source ~/.cache/devenv/hook.nu
     ```
 
+## Setup via the NixOS or home-manager module
+
+!!! tip "New in version 2.2"
+
+[NixOS](https://nixos.org/) and [home-manager](https://github.com/nix-community/home-manager) users can import the flake modules that devenv ships, which install the package and source the shell hook for every shell you have enabled — no rc-file edits required.
+
+Add devenv as a flake input:
+
+```nix title="flake.nix"
+{
+  inputs.devenv.url = "github:cachix/devenv";
+}
+```
+
+=== "NixOS"
+
+    ```nix title="configuration.nix"
+    { inputs, ... }:
+    {
+      imports = [ inputs.devenv.nixosModules.default ];
+
+      programs.devenv.enable = true;
+    }
+    ```
+
+=== "home-manager"
+
+    ```nix title="home.nix"
+    { inputs, ... }:
+    {
+      imports = [ inputs.devenv.homeManagerModules.default ];
+
+      programs.devenv.enable = true;
+    }
+    ```
+
+By default, every supported shell that you have enabled also gets the hook sourced. Disable an individual integration with:
+
+```nix
+programs.devenv.enableBashIntegration = false;
+programs.devenv.enableZshIntegration = false;
+programs.devenv.enableFishIntegration = false;
+programs.devenv.enableNushellIntegration = false; # home-manager only
+```
+
+The exported hook scripts are also available directly under `${pkgs.devenv}/share/devenv/shell-integration/<shell>/hook.<ext>` if you want to wire them up by hand.
+
 ## Trusting a project
 
 Before a project can auto activate, you need to explicitly trust it. This is a security measure that prevents untrusted projects from modifying your shell.

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,7 @@
         };
 
       nixosModules.default = import ./nix/nixos-module.nix;
+      darwinModules.default = import ./nix/nix-darwin-module.nix;
       homeManagerModules.default = import ./nix/home-manager-module.nix;
 
       flakeModule = self.flakeModules.default; # Backwards compatibility

--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,9 @@
           default = self.templates.flake;
         };
 
+      nixosModules.default = import ./nix/nixos-module.nix;
+      homeManagerModules.default = import ./nix/home-manager-module.nix;
+
       flakeModule = self.flakeModules.default; # Backwards compatibility
       flakeModules = {
         default = import ./flake-module.nix self;

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.devenv;
+  hookPath = shell: ext: "${cfg.package}/share/devenv/shell-integration/${shell}/hook.${ext}";
+in
+{
+  options.programs.devenv = {
+    enable = lib.mkEnableOption "devenv, fast declarative reproducible developer environments";
+
+    package = lib.mkPackageOption pkgs "devenv" { };
+
+    enableBashIntegration = lib.hm.shell.mkBashIntegrationOption { inherit config; };
+    enableZshIntegration = lib.hm.shell.mkZshIntegrationOption { inherit config; };
+    enableFishIntegration = lib.hm.shell.mkFishIntegrationOption { inherit config; };
+    enableNushellIntegration = lib.hm.shell.mkNushellIntegrationOption { inherit config; };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      home.packages = [ cfg.package ];
+    }
+
+    (lib.mkIf cfg.enableBashIntegration {
+      programs.bash.initExtra = ''
+        source "${hookPath "bash" "sh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableZshIntegration {
+      programs.zsh.initContent = ''
+        source "${hookPath "zsh" "zsh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableFishIntegration {
+      programs.fish.interactiveShellInit = ''
+        source "${hookPath "fish" "fish"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableNushellIntegration {
+      programs.nushell.extraConfig = ''
+        source "${hookPath "nu" "nu"}"
+      '';
+    })
+  ]);
+}

--- a/nix/nix-darwin-module.nix
+++ b/nix/nix-darwin-module.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.devenv;
+  hookPath = shell: ext: "${cfg.package}/share/devenv/shell-integration/${shell}/hook.${ext}";
+in
+{
+  options.programs.devenv = {
+    enable = lib.mkEnableOption "devenv, fast declarative reproducible developer environments";
+
+    package = lib.mkPackageOption pkgs "devenv" { };
+
+    enableBashIntegration = lib.mkEnableOption "Bash integration" // { default = true; };
+    enableZshIntegration = lib.mkEnableOption "Zsh integration" // { default = true; };
+    enableFishIntegration = lib.mkEnableOption "Fish integration" // { default = true; };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      environment.systemPackages = [ cfg.package ];
+    }
+
+    (lib.mkIf cfg.enableBashIntegration {
+      programs.bash.interactiveShellInit = ''
+        source "${hookPath "bash" "sh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableZshIntegration {
+      programs.zsh.interactiveShellInit = ''
+        source "${hookPath "zsh" "zsh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableFishIntegration {
+      programs.fish.interactiveShellInit = ''
+        source "${hookPath "fish" "fish"}"
+      '';
+    })
+  ]);
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.programs.devenv;
+  hookPath = shell: ext: "${cfg.package}/share/devenv/shell-integration/${shell}/hook.${ext}";
+in
+{
+  options.programs.devenv = {
+    enable = lib.mkEnableOption "devenv, fast declarative reproducible developer environments";
+
+    package = lib.mkPackageOption pkgs "devenv" { };
+
+    enableBashIntegration = lib.mkEnableOption "Bash integration" // { default = true; };
+    enableZshIntegration = lib.mkEnableOption "Zsh integration" // { default = true; };
+    enableFishIntegration = lib.mkEnableOption "Fish integration" // { default = true; };
+  };
+
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    {
+      environment.systemPackages = [ cfg.package ];
+    }
+
+    (lib.mkIf cfg.enableBashIntegration {
+      programs.bash.interactiveShellInit = ''
+        source "${hookPath "bash" "sh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableZshIntegration {
+      programs.zsh.interactiveShellInit = ''
+        source "${hookPath "zsh" "zsh"}"
+      '';
+    })
+
+    (lib.mkIf cfg.enableFishIntegration {
+      programs.fish.interactiveShellInit = ''
+        source "${hookPath "fish" "fish"}"
+      '';
+    })
+  ]);
+}

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -101,6 +101,15 @@ let
           --bash $compdir/devenv.bash \
           --fish $compdir/devenv.fish \
           --zsh $compdir/_devenv
+
+        # Export shell hook scripts under $out/share/devenv/shell-integration/<shell>/
+        # for users (or home-manager modules) to source.
+        integration=$out/share/devenv/shell-integration
+        mkdir -p $integration/bash $integration/zsh $integration/fish $integration/nu
+        $out/bin/devenv hook bash > $integration/bash/hook.sh
+        $out/bin/devenv hook zsh  > $integration/zsh/hook.zsh
+        $out/bin/devenv hook fish > $integration/fish/hook.fish
+        $out/bin/devenv hook nu   > $integration/nu/hook.nu
       '';
 
     meta.mainProgram = "devenv";


### PR DESCRIPTION
- Exports all of the shell hooks in the Nix build under `$out/share/devenv/shell-integration/<shell>/`.
- Exports NixOS and home-manager modules that configure the auto-loading `devenv shell` hooks for each shell.

Fixes #2808.