### PR TITLE
hook: do not exit outer shell on cd-out when DEVENV_ROOT is set externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `devenv hook fish` not activating when starting a new fish shell directly inside a project directory. The initial activation now runs on the first `fish_prompt` event instead of inline during `source`, so the spawned `devenv shell` inherits the real terminal as stdin instead of the closed pipe from `devenv hook fish | source` ([#2798](https://github.com/cachix/devenv/issues/2798)).
 - Fixed `devenv shell` skipping the user's `.zshenv` when launching zsh, which could mangle prompts and break `.zshrc` configurations that depend on env vars defined in `.zshenv`. The user's `.zshenv` is now sourced before `.zshrc` during shell init, matching zsh's documented startup order ([#2802](https://github.com/cachix/devenv/pull/2802)).
 - Fixed the bash/zsh shell hook (`devenv hook bash`/`zsh`) re-launching `devenv shell` on every prompt redraw after the user interrupted a slow eval with Ctrl-C. The hook now caches `$PWD` before launching the subshell, so an aborted or failed activation no longer retries until the user `cd`s away and back.
+- Fixed the shell hook closing the user's terminal when cd-ing out of a project directory while `DEVENV_ROOT` was exported into the outer shell (e.g. via direnv). The "exit on cd-out" path now keys off `_DEVENV_HOOK_DIR`, which is only set on shells the hook spawned, instead of `DEVENV_ROOT` alone ([#2805](https://github.com/cachix/devenv/issues/2805)).
 
 ### Improvements
 

--- a/devenv/hooks/hook.fish
+++ b/devenv/hooks/hook.fish
@@ -4,8 +4,12 @@
 set -q _DEVENV_HOOK_UNTRUSTED; or set -g _DEVENV_HOOK_UNTRUSTED ""
 
 function _devenv_hook --on-variable PWD
-    # Inside devenv shell: exit when leaving the project directory
-    if set -q DEVENV_ROOT
+    # Inside a hook-spawned devenv shell: exit when leaving the project
+    # directory. `_DEVENV_HOOK_DIR` is the marker — set only in shells we
+    # spawned below. `DEVENV_ROOT` alone is not enough: direnv (and other
+    # tools) may export it into the user's outer shell, and an unguarded
+    # `exit` there closes the terminal.
+    if set -q _DEVENV_HOOK_DIR; and set -q DEVENV_ROOT
         switch $PWD
             case "$DEVENV_ROOT" "$DEVENV_ROOT/*"
                 return

--- a/devenv/hooks/hook.posix.sh
+++ b/devenv/hooks/hook.posix.sh
@@ -7,8 +7,12 @@ _devenv_hook() {
     local previous_exit_status=$?
     [[ "$_DEVENV_HOOK_PWD" == "$PWD" ]] && return $previous_exit_status
 
-    # Inside devenv shell: exit when leaving the project directory
-    if [[ -n "${DEVENV_ROOT:-}" ]]; then
+    # Inside a hook-spawned devenv shell: exit when leaving the project
+    # directory. `_DEVENV_HOOK_DIR` is the marker — set only on shells we
+    # spawned below. `DEVENV_ROOT` alone is not enough: direnv (and other
+    # tools) may export it into the user's outer shell, and an unguarded
+    # `exit` there closes the terminal.
+    if [[ -n "${_DEVENV_HOOK_DIR:-}" && -n "${DEVENV_ROOT:-}" ]]; then
         case "$PWD" in
             "${DEVENV_ROOT}"|"${DEVENV_ROOT}"/*) ;;
             *)
@@ -35,7 +39,7 @@ _devenv_hook() {
         # Cache PWD before launching so a SIGINT/failure inside devenv shell
         # doesn't leave us re-launching on every prompt redraw.
         _DEVENV_HOOK_PWD="$PWD"
-        (cd "$project_dir" && devenv shell)
+        (cd "$project_dir" && _DEVENV_HOOK_DIR="$project_dir" devenv shell)
         local exit_dir_file="$project_dir/.devenv/exit-dir"
         if [[ -f "$exit_dir_file" ]]; then
             local target_dir

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -1,0 +1,118 @@
+//! Regression: shell-integration hooks must not call `exit` in the user's
+//! outer shell. Direnv (and similar tools) may export `DEVENV_ROOT` into the
+//! outer shell's env, and an unguarded `exit` on cd-out closes the terminal.
+//! See https://github.com/cachix/devenv/issues/2805
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn devenv_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_devenv")
+}
+
+fn fake_project() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join(".devenv")).unwrap();
+    tmp
+}
+
+fn run(shell: &str, script: &str) -> Output {
+    Command::new(shell).arg("-c").arg(script).output().unwrap()
+}
+
+fn skip_if_missing(shell: &str) -> bool {
+    Command::new("sh")
+        .args(["-c", &format!("command -v {shell}")])
+        .output()
+        .map(|o| !o.status.success())
+        .unwrap_or(true)
+}
+
+/// Outer shell: `DEVENV_ROOT` set but `_DEVENV_HOOK_DIR` unset. cd-out must
+/// NOT terminate the shell.
+fn outer_shell_survives(shell: &str, hook_name: &str, source_cmd: &str, root: &Path) {
+    let script = format!(
+        r#"
+        export DEVENV_ROOT={root:?}
+        {source_cmd}
+        cd /
+        _devenv_hook
+        echo SURVIVED
+        "#,
+        root = root,
+        source_cmd = source_cmd,
+    );
+    let out = run(shell, &script);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("SURVIVED"),
+        "{shell} outer shell exited on cd-out via `devenv hook {hook_name}` (issue #2805).\n\
+         stdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// Inner (hook-spawned) shell: both `_DEVENV_HOOK_DIR` and `DEVENV_ROOT`
+/// set. cd-out MUST exit the shell and write the exit-dir for the parent.
+fn inner_shell_exits(shell: &str, hook_name: &str, source_cmd: &str, root: &Path) {
+    let script = format!(
+        r#"
+        export DEVENV_ROOT={root:?}
+        export _DEVENV_HOOK_DIR={root:?}
+        {source_cmd}
+        cd /
+        _devenv_hook
+        echo SHOULD_NOT_REACH
+        "#,
+        root = root,
+        source_cmd = source_cmd,
+    );
+    let out = run(shell, &script);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("SHOULD_NOT_REACH"),
+        "{shell} inner shell did not exit on cd-out via `devenv hook {hook_name}`.\n\
+         stdout: {stdout}",
+    );
+    let exit_dir = fs::read_to_string(root.join(".devenv/exit-dir")).unwrap();
+    assert_eq!(exit_dir, "/", "{shell}: exit-dir should record cd target");
+}
+
+#[test]
+fn bash_outer_shell_survives_cd_out_when_only_devenv_root_set() {
+    let tmp = fake_project();
+    let src = format!(r#"eval "$({} hook bash)""#, devenv_bin());
+    outer_shell_survives("bash", "bash", &src, tmp.path());
+}
+
+#[test]
+fn bash_inner_shell_exits_on_cd_out_and_writes_exit_dir() {
+    let tmp = fake_project();
+    let src = format!(r#"eval "$({} hook bash)""#, devenv_bin());
+    inner_shell_exits("bash", "bash", &src, tmp.path());
+}
+
+#[test]
+fn fish_outer_shell_survives_cd_out_when_only_devenv_root_set() {
+    if skip_if_missing("fish") {
+        eprintln!("fish not in PATH; skipping");
+        return;
+    }
+    let tmp = fake_project();
+    // `_devenv_hook` is fish's PWD-change handler; calling it directly here
+    // mirrors what fish does on `cd` in an interactive session.
+    let src = format!("{} hook fish | source", devenv_bin());
+    outer_shell_survives("fish", "fish", &src, tmp.path());
+}
+
+#[test]
+fn fish_inner_shell_exits_on_cd_out_and_writes_exit_dir() {
+    if skip_if_missing("fish") {
+        eprintln!("fish not in PATH; skipping");
+        return;
+    }
+    let tmp = fake_project();
+    let src = format!("{} hook fish | source", devenv_bin());
+    inner_shell_exits("fish", "fish", &src, tmp.path());
+}


### PR DESCRIPTION
## Summary

- The shell hooks (`devenv hook fish`/`bash`/`zsh`) call `exit` when the user cd's out of a project, intended to drop them out of the hook-spawned inner shell. The "am I in an inner shell?" check used `DEVENV_ROOT` alone — but direnv (and similar tools) export `DEVENV_ROOT` into the user's outer shell. With that env var set, cd-out called `exit` in the outer shell too, closing the terminal.
- Gates the exit on `_DEVENV_HOOK_DIR` (set only on shells the hook spawned) in addition to `DEVENV_ROOT`. The fish hook already sets `_DEVENV_HOOK_DIR` as the cd target; the posix hook now sets it on the spawn line as well.
- Fixes #2805.

an agent wrote the code (and most of this post) but a human being (me) has confirmed it fixes the issue.

## Test plan

- [x] New integration test `devenv/tests/hook_outer_shell_survives.rs` — bash and fish variants, each covering outer-survives + inner-still-exits
- [x] Verified red against unpatched hooks (both outer-shell tests fail), green with the fix
- [x] Reproduced the original bug interactively in fish before the fix, confirmed gone after
- [x] `cargo test -p devenv commands::hook::` — existing hook unit tests still pass
- [x] `cargo fmt --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)