### PR TITLE
fix(cachix): apply netrc-file before store opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed authenticated Cachix pulls failing with HTTP 401 even when a valid auth token was configured. The token was resolved correctly but applied to Nix too late, after the store had already opened and made its first request, so private cache lookups went out unauthenticated. The netrc credentials are now in place before the store opens.
 - Fixed `devenv shell` lingering as a background process, often pinned at 100%+ CPU, after its terminal window or tab was closed. The shell now reacts to the SIGHUP/SIGINT/SIGTERM that already trigger devenv's graceful shutdown by killing the inner shell, instead of orphaning it ([#2845](https://github.com/cachix/devenv/issues/2845)).
 - Fixed `devenv shell`/`devenv update` failing with `authentication required but no callback set` when a `url."ssh://git@github.com/".insteadOf` git config rewrites GitHub HTTPS URLs to SSH. GitHub flake inputs now resolve over SSH using your ssh-agent ([#2842](https://github.com/cachix/devenv/issues/2842)).
 - Fixed the "N files" counter under "Evaluating shell" inflating from generic Nix log lines. Now only counts actual file read operations.

--- a/devenv-core/src/cachix.rs
+++ b/devenv-core/src/cachix.rs
@@ -6,7 +6,7 @@
 use miette::{IntoDiagnostic, Result, WrapErr};
 use nix_conf_parser::NixConf;
 use serde::{Deserialize, Deserializer};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -97,24 +97,6 @@ impl CachixManager {
         token
     }
 
-    /// Get global Nix settings that must be applied BEFORE store creation
-    ///
-    /// Returns settings like netrc-file path that need to be in place before
-    /// the Nix store makes any HTTP requests.
-    pub fn get_global_settings(&self) -> Result<HashMap<String, String>> {
-        let mut settings = HashMap::new();
-
-        // If an auth token is available (env, secretspec, or cachix
-        // config), set the netrc-file path. The actual file is created
-        // later when we know which caches to configure.
-        if self.resolve_auth_token().is_some() {
-            let netrc_path_str = self.paths.netrc.to_string_lossy().to_string();
-            settings.insert("netrc-file".to_string(), netrc_path_str);
-        }
-
-        Ok(settings)
-    }
-
     /// Ensure netrc file is created and populated with cache credentials
     ///
     /// This should be called after we know which caches to configure.
@@ -140,8 +122,10 @@ impl CachixManager {
     /// Returns a HashMap where keys are Nix option names and values are the option values.
     /// For example: "extra-substituters" => "https://cache1.cachix.org https://cache2.cachix.org"
     ///
-    /// Note: This returns substituters and keys but NOT netrc-file.
-    /// Use get_global_settings() to get netrc-file path before store creation.
+    /// Note: This returns substituters and keys but NOT netrc-file. The
+    /// netrc-file path is carried on [`StoreSettings`] (see
+    /// [`CachixManager::store_settings`]) and applied to the Nix settings
+    /// registry before the store opens.
     pub async fn get_nix_settings(
         &self,
         cachix_caches: &CachixCacheInfo,
@@ -168,7 +152,8 @@ impl CachixManager {
             settings.insert("extra-trusted-public-keys".to_string(), keys.join(" "));
 
             // Ensure netrc file is created with cache credentials
-            // (netrc-file path should already be set via get_global_settings())
+            // (the netrc-file path is applied before the store opens; see
+            // `store_settings`)
             if let Err(e) = self.ensure_netrc_file(&cachix_caches.caches.pull).await {
                 warn!("Failed to create netrc file: {}", e);
             }

--- a/devenv-core/src/cachix.rs
+++ b/devenv-core/src/cachix.rs
@@ -246,8 +246,18 @@ impl CachixManager {
             }
         }
 
+        // Advertise the netrc path whenever a token is resolvable, even
+        // before the file is written. This lets `netrc-file` be applied to
+        // the Nix settings registry *before the store opens* and performs
+        // any authenticated fetch (e.g. a private cache's `nix-cache-info`
+        // probe). The file content is created later by `ensure_netrc_file`,
+        // before the first substituter request. Without this, the netrc
+        // path is only known after cachix config is evaluated — too late,
+        // and private-cache requests go out unauthenticated (HTTP 401).
         if let Some(path) = self.netrc_path.get() {
             settings.netrc_path = Some(PathBuf::from(path));
+        } else if self.resolve_auth_token().is_some() {
+            settings.netrc_path = Some(self.paths.netrc.clone());
         }
 
         Ok(settings)


### PR DESCRIPTION
## Problem

Authenticated Cachix pulls fail with **HTTP 401** even when a valid auth token is configured (`CACHIX_AUTH_TOKEN`, secretspec, or `~/.config/cachix/cachix.dhall`). For a private cache, the first request Nix makes is:

```
warning: unable to download 'https://<cache>.cachix.org/nix-cache-info': HTTP error 401
  Binary cache <cache> doesn't exist or you're not authorized to access it.
```

The token is resolved correctly and the netrc is written correctly (verified: `curl -u token:<authToken>` against the same cache returns 200). The problem is **ordering**: `netrc-file` was applied to Nix only *after* the store had already opened and made its first request, so the credential was never presented.

## Root cause

A regression from `c5078654` (the backend-split refactor). It dropped the call to `CachixManager::get_global_settings()`, whose explicit job was to set `netrc-file` in the Nix settings registry **before the store opens**. That left `get_global_settings()` as dead code, and at startup `store_settings(None)` yields `netrc_path = None`, so `init_nix` skips `netrc-file` entirely. It's only set later via `apply_store_settings`, too late.

## Fix

`store_settings()` now advertises the (fixed) netrc path as soon as a token is resolvable, so `init_nix` can apply `netrc-file` before `open_store`. The file content is still written later by `ensure_netrc_file`, before the first substituter request.

## Testing

Reproduced against a real private cache with the rebuilt binary (cleared `~/.cache/nix/binary-cache-v*.sqlite` to force a fresh probe):

| | `nix-cache-info` probe |
|---|---|
| **Before** | HTTP **401**, "not authorized" warning |
| **After** | success, `span_has_error: false`, **0 warnings** |

- 7/7 `devenv-core` cachix unit tests pass
- `cargo clippy -p devenv-core` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)