### PR TITLE
cachix: allow overriding the secretspec secret name for the auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Improvements
 
-- Cachix now authenticates pulls and pushes without `CACHIX_AUTH_TOKEN` exported in the environment: when the variable is unset, devenv resolves the token from a `CACHIX_AUTH_TOKEN` secretspec secret, then from the auth token stored by the Cachix CLI (`cachix authtoken`) in `~/.config/cachix/cachix.dhall`. The resolved token is passed to the cachix push daemon as well.
+- Cachix now authenticates pulls and pushes without `CACHIX_AUTH_TOKEN` exported in the environment: when the variable is unset, devenv resolves the token from a `CACHIX_AUTH_TOKEN` secretspec secret, then from the auth token stored by the Cachix CLI (`cachix authtoken`) in `~/.config/cachix/cachix.dhall`. The resolved token is passed to the cachix push daemon as well. The secretspec secret name is configurable via `secretspec.cachix_auth_token` in `devenv.yaml` for backends whose policy (e.g. an OpenBao/Vault policy) only grants access to the token under a different name.
 - `devenv repl` now exposes `inputs` alongside `devenv` and `pkgs`, so you can inspect inputs declared in `devenv.yaml` directly from the REPL (e.g. `inputs.nixpkgs.lib.version`).
 - The TUI now shows each process's state as a status dot whose shape encodes the lifecycle (waiting, starting, running, ready, stopped, failed) instead of an identical spinner on every process. The shape carries the state so it reads without relying on color; transient states gently pulse to signal progress.
 - Cleaned up non-TUI console output: surfaces Nix eval/build progress, hides internal debug noise.

--- a/devenv-core/src/cachix.rs
+++ b/devenv-core/src/cachix.rs
@@ -13,9 +13,13 @@ use std::sync::{Arc, OnceLock};
 use tokio::sync::OnceCell;
 use tracing::{debug, warn};
 
-/// Name of the environment variable holding the Cachix auth token, also
-/// used as the secretspec secret name. Single source of truth so the
-/// env-read, secretspec lookup, and daemon child env can't drift.
+/// Name of the environment variable holding the Cachix auth token, and
+/// the default secretspec secret name when no override is provided.
+///
+/// The env-read and the child-process env passed to the cachix push
+/// daemon both always use this exact name (that's what the cachix CLI
+/// reads). Only the secretspec lookup key is overridable, via the
+/// `secretspec.cachix_auth_token` option in `devenv.yaml`.
 pub const CACHIX_AUTH_TOKEN_ENV: &str = "CACHIX_AUTH_TOKEN";
 
 /// Paths specific to Cachix operations

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -399,6 +399,7 @@ pub struct Config {
 }
 
 #[derive(schematic::Config, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub struct SecretspecConfig {
     /// Enable [secretspec integration](../integrations/secretspec.md).
     ///
@@ -418,6 +419,19 @@ pub struct SecretspecConfig {
     /// Added in 1.8.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub provider: Option<String>,
+    /// Name of the secretspec secret to read the Cachix auth token from
+    /// when `CACHIX_AUTH_TOKEN` is not set in the environment.
+    ///
+    /// This is the secret name declared in `secretspec.toml`, not the
+    /// token value. Use this when your secretspec backend (e.g. an
+    /// OpenBao/Vault policy) only grants access to a secret under a name
+    /// other than the default `CACHIX_AUTH_TOKEN`.
+    ///
+    /// Default: `CACHIX_AUTH_TOKEN`.
+    ///
+    /// Added in 2.1.3.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub cachix_auth_token: Option<String>,
 }
 
 // TODO: https://github.com/moonrepo/schematic/issues/105

--- a/devenv-core/src/settings.rs
+++ b/devenv-core/src/settings.rs
@@ -353,6 +353,7 @@ impl SecretSettings {
                 enable,
                 provider: options.secretspec_provider.or(base.provider),
                 profile: options.secretspec_profile.or(base.profile),
+                cachix_auth_token: base.cachix_auth_token,
             })
         } else {
             config.secretspec.clone()
@@ -695,7 +696,7 @@ mod tests {
             secretspec: Some(SecretspecConfig {
                 enable: true,
                 provider: Some("gcp".into()),
-                profile: None,
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -716,6 +717,7 @@ mod tests {
                 enable: true,
                 provider: Some("gcp".into()),
                 profile: Some("prod".into()),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -734,6 +736,7 @@ mod tests {
                 enable: true,
                 provider: Some("gcp".into()),
                 profile: Some("prod".into()),
+                ..Default::default()
             }),
             ..Default::default()
         };
@@ -775,8 +778,8 @@ mod tests {
         let config = Config {
             secretspec: Some(SecretspecConfig {
                 enable: false,
-                provider: None,
                 profile: Some("prod".into()),
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -402,12 +402,20 @@ impl Devenv {
         let mut secretspec_cell: OnceCell<ResolvedSecrets> = OnceCell::new();
         resolve_secretspec_into(&devenv_root, &secret_settings, &mut secretspec_cell)?;
 
-        // Create the cachix manager after secretspec so a `CACHIX_AUTH_TOKEN`
-        // secret can authenticate pulls (netrc) and pushes (daemon env) even
-        // when it isn't exported into the environment.
+        // Create the cachix manager after secretspec so a secretspec secret
+        // can authenticate pulls (netrc) and pushes (daemon env) even when
+        // `CACHIX_AUTH_TOKEN` isn't exported into the environment.
+        //
+        // The lookup key defaults to `CACHIX_AUTH_TOKEN` and is overridable
+        // via `secretspec.cachix_auth_token` in devenv.yaml.
+        let cachix_auth_token_secret = secret_settings
+            .secretspec
+            .as_ref()
+            .and_then(|c| c.cachix_auth_token.as_deref())
+            .unwrap_or(CACHIX_AUTH_TOKEN_ENV);
         let cachix_auth_token = secretspec_cell
             .get()
-            .and_then(|resolved| resolved.secrets.get(CACHIX_AUTH_TOKEN_ENV).cloned());
+            .and_then(|resolved| resolved.secrets.get(cachix_auth_token_secret).cloned());
         let cachix_paths = CachixPaths {
             trusted_keys: cachix_trusted_keys,
             netrc: devenv_dotfile.join("netrc"),

--- a/docs/src/binary-caching.md
+++ b/docs/src/binary-caching.md
@@ -27,6 +27,19 @@ After that you'll need to set `CACHIX_AUTH_TOKEN=XXX` with either [a personal au
     pushing (it is passed to the cachix push daemon), so neither requires
     exporting the token into your environment.
 
+    The secretspec secret name defaults to `CACHIX_AUTH_TOKEN` and is
+    overridable via [`secretspec.cachix_auth_token`](reference/yaml-options.md#secretspeccachix_auth_token)
+    in `devenv.yaml`. Override it when your secretspec backend's policy
+    (e.g. OpenBao/Vault) only grants access to the token under a
+    different name:
+
+    ```yaml title="devenv.yaml"
+    secretspec:
+      enable: true
+      provider: openbao
+      cachix_auth_token: MY_TEAM_CACHIX_TOKEN
+    ```
+
 ## Pull
 
 Configure your new cache:

--- a/docs/src/integrations/secretspec.md
+++ b/docs/src/integrations/secretspec.md
@@ -66,6 +66,26 @@ Then access in `devenv.nix`:
 }
 ```
 
+### Cachix auth token from a non-default secret name
+
+When [resolving the Cachix auth token from secretspec](../binary-caching.md), devenv looks
+up a secret named `CACHIX_AUTH_TOKEN` by default. If your provider's
+policy (e.g. an OpenBao/Vault policy) only grants you access to a
+secret under a different name, set `secretspec.cachix_auth_token` to
+that name:
+
+```yaml title="devenv.yaml"
+secretspec:
+  enable: true
+  provider: openbao
+  cachix_auth_token: MY_TEAM_CACHIX_TOKEN
+```
+
+The value is a *secret name* declared in `secretspec.toml`, not the
+token itself. Only the secretspec lookup is overridable: the
+environment variable and the cachix push daemon still use
+`CACHIX_AUTH_TOKEN` (that is what the Cachix CLI reads).
+
 ## Learn More
 
 - [SecretSpec]

--- a/docs/src/reference/yaml-options.md
+++ b/docs/src/reference/yaml-options.md
@@ -212,6 +212,20 @@ Set to `true` to enforce that the CLI version matches the modules version
 
 !!! tip "New in version 2.1"
 
+## secretspec.cachix_auth_token
+
+Name of the secretspec secret to read the Cachix auth token from
+when `CACHIX_AUTH_TOKEN` is not set in the environment.
+
+This is the secret name declared in `secretspec.toml`, not the
+token value. Use this when your secretspec backend (e.g. an
+OpenBao/Vault policy) only grants access to a secret under a name
+other than the default `CACHIX_AUTH_TOKEN`.
+
+*Type:* `string` · *Default:* `CACHIX_AUTH_TOKEN`
+
+!!! tip "New in version 2.1.3"
+
 ## secretspec.enable
 
 Enable [secretspec integration](../integrations/secretspec.md).


### PR DESCRIPTION
Adds `secretspec.cachix_auth_token` in devenv.yaml so users whose secretspec backend policy (e.g. an OpenBao/Vault policy) only grants access to the Cachix auth token under a non-default secret name can point devenv at it. Defaults to `CACHIX_AUTH_TOKEN`, preserving the behavior introduced in #2858.

Only the secretspec lookup key is overridable; the environment variable and the cachix push daemon child env still use `CACHIX_AUTH_TOKEN` (that is what the Cachix CLI reads).

Also adds `#[serde(rename_all = "snake_case")]` to `SecretspecConfig` so multi-word fields deserialize under their documented snake_case spelling. Existing single-word fields (`enable`, `profile`, `provider`) hid the default behavior; without this, the new option would have been rejected under the spelling shown in the docs.
