### PR TITLE
Drop x86_64-darwin (Intel macOS)

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,8 +38,6 @@ jobs:
             runs-on: '["self-hosted", "linux", "X64"]'
           - system: aarch64-darwin
             runs-on: '["self-hosted", "macOS", "ARM64"]'
-          - system: x86_64-darwin
-            runs-on: '["macos-15-intel"]'
 
     uses: ./.github/workflows/per-system-pipeline.yml
     secrets: inherit

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -52,8 +52,6 @@ jobs:
             runs-on: '["self-hosted", "linux", "X64"]'
           - system: aarch64-darwin
             runs-on: '["self-hosted", "macOS", "ARM64"]'
-          - system: x86_64-darwin
-            runs-on: '["macos-15-intel"]'
 
     uses: ./.github/workflows/per-system-pipeline.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
             runs-on: '["self-hosted", "linux", "X64"]'
           - system: aarch64-darwin
             runs-on: '["self-hosted", "macOS", "ARM64"]'
-          - system: x86_64-darwin
-            runs-on: '["macos-15-intel"]'
 
     uses: ./.github/workflows/build.yml
     secrets: inherit
@@ -62,8 +60,6 @@ jobs:
             runs-on: '["self-hosted", "linux", "X64"]'
           - system: aarch64-darwin
             runs-on: '["self-hosted", "macOS", "ARM64"]'
-          - system: x86_64-darwin
-            runs-on: '["macos-15-intel"]'
 
     uses: ./.github/workflows/pin.yml
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Breaking Changes
 
+- **Dropped `x86_64-darwin` (Intel macOS)**: devenv is no longer built, tested, or released for `x86_64-darwin`. The platform is end-of-life in nixpkgs (26.05 is the last release to support it). Intel Mac users should run devenv via Rosetta on an Apple Silicon machine or pin an older devenv release.
 - **Shell hook auto-activation**: The shell hook (`devenv hook bash`/`zsh`/`fish`/`nu`) and `devenv allow` now detect a project by looking for `devenv.nix` instead of `devenv.yaml`. Projects with only a `devenv.yaml` and no `devenv.nix` will no longer auto-activate; add a `devenv.nix` to restore activation.
 
 ## 2.1.2 (2026-05-13)

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,6 @@
       systems = [
         "x86_64-linux"
         "i686-linux"
-        "x86_64-darwin"
         "aarch64-linux"
         "aarch64-darwin"
       ];


### PR DESCRIPTION
## Summary

Removes `x86_64-darwin` (Intel macOS) from devenv's supported systems and CI.

The `x86_64-darwin` release build has been failing deterministically since 2026-06-03 ([example](https://github.com/cachix/devenv/actions/runs/27151478443/job/80184864967)). A freshly-built `devenv-nix-backend` fails to link the Cachix-substituted `devenv-core`/`devenv-eval-cache` rlibs with `E0463: can't find crate`. The failure is isolated to the ephemeral `macos-15-intel` runner — on every other platform `devenv-nix-backend` is itself a cache hit, so the fresh-against-substituted combination never occurs. Because the darwin build always fails, `devenv-nix-backend` is never pushed to the cache, so every release rebuilds it and fails again (chicken-and-egg).

The platform is also end-of-life upstream: nixpkgs prints `x86_64-darwin will be deprecated; 26.05 is the last release to support it`.

## Changes

- `flake.nix`: remove `x86_64-darwin` from `systems`.
- `release.yml`, `pr-test.yml`, `release-test.yml`: remove `x86_64-darwin` (`macos-15-intel`) from the build/test/pin matrices.
- `CHANGELOG.md`: Breaking Changes entry.

## Impact

Intel Mac users should run devenv via Rosetta on Apple Silicon or pin an older release. `aarch64-darwin` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)