### PR TITLE
hook: do not spawn nested devenv shell when DEVENV_ROOT is already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed orphaned daemon processes when a foreground `devenv up` was started while a daemon was already running. The foreground process would overwrite the daemon's PID file and socket, and on exit delete them — leaving the daemon and its children unmanageable. Foreground `up` now rejects with "Processes already running" when a daemon is active. Also prevented the throwaway manager in `devenv processes down` from deleting the daemon's runtime files on drop.
+- Fixed the shell hook spawning a nested `devenv shell` when the user manually entered `devenv shell` (so `DEVENV_ROOT` was set but `_DEVENV_HOOK_DIR` was not). The "already inside a devenv shell" early-return now keys off `DEVENV_ROOT` again, while the cd-out `exit` still requires `_DEVENV_HOOK_DIR` so direnv-exported `DEVENV_ROOT` in the outer shell does not close the terminal. Follow-up to [#2815](https://github.com/cachix/devenv/pull/2815).
 
 ### Improvements
 

--- a/devenv/hooks/hook.fish
+++ b/devenv/hooks/hook.fish
@@ -4,24 +4,29 @@
 set -q _DEVENV_HOOK_UNTRUSTED; or set -g _DEVENV_HOOK_UNTRUSTED ""
 
 function _devenv_hook --on-variable PWD
-    # Inside a hook-spawned devenv shell: exit when leaving the project
-    # directory. `_DEVENV_HOOK_DIR` is the marker — set only in shells we
-    # spawned below. `DEVENV_ROOT` alone is not enough: direnv (and other
-    # tools) may export it into the user's outer shell, and an unguarded
-    # `exit` there closes the terminal.
-    if test -n "$_DEVENV_HOOK_DIR" -a -n "$DEVENV_ROOT"
-        switch $PWD
-            case "$DEVENV_ROOT" "$DEVENV_ROOT/*"
-                return
-            case '*'
-                # Save target directory so the parent shell can cd there after exit
-                printf '%s' $PWD > "$DEVENV_ROOT/.devenv/exit-dir"
-                exit
+    # `DEVENV_ROOT` set means a devenv shell is already active — hook does
+    # nothing. Hook-spawned shells (marked by `_DEVENV_HOOK_DIR`) additionally
+    # `exit` when cd-ing outside the project so the parent shell can follow.
+    if test -n "$DEVENV_ROOT"
+        if test -n "$_DEVENV_HOOK_DIR"
+            switch $PWD
+                case "$DEVENV_ROOT" "$DEVENV_ROOT/*"
+                case '*'
+                    printf '%s' $PWD > "$DEVENV_ROOT/.devenv/exit-dir"
+                    exit
+            end
         end
+        return
     end
 
-    # stderr flows through so user sees the "not allowed" message
-    set -l project_dir (devenv hook-should-activate)
+    # Suppress stderr when retrying the same untrusted PWD (the "not allowed"
+    # message was already shown the first time round).
+    set -l project_dir
+    if test "$_DEVENV_HOOK_UNTRUSTED" = "$PWD"
+        set project_dir (devenv hook-should-activate 2>/dev/null)
+    else
+        set project_dir (devenv hook-should-activate)
+    end
     set -l exit_code $status
 
     if test $exit_code -eq 0 -a -n "$project_dir"
@@ -46,29 +51,11 @@ function _devenv_hook --on-variable PWD
 end
 
 function _devenv_hook_prompt --on-event fish_prompt
-    # Retry activation for untrusted directories after 'devenv allow'
-    if test -z "$_DEVENV_HOOK_UNTRUSTED"
-        return
-    end
-    # Inside devenv shell: no retry needed
-    if set -q DEVENV_ROOT
-        return
-    end
-
-    set -l project_dir (devenv hook-should-activate 2>/dev/null)
-    if test $status -eq 0 -a -n "$project_dir"
-        set -lx _DEVENV_HOOK_DIR $project_dir
-        fish --no-config -c 'cd -- $_DEVENV_HOOK_DIR; and devenv shell'
-        set -g _DEVENV_HOOK_UNTRUSTED ""
-        # If the devenv shell exited due to cd outside the project, follow the user there
-        set -l exit_dir_file "$project_dir/.devenv/exit-dir"
-        if test -f "$exit_dir_file"
-            set -l target_dir (cat "$exit_dir_file")
-            rm -f "$exit_dir_file"
-            if test -d "$target_dir"
-                builtin cd "$target_dir"
-            end
-        end
+    # Retry activation for untrusted directories after `devenv allow`.
+    # Delegate to `_devenv_hook` so the bail conditions and activation logic
+    # stay in one place.
+    if test -n "$_DEVENV_HOOK_UNTRUSTED"
+        _devenv_hook
     end
 end
 

--- a/devenv/hooks/hook.posix.sh
+++ b/devenv/hooks/hook.posix.sh
@@ -7,20 +7,19 @@ _devenv_hook() {
     local previous_exit_status=$?
     [[ "$_DEVENV_HOOK_PWD" == "$PWD" ]] && return $previous_exit_status
 
-    # Inside a hook-spawned devenv shell: exit when leaving the project
-    # directory. `_DEVENV_HOOK_DIR` is the marker — set only on shells we
-    # spawned below. `DEVENV_ROOT` alone is not enough: direnv (and other
-    # tools) may export it into the user's outer shell, and an unguarded
-    # `exit` there closes the terminal.
-    if [[ -n "${_DEVENV_HOOK_DIR:-}" && -n "${DEVENV_ROOT:-}" ]]; then
-        case "$PWD" in
-            "${DEVENV_ROOT}"|"${DEVENV_ROOT}"/*) ;;
-            *)
-                # Save target directory so the parent shell can cd there after exit
-                printf '%s' "$PWD" > "${DEVENV_ROOT}/.devenv/exit-dir"
-                exit $previous_exit_status
-                ;;
-        esac
+    # `DEVENV_ROOT` set means a devenv shell is already active — hook does
+    # nothing. Hook-spawned shells (marked by `_DEVENV_HOOK_DIR`) additionally
+    # `exit` when cd-ing outside the project so the parent shell can follow.
+    if [[ -n "${DEVENV_ROOT:-}" ]]; then
+        if [[ -n "${_DEVENV_HOOK_DIR:-}" ]]; then
+            case "$PWD" in
+                "${DEVENV_ROOT}"|"${DEVENV_ROOT}"/*) ;;
+                *)
+                    printf '%s' "$PWD" > "${DEVENV_ROOT}/.devenv/exit-dir"
+                    exit $previous_exit_status
+                    ;;
+            esac
+        fi
         _DEVENV_HOOK_PWD="$PWD"
         return $previous_exit_status
     fi

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -1,14 +1,52 @@
-//! Regression: shell-integration hooks must not call `exit` in the user's
-//! outer shell. Direnv (and similar tools) may export `DEVENV_ROOT` into the
-//! outer shell's env, and an unguarded `exit` on cd-out closes the terminal.
-//! See https://github.com/cachix/devenv/issues/2805
+//! Shell-hook regression tests for bash and fish. Each test asserts one
+//! behavior across all available shells; missing shells are skipped.
+//!
+//! - `outer_shell_survives_cd_out` — #2805: direnv-exported `DEVENV_ROOT`
+//!   in the user's outer shell must not turn cd-out into a terminal-killing
+//!   `exit`.
+//! - `inner_shell_exits_on_cd_out` — hook-spawned shells (marker:
+//!   `_DEVENV_HOOK_DIR`) must `exit` and write the exit-dir for the parent.
+//! - `no_respawn_inside_devenv_shell` — follow-up to #2815: a manually
+//!   entered `devenv shell` (no `_DEVENV_HOOK_DIR`) must not re-enter
+//!   activation and spawn a nested shell.
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::process::{Command, Output};
+use std::process::Command;
 
 fn devenv_bin() -> &'static str {
     env!("CARGO_BIN_EXE_devenv")
+}
+
+/// Available shells with the syntax needed to (a) source the hook from the
+/// real `devenv` binary and (b) override `PATH`.
+fn shells() -> Vec<(&'static str, String, fn(&Path) -> String)> {
+    let bash_src = format!(r#"eval "$({} hook bash)""#, devenv_bin());
+    let fish_src = format!("{} hook fish | source", devenv_bin());
+    [
+        ("bash", bash_src, bash_path_override as fn(&Path) -> String),
+        ("fish", fish_src, fish_path_override as fn(&Path) -> String),
+    ]
+    .into_iter()
+    .filter(|(s, _, _)| have(s))
+    .collect()
+}
+
+fn bash_path_override(dir: &Path) -> String {
+    format!(r#"export PATH="{}:$PATH""#, dir.display())
+}
+
+fn fish_path_override(dir: &Path) -> String {
+    format!("set -gx PATH {:?} $PATH", dir)
+}
+
+fn have(shell: &str) -> bool {
+    Command::new("sh")
+        .args(["-c", &format!("command -v {shell}")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 fn fake_project() -> tempfile::TempDir {
@@ -17,102 +55,81 @@ fn fake_project() -> tempfile::TempDir {
     tmp
 }
 
-fn run(shell: &str, script: &str) -> Output {
+fn run(shell: &str, script: &str) -> std::process::Output {
     Command::new(shell).arg("-c").arg(script).output().unwrap()
 }
 
-fn skip_if_missing(shell: &str) -> bool {
-    Command::new("sh")
-        .args(["-c", &format!("command -v {shell}")])
-        .output()
-        .map(|o| !o.status.success())
-        .unwrap_or(true)
-}
-
-/// Outer shell: `DEVENV_ROOT` set but `_DEVENV_HOOK_DIR` unset. cd-out must
-/// NOT terminate the shell.
-fn outer_shell_survives(shell: &str, hook_name: &str, source_cmd: &str, root: &Path) {
-    let script = format!(
-        r#"
-        export DEVENV_ROOT={root:?}
-        {source_cmd}
-        cd /
-        _devenv_hook
-        echo SURVIVED
-        "#,
-        root = root,
-        source_cmd = source_cmd,
-    );
-    let out = run(shell, &script);
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        stdout.contains("SURVIVED"),
-        "{shell} outer shell exited on cd-out via `devenv hook {hook_name}` (issue #2805).\n\
-         stdout: {stdout}\nstderr: {}",
-        String::from_utf8_lossy(&out.stderr),
-    );
-}
-
-/// Inner (hook-spawned) shell: both `_DEVENV_HOOK_DIR` and `DEVENV_ROOT`
-/// set. cd-out MUST exit the shell and write the exit-dir for the parent.
-fn inner_shell_exits(shell: &str, hook_name: &str, source_cmd: &str, root: &Path) {
-    let script = format!(
-        r#"
-        export DEVENV_ROOT={root:?}
-        export _DEVENV_HOOK_DIR={root:?}
-        {source_cmd}
-        cd /
-        _devenv_hook
-        echo SHOULD_NOT_REACH
-        "#,
-        root = root,
-        source_cmd = source_cmd,
-    );
-    let out = run(shell, &script);
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(
-        !stdout.contains("SHOULD_NOT_REACH"),
-        "{shell} inner shell did not exit on cd-out via `devenv hook {hook_name}`.\n\
-         stdout: {stdout}",
-    );
-    let exit_dir = fs::read_to_string(root.join(".devenv/exit-dir")).unwrap();
-    assert_eq!(exit_dir, "/", "{shell}: exit-dir should record cd target");
-}
-
 #[test]
-fn bash_outer_shell_survives_cd_out_when_only_devenv_root_set() {
-    let tmp = fake_project();
-    let src = format!(r#"eval "$({} hook bash)""#, devenv_bin());
-    outer_shell_survives("bash", "bash", &src, tmp.path());
-}
-
-#[test]
-fn bash_inner_shell_exits_on_cd_out_and_writes_exit_dir() {
-    let tmp = fake_project();
-    let src = format!(r#"eval "$({} hook bash)""#, devenv_bin());
-    inner_shell_exits("bash", "bash", &src, tmp.path());
-}
-
-#[test]
-fn fish_outer_shell_survives_cd_out_when_only_devenv_root_set() {
-    if skip_if_missing("fish") {
-        eprintln!("fish not in PATH; skipping");
-        return;
+fn outer_shell_survives_cd_out() {
+    for (shell, src, _) in shells() {
+        let tmp = fake_project();
+        let script = format!(
+            "export DEVENV_ROOT={root:?}\n{src}\ncd /\n_devenv_hook\necho SURVIVED\n",
+            root = tmp.path(),
+        );
+        let out = run(shell, &script);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("SURVIVED"),
+            "[{shell}] outer shell exited on cd-out (issue #2805).\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
     }
-    let tmp = fake_project();
-    // `_devenv_hook` is fish's PWD-change handler; calling it directly here
-    // mirrors what fish does on `cd` in an interactive session.
-    let src = format!("{} hook fish | source", devenv_bin());
-    outer_shell_survives("fish", "fish", &src, tmp.path());
 }
 
 #[test]
-fn fish_inner_shell_exits_on_cd_out_and_writes_exit_dir() {
-    if skip_if_missing("fish") {
-        eprintln!("fish not in PATH; skipping");
-        return;
+fn inner_shell_exits_on_cd_out() {
+    for (shell, src, _) in shells() {
+        let tmp = fake_project();
+        let script = format!(
+            "export DEVENV_ROOT={root:?}\nexport _DEVENV_HOOK_DIR={root:?}\n\
+             {src}\ncd /\n_devenv_hook\necho SHOULD_NOT_REACH\n",
+            root = tmp.path(),
+        );
+        let out = run(shell, &script);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !stdout.contains("SHOULD_NOT_REACH"),
+            "[{shell}] inner shell did not exit on cd-out.\nstdout: {stdout}",
+        );
+        let exit_dir = fs::read_to_string(tmp.path().join(".devenv/exit-dir")).unwrap();
+        assert_eq!(exit_dir, "/", "[{shell}] exit-dir should record cd target");
     }
-    let tmp = fake_project();
-    let src = format!("{} hook fish | source", devenv_bin());
-    inner_shell_exits("fish", "fish", &src, tmp.path());
+}
+
+#[test]
+fn no_respawn_inside_devenv_shell() {
+    for (shell, src, path_override) in shells() {
+        let tmp = fake_project();
+        // Shim `devenv` on PATH so any `hook-should-activate` / `shell`
+        // invocation from inside the hook is recorded.
+        let bin_dir = tempfile::tempdir().unwrap();
+        let calls = bin_dir.path().join("calls");
+        let fake = bin_dir.path().join("devenv");
+        fs::write(
+            &fake,
+            format!("#!/usr/bin/env bash\necho \"$@\" >> {:?}\nexit 0\n", calls),
+        )
+        .unwrap();
+        fs::set_permissions(&fake, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let script = format!(
+            "export DEVENV_ROOT={root:?}\ncd {root:?}\n{src}\n{po}\n_devenv_hook\necho DONE\n",
+            root = tmp.path(),
+            po = path_override(bin_dir.path()),
+        );
+        let out = run(shell, &script);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("DONE"),
+            "[{shell}] hook hung or exited unexpectedly.\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+        let recorded = fs::read_to_string(&calls).unwrap_or_default();
+        assert!(
+            recorded.is_empty(),
+            "[{shell}] hook re-invoked devenv from inside a manually-entered shell.\n\
+             Recorded:\n{recorded}",
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Follow-up to #2815 (reported by @sandydoo): running `devenv shell` manually spawned a second nested shell. With `DEVENV_ROOT` set but no `_DEVENV_HOOK_DIR`, the hook fell through to activation.
- after this PR: 
  - If DEVENV_ROOT` set → hook does nothing.
  - if `_DEVENV_HOOK_DIR` _additionally_ set → `exit` on cd-out so the parent shell can follow.

## Test plan

- [x] Bash + fish regression tests shim `devenv` on PATH and assert no `hook-should-activate` / `shell` call when `DEVENV_ROOT` is set and PWD matches
- [x] Verified red against current main, green with the fix
- [x] Existing #2805 outer-survives and inner-still-exits tests still pass
- [ ] CI green
