### PR TITLE
Generate yaml-options.md from Config doc comments

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -73,6 +73,16 @@ jobs:
           add: docs/src/devenv.schema.json
           message: "Auto generate docs/src/devenv.schema.json"
 
+      - name: Generate devenv.yaml options reference
+        run: devenv shell -- cargo run -- generate-yaml-options-doc
+
+      - uses: EndBug/add-and-commit@v10
+        if: ${{ github.event_name == 'push' }}
+        with:
+          default_author: github_actions
+          add: docs/src/reference/yaml-options.md
+          message: "Auto generate docs/src/reference/yaml-options.md"
+
       - uses: EndBug/add-and-commit@v10
         if: ${{ github.event_name == 'push' }}
         with:

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -40,6 +40,10 @@ pub enum NixBackendType {
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AndroidSdkConfig {
+    /// Accept the Android SDK license.
+    /// Can also be set via the `NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1` environment variable.
+    ///
+    /// Default: `false`.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "acceptLicense", merge = schematic::merge::replace)]
     pub accept_license: bool,
@@ -48,41 +52,89 @@ pub struct AndroidSdkConfig {
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct NixpkgsConfig {
+    /// Allow unfree packages.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "allowUnfree", merge = schematic::merge::replace)]
     pub allow_unfree: bool,
+    /// Allow packages that are not supported on the current system.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 2.0.5.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "allowUnsupportedSystem", merge = schematic::merge::replace)]
     pub allow_unsupported_system: bool,
+    /// Allow packages marked as broken.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "allowBroken", merge = schematic::merge::replace)]
     pub allow_broken: bool,
+    /// Allow packages not built from source.
+    ///
+    /// Default: `true` (nixpkgs default).
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "allowNonSource", merge = schematic::merge::replace)]
     pub allow_non_source: bool,
+    /// Enable CUDA support for nixpkgs.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "cudaSupport", merge = schematic::merge::replace)]
     pub cuda_support: bool,
+    /// Select CUDA capabilities for nixpkgs.
+    ///
+    /// Default: `[]`.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     #[setting(alias = "cudaCapabilities", merge = schematic::merge::append_vec)]
     pub cuda_capabilities: Vec<String>,
+    /// Enable ROCm support for nixpkgs.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 2.0.7.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(alias = "rocmSupport", merge = schematic::merge::replace)]
     pub rocm_support: bool,
+    /// A list of insecure permitted packages.
+    ///
+    /// Default: `[]`.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     #[setting(alias = "permittedInsecurePackages", merge = schematic::merge::append_vec)]
     pub permitted_insecure_packages: Vec<String>,
+    /// A list of unfree packages to allow by name.
+    ///
+    /// Default: `[]`.
+    ///
+    /// Added in 1.9.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     #[setting(alias = "permittedUnfreePackages")]
     pub permitted_unfree_packages: Vec<String>,
-    /// License names to allow (e.g. "mit", "gpl3Only").
-    /// Only applied in bootstrapLib.nix where lib.licenses is available;
-    /// not serialized to NIXPKGS_CONFIG since raw strings won't match license attrsets.
+    /// A list of license names to allow.
+    /// Uses nixpkgs license attribute names (e.g. `gpl3Only`, `mit`, `asl20`).
+    /// See [nixpkgs license list](https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix).
+    ///
+    /// Default: `[]`.
     #[serde(skip_serializing, default)]
     #[setting(alias = "allowlistedLicenses", merge = schematic::merge::append_vec)]
     pub allowlisted_licenses: Vec<String>,
-    /// License names to block (e.g. "unfree", "bsl11").
-    /// Only applied in bootstrapLib.nix; not serialized to NIXPKGS_CONFIG.
+    /// A list of license names to block.
+    /// Uses nixpkgs license attribute names (e.g. `unfree`, `bsl11`).
+    /// See [nixpkgs license list](https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix).
+    ///
+    /// Default: `[]`.
     #[serde(skip_serializing, default)]
     #[setting(alias = "blocklistedLicenses", merge = schematic::merge::append_vec)]
     pub blocklisted_licenses: Vec<String>,
@@ -94,15 +146,30 @@ pub struct NixpkgsConfig {
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Input {
+    /// URI specification of the input.
+    /// See [Supported URI formats](../inputs.md#supported-uri-formats).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub url: Option<String>,
+    /// Does the input contain `flake.nix` or `devenv.nix`.
+    ///
+    /// Default: `true`.
     #[serde(skip_serializing_if = "is_true", default = "true_default")]
     #[setting(default = true)]
     pub flake: bool,
+    /// Another input to "inherit" from by name.
+    /// See [Following inputs](../inputs.md#following-inputs).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub follows: Option<String>,
+    /// Override nested inputs by name.
+    /// See [Following inputs](../inputs.md#following-inputs).
+    ///
+    /// Opaque.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub inputs: BTreeMap<String, Input>,
+    /// A list of overlays to include from the input.
+    /// See [Overlays](../overlays.md).
+    ///
+    /// Default: `[]`.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub overlays: Vec<String>,
 }
@@ -153,7 +220,17 @@ impl TryFrom<&Input> for FlakeInput {
 
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Clean {
+    /// Clean the environment when entering the shell.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.0.
     pub enabled: bool,
+    /// A list of environment variables to keep when cleaning the environment.
+    ///
+    /// Default: `[]`.
+    ///
+    /// Added in 1.0.
     pub keep: Vec<String>,
     // TODO: executables?
 }
@@ -182,6 +259,12 @@ pub struct Nixpkgs {
     #[serde(flatten)]
     #[setting(nested)]
     pub config_: NixpkgsConfig,
+    /// Per-platform nixpkgs configuration.
+    /// Accepts the same options as `nixpkgs`.
+    ///
+    /// Opaque.
+    ///
+    /// Added in 1.7.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     // TODO(v3.0): remove deprecated alias
     #[setting(alias = "per-platform", nested, merge = schematic::merge::merge_btreemap)]
@@ -193,11 +276,18 @@ pub struct Nixpkgs {
 #[serde(rename_all = "snake_case")]
 pub struct Config {
     /// Version requirement for the devenv CLI.
-    /// Set to `true` to enforce CLI matches the modules version,
-    /// or a constraint string like `">=2.0.0"`.
+    /// Set to `true` to enforce that the CLI version matches the modules version
+    /// (from the `devenv` input), or use a constraint string with operators
+    /// (`>=`, `<=`, `>`, `<`, `=`, or a bare version for an exact match).
+    ///
+    /// Added in 2.1.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(merge = schematic::merge::replace)]
     pub require_version: Option<RequireVersion>,
+    /// Map of Nix inputs.
+    /// See [Inputs](../inputs.md).
+    ///
+    /// Default: `inputs.nixpkgs.url: github:cachix/devenv-nixpkgs/rolling`.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     #[setting(nested, merge = schematic::merge::merge_btreemap)]
     pub inputs: BTreeMap<String, Input>,
@@ -222,6 +312,10 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(nested)]
     pub nixpkgs: Option<Nixpkgs>,
+    /// A list of relative paths, absolute paths, or references to inputs to import `devenv.nix` and `devenv.yaml` files.
+    /// See [Composing using imports](../composing-using-imports.md).
+    ///
+    /// Default: `[]`.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     #[setting(merge = schematic::merge::append_vec)]
     pub imports: Vec<String>,
@@ -235,24 +329,56 @@ pub struct Config {
     #[setting(nested)]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub clean: Option<Clean>,
+    /// Relax the hermeticity of the environment.
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.0.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(merge = schematic::merge::replace)]
     pub impure: bool,
+    /// Select the Nix backend used to evaluate `devenv.nix`.
+    ///
+    /// Default: `nix`.
     #[serde(default, skip_serializing_if = "is_default")]
     #[setting(merge = schematic::merge::replace)]
     pub backend: NixBackendType,
     #[setting(nested)]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub secretspec: Option<SecretspecConfig>,
+    /// Default profile to activate.
+    /// Can be overridden by `--profile` CLI flag.
+    /// See [Profiles](../profiles.md).
+    ///
+    /// Added in 1.11.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(merge = schematic::merge::replace)]
     pub profile: Option<String>,
+    /// Enable auto-reload of the shell when files change.
+    /// Can be overridden by `--reload` or `--no-reload` CLI flags.
+    ///
+    /// Default: `true`.
+    ///
+    /// Added in 2.0.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(merge = schematic::merge::replace)]
     pub reload: Option<bool>,
+    /// Error if a port is already in use instead of auto-allocating the next available port.
+    /// Can be overridden by `--strict-ports` or `--no-strict-ports` CLI flags.
+    ///
+    /// Default: `false`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(alias = "strictPorts", merge = schematic::merge::replace)]
     pub strict_ports: Option<bool>,
+    /// Default interactive shell to use when entering the devenv environment.
+    /// Can be overridden by the `--shell` CLI flag.
+    /// Falls back to the `$SHELL` environment variable, then `bash`.
+    ///
+    /// Supported values: `bash`, `zsh`, `fish`, `nu`. Any other value falls back to `bash`.
+    ///
+    /// Default: `$SHELL` or `bash`.
+    ///
+    /// Added in 2.1.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     #[setting(merge = schematic::merge::replace)]
     pub shell: Option<String>,
@@ -263,11 +389,22 @@ pub struct Config {
 
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct SecretspecConfig {
+    /// Enable [secretspec integration](../integrations/secretspec.md).
+    ///
+    /// Default: `false`.
+    ///
+    /// Added in 1.8.
     #[serde(skip_serializing_if = "is_false", default = "false_default")]
     #[setting(default = false)]
     pub enable: bool,
+    /// Secretspec profile name to use.
+    ///
+    /// Added in 1.8.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub profile: Option<String>,
+    /// Secretspec provider to use.
+    ///
+    /// Added in 1.8.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider: Option<String>,
 }
@@ -284,6 +421,381 @@ pub async fn write_json_schema() -> Result<()> {
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to write json schema to {}", path.display()))?;
     Ok(())
+}
+
+pub async fn write_yaml_options_doc() -> Result<()> {
+    let schema = schema_for!(Config);
+    let json: serde_json::Value = serde_json::to_value(&schema)
+        .into_diagnostic()
+        .wrap_err("Failed to serialize JSON schema")?;
+    let rendered = render_yaml_options(&json);
+    let path = Path::new("docs/src/reference/yaml-options.md");
+    tokio::fs::write(path, &rendered)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to write yaml-options to {}", path.display()))?;
+    Ok(())
+}
+
+struct OptionSection {
+    path: String,
+    description: String,
+    added_in: Option<String>,
+    default: Option<String>,
+    type_label: String,
+}
+
+struct ParsedMeta {
+    body: String,
+    added_in: Option<String>,
+    default: Option<String>,
+    opaque: bool,
+}
+
+fn render_yaml_options(schema: &serde_json::Value) -> String {
+    let defs = schema
+        .get("$defs")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let properties = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut sections: Vec<OptionSection> = Vec::new();
+    let visited: HashSet<String> = HashSet::new();
+    for (name, prop) in properties.iter() {
+        collect_sections(name, prop, &defs, &visited, &mut sections);
+    }
+    sections.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let mut out = String::from("# devenv.yaml\n\n");
+    out.push_str("<!-- This file is auto-generated from devenv-core/src/config.rs doc comments. Do not edit. -->\n\n");
+    for section in sections {
+        out.push_str(&render_section(&section));
+    }
+    out
+}
+
+/// Extract the `$ref` target name from a schema, considering direct `$ref` and `anyOf` wrappers.
+fn ref_target(schema: &serde_json::Value) -> Option<String> {
+    if let Some(r) = schema.get("$ref").and_then(|v| v.as_str())
+        && let Some(name) = r.strip_prefix("#/$defs/")
+    {
+        return Some(name.to_string());
+    }
+    if let Some(any) = schema.get("anyOf").and_then(|v| v.as_array()) {
+        let non_null: Vec<&serde_json::Value> = any
+            .iter()
+            .filter(|v| v.get("type").and_then(|t| t.as_str()) != Some("null"))
+            .collect();
+        if non_null.len() == 1 {
+            return ref_target(non_null[0]);
+        }
+    }
+    None
+}
+
+fn collect_sections(
+    path: &str,
+    schema: &serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+    visited: &HashSet<String>,
+    out: &mut Vec<OptionSection>,
+) {
+    if schema.get("deprecated").and_then(|v| v.as_bool()) == Some(true) {
+        return;
+    }
+
+    let resolved = resolve_ref(schema, defs);
+    let description = description_of(schema).unwrap_or_default();
+    let opaque = parse_description(&description).opaque;
+
+    // Map types (BTreeMap<String, T>) -> emit "<path>.<name>.<sub>" sections via additionalProperties.
+    if let Some(additional) = resolved.get("additionalProperties") {
+        let wildcard_path = format!("{}.\\<name\\>", path);
+        let inner_ref = ref_target(additional);
+        let cycle = inner_ref
+            .as_ref()
+            .map(|name| visited.contains(name))
+            .unwrap_or(false);
+        let inner_resolved = resolve_ref(additional, defs);
+
+        if !opaque
+            && !cycle
+            && inner_resolved
+                .get("properties")
+                .and_then(|v| v.as_object())
+                .is_some()
+        {
+            if !description.is_empty() {
+                out.push(make_section(
+                    path,
+                    &type_label(&resolved, defs),
+                    description,
+                ));
+            }
+            let mut next = visited.clone();
+            if let Some(name) = inner_ref {
+                next.insert(name);
+            }
+            if let Some(props) = inner_resolved.get("properties").and_then(|v| v.as_object()) {
+                for (name, sub) in props {
+                    collect_sections(
+                        &format!("{}.{}", wildcard_path, name),
+                        sub,
+                        defs,
+                        &next,
+                        out,
+                    );
+                }
+            }
+            return;
+        }
+        // Cycle, opaque, scalar value type, or no struct properties -> single section.
+        out.push(make_section(
+            path,
+            &type_label(&resolved, defs),
+            description,
+        ));
+        return;
+    }
+
+    // Object with properties (via $ref or inline) -> recurse.
+    let inline_ref = ref_target(schema);
+    let cycle = inline_ref
+        .as_ref()
+        .map(|name| visited.contains(name))
+        .unwrap_or(false);
+    if !opaque
+        && !cycle
+        && let Some(props) = resolved.get("properties").and_then(|v| v.as_object())
+    {
+        if !description.is_empty() {
+            out.push(make_section(
+                path,
+                &type_label(&resolved, defs),
+                description,
+            ));
+        }
+        let mut next = visited.clone();
+        if let Some(name) = inline_ref {
+            next.insert(name);
+        }
+        for (name, sub) in props {
+            collect_sections(&format!("{}.{}", path, name), sub, defs, &next, out);
+        }
+        return;
+    }
+
+    // Leaf scalar / enum / cycle / opaque.
+    let desc = if description.is_empty() {
+        description_of(&resolved).unwrap_or_default()
+    } else {
+        description
+    };
+    out.push(make_section(path, &type_label(&resolved, defs), desc));
+}
+
+fn make_section(path: &str, type_label: &str, raw_description: String) -> OptionSection {
+    let meta = parse_description(&raw_description);
+    OptionSection {
+        path: path.to_string(),
+        description: meta.body,
+        added_in: meta.added_in,
+        default: meta.default,
+        type_label: type_label.to_string(),
+    }
+}
+
+fn parse_description(input: &str) -> ParsedMeta {
+    let mut lines: Vec<String> = input.lines().map(|l| l.to_string()).collect();
+    let mut added_in: Option<String> = None;
+    let mut default: Option<String> = None;
+    let mut opaque = false;
+    // Walk lines from the end, pulling off trailing metadata markers.
+    while let Some(last) = lines.last().cloned() {
+        let trimmed = last.trim();
+        if trimmed.is_empty() {
+            lines.pop();
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Added in ") {
+            added_in = Some(rest.trim_end_matches('.').to_string());
+            lines.pop();
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Default: ") {
+            default = Some(rest.trim_end_matches('.').to_string());
+            lines.pop();
+            continue;
+        }
+        if trimmed == "Opaque." {
+            opaque = true;
+            lines.pop();
+            continue;
+        }
+        break;
+    }
+    ParsedMeta {
+        body: lines.join("\n").trim().to_string(),
+        added_in,
+        default,
+        opaque,
+    }
+}
+
+fn render_section(s: &OptionSection) -> String {
+    let mut out = format!("## {}\n\n", s.path);
+    if !s.description.is_empty() {
+        out.push_str(&s.description);
+        out.push_str("\n\n");
+    }
+    let mut meta = vec![format!("*Type:* {}", s.type_label)];
+    if let Some(default) = &s.default {
+        meta.push(format!("*Default:* {}", default));
+    }
+    out.push_str(&meta.join(" · "));
+    out.push('\n');
+    if let Some(version) = &s.added_in {
+        out.push_str(&format!("\n!!! tip \"New in version {}\"\n", version));
+    }
+    out.push('\n');
+    out
+}
+
+fn description_of(schema: &serde_json::Value) -> Option<String> {
+    schema
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn resolve_ref(
+    schema: &serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    // Direct $ref
+    if let Some(reference) = schema.get("$ref").and_then(|v| v.as_str())
+        && let Some(name) = reference.strip_prefix("#/$defs/")
+        && let Some(target) = defs.get(name)
+    {
+        return target.clone();
+    }
+    // anyOf with one $ref + null -> resolve the $ref.
+    if let Some(any) = schema.get("anyOf").and_then(|v| v.as_array()) {
+        let non_null: Vec<&serde_json::Value> = any
+            .iter()
+            .filter(|v| v.get("type").and_then(|t| t.as_str()) != Some("null"))
+            .collect();
+        if non_null.len() == 1 {
+            return resolve_ref(non_null[0], defs);
+        }
+    }
+    schema.clone()
+}
+
+/// Returns a markdown-ready type expression including outer backticks.
+fn type_label(
+    schema: &serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+) -> String {
+    format!("`{}`", type_label_inner(schema, defs))
+}
+
+fn type_label_inner(
+    schema: &serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+) -> String {
+    let ref_name = ref_target(schema);
+    let resolved = resolve_ref(schema, defs);
+
+    if let Some(enum_values) = resolved.get("enum").and_then(|v| v.as_array()) {
+        let values: Vec<String> = enum_values
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        return values.join(" | ");
+    }
+
+    if let Some(any) = resolved.get("anyOf").and_then(|v| v.as_array()) {
+        let parts: Vec<String> = any
+            .iter()
+            .filter(|v| v.get("type").and_then(|t| t.as_str()) != Some("null"))
+            .map(|v| type_label_inner(v, defs))
+            .collect();
+        if !parts.is_empty() {
+            return parts.join(" | ");
+        }
+    }
+
+    if let Some(types) = resolved.get("type").and_then(|v| v.as_array()) {
+        let non_null: Vec<&str> = types
+            .iter()
+            .filter_map(|t| t.as_str())
+            .filter(|s| *s != "null")
+            .collect();
+        if non_null.len() == 1 {
+            return scalar_label_inner(non_null[0], &resolved, defs, ref_name.as_deref());
+        }
+    }
+
+    if let Some(ty) = resolved.get("type").and_then(|v| v.as_str()) {
+        return scalar_label_inner(ty, &resolved, defs, ref_name.as_deref());
+    }
+
+    ref_name.unwrap_or_else(|| "unknown".to_string())
+}
+
+fn scalar_label_inner(
+    ty: &str,
+    schema: &serde_json::Value,
+    defs: &serde_json::Map<String, serde_json::Value>,
+    ref_name: Option<&str>,
+) -> String {
+    match ty {
+        "boolean" => "boolean".to_string(),
+        "string" => "string".to_string(),
+        "integer" => "integer".to_string(),
+        "number" => "number".to_string(),
+        "array" => {
+            let item_label = schema
+                .get("items")
+                .map(|i| type_label_inner(i, defs))
+                .unwrap_or_else(|| "any".to_string());
+            format!("list of {}", item_label)
+        }
+        "object" => {
+            if let Some(additional) = schema.get("additionalProperties") {
+                let inner_ref = ref_target(additional);
+                let inner = inner_ref
+                    .map(|n| humanize_ref_name(&n))
+                    .unwrap_or_else(|| type_label_inner(additional, defs));
+                format!("attribute set of {}", inner)
+            } else if let Some(name) = ref_name {
+                humanize_ref_name(name)
+            } else {
+                "attribute set".to_string()
+            }
+        }
+        other => other.to_string(),
+    }
+}
+
+/// `NixpkgsConfig` -> `nixpkgs config`, `Input` -> `input`.
+fn humanize_ref_name(name: &str) -> String {
+    let mut out = String::new();
+    for (i, ch) in name.chars().enumerate() {
+        if i > 0 && ch.is_uppercase() {
+            out.push(' ');
+        }
+        for low in ch.to_lowercase() {
+            out.push(low);
+        }
+    }
+    out
 }
 
 impl From<&Path> for Config {

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -829,6 +829,9 @@ pub enum Commands {
     #[clap(hide = true)]
     GenerateJSONSchema,
 
+    #[clap(hide = true)]
+    GenerateYamlOptionsDoc,
+
     /// Print computed paths (dotfile, gc, etc.) for shell integration
     #[clap(hide = true)]
     PrintPaths,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -1063,6 +1063,12 @@ async fn dispatch_command(
                 .wrap_err("Failed to generate JSON schema")?;
             Ok(CommandResult::Done)
         }
+        Commands::GenerateYamlOptionsDoc => {
+            config::write_yaml_options_doc()
+                .await
+                .wrap_err("Failed to generate yaml-options doc")?;
+            Ok(CommandResult::Done)
+        }
         Commands::PrintPaths => {
             let paths = devenv.paths();
             let output = format!(

--- a/docs/src/devenv.schema.json
+++ b/docs/src/devenv.schema.json
@@ -3,34 +3,17 @@
   "title": "Config",
   "type": "object",
   "properties": {
-    "require_version": {
-      "description": "Version requirement for the devenv CLI.\nSet to `true` to enforce CLI matches the modules version,\nor a constraint string like `\">=2.0.0\"`.",
-      "anyOf": [
-        {
-          "$ref": "#/$defs/RequireVersion"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "inputs": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/Input"
       }
     },
-    "allow_unfree": {
-      "type": "boolean",
-      "deprecated": true
+    "allowUnfree": {
+      "type": "boolean"
     },
-    "allow_unsupported_system": {
-      "type": "boolean",
-      "deprecated": true
-    },
-    "allow_broken": {
-      "type": "boolean",
-      "deprecated": true
+    "allowBroken": {
+      "type": "boolean"
     },
     "nixpkgs": {
       "anyOf": [
@@ -48,12 +31,11 @@
         "type": "string"
       }
     },
-    "permitted_insecure_packages": {
+    "permittedInsecurePackages": {
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "deprecated": true
+      }
     },
     "clean": {
       "anyOf": [
@@ -86,40 +68,9 @@
         "string",
         "null"
       ]
-    },
-    "reload": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "strict_ports": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "shell": {
-      "type": [
-        "string",
-        "null"
-      ]
     }
   },
   "$defs": {
-    "RequireVersion": {
-      "description": "Version requirement for the devenv CLI.\n\n- `true`: CLI version must match the modules version (checked during Nix evaluation)\n- A constraint string like `\">=2.0.0\"`: checked before Nix evaluation",
-      "anyOf": [
-        {
-          "description": "When true, CLI version must match the modules version",
-          "type": "boolean"
-        },
-        {
-          "description": "Version constraint string (e.g., \">=2.0.0\", \"2.0.7\")",
-          "type": "string"
-        }
-      ]
-    },
     "Input": {
       "type": "object",
       "properties": {
@@ -155,69 +106,34 @@
     "Nixpkgs": {
       "type": "object",
       "properties": {
-        "allow_unfree": {
+        "allowUnfree": {
           "type": "boolean"
         },
-        "allow_unsupported_system": {
+        "allowBroken": {
           "type": "boolean"
         },
-        "allow_broken": {
+        "cudaSupport": {
           "type": "boolean"
         },
-        "allow_non_source": {
-          "type": "boolean"
-        },
-        "cuda_support": {
-          "type": "boolean"
-        },
-        "cuda_capabilities": {
+        "cudaCapabilities": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "rocm_support": {
-          "type": "boolean"
-        },
-        "permitted_insecure_packages": {
+        "permittedInsecurePackages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permitted_unfree_packages": {
+        "permittedUnfreePackages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "allowlisted_licenses": {
-          "description": "License names to allow (e.g. \"mit\", \"gpl3Only\").\nOnly applied in bootstrapLib.nix where lib.licenses is available;\nnot serialized to NIXPKGS_CONFIG since raw strings won't match license attrsets.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "writeOnly": true
-        },
-        "blocklisted_licenses": {
-          "description": "License names to block (e.g. \"unfree\", \"bsl11\").\nOnly applied in bootstrapLib.nix; not serialized to NIXPKGS_CONFIG.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "writeOnly": true
-        },
-        "android_sdk": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AndroidSdkConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "per_platform": {
+        "per-platform": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/NixpkgsConfig"
@@ -225,78 +141,35 @@
         }
       }
     },
-    "AndroidSdkConfig": {
-      "type": "object",
-      "properties": {
-        "accept_license": {
-          "type": "boolean"
-        }
-      }
-    },
     "NixpkgsConfig": {
       "type": "object",
       "properties": {
-        "allow_unfree": {
+        "allowUnfree": {
           "type": "boolean"
         },
-        "allow_unsupported_system": {
+        "allowBroken": {
           "type": "boolean"
         },
-        "allow_broken": {
+        "cudaSupport": {
           "type": "boolean"
         },
-        "allow_non_source": {
-          "type": "boolean"
-        },
-        "cuda_support": {
-          "type": "boolean"
-        },
-        "cuda_capabilities": {
+        "cudaCapabilities": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "rocm_support": {
-          "type": "boolean"
-        },
-        "permitted_insecure_packages": {
+        "permittedInsecurePackages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permitted_unfree_packages": {
+        "permittedUnfreePackages": {
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "allowlisted_licenses": {
-          "description": "License names to allow (e.g. \"mit\", \"gpl3Only\").\nOnly applied in bootstrapLib.nix where lib.licenses is available;\nnot serialized to NIXPKGS_CONFIG since raw strings won't match license attrsets.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "writeOnly": true
-        },
-        "blocklisted_licenses": {
-          "description": "License names to block (e.g. \"unfree\", \"bsl11\").\nOnly applied in bootstrapLib.nix; not serialized to NIXPKGS_CONFIG.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "writeOnly": true
-        },
-        "android_sdk": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AndroidSdkConfig"
-            },
-            {
-              "type": "null"
-            }
-          ]
         }
       }
     },

--- a/docs/src/devenv.schema.json
+++ b/docs/src/devenv.schema.json
@@ -3,17 +3,34 @@
   "title": "Config",
   "type": "object",
   "properties": {
+    "require_version": {
+      "description": "Version requirement for the devenv CLI.\nSet to `true` to enforce CLI matches the modules version,\nor a constraint string like `\">=2.0.0\"`.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RequireVersion"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "inputs": {
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/Input"
       }
     },
-    "allowUnfree": {
-      "type": "boolean"
+    "allow_unfree": {
+      "type": "boolean",
+      "deprecated": true
     },
-    "allowBroken": {
-      "type": "boolean"
+    "allow_unsupported_system": {
+      "type": "boolean",
+      "deprecated": true
+    },
+    "allow_broken": {
+      "type": "boolean",
+      "deprecated": true
     },
     "nixpkgs": {
       "anyOf": [
@@ -31,11 +48,12 @@
         "type": "string"
       }
     },
-    "permittedInsecurePackages": {
+    "permitted_insecure_packages": {
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "deprecated": true
     },
     "clean": {
       "anyOf": [
@@ -68,9 +86,40 @@
         "string",
         "null"
       ]
+    },
+    "reload": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "strict_ports": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "shell": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "$defs": {
+    "RequireVersion": {
+      "description": "Version requirement for the devenv CLI.\n\n- `true`: CLI version must match the modules version (checked during Nix evaluation)\n- A constraint string like `\">=2.0.0\"`: checked before Nix evaluation",
+      "anyOf": [
+        {
+          "description": "When true, CLI version must match the modules version",
+          "type": "boolean"
+        },
+        {
+          "description": "Version constraint string (e.g., \">=2.0.0\", \"2.0.7\")",
+          "type": "string"
+        }
+      ]
+    },
     "Input": {
       "type": "object",
       "properties": {
@@ -106,34 +155,69 @@
     "Nixpkgs": {
       "type": "object",
       "properties": {
-        "allowUnfree": {
+        "allow_unfree": {
           "type": "boolean"
         },
-        "allowBroken": {
+        "allow_unsupported_system": {
           "type": "boolean"
         },
-        "cudaSupport": {
+        "allow_broken": {
           "type": "boolean"
         },
-        "cudaCapabilities": {
+        "allow_non_source": {
+          "type": "boolean"
+        },
+        "cuda_support": {
+          "type": "boolean"
+        },
+        "cuda_capabilities": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permittedInsecurePackages": {
+        "rocm_support": {
+          "type": "boolean"
+        },
+        "permitted_insecure_packages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permittedUnfreePackages": {
+        "permitted_unfree_packages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "per-platform": {
+        "allowlisted_licenses": {
+          "description": "License names to allow (e.g. \"mit\", \"gpl3Only\").\nOnly applied in bootstrapLib.nix where lib.licenses is available;\nnot serialized to NIXPKGS_CONFIG since raw strings won't match license attrsets.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writeOnly": true
+        },
+        "blocklisted_licenses": {
+          "description": "License names to block (e.g. \"unfree\", \"bsl11\").\nOnly applied in bootstrapLib.nix; not serialized to NIXPKGS_CONFIG.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writeOnly": true
+        },
+        "android_sdk": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndroidSdkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "per_platform": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/NixpkgsConfig"
@@ -141,35 +225,78 @@
         }
       }
     },
+    "AndroidSdkConfig": {
+      "type": "object",
+      "properties": {
+        "accept_license": {
+          "type": "boolean"
+        }
+      }
+    },
     "NixpkgsConfig": {
       "type": "object",
       "properties": {
-        "allowUnfree": {
+        "allow_unfree": {
           "type": "boolean"
         },
-        "allowBroken": {
+        "allow_unsupported_system": {
           "type": "boolean"
         },
-        "cudaSupport": {
+        "allow_broken": {
           "type": "boolean"
         },
-        "cudaCapabilities": {
+        "allow_non_source": {
+          "type": "boolean"
+        },
+        "cuda_support": {
+          "type": "boolean"
+        },
+        "cuda_capabilities": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permittedInsecurePackages": {
+        "rocm_support": {
+          "type": "boolean"
+        },
+        "permitted_insecure_packages": {
           "type": "array",
           "items": {
             "type": "string"
           }
         },
-        "permittedUnfreePackages": {
+        "permitted_unfree_packages": {
           "type": "array",
           "items": {
             "type": "string"
           }
+        },
+        "allowlisted_licenses": {
+          "description": "License names to allow (e.g. \"mit\", \"gpl3Only\").\nOnly applied in bootstrapLib.nix where lib.licenses is available;\nnot serialized to NIXPKGS_CONFIG since raw strings won't match license attrsets.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writeOnly": true
+        },
+        "blocklisted_licenses": {
+          "description": "License names to block (e.g. \"unfree\", \"bsl11\").\nOnly applied in bootstrapLib.nix; not serialized to NIXPKGS_CONFIG.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "writeOnly": true
+        },
+        "android_sdk": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndroidSdkConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },

--- a/docs/src/reference/yaml-options.md
+++ b/docs/src/reference/yaml-options.md
@@ -1,16 +1,28 @@
 # devenv.yaml
 
+<!-- This file is auto-generated from devenv-core/src/config.rs doc comments. Do not edit. -->
+
+## backend
+
+Select the Nix backend used to evaluate `devenv.nix`.
+
+*Type:* `nix` · *Default:* `nix`
+
 ## clean.enabled
 
 Clean the environment when entering the shell.
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.0*
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 1.0"
 
 ## clean.keep
 
 A list of environment variables to keep when cleaning the environment.
 
-*Type:* `list of string` · *Default:* `[]` · *Added in 1.0*
+*Type:* `list of string` · *Default:* `[]`
+
+!!! tip "New in version 1.0"
 
 ## imports
 
@@ -23,7 +35,9 @@ See [Composing using imports](../composing-using-imports.md).
 
 Relax the hermeticity of the environment.
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.0*
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 1.0"
 
 ## inputs
 
@@ -45,12 +59,12 @@ See [Following inputs](../inputs.md#following-inputs).
 
 *Type:* `string`
 
-## inputs.\<name\>.inputs.\<name\>.follows
+## inputs.\<name\>.inputs
 
 Override nested inputs by name.
 See [Following inputs](../inputs.md#following-inputs).
 
-*Type:* `string`
+*Type:* `attribute set of input`
 
 ## inputs.\<name\>.overlays
 
@@ -66,18 +80,13 @@ See [Supported URI formats](../inputs.md#supported-uri-formats).
 
 *Type:* `string`
 
-## nixpkgs.android_sdk.accept_license
-
-Accept the Android SDK license.
-Can also be set via the `NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1` environment variable.
-
-*Type:* `boolean` · *Default:* `false`
-
 ## nixpkgs.allow_broken
 
 Allow packages marked as broken.
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.7*
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 1.7"
 
 ## nixpkgs.allow_non_source
 
@@ -85,17 +94,21 @@ Allow packages not built from source.
 
 *Type:* `boolean` · *Default:* `true` (nixpkgs default)
 
-## nixpkgs.allow_unsupported_system
-
-Allow packages that are not supported on the current system.
-
-*Type:* `boolean` · *Default:* `false` · *Added in 2.0.5*
-
 ## nixpkgs.allow_unfree
 
 Allow unfree packages.
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.7*
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 1.7"
+
+## nixpkgs.allow_unsupported_system
+
+Allow packages that are not supported on the current system.
+
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 2.0.5"
 
 ## nixpkgs.allowlisted_licenses
 
@@ -104,6 +117,13 @@ Uses nixpkgs license attribute names (e.g. `gpl3Only`, `mit`, `asl20`).
 See [nixpkgs license list](https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix).
 
 *Type:* `list of string` · *Default:* `[]`
+
+## nixpkgs.android_sdk.accept_license
+
+Accept the Android SDK license.
+Can also be set via the `NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1` environment variable.
+
+*Type:* `boolean` · *Default:* `false`
 
 ## nixpkgs.blocklisted_licenses
 
@@ -117,38 +137,50 @@ See [nixpkgs license list](https://github.com/NixOS/nixpkgs/blob/master/lib/lice
 
 Select CUDA capabilities for nixpkgs.
 
-*Type:* `list of string` · *Default:* `[]` · *Added in 1.7*
+*Type:* `list of string` · *Default:* `[]`
+
+!!! tip "New in version 1.7"
 
 ## nixpkgs.cuda_support
 
 Enable CUDA support for nixpkgs.
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.7*
+*Type:* `boolean` · *Default:* `false`
 
-## nixpkgs.rocm_support
+!!! tip "New in version 1.7"
 
-Enable ROCm support for nixpkgs.
+## nixpkgs.per_platform
 
-*Type:* `boolean` · *Default:* `false` · *Added in 2.0.7*
+Per-platform nixpkgs configuration.
+Accepts the same options as `nixpkgs`.
+
+*Type:* `attribute set of nixpkgs config`
+
+!!! tip "New in version 1.7"
 
 ## nixpkgs.permitted_insecure_packages
 
 A list of insecure permitted packages.
 
-*Type:* `list of string` · *Default:* `[]` · *Added in 1.7*
+*Type:* `list of string` · *Default:* `[]`
+
+!!! tip "New in version 1.7"
 
 ## nixpkgs.permitted_unfree_packages
 
 A list of unfree packages to allow by name.
 
-*Type:* `list of string` · *Default:* `[]` · *Added in 1.9*
+*Type:* `list of string` · *Default:* `[]`
 
-## nixpkgs.per_platform.\<system\>
+!!! tip "New in version 1.9"
 
-Per-platform nixpkgs configuration.
-Accepts the same options as `nixpkgs`.
+## nixpkgs.rocm_support
 
-*Type:* `attribute set of nixpkgs config` · *Added in 1.7*
+Enable ROCm support for nixpkgs.
+
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 2.0.7"
 
 ## profile
 
@@ -156,32 +188,53 @@ Default profile to activate.
 Can be overridden by `--profile` CLI flag.
 See [Profiles](../profiles.md).
 
-*Type:* `string` · *Added in 1.11*
+*Type:* `string`
+
+!!! tip "New in version 1.11"
 
 ## reload
 
 Enable auto-reload of the shell when files change.
 Can be overridden by `--reload` or `--no-reload` CLI flags.
 
-*Type:* `boolean` · *Default:* `true` · *Added in 2.0*
+*Type:* `boolean` · *Default:* `true`
+
+!!! tip "New in version 2.0"
+
+## require_version
+
+Version requirement for the devenv CLI.
+Set to `true` to enforce that the CLI version matches the modules version
+(from the `devenv` input), or use a constraint string with operators
+(`>=`, `<=`, `>`, `<`, `=`, or a bare version for an exact match).
+
+*Type:* `boolean | string`
+
+!!! tip "New in version 2.1"
 
 ## secretspec.enable
 
 Enable [secretspec integration](../integrations/secretspec.md).
 
-*Type:* `boolean` · *Default:* `false` · *Added in 1.8*
+*Type:* `boolean` · *Default:* `false`
+
+!!! tip "New in version 1.8"
 
 ## secretspec.profile
 
 Secretspec profile name to use.
 
-*Type:* `string` · *Added in 1.8*
+*Type:* `string`
+
+!!! tip "New in version 1.8"
 
 ## secretspec.provider
 
 Secretspec provider to use.
 
-*Type:* `string` · *Added in 1.8*
+*Type:* `string`
+
+!!! tip "New in version 1.8"
 
 ## shell
 
@@ -191,7 +244,9 @@ Falls back to the `$SHELL` environment variable, then `bash`.
 
 Supported values: `bash`, `zsh`, `fish`, `nu`. Any other value falls back to `bash`.
 
-*Type:* `string` · *Default:* `$SHELL` or `bash` · *Added in 2.1*
+*Type:* `string` · *Default:* `$SHELL` or `bash`
+
+!!! tip "New in version 2.1"
 
 ## strict_ports
 
@@ -200,25 +255,3 @@ Can be overridden by `--strict-ports` or `--no-strict-ports` CLI flags.
 
 *Type:* `boolean` · *Default:* `false`
 
-## require_version
-
-Require a specific devenv CLI version. Set to `true` to enforce that the CLI version matches
-the modules version (from the `devenv` input), or use a constraint string with operators.
-
-```yaml
-# Enforce CLI matches modules version (recommended for teams)
-require_version: true
-
-# Or use an explicit constraint
-require_version: ">=2.1"
-```
-
-Supported constraint operators: `>=`, `<=`, `>`, `<`, `=`, or a bare version for exact match.
-
-When set to `true`, the check happens during Nix evaluation and compares the CLI version
-against the version embedded in the `devenv` input. This keeps versions in sync automatically
-after running `devenv update`.
-
-*Type:* `boolean | string` · *Default:* not set
-
-!!! tip "New in version 2.1"


### PR DESCRIPTION
## Summary

- Add `devenv generate-yaml-options-doc` (hidden), a sibling to `generate-json-schema`, that walks the JSON schema produced by schemars for the `Config` struct and emits the `devenv.yaml` options reference as Markdown.
- Annotate `Config`, `Input`, `Clean`, `Nixpkgs`, `NixpkgsConfig`, `SecretspecConfig`, and `AndroidSdkConfig` fields with `///` doc comments.
- Regenerate `docs/src/reference/yaml-options.md` from those comments.
- Wire a new step into the existing `generate.yml` workflow to auto-commit the file on push and fail PRs if it would drift.

Doc-comment conventions parsed from trailing lines:

| Convention | Renders as |
|---|---|
| `Added in X.Y.` | `!!! tip \"New in version X.Y\"` admonition |
| ``Default: `<value>`.`` | `*Default:* <value>` |
| `Opaque.` | leaf section, no recursion into sub-fields |

Known compromises:

- Section order is strictly alphabetical (the manual file was grouped semantically).
- `inputs.<name>.inputs.<name>.follows` collapses to `inputs.<name>.inputs` via cycle detection.
- CI uses `cargo run --` rather than the installed `devenv` because the workflow is still pinned to v1.11.2.

## Test plan

- [ ] Run `devenv generate-yaml-options-doc` locally; confirm `docs/src/reference/yaml-options.md` is regenerated cleanly.
- [ ] Inspect rendered docs at `mkdocs serve` to confirm the `!!! tip` admonitions render.
- [ ] Verify the `generate.yml` workflow auto-commits the file on `push` and fails on drift.