### PR TITLE
feat: Add `--include-envrc` flags to `init` command

### DIFF
--- a/devenv/init/envrc
+++ b/devenv/init/envrc
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+eval "$(devenv direnvrc)"
+
+# You can pass flags to the devenv command
+# For example: use devenv --impure --option services.postgres.enable:bool true
+use devenv

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -719,10 +719,10 @@ pub enum Commands {
     #[command(about = "Scaffold devenv.yaml, devenv.nix, and .gitignore.")]
     Init {
         target: Option<PathBuf>,
+        #[arg(long, help = "Skip .envrc file (default).")]
+        skip_envrc: bool,
         #[arg(long, help = "Include .envrc file.")]
-        envrc: bool,
-        #[arg(long, help = "Skip .envrc file.")]
-        no_envrc: bool,
+        no_skip_envrc: bool,
     },
 
     #[command(about = "Generate devenv.yaml and devenv.nix using AI")]

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -717,7 +717,13 @@ fn is_flag(arg: &std::ffi::OsString) -> bool {
 #[derive(Subcommand, Clone)]
 pub enum Commands {
     #[command(about = "Scaffold devenv.yaml, devenv.nix, and .gitignore.")]
-    Init { target: Option<PathBuf> },
+    Init {
+        target: Option<PathBuf>,
+        #[arg(long, help = "Include .envrc file.")]
+        envrc: bool,
+        #[arg(long, help = "Skip .envrc file.")]
+        no_envrc: bool,
+    },
 
     #[command(about = "Generate devenv.yaml and devenv.nix using AI")]
     Generate,

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -1439,4 +1439,76 @@ mod tests {
         assert_eq!(cli.shell_args.profiles, vec!["test".to_string()]);
         assert!(matches!(cli.command, Commands::Test { .. }));
     }
+
+    #[test]
+    fn init_command_skip_envrc_default() {
+        let argv = preprocess_profile_args(osargs(["devenv", "init"]));
+        let cli = Cli::parse_from(argv);
+        if let Commands::Init {
+            target,
+            skip_envrc,
+            no_skip_envrc,
+        } = cli.command
+        {
+            assert!(target.is_none());
+            assert!(!skip_envrc);
+            assert!(!no_skip_envrc);
+        } else {
+            panic!("Expected Init command");
+        }
+    }
+
+    #[test]
+    fn init_command_skip_envrc_flag() {
+        let argv = preprocess_profile_args(osargs(["devenv", "init", "--skip-envrc"]));
+        let cli = Cli::parse_from(argv);
+        if let Commands::Init {
+            target,
+            skip_envrc,
+            no_skip_envrc,
+        } = cli.command
+        {
+            assert!(target.is_none());
+            assert!(skip_envrc);
+            assert!(!no_skip_envrc);
+        } else {
+            panic!("Expected Init command");
+        }
+    }
+
+    #[test]
+    fn init_command_no_skip_envrc_flag() {
+        let argv = preprocess_profile_args(osargs(["devenv", "init", "--no-skip-envrc"]));
+        let cli = Cli::parse_from(argv);
+        if let Commands::Init {
+            target,
+            skip_envrc,
+            no_skip_envrc,
+        } = cli.command
+        {
+            assert!(target.is_none());
+            assert!(!skip_envrc);
+            assert!(no_skip_envrc);
+        } else {
+            panic!("Expected Init command");
+        }
+    }
+
+    #[test]
+    fn init_command_with_target_and_skip_envrc() {
+        let argv = preprocess_profile_args(osargs(["devenv", "init", "/tmp/test", "--skip-envrc"]));
+        let cli = Cli::parse_from(argv);
+        if let Commands::Init {
+            target,
+            skip_envrc,
+            no_skip_envrc,
+        } = cli.command
+        {
+            assert_eq!(target, Some(PathBuf::from("/tmp/test")));
+            assert!(skip_envrc);
+            assert!(!no_skip_envrc);
+        } else {
+            panic!("Expected Init command");
+        }
+    }
 }

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -721,12 +721,13 @@ pub enum Commands {
         target: Option<PathBuf>,
         #[arg(
             long,
+            conflicts_with = "no_skip_envrc",
+            help = "Skip .envrc file (default).",
             env = "DEVENV_SKIP_ENVRC",
-            value_parser = clap::builder::BoolishValueParser::new(),
-            help = "Skip .envrc file (default)."
+            value_parser = clap::builder::BoolishValueParser::new()
          )]
         skip_envrc: bool,
-        #[arg(long, help = "Include .envrc file.")]
+        #[arg(long, conflicts_with = "skip_envrc", help = "Include .envrc file.")]
         no_skip_envrc: bool,
     },
 

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -719,7 +719,12 @@ pub enum Commands {
     #[command(about = "Scaffold devenv.yaml, devenv.nix, and .gitignore.")]
     Init {
         target: Option<PathBuf>,
-        #[arg(long, help = "Skip .envrc file (default).")]
+        #[arg(
+            long,
+            env = "DEVENV_SKIP_ENVRC",
+            value_parser = clap::builder::BoolishValueParser::new(),
+            help = "Skip .envrc file (default)."
+         )]
         skip_envrc: bool,
         #[arg(long, help = "Include .envrc file.")]
         no_skip_envrc: bool,

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -721,14 +721,11 @@ pub enum Commands {
         target: Option<PathBuf>,
         #[arg(
             long,
-            conflicts_with = "no_skip_envrc",
-            help = "Skip .envrc file (default).",
-            env = "DEVENV_SKIP_ENVRC",
+            help = "Include .envrc file.",
+            env = "DEVENV_INCLUDE_ENVRC",
             value_parser = clap::builder::BoolishValueParser::new()
          )]
-        skip_envrc: bool,
-        #[arg(long, conflicts_with = "skip_envrc", help = "Include .envrc file.")]
-        no_skip_envrc: bool,
+        include_envrc: bool,
     },
 
     #[command(about = "Generate devenv.yaml and devenv.nix using AI")]
@@ -1446,67 +1443,44 @@ mod tests {
         let cli = Cli::parse_from(argv);
         if let Commands::Init {
             target,
-            skip_envrc,
-            no_skip_envrc,
+            include_envrc,
         } = cli.command
         {
             assert!(target.is_none());
-            assert!(!skip_envrc);
-            assert!(!no_skip_envrc);
+            assert!(!include_envrc);
         } else {
             panic!("Expected Init command");
         }
     }
 
     #[test]
-    fn init_command_skip_envrc_flag() {
-        let argv = preprocess_profile_args(osargs(["devenv", "init", "--skip-envrc"]));
+    fn init_command_include_envrc_flag() {
+        let argv = preprocess_profile_args(osargs(["devenv", "init", "--include-envrc"]));
         let cli = Cli::parse_from(argv);
         if let Commands::Init {
             target,
-            skip_envrc,
-            no_skip_envrc,
+            include_envrc,
         } = cli.command
         {
             assert!(target.is_none());
-            assert!(skip_envrc);
-            assert!(!no_skip_envrc);
+            assert!(include_envrc);
         } else {
             panic!("Expected Init command");
         }
     }
 
     #[test]
-    fn init_command_no_skip_envrc_flag() {
-        let argv = preprocess_profile_args(osargs(["devenv", "init", "--no-skip-envrc"]));
+    fn init_command_with_target_and_include_envrc() {
+        let argv =
+            preprocess_profile_args(osargs(["devenv", "init", "/tmp/test", "--include-envrc"]));
         let cli = Cli::parse_from(argv);
         if let Commands::Init {
             target,
-            skip_envrc,
-            no_skip_envrc,
-        } = cli.command
-        {
-            assert!(target.is_none());
-            assert!(!skip_envrc);
-            assert!(no_skip_envrc);
-        } else {
-            panic!("Expected Init command");
-        }
-    }
-
-    #[test]
-    fn init_command_with_target_and_skip_envrc() {
-        let argv = preprocess_profile_args(osargs(["devenv", "init", "/tmp/test", "--skip-envrc"]));
-        let cli = Cli::parse_from(argv);
-        if let Commands::Init {
-            target,
-            skip_envrc,
-            no_skip_envrc,
+            include_envrc,
         } = cli.command
         {
             assert_eq!(target, Some(PathBuf::from("/tmp/test")));
-            assert!(skip_envrc);
-            assert!(!no_skip_envrc);
+            assert!(include_envrc);
         } else {
             panic!("Expected Init command");
         }

--- a/devenv/src/commands/init.rs
+++ b/devenv/src/commands/init.rs
@@ -56,7 +56,7 @@ const TEMPLATES: &[Template] = &[
     },
 ];
 
-pub fn run(target: Option<&Path>, verbosity: VerbosityLevel, skip_envrc: bool) -> Result<()> {
+pub fn run(target: Option<&Path>, verbosity: VerbosityLevel, include_envrc: bool) -> Result<()> {
     let _console = devenv_console::install(verbosity);
 
     let target = match target {
@@ -71,7 +71,7 @@ pub fn run(target: Option<&Path>, verbosity: VerbosityLevel, skip_envrc: bool) -
         .wrap_err_with(|| format!("Failed to create {}", target.display()))?;
 
     for tmpl in TEMPLATES {
-        if tmpl.source == "envrc" && skip_envrc {
+        if tmpl.source == "envrc" && !include_envrc {
             continue;
         }
         let file = PROJECT_DIR.get_file(tmpl.source).ok_or_else(|| {

--- a/devenv/src/commands/init.rs
+++ b/devenv/src/commands/init.rs
@@ -45,13 +45,18 @@ const TEMPLATES: &[Template] = &[
         on_exists: OnExists::Confirm,
     },
     Template {
+        source: "envrc",
+        target: ".envrc",
+        on_exists: OnExists::Confirm,
+    },
+    Template {
         source: "gitignore",
         target: ".gitignore",
         on_exists: OnExists::Append,
     },
 ];
 
-pub fn run(target: Option<&Path>, verbosity: VerbosityLevel) -> Result<()> {
+pub fn run(target: Option<&Path>, verbosity: VerbosityLevel, skip_envrc: bool) -> Result<()> {
     let _console = devenv_console::install(verbosity);
 
     let target = match target {
@@ -66,6 +71,9 @@ pub fn run(target: Option<&Path>, verbosity: VerbosityLevel) -> Result<()> {
         .wrap_err_with(|| format!("Failed to create {}", target.display()))?;
 
     for tmpl in TEMPLATES {
+        if tmpl.source == "envrc" && skip_envrc {
+            continue;
+        }
         let file = PROJECT_DIR.get_file(tmpl.source).ok_or_else(|| {
             miette!(
                 "Bundled template {} is missing from the binary",

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -84,7 +84,7 @@ fn main_inner() -> Result<()> {
             } => {
                 let verbosity = resolve_verbosity(&cli.cli_options);
                 let skip_envrc =
-                    devenv_core::settings::flag(*skip_envrc, *no_skip_envrc).unwrap_or_default();
+                    devenv_core::settings::flag(*skip_envrc, *no_skip_envrc).unwrap_or(true);
                 return commands::init::run(target.as_deref(), verbosity, skip_envrc);
             }
             Commands::Inputs {

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -79,11 +79,12 @@ fn main_inner() -> Result<()> {
             }
             Commands::Init {
                 target,
-                envrc,
-                no_envrc,
+                skip_envrc,
+                no_skip_envrc,
             } => {
                 let verbosity = resolve_verbosity(&cli.cli_options);
-                let skip_envrc = devenv_core::settings::flag(*no_envrc, *envrc).unwrap_or_default();
+                let skip_envrc =
+                    devenv_core::settings::flag(*skip_envrc, *no_skip_envrc).unwrap_or_default();
                 return commands::init::run(target.as_deref(), verbosity, skip_envrc);
             }
             Commands::Inputs {

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -77,9 +77,14 @@ fn main_inner() -> Result<()> {
             Commands::DaemonProcesses { config_file } => {
                 return commands::daemon_processes::run(config_file);
             }
-            Commands::Init { target } => {
+            Commands::Init {
+                target,
+                envrc,
+                no_envrc,
+            } => {
                 let verbosity = resolve_verbosity(&cli.cli_options);
-                return commands::init::run(target.as_deref(), verbosity);
+                let skip_envrc = devenv_core::settings::flag(no_envrc, envrc).unwrap_or_default();
+                return commands::init::run(target.as_deref(), verbosity, skip_envrc);
             }
             Commands::Inputs {
                 command: InputsCommand::Add { name, url, follows },

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -83,7 +83,7 @@ fn main_inner() -> Result<()> {
                 no_envrc,
             } => {
                 let verbosity = resolve_verbosity(&cli.cli_options);
-                let skip_envrc = devenv_core::settings::flag(no_envrc, envrc).unwrap_or_default();
+                let skip_envrc = devenv_core::settings::flag(*no_envrc, *envrc).unwrap_or_default();
                 return commands::init::run(target.as_deref(), verbosity, skip_envrc);
             }
             Commands::Inputs {

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -79,13 +79,10 @@ fn main_inner() -> Result<()> {
             }
             Commands::Init {
                 target,
-                skip_envrc,
-                no_skip_envrc,
+                include_envrc,
             } => {
                 let verbosity = resolve_verbosity(&cli.cli_options);
-                let skip_envrc =
-                    devenv_core::settings::flag(*skip_envrc, *no_skip_envrc).unwrap_or(true);
-                return commands::init::run(target.as_deref(), verbosity, skip_envrc);
+                return commands::init::run(target.as_deref(), verbosity, *include_envrc);
             }
             Commands::Inputs {
                 command: InputsCommand::Add { name, url, follows },

--- a/docs/src/integrations/direnv.md
+++ b/docs/src/integrations/direnv.md
@@ -46,7 +46,7 @@ Create an `.envrc` file in your project directory with the following content:
 This file configures direnv to use devenv for shell activation.
 
 !!! note
-    `devenv init` does not create a `.envrc` file by default. Use `devenv init --no-skip-envrc` to include it.
+    `devenv init` does not create a `.envrc` file by default. Use `devenv init --include-envrc` to include it.
 
 ## Approving and loading the shell
 

--- a/docs/src/integrations/direnv.md
+++ b/docs/src/integrations/direnv.md
@@ -46,7 +46,7 @@ Create an `.envrc` file in your project directory with the following content:
 This file configures direnv to use devenv for shell activation.
 
 !!! note
-    `.envrc` is not created by `devenv init`. You need to create it manually.
+    `devenv init` does not create a `.envrc` file by default. Use `devenv init --no-skip-envrc` to include it.
 
 ## Approving and loading the shell
 


### PR DESCRIPTION
I recently upgraded to the latest devenv and noticed that `.envrc` is no longer generated by `devenv init`. I also came across the page announcing [native auto-activation without direnv](https://devenv.sh/integrations/direnv/), which includes the note:

> .envrc is not created by devenv init. You need to create it manually.

This PR aims to make `.envrc` generation more convenient by avoiding the need to manually copy and paste the snippet from the direnv documentation. Instead, it adds support for generating `.envrc` as part of `devenv init` when the `--include-envrc` flag is explicitly provided.

**Why not generate `.envrc` by default during `devenv init`?**

I’m not fully aware of the reasons behind removing `.envrc` from the default scaffolding. To stay aligned with the current behavior, this PR does not reintroduce it by default but instead makes it opt-in via a flag.

That said, the flag name (`--include-envrc`) may be somewhat confusing, and I’m open to suggestions for a clearer alternative.