### PR TITLE
hook: preserve _DEVENV_HOOK_DIR across env cleaning, align fish guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `devenv --profile <name> <subcommand>` failing when the profile name shadows a subcommand (e.g. `devenv --profile test test`). The profile value is now consumed before clap's subcommand precedence check ([#2821](https://github.com/cachix/devenv/issues/2821)).
 - Fixed Nix syntax errors in `devenv.nix` being reported as unrelated warnings (e.g. `warning: Ignoring the client-specified setting 'system'...`) instead of the actual syntax error. Warning-prefixed log entries emitted before the failing operation no longer shadow the real diagnostic ([#2820](https://github.com/cachix/devenv/issues/2820)).
+- Fixed the shell hook's "exit on cd-out" feature silently breaking under `clean.enabled = true`. `_DEVENV_HOOK_DIR` is now always preserved across env cleaning, so the hook-spawned shell still exits when the user `cd`s out of the project. Also aligned the fish hook's marker check with the posix one (non-empty value, not just "set").
 
 ### Improvements
 

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -236,14 +236,25 @@ pub struct Clean {
 }
 
 impl Clean {
+    /// Variables devenv requires internally and must survive env cleaning.
+    /// `_DEVENV_HOOK_DIR` marks shells spawned by `devenv hook`; the shell
+    /// hooks rely on its presence to know whether `cd`-ing out of the
+    /// project should exit the current shell.
+    const ALWAYS_KEEP: &'static [&'static str] = &["_DEVENV_HOOK_DIR"];
+
     /// Return host environment variables filtered by the clean/keep settings.
     ///
-    /// When `enabled`, only variables whose name appears in `keep` are
-    /// returned. Otherwise every host variable is returned.
+    /// When `enabled`, only variables whose name appears in `keep` or
+    /// `ALWAYS_KEEP` are returned. Otherwise every host variable is returned.
     pub fn kept_env_vars(&self) -> HashMap<String, String> {
         let vars = std::env::vars();
         if self.enabled {
-            let keep: HashSet<&str> = self.keep.iter().map(|s| s.as_str()).collect();
+            let keep: HashSet<&str> = self
+                .keep
+                .iter()
+                .map(|s| s.as_str())
+                .chain(Self::ALWAYS_KEEP.iter().copied())
+                .collect();
             vars.filter(|(key, _)| keep.contains(key.as_str()))
                 .collect()
         } else {

--- a/devenv/hooks/hook.fish
+++ b/devenv/hooks/hook.fish
@@ -9,7 +9,7 @@ function _devenv_hook --on-variable PWD
     # spawned below. `DEVENV_ROOT` alone is not enough: direnv (and other
     # tools) may export it into the user's outer shell, and an unguarded
     # `exit` there closes the terminal.
-    if set -q _DEVENV_HOOK_DIR; and set -q DEVENV_ROOT
+    if test -n "$_DEVENV_HOOK_DIR" -a -n "$DEVENV_ROOT"
         switch $PWD
             case "$DEVENV_ROOT" "$DEVENV_ROOT/*"
                 return


### PR DESCRIPTION
## Summary

Two follow-ups to #2815 (the cd-out-kills-terminal fix):

- **`clean.enabled = true` regression.** The hook fix relies on a private marker (`_DEVENV_HOOK_DIR`) reaching the user's interactive shell. With `clean.enabled = true` and the marker not listed in `clean.keep`, `Clean::kept_env_vars` was stripping it — so the hook-spawned shell silently stopped exiting on cd-out for that cohort. Adds an internal `ALWAYS_KEEP` set so devenv-private markers survive cleaning regardless of user config.
- **Fish/posix guard mismatch.** `hook.fish` used `set -q` (true on empty string) while `hook.posix.sh` used `-n` (false on empty). Aligned fish on the non-empty semantics so both shells agree.

## Test plan

- [x] `cargo nextest run -p devenv-core` — 155/155 pass
- [x] `cargo nextest run -p devenv --test hook_outer_shell_survives` — 4/4 pass (bash + fish, outer-survives + inner-exits)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p devenv-core -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)