### PR TITLE
Fix nushell activation script

### DIFF
--- a/devenv/hooks/hook.nu
+++ b/devenv/hooks/hook.nu
@@ -1,8 +1,7 @@
 # devenv hook for nushell
 # Usage: Add to your config.nu:
-#   source (devenv hook nu | save --force ~/.cache/devenv/hook.nu; "~/.cache/devenv/hook.nu")
-# Or: devenv hook nu | save --force ~/.cache/devenv/hook.nu
-#     source ~/.cache/devenv/hook.nu
+#   mkdir ($nu.default-config-dir | path join autoload)
+#   devenv hook nu | save --force ($nu.default-config-dir | path join autoload/devenv-hook.nu)
 
 $env._DEVENV_HOOK_UNTRUSTED = ""
 

--- a/docs/src/auto-activation.md
+++ b/docs/src/auto-activation.md
@@ -29,9 +29,8 @@ Add one line to your shell configuration file:
 === "Nushell"
 
     ```nu title="config.nu"
-    mkdir ~/.cache/devenv
-    devenv hook nu | save --force ~/.cache/devenv/hook.nu
-    source ~/.cache/devenv/hook.nu
+    mkdir ($nu.default-config-dir | path join autoload)
+    devenv hook nu | save --force ($nu.default-config-dir | path join autoload/devenv-hook.nu)
     ```
 
 ## Trusting a project


### PR DESCRIPTION
Fix https://github.com/cachix/devenv/issues/2905

The [previous fix](https://github.com/cachix/devenv/pull/2906) did not actually solve the issue - in my testing I must have mistakenly created the script manually at some point, which fixed the issue. The actual root problem is that the hook script must be created before the nushell script is parsed. See the nushell documenation for an explanation: https://www.nushell.sh/book/thinking_in_nu.html#example-dynamically-generating-source

This fix instead creates the devenv hook as an autoload script, which will be run by nushell later in its setup process.