### PR TITLE
wiremock: support setting the --rootDir directly

### DIFF
--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -36777,6 +36777,32 @@ The port number for the HTTP server to listen on.
 
 
 
+## services.wiremock.rootDir
+
+
+
+Path to the WireMock root directory containing mappings and files.
+Cannot be set together with ` mappings `.
+See [https://wiremock.org/docs/standalone/java-jar/\#command-line-options](https://wiremock.org/docs/standalone/java-jar/\#command-line-options) for more information.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/services/wiremock.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/wiremock.nix)
+
+
+
 ## services.wiremock.verbose
 
 

--- a/docs/src/services/wiremock.md
+++ b/docs/src/services/wiremock.md
@@ -166,6 +166,32 @@ The port number for the HTTP server to listen on\.
 
 
 
+### services\.wiremock\.rootDir
+
+
+
+Path to the WireMock root directory containing mappings and files\.
+Cannot be set together with ` mappings `\.
+See [https://wiremock\.org/docs/standalone/java-jar/\#command-line-options](https://wiremock\.org/docs/standalone/java-jar/\#command-line-options) for more information\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github\.com/cachix/devenv/blob/main/src/modules/services/wiremock\.nix](https://github.com/cachix/devenv/blob/main/src/modules/services/wiremock.nix)
+
+
+
 ### services\.wiremock\.verbose
 
 

--- a/src/modules/services/wiremock.nix
+++ b/src/modules/services/wiremock.nix
@@ -8,7 +8,7 @@ let
   allocatedPort = config.processes.wiremock.ports.main.value;
 
   mappingsFormat = pkgs.formats.json { };
-  rootDir = pkgs.linkFarm "wiremock-root" [
+  generatedRootDir = pkgs.linkFarm "wiremock-root" [
     {
       name = "mappings/mappings.json";
       path = mappingsFormat.generate "mappings.json" {
@@ -16,6 +16,7 @@ let
       };
     }
   ];
+  effectiveRootDir = if cfg.rootDir != null then cfg.rootDir else generatedRootDir;
 in
 {
   options.services.wiremock = {
@@ -47,6 +48,15 @@ in
       default = false;
       description = ''
         Whether to log verbosely to stdout.
+      '';
+    };
+    rootDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to the WireMock root directory containing mappings and files.
+        Cannot be set together with `mappings`.
+        See <https://wiremock.org/docs/standalone/java-jar/#command-line-options> for more information.
       '';
     };
     mappings = mkOption {
@@ -85,12 +95,18 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.rootDir != null && cfg.mappings != [ ]);
+        message = "services.wiremock: 'rootDir' and 'mappings' cannot be set at the same time.";
+      }
+    ];
     processes.wiremock.ports.main.allocate = basePort;
     processes.wiremock.exec =
       let
         arguments = [
           "--port ${toString allocatedPort}"
-          "--root-dir ${rootDir}"
+          "--root-dir ${effectiveRootDir}"
         ]
         ++ lib.optional cfg.disableBanner "--disable-banner"
         ++ lib.optional cfg.verbose "--verbose";


### PR DESCRIPTION
Adds a rootDir option (null or absolute path, default null) to the WireMock service module, allowing users to point WireMock at an existing directory instead of generating one from the mappings option.

This is useful for projects that already have a WireMock collection used by integration tests