### PR TITLE
shell: exit cleanly on terminal hangup instead of orphaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed stale task and option results that lingered when `devenv.nix` was edited while a command was already evaluating. The eval cache no longer stores results whose tracked input files were modified mid-evaluation, so the next run no longer needs `.devenv/nix-eval-cache.db*` to be wiped to see the new definitions ([#2745](https://github.com/cachix/devenv/issues/2745)).
 - Fixed long lines in `devenv shell` getting a hard newline inserted at the wrap point when copying to clipboard. The shell now preserves the soft-wrap when flushing wrapped output into the terminal's scrollback, so clipboard copy keeps the original single line ([#2865](https://github.com/cachix/devenv/issues/2865)).
 - Fixed files declared with the `files` option not being regenerated when an auto-loaded (`devenv allow`) shell reloaded after `devenv update`. enterShell tasks (including `devenv:files`) now re-run on hot-reload, matching a fresh shell entry, instead of only updating environment variables ([#2864](https://github.com/cachix/devenv/issues/2864)).
+- Fixed `devenv shell` lingering as a background process, often pinned at 100%+ CPU, after its terminal window or tab was closed. The shell now detects the controlling-terminal hangup and exits, terminating the inner shell with it, instead of orphaning and draining the battery ([#2845](https://github.com/cachix/devenv/issues/2845)).
 
 ### Improvements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-escape",
+ "signal-hook 0.4.4",
  "similar 3.1.0",
  "sqlx",
  "tempfile",

--- a/devenv-shell/src/lib.rs
+++ b/devenv-shell/src/lib.rs
@@ -36,7 +36,9 @@ pub use status_line::{
 };
 
 // Main session
-pub use session::{SessionConfig, SessionError, SessionIo, ShellSession, TuiHandoff};
+pub use session::{
+    SessionConfig, SessionError, SessionIo, ShellSession, TuiHandoff, terminate_active_shell,
+};
 
 // Re-export for convenience
 pub use portable_pty::{CommandBuilder, PtySize};

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -30,8 +30,8 @@ use libghostty_vt::style::{Style, StyleColor, Underline};
 use libghostty_vt::terminal::{Options as TerminalOptions, Point, Terminal};
 use portable_pty::PtySize;
 use std::fmt::Write as FmtWrite;
-use std::io::{self, IsTerminal, Read, Write};
-use std::sync::Arc;
+use std::io::{self, Read, Write};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::{mpsc as tokio_mpsc, oneshot};
@@ -40,6 +40,49 @@ use tokio::sync::{mpsc as tokio_mpsc, oneshot};
 const KEYBIND_TOGGLE_PAUSE: [u8; 2] = [0x1b, 0x04]; // Ctrl-Alt-D
 const KEYBIND_LIST_WATCHED: [u8; 2] = [0x1b, 0x17]; // Ctrl-Alt-W
 const KEYBIND_TOGGLE_ERROR: [u8; 2] = [0x1b, 0x05]; // Ctrl-Alt-E
+
+/// The inner shell's PTY for the currently running session, if any.
+///
+/// Lets the process-wide signal handler (which runs on its own OS thread, since
+/// tokio's signal delivery is unreliable across devenv's multiple runtimes)
+/// reach in and kill the inner shell on SIGINT/SIGTERM/SIGHUP. Without this the
+/// inner shell — which lives in its own session via the PTY — would outlive a
+/// terminated `devenv` and leave an orphan.
+static ACTIVE_SHELL_PTY: Mutex<Option<Arc<Pty>>> = Mutex::new(None);
+
+/// Kill the inner shell of the active session, if one is running.
+///
+/// Returns `true` if a shell was active (and was asked to die). Intended to be
+/// called from a signal handler thread; after this returns `true` the caller
+/// should exit the process — the inner shell won't outlive us.
+pub fn terminate_active_shell() -> bool {
+    let guard = ACTIVE_SHELL_PTY.lock().unwrap();
+    match guard.as_ref() {
+        Some(pty) => {
+            // kill() must stay non-blocking: the signal thread holds this lock
+            // across the call, and blocking here would stall signal handling.
+            let _ = pty.kill();
+            true
+        }
+        None => false,
+    }
+}
+
+/// Registers the active session's PTY for the lifetime of the guard.
+struct ActiveShellGuard;
+
+impl ActiveShellGuard {
+    fn register(pty: Arc<Pty>) -> Self {
+        *ACTIVE_SHELL_PTY.lock().unwrap() = Some(pty);
+        ActiveShellGuard
+    }
+}
+
+impl Drop for ActiveShellGuard {
+    fn drop(&mut self) {
+        *ACTIVE_SHELL_PTY.lock().unwrap() = None;
+    }
+}
 
 fn dump_row_from_cells(buf: &mut String, vt: &Terminal<'_, '_>, point: Point, cells: &[Cell]) {
     // TODO(libghostty-rs): Style::is_default() returns true for RGB-bg-only styles
@@ -645,6 +688,10 @@ impl ShellSession {
 
         let pty = Arc::new(Pty::spawn(initial_cmd, pty_size)?);
 
+        // Expose the inner shell to the signal handler so it can be killed if
+        // devenv is terminated; cleared when this session ends.
+        let _active_shell_guard = ActiveShellGuard::register(Arc::clone(&pty));
+
         // Handle TUI handoff if present
         if let Some(handoff) = handoff {
             // Signal TUI that initial build is complete and we're ready for terminal
@@ -663,9 +710,56 @@ impl ShellSession {
         tracing::trace!("session: raw mode active");
 
         let injected_stdin = io.stdin.is_some();
+        // Whether stdin is the real controlling terminal. Gates the cursor-position
+        // query and the hangup watchdog: both only make sense against a real TTY,
+        // not injected (tests) or piped (non-interactive) stdin.
+        let stdin_is_tty = !injected_stdin && crate::terminal::is_tty();
         let stdout_raw: Box<dyn Write + Send> = io.stdout.unwrap_or_else(|| Box::new(io::stdout()));
         let mut stdout: Box<dyn Write + Send> = Box::new(io::BufWriter::new(stdout_raw));
         let stdin_source: Box<dyn Read + Send> = io.stdin.unwrap_or_else(|| Box::new(io::stdin()));
+
+        // Hangup watchdog. When the controlling terminal hangs up (host terminal
+        // or tab closed) poll() reports POLLHUP on stdin. This is a belt-and-
+        // suspenders companion to the signal handler: a closed terminal also
+        // raises SIGHUP, but detecting the hangup directly guarantees we never
+        // linger as a CPU-burning orphan. Kills the inner shell, then exits.
+        #[cfg(unix)]
+        if stdin_is_tty {
+            use std::os::unix::io::AsRawFd;
+            let fd = io::stdin().as_raw_fd();
+            let pty_for_hangup = Arc::clone(&pty);
+            std::thread::Builder::new()
+                .name("session-hangup".into())
+                .spawn(move || {
+                    loop {
+                        // events = 0 → poll wakes only on POLLHUP/POLLERR/POLLNVAL
+                        // (always reported), never on readable input, so this
+                        // blocks until hangup instead of busy-looping.
+                        let mut pfd = libc::pollfd {
+                            fd,
+                            events: 0,
+                            revents: 0,
+                        };
+                        let r = unsafe { libc::poll(&mut pfd, 1, -1) };
+                        if r < 0 {
+                            if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                                continue;
+                            }
+                            break;
+                        }
+                        if pfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0 {
+                            let _ = pty_for_hangup.kill();
+                            // _exit, not process::exit: this thread isn't
+                            // registered with Boehm GC, so running atexit
+                            // handlers (GC/Nix teardown) from here can deadlock.
+                            // 128 + SIGHUP: a terminal hangup is a SIGHUP, even
+                            // though we detected it via poll() rather than the signal.
+                            unsafe { libc::_exit(128 + libc::SIGHUP) };
+                        }
+                    }
+                })
+                .expect("failed to spawn session-hangup thread");
+        }
 
         // Query cursor position FIRST before any terminal resets.
         // This tells us where TUI left the cursor after its final render.
@@ -673,7 +767,7 @@ impl ShellSession {
         // via stdin, so this would hang if stdin is not a TTY.
         // crossterm::cursor::position() handles the DSR query, parsing, and has a
         // built-in 2s timeout for environments that don't respond (Docker, CI).
-        let cursor_row = if !injected_stdin && io::stdin().is_terminal() {
+        let cursor_row = if stdin_is_tty {
             match crossterm::cursor::position() {
                 Ok((_col, row)) => row + 1, // crossterm returns 0-based, we need 1-based
                 Err(e) => {
@@ -853,21 +947,25 @@ impl ShellSession {
             )
         });
 
-        // Wait for VT thread without blocking the tokio runtime
-        let exit_code = tokio::task::spawn_blocking(move || {
+        // Wait for VT thread without blocking the tokio runtime.
+        let join_result = tokio::task::spawn_blocking(move || {
             vt_handle.join().unwrap_or(Err(SessionError::ChannelClosed))
         })
         .await
-        .map_err(|_| SessionError::ChannelClosed)??;
+        .map_err(|_| SessionError::ChannelClosed)
+        .and_then(|r| r);
 
+        // Always kill the inner shell and notify the coordinator, even when the
+        // VT thread failed. Otherwise an error here would skip teardown: the
+        // inner shell (in its own session) would be orphaned and the coordinator
+        // would wait forever for an `Exited` that never comes.
         let _ = pty.kill();
-
-        // Notify coordinator that shell exited
+        let exit_code = join_result.as_ref().ok().copied().flatten();
         if let Err(e) = event_tx.try_send(ShellEvent::Exited { exit_code }) {
             tracing::trace!("failed to send Exited event: {e}");
         }
 
-        Ok(exit_code)
+        join_result
     }
 
     /// Main event loop handling stdin, PTY output, and coordinator commands.
@@ -1270,5 +1368,62 @@ impl ShellSession {
 impl Default for ShellSession {
     fn default() -> Self {
         Self::with_defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portable_pty::CommandBuilder;
+
+    /// Regression test for devenv#2845: the signal handler must be able to find
+    /// and kill the active session's inner shell. If it can't, closing the
+    /// terminal leaves an orphaned `devenv` (and inner shell) burning CPU.
+    ///
+    /// This lives in the lib-test binary, the only place that touches the
+    /// process-global `ACTIVE_SHELL_PTY`, so it has exclusive access.
+    #[test]
+    fn terminate_active_shell_kills_registered_inner_shell() {
+        assert!(
+            !terminate_active_shell(),
+            "no session registered yet, nothing to terminate"
+        );
+
+        // A long-lived inner shell, registered the way `ShellSession::run` does.
+        let mut cmd = CommandBuilder::new("sleep");
+        cmd.arg("60");
+        let size = PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let pty = Arc::new(Pty::spawn(cmd, size).expect("spawn inner pty"));
+        let guard = ActiveShellGuard::register(Arc::clone(&pty));
+
+        // The signal handler path can now reach in and kill it.
+        assert!(terminate_active_shell(), "registered inner shell not found");
+
+        // Confirm the inner shell actually died. The kill is synchronous; the
+        // bounded poll is only a safety net against a hang.
+        let mut status = None;
+        for _ in 0..500 {
+            status = pty.try_wait().expect("try_wait");
+            if status.is_some() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            status.is_some(),
+            "inner shell still running after terminate_active_shell"
+        );
+
+        // Ending the session (dropping the guard) clears the registration.
+        drop(guard);
+        assert!(
+            !terminate_active_shell(),
+            "registration should be cleared when the session ends"
+        );
     }
 }

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -37,6 +37,7 @@ miette.workspace = true
 nix.workspace = true
 schemars.workspace = true
 serde.workspace = true
+signal-hook.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
 tempfile.workspace = true

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -23,7 +23,7 @@ use std::{
     os, panic,
     path::{Path, PathBuf},
     process::{self, Command},
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, Once, OnceLock, Weak},
     time::Duration,
 };
 use tempfile::TempDir;
@@ -460,6 +460,77 @@ fn handoff() -> (RenderSide, BackendSide) {
     )
 }
 
+/// Current shutdown handle for the signal thread to drive. Updated each `run()`
+/// (the secrets-retry loop builds a fresh `Shutdown` per attempt).
+static SIGNAL_SHUTDOWN: OnceLock<Mutex<Weak<Shutdown>>> = OnceLock::new();
+static SIGNAL_THREAD: Once = Once::new();
+
+/// Handle SIGINT/SIGTERM/SIGHUP on a dedicated OS thread.
+///
+/// We don't route these through `tokio::signal`: devenv runs several tokio
+/// runtimes (renderer, backend, owner) and tokio's signal delivery is tied to
+/// one runtime's driver, so signals were silently dropped while a shell session
+/// held the runtime — which is what left `devenv shell` orphaned (and burning
+/// CPU) when its terminal closed. A `signal-hook` thread is runtime-independent
+/// and uses sigaction (no signal-mask blocking), so child processes — including
+/// the inner shell — keep their normal signal behavior. (tokio signals are still
+/// used for non-lifecycle signals like SIGWINCH in the shell session.)
+///
+/// On a signal we always abort any in-flight Nix evaluation. If an interactive
+/// shell is running we kill its inner shell and exit immediately (the tokio
+/// teardown path isn't reliable while a shell session holds the runtime, and the
+/// inner shell, living in its own session, would otherwise be orphaned). For
+/// other commands we drive graceful shutdown; a second signal force-exits.
+fn install_signal_handler(shutdown: &Arc<Shutdown>) {
+    let slot = SIGNAL_SHUTDOWN.get_or_init(|| Mutex::new(Weak::new()));
+    *slot.lock().unwrap() = Arc::downgrade(shutdown);
+
+    SIGNAL_THREAD.call_once(|| {
+        use signal_hook::consts::{SIGHUP, SIGINT, SIGTERM};
+        use signal_hook::iterator::Signals;
+
+        let mut signals = match Signals::new([SIGINT, SIGTERM, SIGHUP]) {
+            Ok(signals) => signals,
+            Err(e) => {
+                tracing::warn!("failed to install signal handler: {e}");
+                return;
+            }
+        };
+
+        std::thread::Builder::new()
+            .name("devenv-signals".into())
+            .spawn(move || {
+                for signal in signals.forever() {
+                    // Abort any in-flight Nix evaluation so it stops promptly.
+                    devenv_nix_backend::trigger_interrupt();
+
+                    if devenv_shell::terminate_active_shell() {
+                        // An interactive shell is running: its inner shell has
+                        // been killed; exit now. Use _exit, not process::exit:
+                        // this thread isn't registered with Boehm GC, and
+                        // running atexit handlers (GC/Nix teardown) from here can
+                        // deadlock. The tokio teardown path is also unreliable
+                        // while a shell session holds the runtime.
+                        unsafe { nix::libc::_exit(128 + signal) };
+                    }
+
+                    // Other commands: drive graceful shutdown; a second signal
+                    // force-exits.
+                    match SIGNAL_SHUTDOWN
+                        .get()
+                        .and_then(|m| m.lock().unwrap().upgrade())
+                    {
+                        Some(shutdown) => shutdown.handle_interrupt(),
+                        // No live Shutdown to drive (between run() attempts): the
+                        // Nix interrupt above already fired, so nothing else to do.
+                        None => tracing::debug!("signal received with no active shutdown handle"),
+                    }
+                }
+            })
+            .expect("failed to spawn devenv-signals thread");
+    });
+}
+
 /// Single entry point for all command execution.
 ///
 /// Both TUI and direct modes share the same structure:
@@ -467,6 +538,9 @@ fn handoff() -> (RenderSide, BackendSide) {
 /// 2. Backend runs on a dedicated GC-registered thread
 /// 3. TUI runs on the main thread (if enabled), otherwise we just wait
 fn run(ui: UiOptions, backend: BackendOptions, shutdown: Arc<Shutdown>) -> Result<()> {
+    // Install the signal handler before spawning the backend/worker threads.
+    install_signal_handler(&shutdown);
+
     let (renderer, _activity_guard) = Renderer::init(&ui);
 
     let _tracing_guard = devenv_tracing::init_tracing(ui.log_level, &ui.tracing_specs);
@@ -502,8 +576,6 @@ fn run(ui: UiOptions, backend: BackendOptions, shutdown: Arc<Shutdown>) -> Resul
         .stack_size(devenv_nix_backend::NIX_STACK_SIZE)
         .spawn(move || {
             build_gc_runtime().block_on(async {
-                shutdown_clone.install_signals().await;
-
                 let output = run_backend(backend, shutdown_clone.clone(), backend_side).await;
 
                 // Fallback for paths that didn't run cleanup themselves


### PR DESCRIPTION
## Summary

Fixes [#2845](https://github.com/cachix/devenv/issues/2845): `devenv shell` could linger as a background process, often pinned at 100%+ CPU, after its terminal window or tab was closed.

**Root cause:** devenv runs several tokio runtimes (renderer, backend, owner) and `tokio::signal` ties delivery to a single runtime's driver, so SIGHUP/SIGINT/SIGTERM were silently dropped while a shell session held the runtime. The shell was never told to exit, and the inner shell (in its own PTY session) outlived it.

**Fix:**
- Handle SIGINT/SIGTERM/SIGHUP on a dedicated `signal-hook` OS thread — runtime-independent and `sigaction`-based (no signal-mask blocking, so child processes keep normal signal behavior). On a signal it aborts any in-flight Nix eval; if a shell is active it kills the inner shell and exits, otherwise drives graceful shutdown (second signal force-exits).
- A POLLHUP watchdog on stdin detects controlling-terminal hangup directly (belt-and-suspenders — a closed terminal is exactly what a closed VS Code tab does).
- Teardown threads use `_exit` rather than `process::exit`, because running atexit handlers (Boehm GC / Nix) from a non-GC-registered thread can deadlock.
- Hardened the session so a VT-thread error always kills the PTY and notifies the coordinator, instead of orphaning the inner shell and hanging coordinator teardown.
- Added a regression test (`terminate_active_shell_kills_registered_inner_shell`).

## Test plan

Verified on Linux with a PTY harness driving the real event loop — all teardown paths exit in ~1s and kill the inner shell, no orphan/spin/hang:

- [x] Close controlling terminal → exit 129, inner shell gone
- [x] `kill -HUP` → exit 129, inner shell gone
- [x] `kill -TERM` → exit 143, inner shell gone
- [x] Normal `exit` → exit 0 (graceful), inner shell gone
- [x] `devenv shell -- echo` still works (rc 0, no regression)
- [x] `cargo nextest -p devenv-shell` → 131/131 pass; fmt + clippy clean
- [ ] **macOS** smoke test: close a VS Code tab running `devenv shell`, confirm no `.devenv-wrap` lingers
- [ ] Ctrl-C during `devenv up` / `build` / `test` (signal handling now applies to all commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)