### PR TITLE
chore: update old nixos wiki link

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -140,7 +140,7 @@ in
     unsetEnvVars = lib.mkOption {
       type = types.listOf types.str;
       description = "A list of removed environment variables to make the shell/direnv more lean.";
-      # manually determined with knowledge from https://nixos.wiki/wiki/C
+      # manually determined with knowledge from https://wiki.nixos.org/wiki/C
       default = [
         "HOST_PATH"
         "NIX_BUILD_CORES"


### PR DESCRIPTION
I'm working on replacing all references to `nixos.wiki` with `wiki.nixos.org` across all nix-related repos. This increases visibility of the official wiki so that someday there will no longer be any confusion.