### PR TITLE
cli: walk up parent directories to find devenv.nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Improvements
 
 `devenv shell` now registers zsh completions from packages in the devenv profile. A generated `.zshenv` prepends `$DEVENV_PROFILE/share/zsh/site-functions` to `fpath` before `/etc/zshrc` runs, so the system `compinit` picks up the new directory.
+- `devenv` now walks up parent directories to find `devenv.nix`, so commands like `devenv shell` work from any subdirectory of a project ([#2232](https://github.com/cachix/devenv/issues/2232)).
 - Bumped `secretspec` to `v0.10.1`. The new `bws` (Bitwarden Secrets Manager) feature is not enabled because its transitive `bitwarden` crate conflicts with `sqlx` 0.8 on `libsqlite3-sys` and pins `typenum` to 1.18.
 - Bumped `iocraft` to `0.8.2` and switched the `[patch.crates-io]` entry from the `cachix/iocraft` fork to upstream `ccbrown/iocraft` `main`, now that the row-level diff and stderr rendering patches are merged upstream.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 ### Improvements
 
 - `devenv shell` now registers zsh completions from packages in the devenv profile. A generated `.zshenv` prepends `$DEVENV_PROFILE/share/zsh/site-functions` to `fpath` before `/etc/zshrc` runs, so the system `compinit` picks up the new directory.
+- `devenv` now walks up parent directories to find `devenv.nix`, so commands like `devenv shell` work from any subdirectory of a project. The shell and `devenv shell -- <cmd>` still run from the directory you invoked them in, so relative paths resolve where you expect ([#2232](https://github.com/cachix/devenv/issues/2232)).
 - Bumped `secretspec` to `v0.10.1`. The new `bws` (Bitwarden Secrets Manager) feature is not enabled because its transitive `bitwarden` crate conflicts with `sqlx` 0.8 on `libsqlite3-sys` and pins `typenum` to 1.18.
 - Bumped `iocraft` to `0.8.2` and switched the `[patch.crates-io]` entry from the `cachix/iocraft` fork to upstream `ccbrown/iocraft` `main`, now that the row-level diff and stderr rendering patches are merged upstream.
 - `devenv.yaml` options are now documented in `snake_case` (e.g. `allow_unfree`, `clean_env`). The previous `camelCase` spellings remain supported for backward compatibility.

--- a/devenv-core/src/paths.rs
+++ b/devenv-core/src/paths.rs
@@ -1,6 +1,6 @@
 //! On-disk layout for a devenv project.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct DevenvPaths {
@@ -12,4 +12,41 @@ pub struct DevenvPaths {
     pub runtime: PathBuf,
     pub state: Option<PathBuf>,
     pub git_root: Option<PathBuf>,
+}
+
+/// Walk up from `start` looking for a directory containing `devenv.nix`.
+/// Returns the first ancestor (including `start` itself) that contains it,
+/// or `None` if none is found before reaching the filesystem root.
+pub fn find_project_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|d| d.join("devenv.nix").exists())
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_marker_in_start_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("devenv.nix"), "").unwrap();
+        assert_eq!(find_project_root(tmp.path()).as_deref(), Some(tmp.path()));
+    }
+
+    #[test]
+    fn walks_up_to_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("devenv.nix"), "").unwrap();
+        let nested = tmp.path().join("a/b/c");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(find_project_root(&nested).as_deref(), Some(tmp.path()));
+    }
+
+    #[test]
+    fn returns_none_when_no_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(find_project_root(tmp.path()).is_none());
+    }
 }

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -72,6 +72,11 @@ pub struct DevenvOptions {
     pub devenv_root: Option<PathBuf>,
     pub devenv_dotfile: Option<PathBuf>,
     pub devenv_state: Option<PathBuf>,
+    /// Directory to run the interactive shell and `-- cmd` in. Set when the
+    /// project root was discovered in a parent directory, so commands run from
+    /// where the user invoked devenv rather than the (chdir'd) root. `None`
+    /// inherits the process working directory.
+    pub shell_cwd: Option<PathBuf>,
     pub shutdown: Arc<tokio_shutdown::Shutdown>,
     pub is_testing: bool,
 }
@@ -93,6 +98,7 @@ impl DevenvOptions {
             devenv_root: None,
             devenv_dotfile: None,
             devenv_state: None,
+            shell_cwd: None,
             shutdown,
             is_testing: false,
         }
@@ -225,6 +231,8 @@ pub struct Devenv {
     devenv_root: PathBuf,
     devenv_dotfile: PathBuf,
     devenv_state: Option<PathBuf>,
+    // Where to run the interactive shell / `-- cmd`. See `DevenvOptions::shell_cwd`.
+    shell_cwd: Option<PathBuf>,
     devenv_dot_gc: PathBuf,
     devenv_home_gc: PathBuf,
     devenv_tmp: PathBuf,
@@ -507,6 +515,7 @@ impl Devenv {
             devenv_root,
             devenv_dotfile,
             devenv_state: options.devenv_state,
+            shell_cwd: options.shell_cwd,
             devenv_dot_gc,
             devenv_home_gc,
             devenv_tmp,
@@ -588,6 +597,12 @@ impl Devenv {
     /// Get the path to the .devenv directory
     pub fn dotfile(&self) -> &Path {
         &self.devenv_dotfile
+    }
+
+    /// Directory the interactive shell / `-- cmd` should run in, when the
+    /// project root was discovered in a parent directory.
+    pub fn shell_cwd(&self) -> Option<&Path> {
+        self.shell_cwd.as_deref()
     }
 
     /// Get the process runtime directory, creating it on first access.
@@ -736,6 +751,13 @@ impl Devenv {
         let bash = self.get_bash_path().await?;
 
         let mut shell_cmd = process::Command::new(&bash);
+
+        // When the project root was discovered in a parent directory, run from
+        // where the user actually invoked devenv rather than the root we
+        // chdir'd into. The env is root-scoped; the working directory is not.
+        if let Some(cwd) = &self.shell_cwd {
+            shell_cmd.current_dir(cwd);
+        }
 
         // The Nix output ends with "exec bash" which would start a new shell without
         // the devenv environment. Strip it for ALL modes - we handle shell execution ourselves.

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -19,6 +19,7 @@ use devenv_core::{
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
@@ -172,6 +173,7 @@ struct RunContext {
     log_level: devenv_tracing::Level,
     tracing_specs: Vec<TraceOutputSpec>,
     tracing_owns_terminal: bool,
+    discovered_root: Option<PathBuf>,
 }
 
 /// Detect whether we are running inside an AI coding agent.
@@ -227,6 +229,34 @@ impl RunContext {
         let tracing_owns_terminal = tracing_specs
             .iter()
             .any(|s| s.destination.targets_terminal());
+
+        // Walk up parent directories to find devenv.nix. Skip when the user has
+        // explicitly chosen a source (`--from`) or is constructing a project via
+        // module-option overrides (`-O`). Has to run before Config::load() reads
+        // "./devenv.yaml".
+        let discovered_root = if cli.from.is_none()
+            && cli.input_overrides.nix_module_options.is_empty()
+        {
+            std::env::current_dir()
+                .ok()
+                .and_then(|cwd| devenv_core::paths::find_project_root(&cwd).filter(|r| r != &cwd))
+        } else {
+            None
+        };
+        if let Some(root) = &discovered_root {
+            std::env::set_current_dir(root)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to chdir to discovered project root: {}",
+                        root.display()
+                    )
+                })?;
+            // Safety: RunContext::build runs single-threaded before tokio starts.
+            unsafe {
+                std::env::set_var("PWD", root);
+            }
+        }
 
         let mut config = Config::load()?;
         config.check_version(crate_version!())?;
@@ -337,6 +367,7 @@ impl RunContext {
             log_level,
             tracing_specs,
             tracing_owns_terminal,
+            discovered_root,
         })
     }
 }
@@ -370,6 +401,10 @@ fn run(ctx: RunContext) -> Result<()> {
 
     let _tracing_guard =
         devenv_tracing::init_tracing(ctx.log_level, &ctx.tracing_specs, cli_output);
+
+    if let Some(root) = &ctx.discovered_root {
+        tracing::info!("Discovered devenv.nix in {}", root.display());
+    }
 
     let tui = ctx.tui;
     let needs_terminal_handoff = ctx.needs_terminal_handoff;

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -120,6 +120,7 @@ struct UiOptions {
     log_level: devenv_tracing::Level,
     tracing_specs: Vec<TraceOutputSpec>,
     verbosity: VerbosityLevel,
+    discovered_root: Option<PathBuf>,
 }
 
 /// Options for the backend thread: resolved devenv config plus what to run.
@@ -211,6 +212,38 @@ impl TestDirs {
 fn resolve(cli: Cli, shutdown: Arc<Shutdown>) -> Result<(UiOptions, BackendOptions)> {
     let command = cli.command;
 
+    // Walk up parent directories to find devenv.nix. Skip when the user has
+    // explicitly chosen a source (`--from`) or is constructing a project via
+    // module-option overrides (`-O`). Has to run before Config::load() reads
+    // "./devenv.yaml".
+    let original_cwd = env::current_dir().ok();
+    let discovered_root = if cli.from.is_none() && cli.input_overrides.nix_module_options.is_empty()
+    {
+        original_cwd.as_deref().and_then(|cwd| {
+            devenv_core::paths::find_project_root(cwd).filter(|r| r.as_path() != cwd)
+        })
+    } else {
+        None
+    };
+    // When discovery moves us into a parent root, remember the directory the
+    // user actually invoked from so the interactive shell and `-- cmd` still
+    // run there. The devenv environment is root-scoped; the cwd is not.
+    let shell_cwd = discovered_root.as_ref().and_then(|_| original_cwd.clone());
+    if let Some(root) = &discovered_root {
+        env::set_current_dir(root)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "Failed to chdir to discovered project root: {}",
+                    root.display()
+                )
+            })?;
+        // Safety: resolve() runs single-threaded before tokio starts.
+        unsafe {
+            env::set_var("PWD", root);
+        }
+    }
+
     // UI options: verbosity, log level, tracing, TUI. Pure CLI + env, no config.
     let verbosity = resolve_verbosity(&cli.cli_options);
     let quiet = matches!(verbosity, VerbosityLevel::Quiet);
@@ -247,6 +280,7 @@ fn resolve(cli: Cli, shutdown: Arc<Shutdown>) -> Result<(UiOptions, BackendOptio
         log_level,
         tracing_specs,
         verbosity,
+        discovered_root,
     };
 
     // Backend options. Read before the `From` conversions consume `cli.nix_args`.
@@ -332,6 +366,7 @@ fn resolve(cli: Cli, shutdown: Arc<Shutdown>) -> Result<(UiOptions, BackendOptio
         devenv_root: None,
         devenv_dotfile: test_dirs.dotfile.clone(),
         devenv_state: test_dirs.state.clone(),
+        shell_cwd,
         shutdown,
         is_testing,
     };
@@ -474,6 +509,10 @@ fn run(ui: UiOptions, backend: BackendOptions, shutdown: Arc<Shutdown>) -> Resul
 
     let _tracing_guard = devenv_tracing::init_tracing(ui.log_level, &ui.tracing_specs);
 
+    if let Some(root) = &ui.discovered_root {
+        tracing::info!("Discovered devenv.nix in {}", root.display());
+    }
+
     let tui = ui.tui;
     let verbosity = ui.verbosity;
 
@@ -598,6 +637,7 @@ async fn run_backend(
         let bash_path = devenv.get_bash_path().await?;
         let clean = devenv.shell_settings.clean.clone();
         let shell = devenv.shell_settings.shell.clone();
+        let shell_cwd = devenv.shell_cwd().map(Path::to_path_buf);
         let (task_exports, task_messages) = devenv.run_enter_shell_tasks(None, verbosity).await?;
 
         let (client, owner_handle) = devenv::reload::spawn_owner(devenv, verbosity);
@@ -615,6 +655,7 @@ async fn run_backend(
             task_exports,
             task_messages,
             shutdown: shutdown.clone(),
+            shell_cwd,
         })
         .await
         .map(|exit_code| {
@@ -1015,6 +1056,7 @@ struct ReloadShellArgs {
     task_exports: BTreeMap<String, String>,
     task_messages: Vec<String>,
     shutdown: Arc<Shutdown>,
+    shell_cwd: Option<PathBuf>,
 }
 
 /// Run shell with hot-reload.
@@ -1044,6 +1086,7 @@ async fn run_reload_shell(args: ReloadShellArgs) -> Result<Option<u32>> {
         task_exports,
         task_messages,
         shutdown,
+        shell_cwd,
     } = args;
 
     // Watch files come from the eval cache during the first build.
@@ -1063,6 +1106,7 @@ async fn run_reload_shell(args: ReloadShellArgs) -> Result<Option<u32>> {
         task_exports,
         task_messages,
         shell,
+        shell_cwd,
     };
 
     let (command_tx, command_rx) = tokio::sync::mpsc::channel(16);

--- a/devenv/src/reload/mod.rs
+++ b/devenv/src/reload/mod.rs
@@ -35,6 +35,9 @@ pub struct DevenvShellBuilder {
     pub task_exports: BTreeMap<String, String>,
     pub task_messages: Vec<String>,
     pub shell: String,
+    /// Directory to start the interactive shell in. Set when the project root
+    /// was discovered in a parent directory; `None` uses the build context cwd.
+    pub shell_cwd: Option<PathBuf>,
 }
 
 impl ShellBuilder for DevenvShellBuilder {
@@ -118,7 +121,7 @@ impl DevenvShellBuilder {
             cmd_builder.arg(arg);
         }
 
-        cmd_builder.cwd(&ctx.cwd);
+        cmd_builder.cwd(self.shell_cwd.as_deref().unwrap_or(&ctx.cwd));
         set_reload_file_env(&mut cmd_builder, ctx);
 
         let shell_for_env = target_shell_path.as_deref().unwrap_or(bash);

--- a/tests/cli-subdir-discovery/.test-config.yml
+++ b/tests/cli-subdir-discovery/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/cli-subdir-discovery/.test.sh
+++ b/tests/cli-subdir-discovery/.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -xe
+set -o pipefail
+
+proj_root="$(pwd)"
+mkdir -p sub/nested
+
+# Discovery from one level deep
+(cd sub && devenv print-paths | grep -Fxq "DEVENV_ROOT=\"$proj_root\"")
+
+# Discovery from two levels deep
+(cd sub/nested && devenv print-paths | grep -Fxq "DEVENV_ROOT=\"$proj_root\"")
+
+# Negative case: outside any project, original error preserved
+outside="$(mktemp -d)"
+trap 'rm -rf "$outside"' EXIT
+output="$(cd "$outside" && devenv print-paths 2>&1 || true)"
+if echo "$output" | grep -q "devenv.nix does not exist"; then
+  echo "✓ negative case: error preserved outside any project"
+else
+  echo "expected 'devenv.nix does not exist' outside any project, got:"
+  echo "$output"
+  exit 1
+fi

--- a/tests/cli-subdir-discovery/.test.sh
+++ b/tests/cli-subdir-discovery/.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -xe
+set -o pipefail
+
+proj_root="$(pwd)"
+mkdir -p sub/nested
+
+# Discovery from one level deep
+(cd sub && devenv print-paths | grep -Fxq "DEVENV_ROOT=\"$proj_root\"")
+
+# Discovery from two levels deep
+(cd sub/nested && devenv print-paths | grep -Fxq "DEVENV_ROOT=\"$proj_root\"")
+
+# `devenv shell -- <cmd>` runs from the directory you invoked it in, not the
+# discovered project root, so relative paths resolve where the user expects.
+(cd sub && echo 'echo ran-in-sub' > rel.sh
+ devenv shell -- bash rel.sh | grep -Fq ran-in-sub)
+
+# Negative case: outside any project, original error preserved
+outside="$(mktemp -d)"
+trap 'rm -rf "$outside"' EXIT
+output="$(cd "$outside" && devenv print-paths 2>&1 || true)"
+if echo "$output" | grep -q "devenv.nix does not exist"; then
+  echo "✓ negative case: error preserved outside any project"
+else
+  echo "expected 'devenv.nix does not exist' outside any project, got:"
+  echo "$output"
+  exit 1
+fi

--- a/tests/cli-subdir-discovery/devenv.nix
+++ b/tests/cli-subdir-discovery/devenv.nix
@@ -1,0 +1,3 @@
+{ pkgs, ... }: {
+  packages = [ pkgs.hello ];
+}


### PR DESCRIPTION
## Summary

- When `devenv.nix` is missing in cwd, walk up parent directories before erroring. Commands like `devenv shell` now work from any subdirectory of a project — fixes the friction when editors open terminals in nested folders.
- Discovery is skipped when `--from` or `-O` is used, since those construct the project from explicit inputs.
- Fixes #2232.

## Test plan

- [x] Unit tests for `find_project_root` (marker in start dir, walks up to parent, returns none when missing)
- [x] Integration test `tests/cli-subdir-discovery` verifies discovery from one and two levels deep, plus negative case outside any project
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)