### PR TITLE
fix(rust): cranelift no longer overwrites default components

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -3,6 +3,13 @@
 let
   cfg = config.languages.rust;
 
+  # The components to actually install in the toolchain. Appends the cranelift
+  # codegen backend on top of the user-configured `components` (which keeps its
+  # default) rather than overriding them.
+  componentsToInstall =
+    cfg.components
+    ++ lib.optional cfg.cranelift.enable "rustc-codegen-cranelift-preview";
+
   validChannels = [ "nixpkgs" "stable" "beta" "nightly" ];
 
   rust-overlay = config.lib.getInput {
@@ -405,8 +412,6 @@ in
 
         # Allow clippy to access the internet to fetch dependencies.
         git-hooks.hooks.clippy.settings.offline = lib.mkDefault false;
-
-        languages.rust.components = lib.mkIf cfg.cranelift.enable (lib.mkAfter [ "rustc-codegen-cranelift-preview" ]);
       }
     )
 
@@ -437,7 +442,7 @@ in
       languages.rust.toolchainPackage = lib.mkDefault (
         pkgs.symlinkJoin {
           name = "rust-toolchain-${cfg.channel}";
-          paths = builtins.map (c: cfg.toolchain.${c} or (throw "toolchain.${c}")) cfg.components;
+          paths = builtins.map (c: cfg.toolchain.${c} or (throw "toolchain.${c}")) componentsToInstall;
         }
       );
       languages.rust.lsp.package = lib.mkDefault cfg.toolchain.rust-analyzer;
@@ -506,7 +511,7 @@ in
             in
               cfg.toolchain.${c} or cfg.toolchain.${resolvedName} or toolchainComponents.${resolvedName}
           )
-          cfg.components;
+          componentsToInstall;
 
         allSelectedComponents = resolvedComponents ++ targetComponents;
 


### PR DESCRIPTION
## Problem

Enabling `languages.rust.cranelift.enable` wiped out the default `languages.rust.components`, so the toolchain shipped only the cranelift codegen backend and `cargo`/`rustc`/etc. were never installed. Entering the shell and running `cargo` failed with "command not found".

```nix
languages.rust = {
  enable = true;
  channel = "nightly";
  cranelift.enable = true;
};
```

## Root cause

The `components` option declares a `default`. In the module system, an option's `default` is only used when there are **no** definitions. The cranelift wiring set `languages.rust.components = mkIf … (mkAfter [ "rustc-codegen-cranelift-preview" ])`, which is a normal-priority *definition* — so it discarded the default entirely, leaving `components = [ "rustc-codegen-cranelift-preview" ]`.

This also explains the existing workaround: explicitly setting `components = [ "rustc" "cargo" … ]` adds a second same-priority definition that concatenates with cranelift's, restoring the full list.

## Fix

Stop injecting the cranelift component as a competing option definition. Instead derive `componentsToInstall = cfg.components ++ lib.optional cfg.cranelift.enable "rustc-codegen-cranelift-preview"` and use it at the two toolchain-build sites. This keeps the `components` default (and any user override) intact while still appending cranelift.

## Verification

Isolated `evalModules` reproduction of the merge behavior:

| Case | `components` result |
|------|---------------------|
| old, no user override | `[ "rustc-codegen-cranelift-preview" ]` ← the bug |
| old, user lists components | full list + cranelift ← why the workaround worked |
| new, no user override | `[ rustc cargo clippy rustfmt rust-analyzer rustc-codegen-cranelift-preview ]` ✅ |
| new, user lists components | full list + cranelift ✅ |

Fixes #2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)