### PR TITLE
fix: prevent orphaned daemon processes on concurrent devenv up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Fixed orphaned daemon processes when a foreground `devenv up` was started while a daemon was already running. The foreground process would overwrite the daemon's PID file and socket, and on exit delete them — leaving the daemon and its children unmanageable. Foreground `up` now rejects with "Processes already running" when a daemon is active. Also prevented the throwaway manager in `devenv processes down` from deleting the daemon's runtime files on drop.
+
 ### Improvements
 
 - Cleaned up non-TUI console output: surfaces Nix eval/build progress, hides internal debug noise.

--- a/devenv-processes/src/manager.rs
+++ b/devenv-processes/src/manager.rs
@@ -224,6 +224,10 @@ pub struct NativeProcessManager {
     /// Optional notify handle fired when a process lifecycle changes (e.g. not-started
     /// process is manually started). The task system uses this to re-check dependencies.
     task_notify: Option<Arc<Notify>>,
+    /// Whether this instance owns the runtime files (socket, pid file) and should
+    /// clean them up on drop. Set to false for control-client instances that
+    /// connect to an existing daemon — they should not delete the daemon's files.
+    owns_runtime_files: bool,
 }
 
 /// Build a human-readable description of the readiness probe for TUI display.
@@ -438,7 +442,14 @@ impl NativeProcessManager {
             shutdown: CancellationToken::new(),
             processes_activity: Arc::new(RwLock::new(None)),
             task_notify: None,
+            owns_runtime_files: true,
         })
+    }
+
+    /// Mark this instance as a control client that should not clean up
+    /// runtime files (socket, pid file) on drop.
+    pub fn set_control_client(&mut self) {
+        self.owns_runtime_files = false;
     }
 
     /// Set the notify handle used to wake the task dependency loop
@@ -1927,8 +1938,13 @@ impl Drop for NativeProcessManager {
     fn drop(&mut self) {
         // Signal supervisors to exit so they don't keep running after the manager is gone
         self.shutdown_supervisors();
-        let _ = std::fs::remove_file(self.api_socket_path());
-        let _ = std::fs::remove_file(self.manager_pid_file());
+        // Only clean up runtime files if this instance owns them. Control-client
+        // instances (used by `devenv processes down`) should not delete the
+        // daemon's socket and pid file, as the daemon may still be shutting down.
+        if self.owns_runtime_files {
+            let _ = std::fs::remove_file(self.api_socket_path());
+            let _ = std::fs::remove_file(self.manager_pid_file());
+        }
     }
 }
 

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -1599,6 +1599,20 @@ impl Devenv {
                 return self.spawn_daemon_processes(config).await;
             }
 
+            // Check if a daemon is already running. Without this guard a
+            // foreground `devenv up` would overwrite the daemon's PID file
+            // and socket, and its Drop would delete them — orphaning the
+            // daemon and its child processes.
+            let pid_file = self.native_manager_pid_file();
+            if let Ok(processes::PidStatus::Running(pid)) =
+                processes::check_pid_file(&pid_file).await
+            {
+                bail!(
+                    "Processes already running with PID {}. Stop them first with: devenv processes down",
+                    pid
+                );
+            }
+
             let tasks_runner =
                 tasks::Tasks::builder(config, VerbosityLevel::Normal, self.shutdown.clone())
                     .build()
@@ -1798,9 +1812,12 @@ impl Devenv {
         // Determine which manager is running and create appropriate instance
         let manager: Box<dyn processes::ProcessManager> = if self.native_manager_pid_file().exists()
         {
-            // Native process manager is running
+            // Native process manager is running — create a control client
+            // that won't delete the daemon's runtime files on drop
             let runtime_dir = self.process_runtime_dir()?.clone();
-            Box::new(processes::NativeProcessManager::new(runtime_dir)?)
+            let mut manager = processes::NativeProcessManager::new(runtime_dir)?;
+            manager.set_control_client();
+            Box::new(manager)
         } else if self.processes_pid().exists() {
             // Process-compose is running
             // We don't need the procfile_script for stopping, just use a dummy path

--- a/tests/processes-daemon-down/.test-config.yml
+++ b/tests/processes-daemon-down/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/processes-daemon-down/.test.sh
+++ b/tests/processes-daemon-down/.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Test that the native process manager prevents orphaned daemon processes.
+#
+# Without the fix, a foreground `devenv up` would overwrite the daemon's PID
+# file and socket. When the foreground process exited, its Drop impl would
+# delete those files, orphaning the daemon and its children.
+
+set -ex
+
+PORT=18457
+
+wait_for_port() {
+  for i in $(seq 1 30); do
+    if curl -s -o /dev/null http://127.0.0.1:$PORT/ 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+port_free() {
+  ! curl -s -o /dev/null --connect-timeout 1 http://127.0.0.1:$PORT/ 2>/dev/null
+}
+
+wait_for_port_free() {
+  for i in $(seq 1 15); do
+    if port_free; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# === Test 1: up -d then down cleans up ===
+echo "--- Test 1: basic up -d / down ---"
+devenv up -d
+devenv processes wait
+wait_for_port
+devenv processes down
+wait_for_port_free || { echo "FAIL: port still bound after down"; exit 1; }
+echo "PASS: basic up -d / down"
+
+# === Test 2: foreground up rejects when daemon running ===
+echo "--- Test 2: foreground up rejects when daemon running ---"
+devenv up -d
+devenv processes wait
+wait_for_port
+
+# Try foreground up — should fail with "already running"
+# Use timeout so we don't wait for crash-looping processes if the guard is missing.
+if timeout 10 devenv up --no-tui 2>&1; then
+  echo "FAIL: foreground up should have been rejected"
+  devenv processes down || true
+  exit 1
+fi
+echo "Foreground up correctly rejected"
+
+# Daemon should still be healthy
+curl -s -o /dev/null http://127.0.0.1:$PORT/ || { echo "FAIL: daemon died"; exit 1; }
+devenv processes down
+sleep 1
+port_free || { echo "FAIL: port still bound"; exit 1; }
+echo "PASS: foreground up rejects when daemon running"
+
+# === Test 3: up -d / down / restart ===
+echo "--- Test 3: restart after down ---"
+devenv up -d
+devenv processes wait
+wait_for_port
+devenv processes down
+wait_for_port_free || { echo "FAIL: port bound before restart"; exit 1; }
+
+devenv up -d
+devenv processes wait
+wait_for_port || { echo "FAIL: restart failed"; exit 1; }
+devenv processes down
+sleep 1
+port_free || { echo "FAIL: port bound after second down"; exit 1; }
+echo "PASS: restart after down"
+
+# === Test 4: double down is safe ===
+echo "--- Test 4: double down ---"
+devenv up -d
+devenv processes wait
+devenv processes down
+wait_for_port_free || true
+# Second down should fail gracefully, not crash
+devenv processes down 2>&1 || true
+port_free || { echo "FAIL: port bound after double down"; exit 1; }
+echo "PASS: double down"
+
+echo "All daemon-down tests passed!"

--- a/tests/processes-daemon-down/devenv.nix
+++ b/tests/processes-daemon-down/devenv.nix
@@ -1,0 +1,9 @@
+# Test that a foreground `devenv up` refuses to start when a daemon is already
+# running, and that `devenv processes down` correctly stops the daemon without
+# leaving orphaned child processes.
+{ pkgs, ... }:
+{
+  packages = [ pkgs.python3 pkgs.curl ];
+  process.manager.implementation = "native";
+  processes.http.exec = "exec python3 -m http.server 18457";
+}


### PR DESCRIPTION
## Summary

- When a foreground `devenv up` was started while a daemon was already running (`devenv up -d`), it would overwrite the daemon's PID file and socket. On exit, its `Drop` impl deleted those files, leaving the daemon and its child processes orphaned — `devenv processes down` would report "No process manager is running" while the old processes kept ports bound.
- Added an "already running" guard to the foreground startup path (`up()` in `mod.rs`), matching the existing check in `spawn_daemon_processes()`.
- Marked the throwaway `NativeProcessManager` in `down()` as a control client so it does not delete the daemon's runtime files on drop.

## Test plan

- [x] New integration test `tests/processes-daemon-down/` with 4 sub-tests:
  1. Basic `up -d` / `down` lifecycle
  2. Foreground `up` rejects when daemon is already running (the primary fix)
  3. Restart after `down` works cleanly
  4. Double `down` fails gracefully
- [x] Verified test **fails without the fix** (foreground `up` orphans the daemon)
- [x] Verified test **passes with the fix**
- [x] All 125 existing unit tests pass (`cargo nextest run -p devenv-processes`)
- [x] `cargo fmt --check` and `cargo clippy` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)