### PR TITLE
config: canonicalize existing ancestor for import-path validation on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `devenv test --no-tui` (and any other non-TUI invocation) silently discarding all output from the `enterTest` script, so the test runner's output, traces, and failure messages never reached the terminal or CI logs. Output from commands run in the shell is now printed in non-TUI mode.
 - Fixed `watch` paths being ignored for one-shot processes that exit immediately (e.g. code generators). The file watcher was torn down as soon as the process exited, so later edits never triggered a re-run. Watched one-shot processes now stay parked after exiting and re-run when a watched file changes.
 - Fixed `devenv up` intermittently failing to start processes with "Failed to initialize task cache: ... pool timed out while waiting for an open connection", most often in CI. The processes that a non-native process manager (e.g. process-compose) launches each open the same task cache database concurrently and raced to create and migrate it; the database is now initialized once before the processes start ([#2897](https://github.com/cachix/devenv/issues/2897)).
+- Fixed import path validation rejecting valid input-relative imports on macOS, where `TMPDIR` resolves via the `/var → /private/var` symlink (`Import path '<name>/...' resolves outside the git repository`). `validate_within_root` now canonicalizes the longest existing ancestor of the path before comparing against the root.
 
 ### Improvements
 

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -1245,21 +1245,13 @@ impl Config {
             && let Some(canonical_root) = canonical_root
         {
             // Import path doesn't exist, but root does.
-            // Canonicalize the parent directory to resolve symlinks
-            // (e.g. /tmp -> /run/user/...), falling back to lexical
-            // normalization only when the parent doesn't exist either.
-            let abs_import = if let Some(parent) = import_path.parent() {
-                if let Ok(canonical_parent) = parent.canonicalize() {
-                    canonical_parent.join(import_path.file_name().unwrap_or_default())
-                } else if import_path.is_absolute() {
-                    Self::normalize_path_components(import_path)
-                } else if let Ok(cwd) = std::env::current_dir() {
-                    Self::normalize_path_components(&cwd.join(import_path))
-                } else {
-                    return Ok(());
-                }
-            } else if import_path.is_absolute() {
-                Self::normalize_path_components(import_path)
+            // Walk up the path looking for an existing ancestor that we can
+            // canonicalize (so symlinks like macOS `/var -> /private/var` get
+            // resolved), then append the remaining components lexically.
+            let abs_import = if import_path.is_absolute() {
+                Self::canonicalize_existing_ancestor(import_path)
+            } else if let Ok(cwd) = std::env::current_dir() {
+                Self::canonicalize_existing_ancestor(&cwd.join(import_path))
             } else {
                 return Ok(());
             };
@@ -1285,6 +1277,35 @@ impl Config {
         // The path will be validated when it's actually used
 
         Ok(())
+    }
+
+    /// Resolve an absolute path by canonicalizing the longest existing prefix
+    /// and appending the remaining components lexically. This handles paths
+    /// whose leaves don't exist yet while still resolving symlinks anywhere
+    /// up the chain (e.g. macOS `/var/folders/...` -> `/private/var/folders/...`).
+    fn canonicalize_existing_ancestor(path: &Path) -> PathBuf {
+        let mut probe = path.to_path_buf();
+        let mut tail: Vec<std::ffi::OsString> = Vec::new();
+        loop {
+            match probe.canonicalize() {
+                Ok(canonical) => {
+                    let mut result = canonical;
+                    for component in tail.iter().rev() {
+                        result.push(component);
+                    }
+                    return result;
+                }
+                Err(_) => {
+                    let file_name = probe.file_name().map(|n| n.to_os_string());
+                    if !probe.pop() || file_name.is_none() {
+                        // Nothing exists along the way; fall back to lexical
+                        // normalization of the original path.
+                        return Self::normalize_path_components(path);
+                    }
+                    tail.push(file_name.unwrap());
+                }
+            }
+        }
     }
 
     /// Normalizes a path by resolving `.` and `..` components without requiring the path to exist.


### PR DESCRIPTION
Split out of #2849 (the actionable-error PR bundled this unrelated fix).

## Problem

`validate_within_root` rejected valid input-relative imports on macOS, where `TMPDIR` resolves via the `/var -> /private/var` symlink and the import path's leaf does not exist yet:

```
Import path '<name>/...' resolves outside the git repository
```

## Fix

Resolve the longest existing ancestor of the path with `canonicalize` and append the remaining components lexically, so symlinks anywhere up the chain are followed even when the leaf is absent. Falls back to lexical normalization only when nothing along the path exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)