### PR TITLE
Fix `devenv test --no-tui` swallowing all test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed stale task and option results that lingered when `devenv.nix` was edited while a command was already evaluating. The eval cache no longer stores results whose tracked input files were modified mid-evaluation, so the next run no longer needs `.devenv/nix-eval-cache.db*` to be wiped to see the new definitions ([#2745](https://github.com/cachix/devenv/issues/2745)).
 - Fixed long lines in `devenv shell` getting a hard newline inserted at the wrap point when copying to clipboard. The shell now preserves the soft-wrap when flushing wrapped output into the terminal's scrollback, so clipboard copy keeps the original single line ([#2865](https://github.com/cachix/devenv/issues/2865)).
 - Fixed files declared with the `files` option not being regenerated when an auto-loaded (`devenv allow`) shell reloaded after `devenv update`. enterShell tasks (including `devenv:files`) now re-run on hot-reload, matching a fresh shell entry, instead of only updating environment variables ([#2864](https://github.com/cachix/devenv/issues/2864)).
+- Fixed `devenv test --no-tui` (and any other non-TUI invocation) silently discarding all output from the `enterTest` script, so the test runner's output, traces, and failure messages never reached the terminal or CI logs. Output from commands run in the shell is now printed in non-TUI mode.
 
 ### Improvements
 

--- a/devenv/src/console.rs
+++ b/devenv/src/console.rs
@@ -247,7 +247,10 @@ impl ConsoleOutput {
             ActivityEvent::Operation(Operation::Complete { id, outcome, .. }) => {
                 self.end(id, outcome)
             }
-            ActivityEvent::Operation(_) => {}
+            ActivityEvent::Operation(Operation::Log {
+                id, line, is_error, ..
+            }) => self.log(id, &line, is_error),
+            ActivityEvent::Operation(Operation::Progress { .. }) => {}
 
             ActivityEvent::Message(msg) => self.message(msg.level, &msg.text),
             ActivityEvent::SetExpected(_) | ActivityEvent::Shell(_) => {}


### PR DESCRIPTION
## Summary

In `--no-tui` mode (CI, `DEVENV_TUI=false`, headless sessions), the stdout/stderr produced by the `enterTest` script — the test runner output, `set -x` traces, helper-script output, everything the user actually cares about — never reached the terminal.

The test script ran to completion and its exit status was honored, but the non-TUI console renderer in `devenv/src/console.rs` had a catch-all match arm that silently discarded `Operation::Log` events. Every other activity type (`Build`, `Task`, `Command`, `Process`, `Evaluate`) had a matching `::Log` arm; `Operation` was the only one missing it.

This affected **every** caller of `Devenv::run_in_shell` (which wraps its child in an `operation` activity), but the most visible victim was `devenv test`, whose Phase 5 runs the `enterTest` script through that helper.

```
$ devenv test --no-tui --verbose
…
• Running tests
✓ Running tests in 199s        ← ran for 199s, zero output in between
• Tests passed :)
```

## Root cause

Child output flows through the activity event bus to two independent consumers. The TUI renderer handled `Operation::Log`; the non-TUI console renderer dropped it through `Operation(_) => {}`.

```mermaid
flowchart TD
    Child["enterTest child process<br/>stdout / stderr"] --> RIS["run_in_shell<br/>reads each line"]
    RIS --> Log["activity.log() / activity.error()"]
    Log --> Make["make_log_event()"]
    Make --> Bus(["ActivityEvent::Operation(Operation::Log)<br/>on the event bus"])

    Bus --> TUI["TUI renderer"]
    Bus --> Console["console.rs handle()<br/>(non-TUI)"]

    TUI --> Screen([Visible on screen ✓])

    Console --> Match{"match event"}
    Match -->|"Operation::Start / Complete"| Begin([rendered ✓])
    Match -->|"Operation(_) => {}"| Drop([❌ line dropped on the floor])

    style Drop fill:#ffd6d6,stroke:#cc0000,color:#7a0000
    style Bus fill:#e6f0ff,stroke:#3366cc,color:#13366b
    style Screen fill:#d6ffd6,stroke:#009900,color:#0a5a0a
    style Begin fill:#d6ffd6,stroke:#009900,color:#0a5a0a
```

## The fix

One-line change in `devenv/src/console.rs`, mirroring the pattern used for every other activity type:

```diff
-            ActivityEvent::Operation(_) => {}
+            ActivityEvent::Operation(Operation::Log {
+                id, line, is_error, ..
+            }) => self.log(id, &line, is_error),
+            ActivityEvent::Operation(Operation::Progress { .. }) => {}
```

The explicit `Progress` arm replaces the catch-all so that any future variant added to `Operation` fails the exhaustiveness check at compile time instead of silently disappearing again — matching how `Task::Progress` / `Process::Status` are already handled in the same `match`.

## Verification

- `cargo build -p devenv` — clean (exit 0).
- After the patch, `devenv test --no-tui` prints the full `set -x` trace and every line of test-runner output, indented under the parent "Running tests" entry (same `self.log(...)` codepath as `Task::Log` / `Process::Log`, so no new formatting).

## Affected versions

`main` (verified at `e5f1a41c`) and released versions back through at least `v2.1.2`.
