### PR TITLE
fix(modules): set module system class

### DIFF
--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -214,6 +214,7 @@ rec {
 
       # Phase 1: Base evaluation to extract profile definitions
       baseProject = lib.evalModules {
+        class = "devenv";
         specialArgs = inputs // {
           inherit inputs secretspec primops;
         };
@@ -493,6 +494,7 @@ rec {
         let
           evalPkgs = mkPkgsForSystem evalSystem;
           evalProject = lib.evalModules {
+            class = "devenv";
             specialArgs = inputs // {
               inherit inputs secretspec primops;
             };
@@ -579,6 +581,7 @@ rec {
         lib = pkgs.lib;
 
         project = lib.evalModules {
+          class = "devenv";
           specialArgs = allInputs // {
             inputs = allInputs;
             secretspec = null;

--- a/flake.nix
+++ b/flake.nix
@@ -220,7 +220,10 @@
             ]
             ++ args.modules;
 
-            project = lib.evalModules { inherit modules specialArgs; };
+            project = lib.evalModules {
+              class = "devenv";
+              inherit modules specialArgs;
+            };
           in
           project;
 


### PR DESCRIPTION
This allows modules to know if they are in a devenv module or one from another class, and allows devenv to give a reasonable warning upon importing modules from home manager or nixos that will not work here.

One consideration to keep in mind is that we may wish to set `_class = "devenv";` in the modules we provide here as well.

This is not necessary, however, as modules with `_class = null;`, which is the default, are always allowed.

What setting _class in the modules we provide would do, would be that it would prevent them from being imported in home manager and nixos at top level, where they would not work.

The reason this PR is being made, is that [nix-wrapper-modules](https://github.com/BirdeeHub/nix-wrapper-modules) allows specification of options for target module systems that you will be installing them in. However, [those install options](https://birdeehub.github.io/nix-wrapper-modules/md/getting-started.html#nixos-home-manager-and-friends) [require `_class`](https://github.com/BirdeeHub/nix-wrapper-modules/blob/6d9506b09f8fbe0429153da1cebef2bd61a98848/lib/core.nix#L177-L371) in order to figure out which one it is in.

Setting class for devenv modules is something I believe to make sense, as devenv provides many modules and all are compatible with one another but not other module systems.