### PR TITLE
Run interactive processes directly on the PTY

### DIFF
--- a/src/modules/process-managers/process-compose.nix
+++ b/src/modules/process-managers/process-compose.nix
@@ -178,6 +178,11 @@ in
               let
                 command =
                   if !value.start.enable then value.exec
+                  # Interactive processes must be a direct child of the process-compose PTY.
+                  # Routing them through `devenv-tasks` pipes their stdout/stderr and breaks
+                  # interactivity (no prompt, block-buffered output). They therefore bypass
+                  # the task runner and lose before/after task-dependency handling.
+                  else if value.process-compose.is_interactive or false then value.exec
                   else if value.process-compose.is_elevated or false
                   then config.process.taskCommandsBase.${name}
                   else config.process.taskCommands.${name};

--- a/tests/process-compose-interactive/devenv.nix
+++ b/tests/process-compose-interactive/devenv.nix
@@ -1,0 +1,37 @@
+{ pkgs, lib, config, ... }:
+let
+  pcProcesses = config.process.managers.process-compose.settings.processes;
+in
+{
+  process.manager.implementation = "process-compose";
+
+  # An interactive process must be a direct child of the process-compose PTY.
+  # Routing it through the `devenv-tasks` runner pipes its stdout/stderr and
+  # breaks interactivity (no prompt, block-buffered output). Its generated
+  # `command` must therefore be the raw `exec`, not the devenv-tasks wrapper.
+  processes.repl = {
+    exec = "python3";
+    process-compose.is_interactive = true;
+  };
+
+  # A regular process must still be routed through `devenv-tasks` so that
+  # task-dependency handling and env injection keep working.
+  processes.web = {
+    exec = "sleep infinity";
+  };
+
+  assertions = [
+    {
+      assertion = pcProcesses.repl.command == "python3";
+      message = "interactive process should run `exec` directly, not via devenv-tasks. Got: ${pcProcesses.repl.command}";
+    }
+    {
+      assertion = lib.hasInfix "devenv-tasks" pcProcesses.web.command;
+      message = "non-interactive process should still route through devenv-tasks. Got: ${pcProcesses.web.command}";
+    }
+  ];
+
+  enterTest = ''
+    echo "interactive process command assertions passed"
+  '';
+}


### PR DESCRIPTION
I was seeing interactive processes via process-compose (`process-compose.is_interactive = true`)
not properly receiving input:

<img width="1600" height="751" alt="Screenshot of process-compose running a Python3 REPL interactive process that ignores input" src="https://github.com/user-attachments/assets/85b8b15a-dadf-4a06-afc8-2dfb653b9dea" />

Claude says it's because devenv-tasks capture the child's stdout/stderr on pipes, causing the interactive program to never own the process-compose PTY for output. And thus: no prompt appeared, output was block-buffered, and a REPL looked dead.

With this change interactive processes now bypass devenv-tasks and use their `exec` directly, so process-compose runs them straight on its PTY.

But.. that also means an interactive process no longer goes through devenv-tasks, so its before/after task dependencies and DEVENV_TASK_* env injection mechanisms are not applied. Is that acceptable?

I'm not sure that I'm enough of an expert to understand the full implication of this change, and I can't seem to run the tests locally (getting `Problem with the SSL CA cert` errors) so I worked blind. But I'm providing this PR in case a maintainer can verify it adds value or can provide feedback on how this might be better approached.