### PR TITLE
feat: disable LSP in devenv docker image

### DIFF
--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -70,7 +70,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 devenv-nix-backend-macros.workspace = true
 
 [features]
-default = ["otlp-grpc"]
+default = ["otlp-grpc","lsp"]
 otlp = [
   "dep:opentelemetry",
   "dep:opentelemetry_sdk",
@@ -80,6 +80,7 @@ otlp = [
 otlp-grpc = ["otlp", "opentelemetry-otlp/grpc-tonic"]
 otlp-http-protobuf = ["otlp", "opentelemetry-otlp/http-proto"]
 otlp-http-json = ["otlp", "opentelemetry-otlp/http-json"]
+lsp = []
 test-all = [
   "test-mcp",
   "devenv-processes/test-all",

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -848,6 +848,7 @@ pub enum Commands {
         http: Option<Option<u16>>,
     },
 
+    #[cfg(feature = "lsp")]
     #[command(about = "Start the nixd language server for devenv.nix.")]
     Lsp {
         #[arg(long, help = "Print nixd configuration and exit")]

--- a/devenv/src/lib.rs
+++ b/devenv/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cli;
 pub mod commands;
 pub mod console;
 mod devenv;
+#[cfg(feature = "lsp")]
 pub mod lsp;
 pub mod mcp;
 pub mod nix_log_bridge;

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -230,12 +230,13 @@ fn resolve(cli: Cli, shutdown: Arc<Shutdown>) -> Result<(UiOptions, BackendOptio
             is_tty && !is_ci && !is_ai_agent()
         });
     // Some commands don't support the TUI regardless of user options.
-    let tui_unsupported = matches!(
-        &command,
-        Commands::Mcp { http: None } // stdio mode needs stderr for output
-                | Commands::Lsp { .. } // LSP needs direct stdout for protocol/config output
-                | Commands::PrintPaths // print output directly, no TUI needed
-    );
+    let tui_unsupported = match &command {
+        Commands::Mcp { http: None } => true,// stdio mode needs stderr for output
+        #[cfg(feature = "lsp")]
+        Commands::Lsp { .. } => true, // LSP needs direct stdout for protocol/config output
+        | Commands::PrintPaths // print output directly, no TUI needed
+        | _ => false,
+    };
     let tui = tui_requested && !tui_unsupported && !tracing_owns_terminal && !quiet;
 
     let ui = UiOptions {
@@ -969,6 +970,7 @@ async fn dispatch_command(
             devenv::mcp::run_mcp_server(mcp_options, http.map(|p| p.unwrap_or(8080))).await?;
             Ok(CommandResult::Done)
         }
+        #[cfg(feature = "lsp")]
         Commands::Lsp { print_config } => {
             devenv::lsp::run(devenv, print_config).await?;
             Ok(CommandResult::Done)

--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,7 @@
         // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           devenv-image = import ./containers/devenv/image.nix {
             inherit pkgs;
-            inherit (self.packages.${system}) devenv;
+            devenv = workspace.crates.devenv-for-container;
           };
         }
       );

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -56,7 +56,7 @@ let
   xtask = cargoNix.workspaceMembers.xtask.build;
 
   # Wrap the devenv binary with required paths
-  wrapDevenv = drv: stdenv.mkDerivation {
+  mkWrapDevenv = { withLsp ? true }: drv: stdenv.mkDerivation {
     pname = "devenv-wrapped";
     inherit version;
     src = drv;
@@ -71,6 +71,7 @@ let
         setDefaultLocaleArchive = lib.optionalString (glibcLocalesUtf8 != null) ''
           --set-default LOCALE_ARCHIVE ${glibcLocalesUtf8}/lib/locale/locale-archive
         '';
+        nixdPath = lib.optionalString withLsp ":${lib.getBin nixd}/bin";
       in
       ''
         mkdir -p $out/bin
@@ -79,11 +80,11 @@ let
         cp $devenvRunTests/bin/devenv-run-tests $out/bin/
 
         wrapProgram $out/bin/devenv \
-          --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin:${lib.getBin nixd}/bin" \
+          --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin${nixdPath}" \
           ${setDefaultLocaleArchive}
 
         wrapProgram $out/bin/devenv-run-tests \
-          --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin:${lib.getBin nixd}/bin" \
+          --prefix PATH ":" "$out/bin:${lib.getBin cachix}/bin${nixdPath}" \
           ${setDefaultLocaleArchive}
 
         # Generate manpages
@@ -105,6 +106,8 @@ let
 
     meta.mainProgram = "devenv";
   };
+
+  wrapDevenv = mkWrapDevenv { };
 in
 {
   inherit version;
@@ -115,6 +118,10 @@ in
   crates = {
     # Main devenv package with wrapping and shell completions
     devenv = wrapDevenv cargoNix.workspaceMembers.devenv.build;
+
+    # devenv built without LSP support for use in container images
+    devenv-for-container = (mkWrapDevenv { withLsp = false; })
+      (cargoNix.workspaceMembers.devenv.build.override { features = [ ]; });
 
     # devenv-tasks standalone
     devenv-tasks = cargoNix.workspaceMembers.devenv-tasks.build;


### PR DESCRIPTION
The changes gate the lsp feature behind #[cfg(feature = "lsp")] in Rust and build a devenv-for-container variant without nixd in the PATH wrapper, keeping nixd (and its 540 Mo LLVM dep) out of the image closure entirely.

see #2655 