### PR TITLE
fix(tui): stop high idle CPU in foreground mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `devenv up` (and other TUI commands) burning significant CPU while idle — roughly 10-15% per managed process — even when every process was quiet. The foreground UI was recomputing its layout dozens of times per second regardless of whether anything changed, and each idle process woke the whole UI twice a second. The TUI now only redraws when the model actually changes, with a slow heartbeat to keep elapsed timers ticking ([#2915](https://github.com/cachix/devenv/issues/2915)).
 - Fixed authenticated Cachix pulls failing with HTTP 401 even when a valid auth token was configured. The token was resolved correctly but applied to Nix too late, after the store had already opened and made its first request, so private cache lookups went out unauthenticated. The netrc credentials are now in place before the store opens.
 - Fixed `devenv shell` lingering as a background process, often pinned at 100%+ CPU, after its terminal window or tab was closed. The shell now reacts to the SIGHUP/SIGINT/SIGTERM that already trigger devenv's graceful shutdown by killing the inner shell, instead of orphaning it ([#2845](https://github.com/cachix/devenv/issues/2845)).
 - Fixed `devenv shell`/`devenv update` failing with `authentication required but no callback set` when a `url."ssh://git@github.com/".insteadOf` git config rewrites GitHub HTTPS URLs to SSH. GitHub flake inputs now resolve over SSH using your ssh-agent ([#2842](https://github.com/cachix/devenv/issues/2842)).

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7564,6 +7564,11 @@ rec {
             packageId = "insta";
             features = [ "filters" "json" ];
           }
+          {
+            name = "tokio";
+            packageId = "tokio";
+            features = [ "process" "fs" "io-util" "macros" "rt-multi-thread" "sync" "time" "test-util" ];
+          }
         ];
         features = {
           "test-all" = [ "deterministic-tui" ];

--- a/devenv-tui/Cargo.toml
+++ b/devenv-tui/Cargo.toml
@@ -66,6 +66,7 @@ path = "src/bin/tui-replay.rs"
 [dev-dependencies]
 insta.workspace = true
 devenv-activity = { workspace = true, features = ["test-helpers"] }
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 default = []

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -12,7 +12,7 @@ use devenv_activity::{ActivityEvent, ActivityLevel};
 use devenv_processes::ProcessCommand;
 use iocraft::prelude::*;
 use std::io::{self, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 use tokio::sync::{Notify, mpsc, oneshot};
 use tokio_shutdown::Shutdown;
@@ -23,6 +23,12 @@ use tracing::debug;
 /// type-keyed context lookup can resolve them independently.
 #[derive(Clone)]
 pub struct RenderShutdown(pub Arc<Notify>);
+
+/// Monotonic counter bumped by the event processor whenever the activity model
+/// changes. The render loop reads it to skip layout-recomputing redraws while
+/// idle (see `throttled_notify_loop`). Provided to components via context.
+#[derive(Clone)]
+pub struct ModelVersion(pub Arc<AtomicU64>);
 
 /// Cooperative exit flag for TUI shutdown.
 ///
@@ -160,6 +166,10 @@ impl TuiApp {
         let config = Arc::new(self.config);
         let activity_model = Arc::new(RwLock::new(ActivityModel::with_config(config.clone())));
         let notify = Arc::new(Notify::new());
+        // Bumped on every activity-model change so the render loop can tell a
+        // real update from an idle safety-net wake and avoid redrawing (and
+        // recomputing the layout) when nothing changed.
+        let model_version = Arc::new(AtomicU64::new(0));
         // Separate notify for shutdown — bypasses render throttle so the
         // cooperative exit flag is observed promptly instead of waiting for
         // the next throttle tick (which can lose intermediate notifies).
@@ -175,6 +185,7 @@ impl TuiApp {
         let event_processor_handle = tokio::spawn({
             let activity_model = activity_model.clone();
             let notify = notify.clone();
+            let model_version = model_version.clone();
             let render_shutdown = render_shutdown.clone();
             let exit_flag = exit_flag.clone();
             let event_batch_size = config.event_batch_size;
@@ -189,6 +200,10 @@ impl TuiApp {
                             let Some(event) = event else {
                                 // Channel closed unexpectedly
                                 exit_flag.set();
+                                // Bump the version alongside the notify so the
+                                // render loop treats this as a real change (kept
+                                // in lockstep with the other notify sites).
+                                model_version.fetch_add(1, Ordering::Release);
                                 notify.notify_waiters();
                                 render_shutdown.notify_waiters();
                                 break;
@@ -202,13 +217,21 @@ impl TuiApp {
                                 }
                             }
 
+                            let mut any_changed = false;
                             if let Ok(mut m) = activity_model.write() {
                                 for event in batch.drain(..) {
-                                    m.apply_activity_event(event);
+                                    any_changed |= m.apply_activity_event(event);
                                 }
                             }
 
-                            notify.notify_waiters();
+                            // Only wake the render loop when the batch actually
+                            // changed the visible model; pure no-op events (e.g.
+                            // shell events, skipped .narinfo fetches) don't force
+                            // a layout-recomputing redraw.
+                            if any_changed {
+                                model_version.fetch_add(1, Ordering::Release);
+                                notify.notify_waiters();
+                            }
                         }
 
                         _ = &mut backend_notified => {
@@ -229,6 +252,7 @@ impl TuiApp {
                             // Signal component to exit cooperatively. Set before
                             // notify so the triggered re-render sees the flag.
                             exit_flag.set();
+                            model_version.fetch_add(1, Ordering::Release);
                             notify.notify_waiters();
                             // Bypass render throttle so the exit flag is observed
                             // on the next frame instead of after another throttle tick.
@@ -258,6 +282,7 @@ impl TuiApp {
                 activity_model.clone(),
                 ui_state.clone(),
                 notify.clone(),
+                model_version.clone(),
                 render_shutdown.clone(),
                 shutdown.clone(),
                 config.clone(),
@@ -533,6 +558,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let activity_model = hooks.use_context::<Arc<RwLock<ActivityModel>>>();
     let ui_state = hooks.use_context::<Arc<RwLock<UiState>>>();
     let notify = hooks.use_context::<Arc<Notify>>();
+    let model_version = hooks.use_context::<ModelVersion>().0.clone();
     let render_shutdown = hooks.use_context::<RenderShutdown>().0.clone();
     let (terminal_width, terminal_height) = hooks.use_terminal_size();
     let mut should_exit = hooks.use_state(|| false);
@@ -549,10 +575,12 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let redraw = hooks.use_state(|| 0u64);
     hooks.use_future({
         let notify = notify.clone();
+        let model_version = model_version.clone();
         let render_shutdown = render_shutdown.clone();
         let max_fps = config.max_fps;
         async move {
-            crate::throttled_notify_loop(notify, render_shutdown, redraw, max_fps).await;
+            crate::throttled_notify_loop(notify, render_shutdown, model_version, redraw, max_fps)
+                .await;
         }
     });
 
@@ -578,6 +606,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         let ui_state = ui_state.clone();
         let shutdown = shutdown.clone();
         let command_tx = command_tx.clone();
+        let notify = notify.clone();
         let mut scroll_handle = scroll_handle;
         let scroll_view_active = scroll_view_active;
 
@@ -586,92 +615,109 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 && key_event.kind != KeyEventKind::Release
             {
                 debug!("Key event: {:?}", key_event);
-                if handle_interrupt_prompt_key(&key_event, &ui_state, &shutdown) {
-                    return;
-                }
-
-                match key_event.code {
-                    KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        if !request_interrupt_prompt(command_tx.as_ref(), &ui_state) {
-                            shutdown.handle_interrupt();
-                        }
-                    }
-                    KeyCode::Char('r') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Restart selected process
-                        if let Some(tx) = command_tx.as_ref()
-                            && let Ok(ui) = ui_state.read()
-                            && let Some(activity_id) = ui.selected_activity
-                            && let Ok(model) = activity_model.read()
-                            && let Some(activity) = model.get_activity(activity_id)
-                            && matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+                if !handle_interrupt_prompt_key(&key_event, &ui_state, &shutdown) {
+                    match key_event.code {
+                        KeyCode::Char('c')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
                         {
-                            let _ = tx.try_send(ProcessCommand::Restart(activity.name.clone()));
+                            if !request_interrupt_prompt(command_tx.as_ref(), &ui_state) {
+                                shutdown.handle_interrupt();
+                            }
                         }
-                    }
-                    KeyCode::Char('x') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Stop selected process (only if active)
-                        if let Some(tx) = command_tx.as_ref()
-                            && let Ok(ui) = ui_state.read()
-                            && let Some(activity_id) = ui.selected_activity
-                            && let Ok(model) = activity_model.read()
-                            && let Some(activity) = model.get_activity(activity_id)
-                            && let crate::model::ActivityVariant::Process(ref proc) =
-                                activity.variant
-                            && proc.status.is_stoppable()
+                        KeyCode::Char('r')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
                         {
-                            let _ = tx.try_send(ProcessCommand::Stop(activity.name.clone()));
-                        }
-                    }
-                    KeyCode::Char('e') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        if let Ok(mut ui) = ui_state.write()
-                            && let Some(activity_id) = ui.selected_activity
-                        {
-                            ui.view_mode = ViewMode::ExpandedLogs { activity_id };
-                            should_exit.set(true);
-                        }
-                    }
-                    KeyCode::Char('h') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
-                        if let Ok(model) = activity_model.read()
-                            && let Ok(mut ui) = ui_state.write()
-                        {
-                            ui.toggle_hide_stopped_processes();
-                            if let Some(id) = ui.selected_activity
-                                && !model.is_selectable(id, &ui)
+                            // Restart selected process
+                            if let Some(tx) = command_tx.as_ref()
+                                && let Ok(ui) = ui_state.read()
+                                && let Some(activity_id) = ui.selected_activity
+                                && let Ok(model) = activity_model.read()
+                                && let Some(activity) = model.get_activity(activity_id)
+                                && matches!(
+                                    activity.variant,
+                                    crate::model::ActivityVariant::Process(_)
+                                )
                             {
+                                let _ = tx.try_send(ProcessCommand::Restart(activity.name.clone()));
+                            }
+                        }
+                        KeyCode::Char('x')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            // Stop selected process (only if active)
+                            if let Some(tx) = command_tx.as_ref()
+                                && let Ok(ui) = ui_state.read()
+                                && let Some(activity_id) = ui.selected_activity
+                                && let Ok(model) = activity_model.read()
+                                && let Some(activity) = model.get_activity(activity_id)
+                                && let crate::model::ActivityVariant::Process(ref proc) =
+                                    activity.variant
+                                && proc.status.is_stoppable()
+                            {
+                                let _ = tx.try_send(ProcessCommand::Stop(activity.name.clone()));
+                            }
+                        }
+                        KeyCode::Char('e')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            if let Ok(mut ui) = ui_state.write()
+                                && let Some(activity_id) = ui.selected_activity
+                            {
+                                ui.view_mode = ViewMode::ExpandedLogs { activity_id };
+                                should_exit.set(true);
+                            }
+                        }
+                        KeyCode::Char('h')
+                            if key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+                        {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                ui.toggle_hide_stopped_processes();
+                                if let Some(id) = ui.selected_activity
+                                    && !model.is_selectable(id, &ui)
+                                {
+                                    ui.selected_activity = None;
+                                }
+                            }
+                        }
+                        KeyCode::Down | KeyCode::Up => {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                let selectable = model.get_selectable_activity_ids(&ui);
+                                ui.select_activity(&selectable, key_event.code == KeyCode::Down);
+                                if let Some(selected_id) = ui.selected_activity
+                                    && *scroll_view_active.read()
+                                {
+                                    let display = model.get_display_activities(&ui);
+                                    let heights = activity_heights.read();
+                                    scroll_selected_into_view(
+                                        &mut scroll_handle.write(),
+                                        &heights,
+                                        &display,
+                                        selected_id,
+                                    );
+                                }
+                            }
+                        }
+                        KeyCode::Esc => {
+                            if let Ok(mut ui) = ui_state.write() {
                                 ui.selected_activity = None;
                             }
-                        }
-                    }
-                    KeyCode::Down | KeyCode::Up => {
-                        if let Ok(model) = activity_model.read()
-                            && let Ok(mut ui) = ui_state.write()
-                        {
-                            let selectable = model.get_selectable_activity_ids(&ui);
-                            ui.select_activity(&selectable, key_event.code == KeyCode::Down);
-                            if let Some(selected_id) = ui.selected_activity
-                                && *scroll_view_active.read()
-                            {
-                                let display = model.get_display_activities(&ui);
-                                let heights = activity_heights.read();
-                                scroll_selected_into_view(
-                                    &mut scroll_handle.write(),
-                                    &heights,
-                                    &display,
-                                    selected_id,
-                                );
+                            if *scroll_view_active.read() {
+                                scroll_handle.write().scroll_to_bottom();
                             }
                         }
+                        _ => {}
                     }
-                    KeyCode::Esc => {
-                        if let Ok(mut ui) = ui_state.write() {
-                            ui.selected_activity = None;
-                        }
-                        if *scroll_view_active.read() {
-                            scroll_handle.write().scroll_to_bottom();
-                        }
-                    }
-                    _ => {}
                 }
+
+                // Key handlers above mutate `ui_state` (and the interrupt
+                // prompt), which iocraft cannot observe on its own. Wake the
+                // render loop so the change is painted promptly instead of
+                // waiting for the idle heartbeat (#2915).
+                notify.notify_waiters();
             }
         }
     });
@@ -740,6 +786,7 @@ async fn run_view(
     activity_model: Arc<RwLock<ActivityModel>>,
     ui_state: Arc<RwLock<UiState>>,
     notify: Arc<Notify>,
+    model_version: Arc<AtomicU64>,
     render_shutdown: Arc<Notify>,
     shutdown: Arc<Shutdown>,
     config: Arc<TuiConfig>,
@@ -769,12 +816,14 @@ async fn run_view(
                 ContextProvider(value: Context::owned(config.clone())) {
                     ContextProvider(value: Context::owned(shutdown.clone())) {
                         ContextProvider(value: Context::owned(notify.clone())) {
-                            ContextProvider(value: Context::owned(RenderShutdown(render_shutdown.clone()))) {
-                                ContextProvider(value: Context::owned(activity_model.clone())) {
-                                    ContextProvider(value: Context::owned(ui_state.clone())) {
-                                        ContextProvider(value: Context::owned(command_tx.clone())) {
-                                            ContextProvider(value: Context::owned(exit_flag.clone())) {
-                                                MainView
+                            ContextProvider(value: Context::owned(ModelVersion(model_version.clone()))) {
+                                ContextProvider(value: Context::owned(RenderShutdown(render_shutdown.clone()))) {
+                                    ContextProvider(value: Context::owned(activity_model.clone())) {
+                                        ContextProvider(value: Context::owned(ui_state.clone())) {
+                                            ContextProvider(value: Context::owned(command_tx.clone())) {
+                                                ContextProvider(value: Context::owned(exit_flag.clone())) {
+                                                    MainView
+                                                }
                                             }
                                         }
                                     }
@@ -810,13 +859,15 @@ async fn run_view(
                 ContextProvider(value: Context::owned(config.clone())) {
                     ContextProvider(value: Context::owned(shutdown.clone())) {
                         ContextProvider(value: Context::owned(notify.clone())) {
-                            ContextProvider(value: Context::owned(RenderShutdown(render_shutdown.clone()))) {
-                                ContextProvider(value: Context::owned(activity_model.clone())) {
-                                    ContextProvider(value: Context::owned(ui_state.clone())) {
-                                        ContextProvider(value: Context::owned(command_tx.clone())) {
-                                            ContextProvider(value: Context::owned(exit_flag.clone())) {
-                                                ContextProvider(value: Context::owned(activity_id)) {
-                                                    ExpandedLogView
+                            ContextProvider(value: Context::owned(ModelVersion(model_version.clone()))) {
+                                ContextProvider(value: Context::owned(RenderShutdown(render_shutdown.clone()))) {
+                                    ContextProvider(value: Context::owned(activity_model.clone())) {
+                                        ContextProvider(value: Context::owned(ui_state.clone())) {
+                                            ContextProvider(value: Context::owned(command_tx.clone())) {
+                                                ContextProvider(value: Context::owned(exit_flag.clone())) {
+                                                    ContextProvider(value: Context::owned(activity_id)) {
+                                                        ExpandedLogView
+                                                    }
                                                 }
                                             }
                                         }

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -5,7 +5,9 @@ use devenv_activity::ProcessStatus;
 use human_repr::{HumanCount, HumanThroughput};
 use iocraft::prelude::*;
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Notify;
 
 // Import shared UI constants from devenv-shell
 pub use devenv_shell::{
@@ -135,9 +137,41 @@ pub fn StatusDot(mut hooks: Hooks, props: &StatusDotProps) -> impl Into<AnyEleme
     // (iocraft rules of hooks); `pulse` can flip as a process changes state,
     // so always register them and gate only the rendering.
     let mut bright = hooks.use_state(|| true);
+    // Non-reactive mirror of `pulse`, refreshed every render. The animation
+    // future reads it to decide whether to toggle `bright`. Writing a `Ref`
+    // does not mark the component dirty, so updating this never forces a redraw.
+    let mut pulse_active = hooks.use_ref(|| props.pulse);
+    pulse_active.set(props.pulse);
+    // Wake source so the animation future can fully park while the dot is
+    // steady, instead of polling a timer twice a second per dot — which would
+    // scale idle wakeups with the number of processes (#2915). We signal it on
+    // the steady -> pulsing transition; `notify_one` stores a permit, so a wake
+    // raised before the future parks is never lost.
+    let wake = hooks.use_ref(|| Arc::new(Notify::new()));
+    let mut was_pulsing = hooks.use_ref(|| false);
+    if props.pulse && !was_pulsing.get() {
+        wake.read().notify_one();
+    }
+    was_pulsing.set(props.pulse);
+
+    let wake_fut = wake.read().clone();
     hooks.use_future(async move {
         loop {
+            // Steady dot: park until it starts pulsing again, so a screen full
+            // of running processes wakes no timers.
+            if !pulse_active.try_get().unwrap_or(false) {
+                wake_fut.notified().await;
+                continue;
+            }
             tokio::time::sleep(Duration::from_millis(PULSE_INTERVAL_MS)).await;
+            // Re-check after sleeping. Use `try_get` (not the panicking `get`)
+            // so a dropped owner ends the loop cleanly, matching `bright` below.
+            let Some(active) = pulse_active.try_get() else {
+                break;
+            };
+            if !active {
+                continue;
+            }
             let Some(val) = bright.try_get() else {
                 break;
             };

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -97,6 +97,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let ui_state = hooks.use_context::<Arc<RwLock<UiState>>>();
     let activity_id = *hooks.use_context::<u64>();
     let notify = hooks.use_context::<Arc<Notify>>();
+    let model_version = hooks.use_context::<crate::app::ModelVersion>().0.clone();
     let render_shutdown = hooks.use_context::<crate::app::RenderShutdown>().0.clone();
     let shutdown = hooks.use_context::<Arc<Shutdown>>();
     let command_tx = hooks.use_context::<Option<mpsc::Sender<ProcessCommand>>>();
@@ -119,10 +120,12 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let redraw = hooks.use_state(|| 0u64);
     hooks.use_future({
         let notify = notify.clone();
+        let model_version = model_version.clone();
         let render_shutdown = render_shutdown.clone();
         let max_fps = config.max_fps;
         async move {
-            crate::throttled_notify_loop(notify, render_shutdown, redraw, max_fps).await;
+            crate::throttled_notify_loop(notify, render_shutdown, model_version, redraw, max_fps)
+                .await;
         }
     });
 
@@ -166,6 +169,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         let ui_state = ui_state.clone();
         let shutdown = shutdown.clone();
         let command_tx = command_tx.clone();
+        let notify = notify.clone();
         move |event| match event {
             TerminalEvent::Key(key_event) => {
                 if key_event.kind == KeyEventKind::Release {
@@ -189,6 +193,10 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         is_selecting: &mut is_selecting,
                     },
                 );
+                // Exit keys flip `view_mode` on `ui_state`, which iocraft can't
+                // observe; wake the render loop so leaving the view is prompt
+                // instead of waiting for the idle heartbeat (#2915).
+                notify.notify_waiters();
             }
             TerminalEvent::FullscreenMouse(mouse_event) => {
                 let prompt_active = ui_state

--- a/devenv-tui/src/lib.rs
+++ b/devenv-tui/src/lib.rs
@@ -1,5 +1,6 @@
 use iocraft::prelude::State;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tokio::sync::Notify;
 
@@ -26,56 +27,282 @@ pub use devenv_shell::{
     SessionConfig, SessionError, SessionIo, ShellCommand, ShellEvent, ShellSession, TuiHandoff,
 };
 
-/// Runs a loop that waits for notifications and triggers redraws at a throttled rate.
+/// Idle heartbeat: when nothing in the model has changed, the loop still emits
+/// a redraw at this slow rate so that elapsed-time displays keep ticking. This
+/// is what keeps idle CPU minimal — instead of recomputing the (taffy) layout
+/// ~`max_fps` times per second, an idle TUI redraws roughly once per second.
+const IDLE_HEARTBEAT_MS: u64 = 1000;
+
+/// Sink that triggers a single UI redraw.
 ///
-/// Uses leading-edge throttling:
-/// - Waits for notification OR timeout (whichever comes first)
-/// - On wake: triggers redraw, then sleeps to enforce FPS cap
-/// - Subsequent notifications during throttle sleep are coalesced (model accumulates)
+/// Abstracted behind a trait so the throttle/coalescing logic can be unit-tested
+/// without constructing an iocraft `State` (which can only be built inside a
+/// component's render via `Hooks::use_state`).
+pub trait RedrawSink {
+    /// Trigger one redraw. Returns `false` if the underlying state is gone (its
+    /// owner has been dropped), signalling the loop to stop.
+    fn trigger(&mut self) -> bool;
+}
+
+impl RedrawSink for State<u64> {
+    fn trigger(&mut self) -> bool {
+        match self.try_get() {
+            Some(val) => {
+                self.set(val.wrapping_add(1));
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// Runs a loop that triggers UI redraws, throttled to cap the frame rate.
 ///
-/// The timeout on the notification wait serves as a safety net: `Notify::notify_waiters()`
-/// only wakes tasks that are actively waiting on `notified()`. If a notification arrives
-/// while we're in the throttle sleep, it's lost. The timeout ensures we periodically
-/// check for state changes (like the final Done event) even if we missed a notification.
+/// `version` is a monotonic counter bumped by the event processor whenever the
+/// activity model changes. The loop redraws (recomputing the taffy layout) on:
+/// - the very first frame (so the UI draws on startup),
+/// - any real model change (`version` advanced),
+/// - an explicit `notify` wake with no version change — e.g. a keypress that
+///   mutated `ui_state`, which iocraft cannot observe on its own and which would
+///   otherwise not repaint until the heartbeat (#2915), and
+/// - a slow [`IDLE_HEARTBEAT_MS`] heartbeat (so elapsed-time displays advance).
 ///
-/// The `shutdown` notify bypasses the throttle: when fired, the loop emits one final
-/// redraw and returns immediately, so cooperative-exit flags are observed without
-/// waiting up to a full throttle period.
+/// This is the fix for the high idle-CPU behaviour (#2915): previously the loop
+/// redrew on every safety-net timeout (~`max_fps` times/sec) regardless of
+/// whether anything changed, continuously recomputing the flexbox layout. Now an
+/// idle TUI redraws roughly once per second.
+///
+/// Lost-wakeup safety: `Notify::notify_waiters` only wakes tasks already parked
+/// on `notified()` and stores no permit. We therefore register interest (via
+/// `Notified::enable`) *before* reading `version`, so a notification that races
+/// our check is observed on the very next wait rather than being dropped until
+/// the heartbeat.
+///
+/// Throttling/coalescing: after any redraw we sleep at least `throttle` before
+/// the next one; notifications during that sleep are coalesced because `version`
+/// keeps climbing and is re-read on the next iteration.
+///
+/// The `shutdown` notify bypasses everything: when fired the loop emits one
+/// final redraw and returns immediately, so cooperative-exit flags are observed
+/// without waiting up to a full throttle period.
+///
+/// `redraw` is generic over [`RedrawSink`] so the throttle/coalescing logic can
+/// be unit-tested without constructing an iocraft `State`.
 pub async fn throttled_notify_loop(
     notify: Arc<Notify>,
     shutdown: Arc<Notify>,
-    mut redraw: State<u64>,
+    version: Arc<AtomicU64>,
+    mut redraw: impl RedrawSink,
     max_fps: u64,
 ) {
-    let throttle_duration = Duration::from_millis(1000 / max_fps);
+    // `max(1)` guards the division: a misconfigured `max_fps` of 0 would panic.
+    let throttle = Duration::from_millis(1000 / max_fps.max(1));
+    let idle_heartbeat = Duration::from_millis(IDLE_HEARTBEAT_MS);
+
+    // Force the first frame regardless of the starting version.
+    let mut rendered_version = u64::MAX;
 
     loop {
-        // Wait for notification OR timeout. The timeout ensures we don't miss the final
-        // state if a notification arrived during the previous throttle sleep.
-        tokio::select! {
-            _ = notify.notified() => {}
-            _ = tokio::time::sleep(throttle_duration) => {}
-            _ = shutdown.notified() => {
-                if let Some(val) = redraw.try_get() {
-                    redraw.set(val.wrapping_add(1));
+        // Register for notifications before reading `version` (see "Lost-wakeup
+        // safety" above). `enable()` registers the waiter without awaiting.
+        let notified = notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        let current = version.load(Ordering::Acquire);
+        let changed = current != rendered_version;
+        rendered_version = current;
+
+        if !changed {
+            // Idle: wait for a model change, an explicit wake (input), the
+            // heartbeat (to tick elapsed timers), or shutdown.
+            tokio::select! {
+                _ = notified.as_mut() => {}
+                _ = tokio::time::sleep(idle_heartbeat) => {}
+                _ = shutdown.notified() => {
+                    redraw.trigger();
+                    return;
                 }
-                return;
             }
+            // Re-read after waking, then redraw unconditionally: a heartbeat or
+            // input wake still needs to repaint (timers / ui_state), and a model
+            // change is picked up here too.
+            rendered_version = version.load(Ordering::Acquire);
         }
-        let Some(val) = redraw.try_get() else {
+
+        if !redraw.trigger() {
             break;
-        };
-        redraw.set(val.wrapping_add(1));
-        // Throttle: minimum time between renders to cap FPS.
-        // Shutdown also bypasses this sleep so the final render fires promptly.
+        }
+
+        // Cap the frame rate: at least `throttle` between redraws.
         tokio::select! {
-            _ = tokio::time::sleep(throttle_duration) => {}
+            _ = tokio::time::sleep(throttle) => {}
             _ = shutdown.notified() => {
-                if let Some(val) = redraw.try_get() {
-                    redraw.set(val.wrapping_add(1));
-                }
+                redraw.trigger();
                 return;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU64;
+    use tokio::task::JoinHandle;
+
+    /// Test redraw sink that just counts how many times it was triggered.
+    struct CountingSink(Arc<AtomicU64>);
+
+    impl RedrawSink for CountingSink {
+        fn trigger(&mut self) -> bool {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+    }
+
+    /// Handles to a spawned loop under test.
+    struct Harness {
+        notify: Arc<Notify>,
+        shutdown: Arc<Notify>,
+        version: Arc<AtomicU64>,
+        count: Arc<AtomicU64>,
+        handle: JoinHandle<()>,
+    }
+
+    impl Harness {
+        fn spawn() -> Self {
+            let notify = Arc::new(Notify::new());
+            let shutdown = Arc::new(Notify::new());
+            let version = Arc::new(AtomicU64::new(0));
+            let count = Arc::new(AtomicU64::new(0));
+            let handle = tokio::spawn(throttled_notify_loop(
+                notify.clone(),
+                shutdown.clone(),
+                version.clone(),
+                CountingSink(count.clone()),
+                60,
+            ));
+            Self {
+                notify,
+                shutdown,
+                version,
+                count,
+                handle,
+            }
+        }
+
+        fn redraws(&self) -> u64 {
+            self.count.load(Ordering::Relaxed)
+        }
+
+        async fn stop(self) {
+            self.shutdown.notify_waiters();
+            let _ = self.handle.await;
+        }
+    }
+
+    /// Regression test for #2915: an idle TUI must not redraw (recompute layout)
+    /// at the full frame rate. With virtual time we advance 10 seconds with no
+    /// model changes and assert the loop redrew only a handful of times (initial
+    /// frame + ~1 heartbeat/sec), not ~`max_fps`/sec.
+    #[tokio::test(start_paused = true)]
+    async fn idle_does_not_redraw_at_frame_rate() {
+        let h = Harness::spawn();
+
+        // Advance virtual time 10s with no notifications and no version bumps.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let redraws = h.redraws();
+        h.stop().await;
+
+        // At 60fps the old loop would redraw ~30/sec => ~300 over 10s. The new
+        // loop should be roughly: 1 initial + ~10 heartbeats.
+        assert!(
+            redraws <= 20,
+            "idle redraws should be ~1/sec, got {redraws} over 10s"
+        );
+    }
+
+    /// A model change must trigger a redraw promptly.
+    #[tokio::test(start_paused = true)]
+    async fn model_change_triggers_redraw() {
+        let h = Harness::spawn();
+
+        // Let the initial frame settle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let before = h.redraws();
+
+        // Simulate a model change.
+        h.version.fetch_add(1, Ordering::Release);
+        h.notify.notify_waiters();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let after = h.redraws();
+        assert!(
+            after > before,
+            "a model change must trigger a redraw (before={before}, after={after})"
+        );
+
+        h.stop().await;
+    }
+
+    /// An explicit notify with NO version change (e.g. a keypress that mutated
+    /// `ui_state`) must still trigger a redraw — otherwise input would not
+    /// repaint until the idle heartbeat (#2915).
+    #[tokio::test(start_paused = true)]
+    async fn input_notify_without_version_change_triggers_redraw() {
+        let h = Harness::spawn();
+
+        // Let the initial frame settle so the loop is parked idle.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let before = h.redraws();
+
+        // Notify without bumping the version, as the key handlers do.
+        h.notify.notify_waiters();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let after = h.redraws();
+        assert!(
+            after > before,
+            "an input notify must trigger a redraw (before={before}, after={after})"
+        );
+
+        h.stop().await;
+    }
+
+    /// A burst of rapid changes must be throttled, not redrawn once per change.
+    #[tokio::test(start_paused = true)]
+    async fn rapid_changes_are_throttled() {
+        let h = Harness::spawn();
+
+        // Flood with changes for ~1s of virtual time. Yield via a tiny sleep so
+        // paused-time auto-advance can run the render loop between bumps.
+        for _ in 0..1000 {
+            h.version.fetch_add(1, Ordering::Release);
+            h.notify.notify_waiters();
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        let redraws = h.redraws();
+        h.stop().await;
+
+        // ~1s at 60fps throttle => on the order of 60 frames, not ~1000.
+        assert!(
+            redraws < 200,
+            "rapid changes should be throttled toward the fps cap, got {redraws}"
+        );
+    }
+
+    /// Shutdown emits a final redraw and the loop returns.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_triggers_final_redraw_and_exits() {
+        let h = Harness::spawn();
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        h.shutdown.notify_waiters();
+
+        // The loop must actually return after shutdown.
+        h.handle.await.expect("loop should exit on shutdown");
+        assert!(h.count.load(Ordering::Relaxed) >= 1);
     }
 }

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -351,20 +351,49 @@ impl ActivityModel {
         &self.config
     }
 
-    pub fn apply_activity_event(&mut self, event: ActivityEvent) {
+    /// Apply an activity event to the model. Returns `true` if the event may
+    /// have changed the visible model (so the UI should redraw), and `false`
+    /// for known no-ops (shell events, skipped `.narinfo` fetches) so the render
+    /// loop is not woken needlessly.
+    pub fn apply_activity_event(&mut self, event: ActivityEvent) -> bool {
         match event {
-            ActivityEvent::Build(build_event) => self.handle_build_event(build_event),
+            ActivityEvent::Build(build_event) => {
+                self.handle_build_event(build_event);
+                true
+            }
             ActivityEvent::Fetch(fetch_event) => self.handle_fetch_event(fetch_event),
-            ActivityEvent::Evaluate(eval_event) => self.handle_evaluate_event(eval_event),
-            ActivityEvent::Task(task_event) => self.handle_task_event(task_event),
-            ActivityEvent::Command(cmd_event) => self.handle_command_event(cmd_event),
-            ActivityEvent::Process(proc_event) => self.handle_process_event(proc_event),
-            ActivityEvent::Operation(op_event) => self.handle_operation_event(op_event),
-            ActivityEvent::Message(msg) => self.handle_message(msg),
-            ActivityEvent::SetExpected(expected) => self.handle_set_expected(expected),
+            ActivityEvent::Evaluate(eval_event) => {
+                self.handle_evaluate_event(eval_event);
+                true
+            }
+            ActivityEvent::Task(task_event) => {
+                self.handle_task_event(task_event);
+                true
+            }
+            ActivityEvent::Command(cmd_event) => {
+                self.handle_command_event(cmd_event);
+                true
+            }
+            ActivityEvent::Process(proc_event) => {
+                self.handle_process_event(proc_event);
+                true
+            }
+            ActivityEvent::Operation(op_event) => {
+                self.handle_operation_event(op_event);
+                true
+            }
+            ActivityEvent::Message(msg) => {
+                self.handle_message(msg);
+                true
+            }
+            ActivityEvent::SetExpected(expected) => {
+                self.handle_set_expected(expected);
+                true
+            }
             ActivityEvent::Shell(_) => {
-                // Shell events are handled separately by the shell runner
-                // They don't affect the activity model
+                // Shell events are handled separately by the shell runner;
+                // they don't affect the activity model.
+                false
             }
         }
     }
@@ -433,7 +462,9 @@ impl ActivityModel {
         }
     }
 
-    fn handle_fetch_event(&mut self, event: Fetch) {
+    /// Returns `true` if the model may have changed; `false` for skipped
+    /// `.narinfo` downloads, which are not displayed.
+    fn handle_fetch_event(&mut self, event: Fetch) -> bool {
         match event {
             Fetch::Start {
                 id,
@@ -449,7 +480,7 @@ impl ActivityModel {
                 // 2. A Download activity for the actual .narinfo HTTP request
                 // We only display the Query since it has the better name.
                 if kind == FetchKind::Download && name.ends_with(".narinfo") {
-                    return;
+                    return false;
                 }
 
                 let substituter = url.as_ref().and_then(|u| {
@@ -471,14 +502,17 @@ impl ActivityModel {
                     FetchKind::Copy => ActivityVariant::Copy,
                 };
                 self.create_activity(id, name, parent, url, variant, ActivityLevel::Info);
+                true
             }
             Fetch::Complete { id, outcome, .. } => {
                 self.handle_activity_complete(id, outcome);
+                true
             }
             Fetch::Progress {
                 id, current, total, ..
             } => {
                 self.handle_byte_progress(id, current, total);
+                true
             }
         }
     }


### PR DESCRIPTION
The foreground TUI recomputed its flexbox layout dozens of times per second while idle, burning ~10-15% CPU per managed process even when every process was quiet (#2915).

Two independent drivers, both forcing full-tree layout recomputes:

- throttled_notify_loop redrew on every safety-net timeout (~max_fps/sec) regardless of whether the model changed. It now tracks a ModelVersion counter bumped by the event processor and only redraws on real changes, plus a slow heartbeat to keep elapsed timers ticking. It registers for notifications before reading the version (Notified::enable) so a racing notify is never lost, and keypresses that only mutate ui_state — which iocraft cannot observe on its own — now wake the loop so input stays responsive instead of lagging until the next heartbeat.
- StatusDot's pulse future toggled state every 500ms for every process even when not pulsing, waking the whole UI for an invisible re-render. It now fully parks while steady and is woken on the steady->pulsing transition, so a screen of running processes wakes no timers.

Also gates redraws on real model changes (no-op shell and skipped .narinfo events no longer force a frame) and guards the fps divisor against zero.

Refactors the throttle loop over a RedrawSink trait so the logic is unit-testable without an iocraft State, with deterministic virtual-clock tests: idle redraws drop from ~300 to ~10 over 10s, plus coverage that a ui_state-only wake still repaints.