### PR TITLE
cachix: apply netrc-file before adding substituters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed Nix syntax errors in `devenv.nix` being reported as unrelated warnings (e.g. `warning: Ignoring the client-specified setting 'system'...`) instead of the actual syntax error. Warning-prefixed log entries emitted before the failing operation no longer shadow the real diagnostic ([#2820](https://github.com/cachix/devenv/issues/2820)).
 - Fixed the shell hook's "exit on cd-out" feature silently breaking under `clean.enabled = true`. `_DEVENV_HOOK_DIR` is now always preserved across env cleaning, so the hook-spawned shell still exits when the user `cd`s out of the project. Also aligned the fish hook's marker check with the posix one (non-empty value, not just "set").
 - Fixed TUI panic ("attempt to read state after owner was dropped") when pressing Esc with content that fits in the viewport. The Esc handler now only scrolls when the ScrollView is actually mounted, matching the existing guard on up/down navigation.
+- Fixed private cachix caches failing with HTTP 401 on `nix-cache-info` after the v2.1 lazy cachix refactor. `apply_store_settings` now sets the `netrc-file` global before adding substituters, so the authenticated probe Nix sends when registering a private substituter picks up the credentials written by the cachix manager.
 
 ### Improvements
 

--- a/devenv-nix-backend/src/backend.rs
+++ b/devenv-nix-backend/src/backend.rs
@@ -1127,12 +1127,14 @@ impl NixCBackend {
         Ok(json_str)
     }
 
-    /// Apply substituters and trusted public keys to the open store.
+    /// Apply substituters, trusted public keys, and the netrc-file path
+    /// to the open store.
     ///
     /// Use after backend init when the cachix configuration has been
-    /// evaluated (the `netrc-file` global setting is the one piece that
-    /// must land before the store opens; everything else is additive
-    /// and can be applied here). Failures are logged warn but never
+    /// evaluated. The `netrc-file` global must land before
+    /// `add_substituter` runs — adding a substituter triggers an
+    /// authenticated `nix-cache-info` probe, and a private cache without
+    /// netrc would get 401. Failures are logged warn but never
     /// fatal — devenv continues without the cachix substituters.
     pub fn apply_store_settings(&self, store_settings: &StoreSettings) {
         // Open an eval scope on the bridge so substituter info fetches
@@ -1140,6 +1142,12 @@ impl NixCBackend {
         // inside the C call nest under the current TUI activity.
         let _eval_guard =
             devenv_activity::current_activity_id().map(|id| self.nix_log_bridge.begin_eval(id));
+        if let Some(netrc) = &store_settings.netrc_path
+            && let Some(s) = netrc.to_str()
+            && let Err(e) = settings::set("netrc-file", s).to_miette()
+        {
+            tracing::warn!("Failed to set netrc-file: {}", e);
+        }
         apply_substituters_and_keys(self.cnix_store.inner(), store_settings);
     }
 


### PR DESCRIPTION
## Summary

- The v2.1 lazy cachix refactor (6412b4de) moved cachix setup to run after `init_nix` and `open_store`. The new `apply_store_settings` only configured substituters and trusted keys — it never set the `netrc-file` global. With no other call site for `netrc-file` left, private caches in `cachix.pull` failed with HTTP 401 on `nix-cache-info` as soon as `store.add_substituter` was called.
- Apply `netrc-file` inside `apply_store_settings` *before* wiring up substituters. Nix re-reads `netrc-file` per HTTP request, so applying it after the store is open is fine for the cache-info probe and all later fetches.

## Repro

```nix
{
  cachix.pull = [ "your-private-cache" ];
}
```

With `CACHIX_AUTH_TOKEN` set, `devenv shell` in 2.1.x reliably fails with:

```
error: unable to download 'https://your-private-cache.cachix.org/nix-cache-info': HTTP error 401
```

## Test plan

- [ ] `devenv shell` against a private cachix cache succeeds with `CACHIX_AUTH_TOKEN` set
- [ ] Public caches still work unchanged
- [ ] `cargo build -p devenv-nix-backend` (verified locally)
- [ ] `cargo clippy -p devenv-nix-backend` (verified locally; only pre-existing warnings in `logger.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)