### PR TITLE
Fix nushell activation script when cache directory does not exist

### DIFF
--- a/docs/src/auto-activation.md
+++ b/docs/src/auto-activation.md
@@ -29,6 +29,7 @@ Add one line to your shell configuration file:
 === "Nushell"
 
     ```nu title="config.nu"
+    mkdir ~/.cache/devenv
     devenv hook nu | save --force ~/.cache/devenv/hook.nu
     source ~/.cache/devenv/hook.nu
     ```


### PR DESCRIPTION
Fix https://github.com/cachix/devenv/issues/2905
Update the documentation so that the setup script creates the directory before writing and sourcing the hook file.