### PR TITLE
perf(shell): speed up nested full-screen TUIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### Improvements
 
+- Sped up `devenv shell` when running nested full-screen TUIs (e.g. neovim, claude-code), where rendering previously lagged on larger terminals. Each frame now reads and redraws only the rows that actually changed instead of the whole screen, so a single-line update no longer costs a full-screen repaint.
 - `DEVENV_HOME` now overrides where devenv stores all per-user data (GC roots, trust database, cached keys), not just the trust database.
 - `DEVENV_RUNTIME` can now be set to override where a project stores its sockets and other runtime files. To relocate runtime files for all projects at once, prefer `XDG_RUNTIME_DIR`, which keeps each project's directory separate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 
 ### Improvements
 
-- Sped up `devenv shell` when running nested full-screen TUIs (e.g. neovim, claude-code), where rendering previously lagged on larger terminals. Each frame now reads and redraws only the rows that actually changed instead of the whole screen, so a single-line update no longer costs a full-screen repaint.
+- Sped up `devenv shell` when running nested full-screen TUIs (e.g. neovim, claude-code), where rendering previously lagged on larger terminals. Full-screen apps now have their output forwarded straight to the terminal (with the status line row kept protected) instead of being re-rendered frame by frame, and outside of full-screen apps each frame redraws only the rows that actually changed.
 - `DEVENV_HOME` now overrides where devenv stores all per-user data (GC roots, trust database, cached keys), not just the trust database.
 - `DEVENV_RUNTIME` can now be set to override where a project stores its sockets and other runtime files. To relocate runtime files for all projects at once, prefer `XDG_RUNTIME_DIR`, which keeps each project's directory separate.
 

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6546,10 +6546,6 @@ rec {
             name = "whoami";
             packageId = "whoami";
           }
-          {
-            name = "xdg";
-            packageId = "xdg";
-          }
         ];
         devDependencies = [
           {
@@ -6746,6 +6742,10 @@ rec {
             packageId = "devenv-activity";
           }
           {
+            name = "hex";
+            packageId = "hex";
+          }
+          {
             name = "miette";
             packageId = "miette";
             features = [ "fancy" ];
@@ -6814,6 +6814,10 @@ rec {
           {
             name = "serde_yaml";
             packageId = "serde_yaml";
+          }
+          {
+            name = "sha2";
+            packageId = "sha2 0.11.0";
           }
           {
             name = "socket2";
@@ -7172,16 +7176,16 @@ rec {
             packageId = "devenv-activity";
           }
           {
+            name = "devenv-core";
+            packageId = "devenv-core";
+          }
+          {
             name = "devenv-event-sources";
             packageId = "devenv-event-sources";
           }
           {
             name = "futures";
             packageId = "futures";
-          }
-          {
-            name = "hex";
-            packageId = "hex";
           }
           {
             name = "miette";
@@ -7214,10 +7218,6 @@ rec {
           {
             name = "serde_json";
             packageId = "serde_json";
-          }
-          {
-            name = "sha2";
-            packageId = "sha2 0.11.0";
           }
           {
             name = "signal-hook";

--- a/devenv-shell/src/escape/mod.rs
+++ b/devenv-shell/src/escape/mod.rs
@@ -21,12 +21,19 @@ use osc::{OscParser, OscResult};
 const FORWARDED_MODES: &[u16] = &[
     1, // cursor key mode (DECCKM) — applications use smkx/rmkx to toggle
     9, // X10 mouse mode (legacy)
-    47, 1047, 1049, // alternate screen
-    1000, 1002, 1003, // mouse tracking
-    1005, 1006, 1015, 1016, // mouse encoding (including SGR pixels)
+    47,
+    1047,
+    1049, // alternate screen
+    1000,
+    1002,
+    1003, // mouse tracking
+    1005,
+    1006,
+    1015,
+    1016, // mouse encoding (including SGR pixels)
     2004, // bracketed paste
     1004, // focus events
-    2026, // synchronized output
+    SYNCHRONIZED_OUTPUT_MODE,
     2031, // color scheme reporting
 ];
 
@@ -37,9 +44,12 @@ pub(crate) const ALT_SCREEN_MODES: &[u16] = &[47, 1047, 1049];
 /// because the PTY has fewer rows than the real terminal (status line).
 pub(crate) const IN_BAND_RESIZE_MODE: u16 = 2048;
 
+/// Mode 2026: synchronized output.
+pub(crate) const SYNCHRONIZED_OUTPUT_MODE: u16 = 2026;
+
 /// Modes that need explicit reset on session exit. Excludes alternate screen
-/// modes (handled via `LeaveAlternateScreen`) and synchronized output (mode
-/// 2026, managed per-frame by the renderer).
+/// modes (handled via `LeaveAlternateScreen`) and synchronized output (tracked
+/// separately so an unterminated application frame can be closed on exit).
 pub const CLEANUP_MODES: &[u16] = &[
     1, // cursor key mode (DECCKM)
     9, // X10 mouse mode
@@ -159,6 +169,11 @@ pub enum SequenceEvent {
     /// CSI 18 t — program is querying text area size in characters.
     /// The session responds with PTY dimensions (not real terminal size).
     TextAreaSizeQuery,
+    /// DECSTR (`CSI ! p`) or RIS (`ESC c`) reset persistent terminal modes.
+    TerminalReset {
+        hard: bool,
+        raw_bytes: Vec<u8>,
+    },
 }
 
 /// Maximum number of CSI parameters to accumulate.
@@ -183,6 +198,8 @@ enum CsiClass {
     /// CSI 18 t — text area size query. Intercepted so we can respond
     /// with PTY dimensions instead of the real terminal size.
     TextAreaSizeQuery,
+    /// DECSTR soft terminal reset.
+    SoftReset,
     /// AVT handles it, no forwarding needed.
     Ignore,
 }
@@ -213,6 +230,9 @@ fn classify_csi(
         // size-reporting queries are not forwarded to the real terminal).
         ([], b't') if first == 18 => CsiClass::TextAreaSizeQuery,
         ([], b't') if matches!(first, 16 | 21) => CsiClass::Forward,
+
+        // DECSTR resets modes whose state the session mirrors onto the host.
+        ([b'!'], b'p') => CsiClass::SoftReset,
 
         // Erase — intercept for renderer coordination
         ([], b'J') if first == 2 => CsiClass::EraseDisplay,
@@ -404,7 +424,8 @@ impl EscapeScanner {
 
     /// Scan a chunk of raw PTY output, appending events to the provided Vec.
     ///
-    /// Unlike [`scan`], this avoids allocating a new Vec on every call.
+    /// Unlike the test-only `scan` convenience method, this avoids allocating
+    /// a new Vec on every call.
     /// The caller can reuse the Vec across invocations.
     pub fn scan_into(&mut self, data: &[u8], events: &mut Vec<SequenceEvent>) {
         for &byte in data {
@@ -440,6 +461,15 @@ impl EscapeScanner {
                             self.seq_bytes.clear();
                             events.push(SequenceEvent::KeypadMode {
                                 application: byte == b'=',
+                            });
+                            self.state = RouterState::Ground;
+                        }
+                        b'c' => {
+                            // RIS hard terminal reset.
+                            let raw_bytes = std::mem::take(&mut self.seq_bytes);
+                            events.push(SequenceEvent::TerminalReset {
+                                hard: true,
+                                raw_bytes,
                             });
                             self.state = RouterState::Ground;
                         }
@@ -728,6 +758,13 @@ impl EscapeScanner {
             CsiClass::TextAreaSizeQuery => {
                 events.push(SequenceEvent::TextAreaSizeQuery);
             }
+            CsiClass::SoftReset => {
+                let raw_bytes = std::mem::take(&mut self.seq_bytes);
+                events.push(SequenceEvent::TerminalReset {
+                    hard: false,
+                    raw_bytes,
+                });
+            }
             CsiClass::Ignore => {}
         }
         self.state = RouterState::Ground;
@@ -921,6 +958,25 @@ mod tests {
             DecModeEvent::Set { modes, .. } => assert_eq!(modes, &[2026]),
             _ => panic!("expected Set"),
         }
+    }
+
+    #[test]
+    fn detects_soft_and_hard_terminal_resets() {
+        let mut scanner = EscapeScanner::new();
+        let events = scanner.scan(b"\x1b[!p\x1bc");
+        assert_eq!(
+            events,
+            [
+                SequenceEvent::TerminalReset {
+                    hard: false,
+                    raw_bytes: b"\x1b[!p".to_vec(),
+                },
+                SequenceEvent::TerminalReset {
+                    hard: true,
+                    raw_bytes: b"\x1bc".to_vec(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/devenv-shell/src/escape/mod.rs
+++ b/devenv-shell/src/escape/mod.rs
@@ -31,11 +31,11 @@ const FORWARDED_MODES: &[u16] = &[
 ];
 
 /// Modes that control alternate screen buffer.
-const ALT_SCREEN_MODES: &[u16] = &[47, 1047, 1049];
+pub(crate) const ALT_SCREEN_MODES: &[u16] = &[47, 1047, 1049];
 
 /// Mode 2048: in-band resize reports. Not forwarded to the real terminal
 /// because the PTY has fewer rows than the real terminal (status line).
-const IN_BAND_RESIZE_MODE: u16 = 2048;
+pub(crate) const IN_BAND_RESIZE_MODE: u16 = 2048;
 
 /// Modes that need explicit reset on session exit. Excludes alternate screen
 /// modes (handled via `LeaveAlternateScreen`) and synchronized output (mode
@@ -85,6 +85,16 @@ impl DecModeEvent {
     /// Whether this event disables in-band resize (mode 2048).
     pub fn disables_in_band_resize(&self) -> bool {
         matches!(self, DecModeEvent::Reset { modes, .. } if modes.contains(&IN_BAND_RESIZE_MODE))
+    }
+
+    /// Whether this event sets (enables) the given mode.
+    pub fn sets_mode(&self, mode: u16) -> bool {
+        matches!(self, DecModeEvent::Set { modes, .. } if modes.contains(&mode))
+    }
+
+    /// Whether this event resets (disables) the given mode.
+    pub fn resets_mode(&self, mode: u16) -> bool {
+        matches!(self, DecModeEvent::Reset { modes, .. } if modes.contains(&mode))
     }
 
     /// Raw bytes of the original sequence for forwarding.

--- a/devenv-shell/src/escape_state.rs
+++ b/devenv-shell/src/escape_state.rs
@@ -5,7 +5,9 @@
 //! kitty keyboard, etc.) so the host can reset them when the shell exits or
 //! when a hot-reload swaps PTYs.
 
-use crate::escape::{CLEANUP_MODES, DecModeEvent, EscapeScanner, SequenceEvent};
+use crate::escape::{
+    CLEANUP_MODES, DecModeEvent, EscapeScanner, SYNCHRONIZED_OUTPUT_MODE, SequenceEvent,
+};
 use crate::pty::Pty;
 use crate::terminal_commands::{
     AUTOWRAP_MODE, ORIGIN_MODE, ReportTextAreaSize, ResetDecMode, ResetModifyOtherKeys, SetDecMode,
@@ -42,6 +44,9 @@ pub struct EscapeState {
     pub modify_other_keys: bool,
     /// Mode 2048 (in-band resize) is enabled by the PTY program.
     pub in_band_resize: bool,
+    /// Mode 2026 synchronized output is currently held open by the PTY
+    /// program. Host overlays must not close the application's frame.
+    pub synchronized_output: bool,
     /// DECOM (mode 6, origin mode) is enabled by the PTY program. During
     /// passthrough the raw stream carries it to the real terminal, where it
     /// makes absolute host addressing region-relative.
@@ -63,6 +68,7 @@ impl EscapeState {
             kitty_keyboard_depth: 0,
             modify_other_keys: false,
             in_band_resize: false,
+            synchronized_output: false,
             origin_mode: false,
             wraparound_disabled: false,
         }
@@ -81,6 +87,12 @@ impl EscapeState {
             self.in_band_resize = true;
         } else if event.disables_in_band_resize() {
             self.in_band_resize = false;
+        }
+
+        if event.sets_mode(SYNCHRONIZED_OUTPUT_MODE) {
+            self.synchronized_output = true;
+        } else if event.resets_mode(SYNCHRONIZED_OUTPUT_MODE) {
+            self.synchronized_output = false;
         }
 
         if event.sets_mode(ORIGIN_MODE) {
@@ -139,6 +151,26 @@ impl EscapeState {
     pub fn apply_modify_other_keys(&mut self, enabled: bool) {
         self.modify_other_keys = enabled;
     }
+
+    /// Update tracked host state after DECSTR or RIS. These resets are
+    /// forwarded only by raw passthrough; the mediated path applies them in
+    /// the VT instead.
+    pub fn apply_terminal_reset(&mut self, hard: bool) {
+        if hard {
+            // RIS returns the terminal to its power-up state, including the
+            // primary screen and all modes tracked here.
+            *self = Self::new();
+            return;
+        }
+
+        // DECSTR resets origin mode, restores autowrap, selects the numeric
+        // keypad and normal cursor keys, and ends synchronized output.
+        self.origin_mode = false;
+        self.wraparound_disabled = false;
+        self.keypad_application_mode = false;
+        self.synchronized_output = false;
+        self.forwarded_dec_modes.remove(&1);
+    }
 }
 
 impl Default for EscapeState {
@@ -150,9 +182,8 @@ impl Default for EscapeState {
 /// Scan raw PTY output for escape sequences (DEC private mode and OSC queries),
 /// forward relevant ones to the real terminal, and update escape state.
 ///
-/// Pass `&mut std::io::sink()` for `stdout` to track state without forwarding
-/// any bytes (useful when the caller writes raw PTY bytes themselves and only
-/// needs the tracking side-effect).
+/// Pass `&mut std::io::sink()` for `stdout` to track state without duplicating
+/// sequences when the caller writes raw PTY bytes itself.
 pub fn process_escape_events(
     scanner: &mut EscapeScanner,
     data: &[u8],
@@ -211,6 +242,10 @@ pub fn process_escape_events(
                 pty.write_all(buf.as_bytes())?;
                 pty.flush()?;
             }
+            SequenceEvent::TerminalReset { hard, raw_bytes } => {
+                stdout.write_all(&raw_bytes)?;
+                esc.apply_terminal_reset(hard);
+            }
             SequenceEvent::KeypadMode { application } => {
                 queue!(stdout, SetKeypadMode { application })?;
                 esc.keypad_application_mode = application;
@@ -245,6 +280,10 @@ pub fn cleanup_forwarded_modes(esc: &EscapeState, stdout: &mut impl Write) -> io
     }
     if esc.modify_other_keys {
         queue!(stdout, ResetModifyOtherKeys)?;
+        needs_flush = true;
+    }
+    if esc.synchronized_output {
+        queue!(stdout, ResetDecMode(SYNCHRONIZED_OUTPUT_MODE))?;
         needs_flush = true;
     }
     // Modes the passthrough stream can carry to the real terminal raw and
@@ -282,6 +321,12 @@ mod tests {
                 SequenceEvent::ModifyOtherKeys { enabled, .. } => {
                     esc.apply_modify_other_keys(*enabled);
                 }
+                SequenceEvent::TerminalReset { hard, .. } => {
+                    esc.apply_terminal_reset(*hard);
+                }
+                SequenceEvent::KeypadMode { application } => {
+                    esc.keypad_application_mode = *application;
+                }
                 _ => {}
             }
         }
@@ -314,6 +359,53 @@ mod tests {
         let forwarded = scan_and_apply(&mut scanner, &mut esc, b"\x1b[?1;2048h");
         assert!(esc.in_band_resize);
         assert!(!forwarded.is_empty(), "mode 1 should be forwarded");
+    }
+
+    #[test]
+    fn synchronized_output_is_tracked_across_reads() {
+        let mut scanner = EscapeScanner::new();
+        let mut esc = EscapeState::new();
+        scan_and_apply(&mut scanner, &mut esc, b"\x1b[?2026h");
+        assert!(esc.synchronized_output);
+        scan_and_apply(&mut scanner, &mut esc, b"\x1b[?2026l");
+        assert!(!esc.synchronized_output);
+    }
+
+    #[test]
+    fn soft_reset_updates_passthrough_mode_state() {
+        let mut scanner = EscapeScanner::new();
+        let mut esc = EscapeState::new();
+        scan_and_apply(
+            &mut scanner,
+            &mut esc,
+            b"\x1b[?1049h\x1b[?1;6;2026h\x1b[?7l\x1b=",
+        );
+        assert!(esc.in_alternate_screen);
+        assert!(esc.origin_mode);
+        assert!(esc.wraparound_disabled);
+        assert!(esc.synchronized_output);
+        assert!(esc.keypad_application_mode);
+        assert!(esc.forwarded_dec_modes.contains(&1));
+
+        scan_and_apply(&mut scanner, &mut esc, b"\x1b[!p");
+        assert!(esc.in_alternate_screen, "DECSTR does not leave alt screen");
+        assert!(!esc.origin_mode);
+        assert!(!esc.wraparound_disabled);
+        assert!(!esc.synchronized_output);
+        assert!(!esc.keypad_application_mode);
+        assert!(!esc.forwarded_dec_modes.contains(&1));
+    }
+
+    #[test]
+    fn hard_reset_clears_passthrough_mode_state() {
+        let mut scanner = EscapeScanner::new();
+        let mut esc = EscapeState::new();
+        scan_and_apply(&mut scanner, &mut esc, b"\x1b[?1049h\x1b[?6;2026h\x1b[?7l");
+        scan_and_apply(&mut scanner, &mut esc, b"\x1bc");
+        assert!(!esc.in_alternate_screen);
+        assert!(!esc.origin_mode);
+        assert!(!esc.wraparound_disabled);
+        assert!(!esc.synchronized_output);
     }
 
     #[test]
@@ -386,7 +478,11 @@ mod tests {
     fn cleanup_resets_tracked_modes() {
         let mut scanner = EscapeScanner::new();
         let mut esc = EscapeState::new();
-        scan_and_apply(&mut scanner, &mut esc, b"\x1b[?1049h\x1b[?1000h\x1b[?2004h");
+        scan_and_apply(
+            &mut scanner,
+            &mut esc,
+            b"\x1b[?1049h\x1b[?1000h\x1b[?2004h\x1b[?2026h",
+        );
         assert!(esc.in_alternate_screen);
         assert!(esc.forwarded_dec_modes.contains(&1000));
         assert!(esc.forwarded_dec_modes.contains(&2004));
@@ -407,6 +503,11 @@ mod tests {
         assert!(
             out.contains("\x1b[?2004l"),
             "expected paste reset, got {:?}",
+            out
+        );
+        assert!(
+            out.contains("\x1b[?2026l"),
+            "expected synchronized-output reset, got {:?}",
             out
         );
     }

--- a/devenv-shell/src/escape_state.rs
+++ b/devenv-shell/src/escape_state.rs
@@ -8,7 +8,8 @@
 use crate::escape::{CLEANUP_MODES, DecModeEvent, EscapeScanner, SequenceEvent};
 use crate::pty::Pty;
 use crate::terminal_commands::{
-    ReportTextAreaSize, ResetDecMode, ResetModifyOtherKeys, SetKeypadMode,
+    AUTOWRAP_MODE, ORIGIN_MODE, ReportTextAreaSize, ResetDecMode, ResetModifyOtherKeys, SetDecMode,
+    SetKeypadMode,
 };
 use crossterm::event::PopKeyboardEnhancementFlags;
 use crossterm::{Command, queue, terminal};
@@ -41,6 +42,14 @@ pub struct EscapeState {
     pub modify_other_keys: bool,
     /// Mode 2048 (in-band resize) is enabled by the PTY program.
     pub in_band_resize: bool,
+    /// DECOM (mode 6, origin mode) is enabled by the PTY program. During
+    /// passthrough the raw stream carries it to the real terminal, where it
+    /// makes absolute host addressing region-relative.
+    pub origin_mode: bool,
+    /// DECAWM (mode 7, autowrap) was disabled by the PTY program. Wrap is on
+    /// by default, so cleanup must re-enable it if the program dies without
+    /// restoring it.
+    pub wraparound_disabled: bool,
 }
 
 impl EscapeState {
@@ -54,6 +63,8 @@ impl EscapeState {
             kitty_keyboard_depth: 0,
             modify_other_keys: false,
             in_band_resize: false,
+            origin_mode: false,
+            wraparound_disabled: false,
         }
     }
 
@@ -70,6 +81,18 @@ impl EscapeState {
             self.in_band_resize = true;
         } else if event.disables_in_band_resize() {
             self.in_band_resize = false;
+        }
+
+        if event.sets_mode(ORIGIN_MODE) {
+            self.origin_mode = true;
+        } else if event.resets_mode(ORIGIN_MODE) {
+            self.origin_mode = false;
+        }
+
+        if event.resets_mode(AUTOWRAP_MODE) {
+            self.wraparound_disabled = true;
+        } else if event.sets_mode(AUTOWRAP_MODE) {
+            self.wraparound_disabled = false;
         }
 
         if !event.has_forwarded_mode() {
@@ -222,6 +245,17 @@ pub fn cleanup_forwarded_modes(esc: &EscapeState, stdout: &mut impl Write) -> io
     }
     if esc.modify_other_keys {
         queue!(stdout, ResetModifyOtherKeys)?;
+        needs_flush = true;
+    }
+    // Modes the passthrough stream can carry to the real terminal raw and
+    // that alter it beyond the session: origin mode is off by default and
+    // autowrap on, so restore both if the program left them flipped.
+    if esc.origin_mode {
+        queue!(stdout, ResetDecMode(ORIGIN_MODE))?;
+        needs_flush = true;
+    }
+    if esc.wraparound_disabled {
+        queue!(stdout, SetDecMode(AUTOWRAP_MODE))?;
         needs_flush = true;
     }
     if needs_flush {

--- a/devenv-shell/src/lib.rs
+++ b/devenv-shell/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod dialect;
 pub mod escape;
 pub mod escape_state;
+mod passthrough;
 mod protocol;
 mod pty;
 mod session;

--- a/devenv-shell/src/passthrough.rs
+++ b/devenv-shell/src/passthrough.rs
@@ -30,15 +30,16 @@
 //!   terminal would immediately report its full height.
 //!
 //! Everything else passes through verbatim: content, styling, cursor moves,
-//! in-bounds scroll regions, and OSC/DCS strings.
+//! in-bounds scroll regions, and terminal string controls.
 //!
 //! The output is *boundary-clean*: `rewrite` never leaves `out` ending inside
-//! an escape sequence or a multi-byte UTF-8 character. CSI sequences, OSC/DCS
-//! strings, and partial codepoints split across reads are buffered and emitted
-//! only once complete, so the caller can safely interleave its own writes
-//! (status line, cursor moves) between `rewrite` calls. The only exception is
-//! a string sequence larger than [`MAX_STRING_LEN`], which is flushed in
-//! chunks to bound memory.
+//! an escape sequence or a multi-byte UTF-8 character. CSI sequences,
+//! OSC/DCS/APC/PM/SOS strings, and partial codepoints split across reads are
+//! buffered and emitted only once complete, so the caller can safely interleave
+//! its own writes (status line, cursor moves) between `rewrite` calls. A string
+//! sequence larger than [`MAX_STRING_LEN`] is flushed in chunks to bound
+//! memory; [`PassthroughFilter::can_interleave_host_output`] reports that case
+//! so the caller can defer host output until the string terminates.
 
 use crate::escape::{ALT_SCREEN_MODES, IN_BAND_RESIZE_MODE};
 use std::io::Write;
@@ -48,21 +49,27 @@ use std::io::Write;
 /// unboundedly.
 const MAX_CSI_LEN: usize = 64;
 
-/// OSC/DCS strings are buffered until their terminator so host writes are
+/// Terminal strings are buffered until their terminator so host writes are
 /// never injected mid-string; payloads beyond this size (huge OSC 52
-/// clipboards, sixel images) are flushed in chunks to bound memory, giving up
-/// the boundary guarantee only for those.
+/// clipboards, sixel or kitty images) are flushed in chunks to bound memory.
 const MAX_STRING_LEN: usize = 1 << 20;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum StringKind {
+    Osc,
+    Dcs,
+    Apc,
+    Pm,
+    Sos,
+}
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum State {
     Ground,
     Esc,
     Csi,
-    Osc,
-    OscEsc,
-    Dcs,
-    DcsEsc,
+    String(StringKind),
+    StringEsc(StringKind),
 }
 
 /// Stateful rewriter for one shell session. Fed every PTY read (the session
@@ -74,9 +81,16 @@ pub struct PassthroughFilter {
     /// Bytes of the CSI sequence currently being accumulated (includes the
     /// leading `ESC [`).
     csi: Vec<u8>,
-    /// Bytes of the OSC/DCS string currently being accumulated (includes the
-    /// leading `ESC ]` / `ESC P`).
+    /// Bytes that precede a replacement escape after an unterminated string.
+    /// They are held until that replacement sequence is complete so output
+    /// never stops while the real terminal is still inside the old string.
+    pending_prefix: Vec<u8>,
+    /// Bytes of the terminal string currently being accumulated (includes its
+    /// `ESC` introducer).
     string_buf: Vec<u8>,
+    /// An oversized terminal string has already been partially emitted. Until
+    /// it terminates, host output would be interpreted as part of its payload.
+    host_output_blocked: bool,
     /// Partial UTF-8 codepoint held back until its continuation bytes arrive.
     utf8: [u8; 4],
     utf8_len: u8,
@@ -88,7 +102,9 @@ impl PassthroughFilter {
         Self {
             state: State::Ground,
             csi: Vec::new(),
+            pending_prefix: Vec::new(),
             string_buf: Vec::new(),
+            host_output_blocked: false,
             utf8: [0; 4],
             utf8_len: 0,
             utf8_need: 0,
@@ -173,38 +189,7 @@ impl PassthroughFilter {
                     }
                     continue;
                 }
-                State::Esc => match b {
-                    b'[' => {
-                        self.csi.clear();
-                        self.csi.extend_from_slice(b"\x1b[");
-                        self.state = State::Csi;
-                    }
-                    b']' => {
-                        self.string_buf.clear();
-                        self.string_buf.extend_from_slice(b"\x1b]");
-                        self.state = State::Osc;
-                    }
-                    b'P' => {
-                        self.string_buf.clear();
-                        self.string_buf.extend_from_slice(b"\x1bP");
-                        self.state = State::Dcs;
-                    }
-                    0x1b => {
-                        // Another ESC restarts; emit the one we held back.
-                        out.push(0x1b);
-                    }
-                    _ => {
-                        // Two-byte escape (e.g. ESC =, ESC >, ESC c): verbatim.
-                        out.push(0x1b);
-                        out.push(b);
-                        if b == b'c' {
-                            // RIS (full reset) clears the scroll margins;
-                            // re-assert the reserved region right after.
-                            push_scroll_region(content_rows, out);
-                        }
-                        self.state = State::Ground;
-                    }
-                },
+                State::Esc => self.handle_esc_byte(b, content_rows, out),
                 State::Csi => {
                     // Bulk-collect parameter and intermediate bytes.
                     let start = i;
@@ -213,9 +198,14 @@ impl PassthroughFilter {
                     }
                     self.csi.extend_from_slice(&data[start..i]);
                     if self.csi.len() > MAX_CSI_LEN {
-                        // Runaway length: emit verbatim and resync to ground.
+                        // Bound a runaway CSI without leaving the real terminal
+                        // inside it: emit the partial sequence followed by CAN,
+                        // which aborts the CSI and returns to ground.
+                        self.flush_pending_prefix(out);
                         out.extend_from_slice(&self.csi);
+                        out.push(0x18);
                         self.csi.clear();
+                        self.host_output_blocked = false;
                         self.state = State::Ground;
                         continue;
                     }
@@ -227,7 +217,8 @@ impl PassthroughFilter {
                     if (0x40..=0x7e).contains(&b) {
                         // Final byte: the CSI is complete.
                         self.csi.push(b);
-                        rewrite_csi(&self.csi, content_rows, out);
+                        self.finish_csi(content_rows, out);
+                        self.host_output_blocked = false;
                         self.csi.clear();
                         self.state = State::Ground;
                     } else if b == 0x1b {
@@ -239,7 +230,9 @@ impl PassthroughFilter {
                         // CAN/SUB abort the sequence; the buffered bytes are
                         // dropped (the terminal never executes them).
                         self.csi.clear();
+                        self.flush_pending_prefix(out);
                         out.push(b);
+                        self.host_output_blocked = false;
                         self.state = State::Ground;
                     } else if b < 0x20 {
                         // C0 controls inside a CSI are executed immediately
@@ -252,16 +245,23 @@ impl PassthroughFilter {
                         // Invalid byte: emit what we have verbatim and resync
                         // to ground.
                         self.csi.push(b);
+                        self.flush_pending_prefix(out);
                         out.extend_from_slice(&self.csi);
                         self.csi.clear();
                         self.state = State::Ground;
                     }
                     continue;
                 }
-                State::Osc => {
-                    // Bulk-buffer the payload up to the next BEL or ESC.
+                State::String(kind) => {
+                    // Bulk-buffer the payload up to the next terminator,
+                    // cancellation control, or ESC.
                     let start = i;
-                    while i < n && data[i] != 0x07 && data[i] != 0x1b {
+                    while i < n
+                        && data[i] != 0x1b
+                        && data[i] != 0x18
+                        && data[i] != 0x1a
+                        && !(kind == StringKind::Osc && data[i] == 0x07)
+                    {
                         i += 1;
                     }
                     self.string_buf.extend_from_slice(&data[start..i]);
@@ -269,43 +269,140 @@ impl PassthroughFilter {
                         self.spill_oversized_string(out);
                         break;
                     }
-                    self.string_buf.push(data[i]);
                     match data[i] {
-                        0x07 => self.flush_string(out), // BEL terminator
-                        _ => self.state = State::OscEsc,
+                        0x07 if kind == StringKind::Osc => {
+                            self.string_buf.push(0x07);
+                            self.flush_string(out);
+                        }
+                        0x18 | 0x1a => {
+                            // CAN/SUB abort a terminal string and execute as
+                            // controls, leaving the parser in ground.
+                            self.string_buf.push(data[i]);
+                            self.flush_string(out);
+                        }
+                        _ => {
+                            self.string_buf.push(0x1b);
+                            self.state = State::StringEsc(kind);
+                        }
                     }
                     i += 1;
                     continue;
                 }
-                State::OscEsc => {
-                    // ESC \ is the ST terminator; anything else aborted the
-                    // string (OSC payloads do not contain bare ESC). Either
-                    // way the buffered bytes are flushed verbatim.
+                State::StringEsc(_kind) if b == b'\\' => {
+                    // ST (ESC \) terminates every terminal string.
                     self.string_buf.push(b);
                     self.flush_string(out);
                 }
-                State::Dcs => {
-                    // Bulk-buffer the payload up to the next ESC.
-                    let start = i;
-                    while i < n && data[i] != 0x1b {
-                        i += 1;
-                    }
-                    self.string_buf.extend_from_slice(&data[start..i]);
-                    if i == n {
-                        self.spill_oversized_string(out);
-                        break;
-                    }
-                    self.string_buf.push(0x1b);
-                    self.state = State::DcsEsc;
-                    i += 1;
-                    continue;
-                }
-                State::DcsEsc => {
-                    self.string_buf.push(b);
-                    self.flush_string(out);
+                State::StringEsc(_kind) => {
+                    // A non-ST ESC aborts the old string and starts a new
+                    // escape sequence. Keep the old prefix buffered until the
+                    // replacement sequence is complete, otherwise host output
+                    // could land between the aborting ESC and its final byte.
+                    debug_assert_eq!(self.string_buf.last(), Some(&0x1b));
+                    self.string_buf.pop();
+                    self.pending_prefix.extend_from_slice(&self.string_buf);
+                    self.string_buf.clear();
+                    self.state = State::Esc;
+                    self.handle_esc_byte(b, content_rows, out);
                 }
             }
             i += 1;
+        }
+    }
+
+    /// Whether the caller may safely write its own escape sequences after the
+    /// latest output from this filter. This is false only after an oversized
+    /// terminal string had to be partially emitted before its terminator.
+    pub fn can_interleave_host_output(&self) -> bool {
+        !self.host_output_blocked
+    }
+
+    /// Cancel an oversized terminal string that has already been partially
+    /// emitted, returning whether the caller must write CAN (`0x18`) before
+    /// emitting host-controlled output.
+    ///
+    /// Fully buffered partial sequences have not reached the real terminal and
+    /// therefore do not need cancellation.
+    pub fn abort_for_host_output(&mut self) -> bool {
+        if !self.host_output_blocked {
+            return false;
+        }
+
+        self.state = State::Ground;
+        self.csi.clear();
+        self.pending_prefix.clear();
+        self.string_buf.clear();
+        self.host_output_blocked = false;
+        self.utf8_len = 0;
+        self.utf8_need = 0;
+        true
+    }
+
+    /// Handle the byte following an ESC. The ESC itself is implicit.
+    fn handle_esc_byte(&mut self, b: u8, content_rows: u16, out: &mut Vec<u8>) {
+        match b {
+            b'[' => {
+                self.csi.clear();
+                self.csi.extend_from_slice(b"\x1b[");
+                self.state = State::Csi;
+            }
+            b']' => self.start_string(StringKind::Osc, b']'),
+            b'P' => self.start_string(StringKind::Dcs, b'P'),
+            b'_' => self.start_string(StringKind::Apc, b'_'),
+            b'^' => self.start_string(StringKind::Pm, b'^'),
+            b'X' => self.start_string(StringKind::Sos, b'X'),
+            0x1b => {
+                // The newer ESC restarts the escape. Keep the older one with
+                // any pending prefix so the byte stream remains verbatim once
+                // a complete replacement sequence is available.
+                self.pending_prefix.push(0x1b);
+                self.state = State::Esc;
+            }
+            _ => {
+                // Two-byte escape (e.g. ESC =, ESC >, ESC c): verbatim.
+                self.flush_pending_prefix(out);
+                out.push(0x1b);
+                out.push(b);
+                if b == b'c' {
+                    // RIS (full reset) clears the scroll margins; re-assert
+                    // the reserved region right after.
+                    push_scroll_region(content_rows, out);
+                }
+                self.host_output_blocked = false;
+                self.state = State::Ground;
+            }
+        }
+    }
+
+    fn start_string(&mut self, kind: StringKind, introducer: u8) {
+        self.string_buf.clear();
+        self.string_buf.push(0x1b);
+        self.string_buf.push(introducer);
+        self.state = State::String(kind);
+    }
+
+    fn flush_pending_prefix(&mut self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.pending_prefix);
+        self.pending_prefix.clear();
+    }
+
+    fn finish_csi(&mut self, content_rows: u16, out: &mut Vec<u8>) {
+        if self.pending_prefix.is_empty() {
+            rewrite_csi(&self.csi, content_rows, out);
+            return;
+        }
+
+        // Recovery from an unterminated terminal string needs the replacement
+        // sequence's ESC to abort that string. If rewriting intentionally drops
+        // the CSI (for example a host-size query), emit CAN after the old prefix
+        // instead so the real terminal still returns to ground.
+        let mut rewritten = Vec::new();
+        rewrite_csi(&self.csi, content_rows, &mut rewritten);
+        self.flush_pending_prefix(out);
+        if rewritten.is_empty() {
+            out.push(0x18);
+        } else {
+            out.extend_from_slice(&rewritten);
         }
     }
 
@@ -325,10 +422,12 @@ impl PassthroughFilter {
         self.utf8_need = need;
     }
 
-    /// Emit the buffered OSC/DCS string and return to ground.
+    /// Emit the buffered terminal string and return to ground.
     fn flush_string(&mut self, out: &mut Vec<u8>) {
+        self.flush_pending_prefix(out);
         out.extend_from_slice(&self.string_buf);
         self.string_buf.clear();
+        self.host_output_blocked = false;
         self.state = State::Ground;
     }
 
@@ -337,8 +436,10 @@ impl PassthroughFilter {
     /// of the boundary guarantee for them.
     fn spill_oversized_string(&mut self, out: &mut Vec<u8>) {
         if self.string_buf.len() > MAX_STRING_LEN {
+            self.flush_pending_prefix(out);
             out.extend_from_slice(&self.string_buf);
             self.string_buf.clear();
+            self.host_output_blocked = true;
         }
     }
 }
@@ -718,6 +819,18 @@ mod tests {
     }
 
     #[test]
+    fn osc_aborted_by_csi_still_filters_replacement_sequence() {
+        let mut f = PassthroughFilter::new();
+        // ESC [ aborts the unterminated OSC and starts a CSI. The size query
+        // must still be stripped; CAN safely returns the real terminal to
+        // ground when the replacement CSI itself has no output.
+        assert_eq!(
+            run(&mut f, b"\x1b]0;title\x1b[18tafter", 24),
+            b"\x1b]0;title\x18after"
+        );
+    }
+
+    #[test]
     fn osc_split_across_reads_is_held_until_complete() {
         let mut f = PassthroughFilter::new();
         let mut out = Vec::new();
@@ -744,6 +857,70 @@ mod tests {
         assert_eq!(out, b"", "partial DCS must be withheld");
         f.rewrite(b"m\x1b\\", 24, &mut out);
         assert_eq!(out, b"\x1bP1$r0m\x1b\\");
+    }
+
+    #[test]
+    fn dcs_aborted_by_csi_still_clamps_replacement_sequence() {
+        let mut f = PassthroughFilter::new();
+        assert_eq!(
+            run(&mut f, b"\x1bPdata\x1b[999;1H", 24),
+            b"\x1bPdata\x1b[24;1H"
+        );
+    }
+
+    #[test]
+    fn apc_split_across_reads_is_held_until_complete() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        // Kitty graphics uses APC (`ESC _ G ... ST`). Holding the complete
+        // command prevents status-line cursor writes from landing in payload.
+        f.rewrite(b"\x1b_Gf=100;AAAA", 24, &mut out);
+        assert!(out.is_empty(), "partial APC must be withheld");
+        assert!(f.can_interleave_host_output());
+        f.rewrite(b"BBBB\x1b\\after", 24, &mut out);
+        assert_eq!(out, b"\x1b_Gf=100;AAAABBBB\x1b\\after");
+    }
+
+    #[test]
+    fn pm_and_sos_strings_are_boundary_clean() {
+        for introducer in [b'^', b'X'] {
+            let mut f = PassthroughFilter::new();
+            let mut out = Vec::new();
+            f.rewrite(&[0x1b, introducer, b'a'], 24, &mut out);
+            assert!(out.is_empty());
+            f.rewrite(b"b\x1b\\", 24, &mut out);
+            assert_eq!(
+                out,
+                [vec![0x1b, introducer, b'a', b'b'], b"\x1b\\".to_vec()].concat()
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_string_blocks_host_output_until_terminated() {
+        let mut f = PassthroughFilter::new();
+        let mut input = b"\x1b_G".to_vec();
+        input.resize(MAX_STRING_LEN + 1, b'A');
+        let out = run(&mut f, &input, 24);
+        assert!(!out.is_empty(), "oversized APC should spill");
+        assert!(!f.can_interleave_host_output());
+
+        let out = run(&mut f, b"\x1b\\", 24);
+        assert_eq!(out, b"\x1b\\");
+        assert!(f.can_interleave_host_output());
+    }
+
+    #[test]
+    fn oversized_string_can_be_cancelled_before_host_output() {
+        let mut f = PassthroughFilter::new();
+        let mut input = b"\x1b_G".to_vec();
+        input.resize(MAX_STRING_LEN + 1, b'A');
+        assert!(!run(&mut f, &input, 24).is_empty());
+
+        assert!(f.abort_for_host_output());
+        assert!(f.can_interleave_host_output());
+        assert!(!f.abort_for_host_output());
+        assert_eq!(run(&mut f, b"plain", 24), b"plain");
     }
 
     #[test]

--- a/devenv-shell/src/passthrough.rs
+++ b/devenv-shell/src/passthrough.rs
@@ -1,0 +1,381 @@
+//! Byte-stream rewrite for alternate-screen passthrough.
+//!
+//! When a full-screen application runs on the alternate screen, devenv can
+//! forward the application's output straight to the real terminal instead of
+//! re-rendering it through the VT (which costs a per-cell read of every changed
+//! row each frame). The application's PTY is sized one row shorter than the real
+//! terminal — the bottom row is reserved for devenv's status line — so the
+//! application never *addresses* the status row. But it can still *scroll over*
+//! it if it resets its scroll region to the full screen, and it can be told the
+//! wrong height if it queries the terminal directly. This filter rewrites the
+//! forwarded stream so the reserved bottom row stays protected:
+//!
+//! - A scroll-region reset (`CSI r`, no params) becomes an explicit
+//!   `CSI 1 ; content_rows r`, so a reset cannot expose the status row.
+//! - Entering the alternate screen (`CSI ? 1049 h` / `47h` / `1047h`) injects
+//!   the same explicit scroll region afterwards, in case the app relies on the
+//!   default region rather than setting its own.
+//! - The text-area-size query (`CSI 18 t`) is dropped, because the host answers
+//!   it with the reserved (one-row-shorter) size; letting the real terminal
+//!   answer too would report the full height and invite the app to draw into
+//!   the status row.
+//!
+//! Everything else passes through verbatim: content, styling, cursor moves,
+//! the app's own explicit scroll regions (already within its shorter height),
+//! and OSC/DCS strings. State is carried across calls so escape sequences split
+//! across reads are still rewritten correctly.
+
+/// Alternate-screen modes whose entry should (re)assert the reserved scroll
+/// region: 1049 (save+alt+clear), 1047 (alt), 47 (legacy alt).
+const ALT_SCREEN_MODES: [u16; 3] = [1049, 1047, 47];
+
+/// A malformed/oversized CSI sequence is flushed verbatim once it exceeds this
+/// many bytes, so a stray `ESC [` in the stream cannot make the filter buffer
+/// unboundedly.
+const MAX_CSI_LEN: usize = 64;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum State {
+    Ground,
+    Esc,
+    Csi,
+    Osc,
+    OscEsc,
+    Dcs,
+    DcsEsc,
+}
+
+/// Stateful rewriter for one passthrough session. Reused across PTY reads.
+pub struct PassthroughFilter {
+    state: State,
+    /// Bytes of the CSI sequence currently being accumulated (includes the
+    /// leading `ESC [`). Only CSI sequences are buffered, since they are the
+    /// only ones rewritten; all other bytes are copied straight to the output.
+    csi: Vec<u8>,
+}
+
+impl PassthroughFilter {
+    pub fn new() -> Self {
+        Self {
+            state: State::Ground,
+            csi: Vec::new(),
+        }
+    }
+
+    /// Reset to the ground state, discarding any partially-buffered sequence.
+    /// Called when passthrough is (re)entered so a sequence left dangling by a
+    /// previous excursion cannot leak into a new one.
+    pub fn reset(&mut self) {
+        self.state = State::Ground;
+        self.csi.clear();
+    }
+
+    /// Append the rewritten form of `data` to `out`. `content_rows` is the
+    /// number of rows available to the app (the real terminal height minus the
+    /// reserved status row).
+    pub fn rewrite(&mut self, data: &[u8], content_rows: u16, out: &mut Vec<u8>) {
+        for &b in data {
+            match self.state {
+                State::Ground => {
+                    if b == 0x1b {
+                        self.state = State::Esc;
+                    } else {
+                        out.push(b);
+                    }
+                }
+                State::Esc => match b {
+                    b'[' => {
+                        self.csi.clear();
+                        self.csi.extend_from_slice(b"\x1b[");
+                        self.state = State::Csi;
+                    }
+                    b']' => {
+                        out.extend_from_slice(b"\x1b]");
+                        self.state = State::Osc;
+                    }
+                    b'P' => {
+                        out.extend_from_slice(b"\x1bP");
+                        self.state = State::Dcs;
+                    }
+                    0x1b => {
+                        // Another ESC restarts; emit the one we held back.
+                        out.push(0x1b);
+                    }
+                    _ => {
+                        // Two-byte escape (e.g. ESC =, ESC >, ESC c): verbatim.
+                        out.push(0x1b);
+                        out.push(b);
+                        self.state = State::Ground;
+                    }
+                },
+                State::Csi => {
+                    if b == 0x1b {
+                        // Abort the partial CSI (matches terminal behavior) and
+                        // start a new sequence.
+                        self.csi.clear();
+                        self.state = State::Esc;
+                    } else {
+                        self.csi.push(b);
+                        if (0x40..=0x7e).contains(&b) {
+                            // Final byte: the CSI is complete.
+                            rewrite_csi(&self.csi, content_rows, out);
+                            self.csi.clear();
+                            self.state = State::Ground;
+                        } else if !(0x20..=0x3f).contains(&b) || self.csi.len() > MAX_CSI_LEN {
+                            // Invalid intermediate/param byte or runaway length:
+                            // emit what we have verbatim and resync to ground.
+                            out.extend_from_slice(&self.csi);
+                            self.csi.clear();
+                            self.state = State::Ground;
+                        }
+                    }
+                }
+                State::Osc => {
+                    out.push(b);
+                    match b {
+                        0x07 => self.state = State::Ground, // BEL terminator
+                        0x1b => self.state = State::OscEsc,
+                        _ => {}
+                    }
+                }
+                State::OscEsc => {
+                    // ESC \ is the ST terminator; anything else, best-effort
+                    // return to ground (OSC payloads do not contain bare ESC).
+                    out.push(b);
+                    self.state = State::Ground;
+                }
+                State::Dcs => {
+                    out.push(b);
+                    if b == 0x1b {
+                        self.state = State::DcsEsc;
+                    }
+                }
+                State::DcsEsc => {
+                    out.push(b);
+                    self.state = State::Ground;
+                }
+            }
+        }
+    }
+}
+
+impl Default for PassthroughFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Append the rewritten form of one complete CSI sequence (`seq`, including the
+/// leading `ESC [`) to `out`.
+fn rewrite_csi(seq: &[u8], content_rows: u16, out: &mut Vec<u8>) {
+    // seq is `ESC [ <params/intermediates> <final>`; len >= 3.
+    let final_byte = seq[seq.len() - 1];
+    let params = &seq[2..seq.len() - 1];
+
+    // Scroll-region reset (`CSI r`) → explicit region protecting the status row.
+    if final_byte == b'r' && params.is_empty() {
+        push_scroll_region(content_rows, out);
+        return;
+    }
+
+    // Text-area-size query (`CSI 18 t`) → drop; the host answers it instead.
+    if final_byte == b't' && params == b"18" {
+        return;
+    }
+
+    // Entering the alternate screen (`CSI ? <modes> h`) → verbatim, then assert
+    // the reserved scroll region in case the app relies on the default.
+    if final_byte == b'h' && params.first() == Some(&b'?') && mode_list_has_alt(&params[1..]) {
+        out.extend_from_slice(seq);
+        push_scroll_region(content_rows, out);
+        return;
+    }
+
+    out.extend_from_slice(seq);
+}
+
+/// Whether a `;`-separated DEC mode parameter list contains an alt-screen mode.
+fn mode_list_has_alt(modes: &[u8]) -> bool {
+    modes
+        .split(|&b| b == b';')
+        .filter_map(|m| std::str::from_utf8(m).ok()?.parse::<u16>().ok())
+        .any(|m| ALT_SCREEN_MODES.contains(&m))
+}
+
+fn push_scroll_region(content_rows: u16, out: &mut Vec<u8>) {
+    out.extend_from_slice(b"\x1b[1;");
+    let mut buf = itoa_u16(content_rows);
+    out.append(&mut buf);
+    out.push(b'r');
+}
+
+/// Decimal-encode a `u16` without pulling in a formatting allocation per call
+/// site (the value is at most 5 digits).
+fn itoa_u16(mut n: u16) -> Vec<u8> {
+    if n == 0 {
+        return vec![b'0'];
+    }
+    let mut digits = Vec::with_capacity(5);
+    while n > 0 {
+        digits.push(b'0' + (n % 10) as u8);
+        n /= 10;
+    }
+    digits.reverse();
+    digits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(filter: &mut PassthroughFilter, data: &[u8], rows: u16) -> Vec<u8> {
+        let mut out = Vec::new();
+        filter.rewrite(data, rows, &mut out);
+        out
+    }
+
+    #[test]
+    fn plain_content_passes_through() {
+        let mut f = PassthroughFilter::new();
+        assert_eq!(run(&mut f, b"hello world\r\n", 24), b"hello world\r\n");
+    }
+
+    #[test]
+    fn bare_scroll_region_reset_is_clamped() {
+        let mut f = PassthroughFilter::new();
+        // CSI r (reset to full screen) must become CSI 1;24 r so a full-screen
+        // app cannot scroll into the reserved status row (row 25).
+        assert_eq!(run(&mut f, b"\x1b[r", 24), b"\x1b[1;24r");
+    }
+
+    #[test]
+    fn explicit_scroll_region_passes_through() {
+        let mut f = PassthroughFilter::new();
+        // The app's PTY is already one row shorter, so an explicit region is
+        // within bounds and must not be touched.
+        assert_eq!(run(&mut f, b"\x1b[1;20r", 24), b"\x1b[1;20r");
+        assert_eq!(run(&mut f, b"\x1b[5;18r", 24), b"\x1b[5;18r");
+    }
+
+    #[test]
+    fn text_area_size_query_is_stripped() {
+        let mut f = PassthroughFilter::new();
+        assert_eq!(run(&mut f, b"a\x1b[18tb", 24), b"ab");
+    }
+
+    #[test]
+    fn other_xtwinops_pass_through() {
+        let mut f = PassthroughFilter::new();
+        // CSI 14 t (text area in pixels) is not the one we intercept.
+        assert_eq!(run(&mut f, b"\x1b[14t", 24), b"\x1b[14t");
+    }
+
+    #[test]
+    fn alt_screen_enter_injects_scroll_region() {
+        let mut f = PassthroughFilter::new();
+        assert_eq!(run(&mut f, b"\x1b[?1049h", 24), b"\x1b[?1049h\x1b[1;24r");
+    }
+
+    #[test]
+    fn alt_screen_enter_compound_modes_injects_once() {
+        let mut f = PassthroughFilter::new();
+        assert_eq!(
+            run(&mut f, b"\x1b[?1049;1006h", 24),
+            b"\x1b[?1049;1006h\x1b[1;24r"
+        );
+    }
+
+    #[test]
+    fn alt_screen_legacy_variants() {
+        for mode in ["47", "1047"] {
+            let mut f = PassthroughFilter::new();
+            let input = format!("\x1b[?{mode}h");
+            let expected = format!("\x1b[?{mode}h\x1b[1;24r");
+            assert_eq!(run(&mut f, input.as_bytes(), 24), expected.as_bytes());
+        }
+    }
+
+    #[test]
+    fn alt_screen_leave_passes_through() {
+        let mut f = PassthroughFilter::new();
+        // Leaving the alt screen must not inject a region.
+        assert_eq!(run(&mut f, b"\x1b[?1049l", 24), b"\x1b[?1049l");
+    }
+
+    #[test]
+    fn unrelated_dec_mode_passes_through() {
+        let mut f = PassthroughFilter::new();
+        // Mouse tracking, bracketed paste, etc. are not alt-screen modes.
+        assert_eq!(run(&mut f, b"\x1b[?1000h", 24), b"\x1b[?1000h");
+        assert_eq!(run(&mut f, b"\x1b[?2004h", 24), b"\x1b[?2004h");
+    }
+
+    #[test]
+    fn sgr_and_cursor_moves_pass_through() {
+        let mut f = PassthroughFilter::new();
+        let input = b"\x1b[1;31m\x1b[10;5HX\x1b[0m";
+        assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn osc_payload_is_not_misread_as_csi() {
+        let mut f = PassthroughFilter::new();
+        // An OSC title containing "[r" / "[18t"-looking bytes must pass verbatim.
+        let input = b"\x1b]0;weird [r [18t title\x07rest";
+        assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn osc_with_st_terminator() {
+        let mut f = PassthroughFilter::new();
+        let input = b"\x1b]8;;http://x\x1b\\link";
+        assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn dcs_payload_passes_through() {
+        let mut f = PassthroughFilter::new();
+        let input = b"\x1bP1$r0m\x1b\\after";
+        assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn csi_split_across_reads_is_rewritten() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        // `CSI r` arriving as "ESC", "[", "r" in three reads.
+        f.rewrite(b"\x1b", 24, &mut out);
+        f.rewrite(b"[", 24, &mut out);
+        f.rewrite(b"r", 24, &mut out);
+        assert_eq!(out, b"\x1b[1;24r");
+    }
+
+    #[test]
+    fn alt_enter_split_across_reads() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        f.rewrite(b"\x1b[?10", 24, &mut out);
+        f.rewrite(b"49h", 24, &mut out);
+        assert_eq!(out, b"\x1b[?1049h\x1b[1;24r");
+    }
+
+    #[test]
+    fn content_around_sequences_is_preserved() {
+        let mut f = PassthroughFilter::new();
+        let out = run(&mut f, b"before\x1b[rmiddle\x1b[18tafter", 30);
+        assert_eq!(out, b"before\x1b[1;30rmiddleafter");
+    }
+
+    #[test]
+    fn reset_clears_dangling_state() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        f.rewrite(b"\x1b[12", 24, &mut out); // partial CSI left dangling
+        f.reset();
+        // After reset, a fresh content byte is emitted as ground, not appended
+        // to the abandoned CSI.
+        out.clear();
+        f.rewrite(b"X", 24, &mut out);
+        assert_eq!(out, b"X");
+    }
+}

--- a/devenv-shell/src/passthrough.rs
+++ b/devenv-shell/src/passthrough.rs
@@ -5,34 +5,54 @@
 //! re-rendering it through the VT (which costs a per-cell read of every changed
 //! row each frame). The application's PTY is sized one row shorter than the real
 //! terminal — the bottom row is reserved for devenv's status line — so the
-//! application never *addresses* the status row. But it can still *scroll over*
-//! it if it resets its scroll region to the full screen, and it can be told the
-//! wrong height if it queries the terminal directly. This filter rewrites the
+//! application never knowingly *addresses* the status row. But it can still
+//! scroll over it, address it via clamped absolute moves, or be told the wrong
+//! height if it queries the terminal directly. This filter rewrites the
 //! forwarded stream so the reserved bottom row stays protected:
 //!
-//! - A scroll-region reset (`CSI r`, no params) becomes an explicit
-//!   `CSI 1 ; content_rows r`, so a reset cannot expose the status row.
+//! - Any DECSTBM (`CSI top;bottom r`) whose bottom margin is omitted, zero, or
+//!   beyond the app's height is clamped to `content_rows`, so no scroll-region
+//!   form can expose the status row.
+//! - Absolute row addressing (`CSI row;col H`/`f`, `CSI row d`) beyond the
+//!   app's height is clamped to `content_rows`; the real terminal would clamp
+//!   it to its own (one-row-taller) bottom, i.e. the status row — this also
+//!   keeps the `CSI 999;999H` + DSR-6 size probe from reporting the full
+//!   height.
 //! - Entering the alternate screen (`CSI ? 1049 h` / `47h` / `1047h`) injects
-//!   the same explicit scroll region afterwards, in case the app relies on the
-//!   default region rather than setting its own.
-//! - The text-area-size query (`CSI 18 t`) is dropped, because the host answers
-//!   it with the reserved (one-row-shorter) size; letting the real terminal
-//!   answer too would report the full height and invite the app to draw into
-//!   the status row.
+//!   the reserved scroll region afterwards, in case the app relies on the
+//!   default region rather than setting its own; DECSTR (`CSI !p`) and RIS
+//!   (`ESC c`) reset the margins, so the region is re-asserted after them too.
+//! - The size queries `CSI 18 t` (cells; the host answers it with the reserved
+//!   size) and `CSI 14 t` (pixels; never forwarded by the mediated path either)
+//!   are dropped, so the real terminal cannot report the unreserved height.
+//! - Mode 2048 (in-band resize) is stripped from DEC mode lists: the host
+//!   sends its own in-band reports with the reserved size, while the real
+//!   terminal would immediately report its full height.
 //!
 //! Everything else passes through verbatim: content, styling, cursor moves,
-//! the app's own explicit scroll regions (already within its shorter height),
-//! and OSC/DCS strings. State is carried across calls so escape sequences split
-//! across reads are still rewritten correctly.
+//! in-bounds scroll regions, and OSC/DCS strings.
+//!
+//! The output is *boundary-clean*: `rewrite` never leaves `out` ending inside
+//! an escape sequence or a multi-byte UTF-8 character. CSI sequences, OSC/DCS
+//! strings, and partial codepoints split across reads are buffered and emitted
+//! only once complete, so the caller can safely interleave its own writes
+//! (status line, cursor moves) between `rewrite` calls. The only exception is
+//! a string sequence larger than [`MAX_STRING_LEN`], which is flushed in
+//! chunks to bound memory.
 
-/// Alternate-screen modes whose entry should (re)assert the reserved scroll
-/// region: 1049 (save+alt+clear), 1047 (alt), 47 (legacy alt).
-const ALT_SCREEN_MODES: [u16; 3] = [1049, 1047, 47];
+use crate::escape::{ALT_SCREEN_MODES, IN_BAND_RESIZE_MODE};
+use std::io::Write;
 
 /// A malformed/oversized CSI sequence is flushed verbatim once it exceeds this
 /// many bytes, so a stray `ESC [` in the stream cannot make the filter buffer
 /// unboundedly.
 const MAX_CSI_LEN: usize = 64;
+
+/// OSC/DCS strings are buffered until their terminator so host writes are
+/// never injected mid-string; payloads beyond this size (huge OSC 52
+/// clipboards, sixel images) are flushed in chunks to bound memory, giving up
+/// the boundary guarantee only for those.
+const MAX_STRING_LEN: usize = 1 << 20;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum State {
@@ -45,13 +65,22 @@ enum State {
     DcsEsc,
 }
 
-/// Stateful rewriter for one passthrough session. Reused across PTY reads.
+/// Stateful rewriter for one shell session. Fed every PTY read (the session
+/// discards the output for mediated batches) so its parse state stays aligned
+/// with the byte stream across mediated/passthrough handoffs — a sequence
+/// split across the handoff is emitted whole instead of leaking a raw tail.
 pub struct PassthroughFilter {
     state: State,
     /// Bytes of the CSI sequence currently being accumulated (includes the
-    /// leading `ESC [`). Only CSI sequences are buffered, since they are the
-    /// only ones rewritten; all other bytes are copied straight to the output.
+    /// leading `ESC [`).
     csi: Vec<u8>,
+    /// Bytes of the OSC/DCS string currently being accumulated (includes the
+    /// leading `ESC ]` / `ESC P`).
+    string_buf: Vec<u8>,
+    /// Partial UTF-8 codepoint held back until its continuation bytes arrive.
+    utf8: [u8; 4],
+    utf8_len: u8,
+    utf8_need: u8,
 }
 
 impl PassthroughFilter {
@@ -59,15 +88,11 @@ impl PassthroughFilter {
         Self {
             state: State::Ground,
             csi: Vec::new(),
+            string_buf: Vec::new(),
+            utf8: [0; 4],
+            utf8_len: 0,
+            utf8_need: 0,
         }
-    }
-
-    /// Reset to the ground state, discarding any partially-buffered sequence.
-    /// Called when passthrough is (re)entered so a sequence left dangling by a
-    /// previous excursion cannot leak into a new one.
-    pub fn reset(&mut self) {
-        self.state = State::Ground;
-        self.csi.clear();
     }
 
     /// Append the rewritten form of `data` to `out`. `content_rows` is the
@@ -77,10 +102,32 @@ impl PassthroughFilter {
         for &b in data {
             match self.state {
                 State::Ground => {
-                    if b == 0x1b {
-                        self.state = State::Esc;
-                    } else {
-                        out.push(b);
+                    if self.utf8_need > 0 {
+                        if (0x80..=0xbf).contains(&b) {
+                            self.utf8[self.utf8_len as usize] = b;
+                            self.utf8_len += 1;
+                            if self.utf8_len == self.utf8_need {
+                                out.extend_from_slice(&self.utf8[..self.utf8_len as usize]);
+                                self.utf8_len = 0;
+                                self.utf8_need = 0;
+                            }
+                            continue;
+                        }
+                        // Malformed continuation: flush what was held and
+                        // process the byte normally.
+                        out.extend_from_slice(&self.utf8[..self.utf8_len as usize]);
+                        self.utf8_len = 0;
+                        self.utf8_need = 0;
+                    }
+                    match b {
+                        0x1b => self.state = State::Esc,
+                        // Multi-byte UTF-8 lead: hold the codepoint back until
+                        // complete so host writes interleaved between reads
+                        // can never split it on the real terminal.
+                        0xc2..=0xdf => self.begin_utf8(b, 2),
+                        0xe0..=0xef => self.begin_utf8(b, 3),
+                        0xf0..=0xf4 => self.begin_utf8(b, 4),
+                        _ => out.push(b),
                     }
                 }
                 State::Esc => match b {
@@ -90,11 +137,13 @@ impl PassthroughFilter {
                         self.state = State::Csi;
                     }
                     b']' => {
-                        out.extend_from_slice(b"\x1b]");
+                        self.string_buf.clear();
+                        self.string_buf.extend_from_slice(b"\x1b]");
                         self.state = State::Osc;
                     }
                     b'P' => {
-                        out.extend_from_slice(b"\x1bP");
+                        self.string_buf.clear();
+                        self.string_buf.extend_from_slice(b"\x1bP");
                         self.state = State::Dcs;
                     }
                     0x1b => {
@@ -105,6 +154,11 @@ impl PassthroughFilter {
                         // Two-byte escape (e.g. ESC =, ESC >, ESC c): verbatim.
                         out.push(0x1b);
                         out.push(b);
+                        if b == b'c' {
+                            // RIS (full reset) clears the scroll margins;
+                            // re-assert the reserved region right after.
+                            push_scroll_region(content_rows, out);
+                        }
                         self.state = State::Ground;
                     }
                 },
@@ -114,6 +168,19 @@ impl PassthroughFilter {
                         // start a new sequence.
                         self.csi.clear();
                         self.state = State::Esc;
+                    } else if b == 0x18 || b == 0x1a {
+                        // CAN/SUB abort the sequence; the buffered bytes are
+                        // dropped (the terminal never executes them).
+                        self.csi.clear();
+                        out.push(b);
+                        self.state = State::Ground;
+                    } else if b < 0x20 {
+                        // C0 controls inside a CSI are executed immediately
+                        // while the sequence continues (VT500 semantics).
+                        // Emit the control now; the CSI follows when complete.
+                        out.push(b);
+                    } else if b == 0x7f {
+                        // DEL is ignored inside a CSI.
                     } else {
                         self.csi.push(b);
                         if (0x40..=0x7e).contains(&b) {
@@ -122,8 +189,8 @@ impl PassthroughFilter {
                             self.csi.clear();
                             self.state = State::Ground;
                         } else if !(0x20..=0x3f).contains(&b) || self.csi.len() > MAX_CSI_LEN {
-                            // Invalid intermediate/param byte or runaway length:
-                            // emit what we have verbatim and resync to ground.
+                            // Invalid byte or runaway length: emit what we
+                            // have verbatim and resync to ground.
                             out.extend_from_slice(&self.csi);
                             self.csi.clear();
                             self.state = State::Ground;
@@ -131,30 +198,56 @@ impl PassthroughFilter {
                     }
                 }
                 State::Osc => {
-                    out.push(b);
+                    self.string_buf.push(b);
                     match b {
-                        0x07 => self.state = State::Ground, // BEL terminator
+                        0x07 => self.flush_string(out), // BEL terminator
                         0x1b => self.state = State::OscEsc,
-                        _ => {}
+                        _ => self.spill_oversized_string(out),
                     }
                 }
                 State::OscEsc => {
-                    // ESC \ is the ST terminator; anything else, best-effort
-                    // return to ground (OSC payloads do not contain bare ESC).
-                    out.push(b);
-                    self.state = State::Ground;
+                    // ESC \ is the ST terminator; anything else aborted the
+                    // string (OSC payloads do not contain bare ESC). Either
+                    // way the buffered bytes are flushed verbatim.
+                    self.string_buf.push(b);
+                    self.flush_string(out);
                 }
                 State::Dcs => {
-                    out.push(b);
+                    self.string_buf.push(b);
                     if b == 0x1b {
                         self.state = State::DcsEsc;
+                    } else {
+                        self.spill_oversized_string(out);
                     }
                 }
                 State::DcsEsc => {
-                    out.push(b);
-                    self.state = State::Ground;
+                    self.string_buf.push(b);
+                    self.flush_string(out);
                 }
             }
+        }
+    }
+
+    fn begin_utf8(&mut self, lead: u8, need: u8) {
+        self.utf8[0] = lead;
+        self.utf8_len = 1;
+        self.utf8_need = need;
+    }
+
+    /// Emit the buffered OSC/DCS string and return to ground.
+    fn flush_string(&mut self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&self.string_buf);
+        self.string_buf.clear();
+        self.state = State::Ground;
+    }
+
+    /// Flush the buffered string prefix once it exceeds [`MAX_STRING_LEN`],
+    /// keeping the parse state. Bounds memory for huge payloads at the cost
+    /// of the boundary guarantee for them.
+    fn spill_oversized_string(&mut self, out: &mut Vec<u8>) {
+        if self.string_buf.len() > MAX_STRING_LEN {
+            out.extend_from_slice(&self.string_buf);
+            self.string_buf.clear();
         }
     }
 }
@@ -165,63 +258,164 @@ impl Default for PassthroughFilter {
     }
 }
 
+/// Parse `;`-separated numeric CSI parameters. Empty entries are `None`
+/// (default). Returns `None` if any entry is non-numeric (colon subparams,
+/// garbage) — callers then pass the sequence through verbatim.
+fn parse_params(params: &[u8]) -> Option<Vec<Option<u16>>> {
+    if params.is_empty() {
+        return Some(Vec::new());
+    }
+    params
+        .split(|&b| b == b';')
+        .map(|p| {
+            if p.is_empty() {
+                Some(None)
+            } else {
+                std::str::from_utf8(p).ok()?.parse::<u16>().ok().map(Some)
+            }
+        })
+        .collect()
+}
+
+/// Read parameter `idx`, treating omitted and `0` as the given default.
+fn param_or(params: &[Option<u16>], idx: usize, default: u16) -> u16 {
+    params
+        .get(idx)
+        .copied()
+        .flatten()
+        .filter(|&v| v > 0)
+        .unwrap_or(default)
+}
+
 /// Append the rewritten form of one complete CSI sequence (`seq`, including the
 /// leading `ESC [`) to `out`.
 fn rewrite_csi(seq: &[u8], content_rows: u16, out: &mut Vec<u8>) {
-    // seq is `ESC [ <params/intermediates> <final>`; len >= 3.
+    // seq is `ESC [ <marker?> <params> <intermediates> <final>`; len >= 3.
     let final_byte = seq[seq.len() - 1];
-    let params = &seq[2..seq.len() - 1];
+    let body = &seq[2..seq.len() - 1];
+    let (marker, rest) = match body.first() {
+        Some(&m @ (b'?' | b'<' | b'=' | b'>')) => (Some(m), &body[1..]),
+        _ => (None, body),
+    };
+    let inter_start = rest
+        .iter()
+        .position(|b| (0x20..=0x2f).contains(b))
+        .unwrap_or(rest.len());
+    let (param_bytes, intermediates) = rest.split_at(inter_start);
 
-    // Scroll-region reset (`CSI r`) → explicit region protecting the status row.
-    if final_byte == b'r' && params.is_empty() {
-        push_scroll_region(content_rows, out);
-        return;
+    match (marker, intermediates, final_byte) {
+        // DECSTBM. The real terminal resolves an omitted/zero bottom margin to
+        // its own (one-row-taller) height, so every form is normalized with
+        // the bottom clamped to the app's height.
+        (None, [], b'r') => {
+            let Some(p) = parse_params(param_bytes) else {
+                out.extend_from_slice(seq);
+                return;
+            };
+            let top = param_or(&p, 0, 1);
+            let bottom = param_or(&p, 1, content_rows).min(content_rows);
+            if top < bottom {
+                let _ = write!(out, "\x1b[{top};{bottom}r");
+            } else {
+                // Degenerate after clamping: fall back to the full protected
+                // region rather than forwarding a region the terminal would
+                // resolve against its taller height.
+                push_scroll_region(content_rows, out);
+            }
+        }
+
+        // XTWINOPS size queries. 18 (cells) is answered by the host with the
+        // reserved size; 14 (pixels) is not forwarded by the mediated path
+        // either — the real terminal's answer would describe the unreserved
+        // full-height text area.
+        (None, [], b't') => {
+            let Some(p) = parse_params(param_bytes) else {
+                out.extend_from_slice(seq);
+                return;
+            };
+            match p.first().copied().flatten() {
+                Some(14) | Some(18) => {}
+                _ => out.extend_from_slice(seq),
+            }
+        }
+
+        // CUP/HVP: absolute addressing is not confined by DECSTBM, so a row
+        // beyond the app's height (e.g. the `CSI 999;999H` size probe) would
+        // clamp onto the real terminal's bottom row — the status row.
+        (None, [], b'H' | b'f') => {
+            let Some(p) = parse_params(param_bytes) else {
+                out.extend_from_slice(seq);
+                return;
+            };
+            if param_or(&p, 0, 1) > content_rows {
+                let col = param_or(&p, 1, 1);
+                let _ = write!(out, "\x1b[{content_rows};{col}");
+                out.push(final_byte);
+            } else {
+                out.extend_from_slice(seq);
+            }
+        }
+
+        // VPA: same clamp as CUP for the row-only form.
+        (None, [], b'd') => {
+            let Some(p) = parse_params(param_bytes) else {
+                out.extend_from_slice(seq);
+                return;
+            };
+            if param_or(&p, 0, 1) > content_rows {
+                let _ = write!(out, "\x1b[{content_rows}d");
+            } else {
+                out.extend_from_slice(seq);
+            }
+        }
+
+        // DEC private mode set/reset. Mode 2048 (in-band resize) is stripped:
+        // the host sends its own reports with the reserved size, while the
+        // real terminal would immediately report its full height. Entering
+        // the alternate screen asserts the reserved scroll region, in case
+        // the app relies on the default region.
+        (Some(b'?'), [], b'h' | b'l') => {
+            let Some(p) = parse_params(param_bytes) else {
+                out.extend_from_slice(seq);
+                return;
+            };
+            let modes: Vec<u16> = p.into_iter().flatten().collect();
+            let kept: Vec<u16> = modes
+                .iter()
+                .copied()
+                .filter(|&m| m != IN_BAND_RESIZE_MODE)
+                .collect();
+            if kept.len() == modes.len() {
+                out.extend_from_slice(seq);
+            } else if !kept.is_empty() {
+                out.extend_from_slice(b"\x1b[?");
+                for (i, m) in kept.iter().enumerate() {
+                    if i > 0 {
+                        out.push(b';');
+                    }
+                    let _ = write!(out, "{m}");
+                }
+                out.push(final_byte);
+            }
+            if final_byte == b'h' && kept.iter().any(|m| ALT_SCREEN_MODES.contains(m)) {
+                push_scroll_region(content_rows, out);
+            }
+        }
+
+        // DECSTR (soft reset) clears the scroll margins; re-assert the
+        // reserved region right after.
+        (None, [b'!'], b'p') => {
+            out.extend_from_slice(seq);
+            push_scroll_region(content_rows, out);
+        }
+
+        _ => out.extend_from_slice(seq),
     }
-
-    // Text-area-size query (`CSI 18 t`) → drop; the host answers it instead.
-    if final_byte == b't' && params == b"18" {
-        return;
-    }
-
-    // Entering the alternate screen (`CSI ? <modes> h`) → verbatim, then assert
-    // the reserved scroll region in case the app relies on the default.
-    if final_byte == b'h' && params.first() == Some(&b'?') && mode_list_has_alt(&params[1..]) {
-        out.extend_from_slice(seq);
-        push_scroll_region(content_rows, out);
-        return;
-    }
-
-    out.extend_from_slice(seq);
-}
-
-/// Whether a `;`-separated DEC mode parameter list contains an alt-screen mode.
-fn mode_list_has_alt(modes: &[u8]) -> bool {
-    modes
-        .split(|&b| b == b';')
-        .filter_map(|m| std::str::from_utf8(m).ok()?.parse::<u16>().ok())
-        .any(|m| ALT_SCREEN_MODES.contains(&m))
 }
 
 fn push_scroll_region(content_rows: u16, out: &mut Vec<u8>) {
-    out.extend_from_slice(b"\x1b[1;");
-    let mut buf = itoa_u16(content_rows);
-    out.append(&mut buf);
-    out.push(b'r');
-}
-
-/// Decimal-encode a `u16` without pulling in a formatting allocation per call
-/// site (the value is at most 5 digits).
-fn itoa_u16(mut n: u16) -> Vec<u8> {
-    if n == 0 {
-        return vec![b'0'];
-    }
-    let mut digits = Vec::with_capacity(5);
-    while n > 0 {
-        digits.push(b'0' + (n % 10) as u8);
-        n /= 10;
-    }
-    digits.reverse();
-    digits
+    // Vec<u8>'s io::Write never fails.
+    let _ = write!(out, "\x1b[1;{content_rows}r");
 }
 
 #[cfg(test)]
@@ -249,6 +443,26 @@ mod tests {
     }
 
     #[test]
+    fn default_param_scroll_region_forms_are_clamped() {
+        // `CSI 0;0r`, `CSI ;r` and `CSI 0r` are semantically identical to a
+        // bare reset; the real terminal resolves the defaulted bottom to its
+        // full (one-row-taller) height.
+        for input in [&b"\x1b[0;0r"[..], b"\x1b[;r", b"\x1b[0r"] {
+            let mut f = PassthroughFilter::new();
+            assert_eq!(run(&mut f, input, 24), b"\x1b[1;24r", "input {input:?}");
+        }
+    }
+
+    #[test]
+    fn omitted_or_oversized_bottom_margin_is_clamped() {
+        let mut f = PassthroughFilter::new();
+        // Top-only DECSTBM: the bottom defaults to the page's last line.
+        assert_eq!(run(&mut f, b"\x1b[5r", 24), b"\x1b[5;24r");
+        // Bottom beyond the app's height clamps to it.
+        assert_eq!(run(&mut f, b"\x1b[1;999r", 24), b"\x1b[1;24r");
+    }
+
+    #[test]
     fn explicit_scroll_region_passes_through() {
         let mut f = PassthroughFilter::new();
         // The app's PTY is already one row shorter, so an explicit region is
@@ -258,16 +472,64 @@ mod tests {
     }
 
     #[test]
+    fn dec_mode_restore_is_not_mistaken_for_decstbm() {
+        let mut f = PassthroughFilter::new();
+        // XTRESTORE (`CSI ? ... r`) restores DEC modes; it is not a scroll
+        // region and must pass verbatim.
+        assert_eq!(run(&mut f, b"\x1b[?1049r", 24), b"\x1b[?1049r");
+    }
+
+    #[test]
     fn text_area_size_query_is_stripped() {
         let mut f = PassthroughFilter::new();
         assert_eq!(run(&mut f, b"a\x1b[18tb", 24), b"ab");
+        // Leading zeros are still the same query.
+        assert_eq!(run(&mut f, b"\x1b[018t", 24), b"");
+    }
+
+    #[test]
+    fn pixel_size_query_is_stripped() {
+        let mut f = PassthroughFilter::new();
+        // The mediated path never forwards CSI 14 t; the real terminal's
+        // answer would describe the full-height text area.
+        assert_eq!(run(&mut f, b"\x1b[14t", 24), b"");
     }
 
     #[test]
     fn other_xtwinops_pass_through() {
         let mut f = PassthroughFilter::new();
-        // CSI 14 t (text area in pixels) is not the one we intercept.
-        assert_eq!(run(&mut f, b"\x1b[14t", 24), b"\x1b[14t");
+        // Cell size (16) and title query (21) are forwarded in mediated mode
+        // too.
+        assert_eq!(run(&mut f, b"\x1b[16t", 24), b"\x1b[16t");
+        assert_eq!(run(&mut f, b"\x1b[21t", 24), b"\x1b[21t");
+    }
+
+    #[test]
+    fn absolute_row_addressing_is_clamped() {
+        let mut f = PassthroughFilter::new();
+        // The `CSI 999;999H` size probe would land the cursor on the real
+        // terminal's bottom row (the status row) and make a DSR-6 report the
+        // unreserved height.
+        assert_eq!(run(&mut f, b"\x1b[999;999H", 24), b"\x1b[24;999H");
+        assert_eq!(run(&mut f, b"\x1b[999d", 24), b"\x1b[24d");
+        assert_eq!(run(&mut f, b"\x1b[30;1f", 24), b"\x1b[24;1f");
+        // In-bounds addressing is untouched, byte for byte.
+        assert_eq!(run(&mut f, b"\x1b[10;5H", 24), b"\x1b[10;5H");
+        assert_eq!(run(&mut f, b"\x1b[24;80H", 24), b"\x1b[24;80H");
+    }
+
+    #[test]
+    fn in_band_resize_mode_is_stripped() {
+        let mut f = PassthroughFilter::new();
+        // The real terminal would answer ?2048h with an in-band report of its
+        // full height; the host sends its own reports with the PTY size.
+        assert_eq!(run(&mut f, b"\x1b[?2048h", 24), b"");
+        assert_eq!(run(&mut f, b"\x1b[?2048l", 24), b"");
+        // Stripped from compound lists, keeping the other modes.
+        assert_eq!(
+            run(&mut f, b"\x1b[?1049;2048h", 24),
+            b"\x1b[?1049h\x1b[1;24r"
+        );
     }
 
     #[test]
@@ -311,10 +573,42 @@ mod tests {
     }
 
     #[test]
+    fn soft_reset_reasserts_scroll_region() {
+        let mut f = PassthroughFilter::new();
+        // DECSTR clears the scroll margins on the real terminal.
+        assert_eq!(run(&mut f, b"\x1b[!p", 24), b"\x1b[!p\x1b[1;24r");
+    }
+
+    #[test]
+    fn full_reset_reasserts_scroll_region() {
+        let mut f = PassthroughFilter::new();
+        // RIS clears the scroll margins on the real terminal.
+        assert_eq!(run(&mut f, b"\x1bc", 24), b"\x1bc\x1b[1;24r");
+    }
+
+    #[test]
     fn sgr_and_cursor_moves_pass_through() {
         let mut f = PassthroughFilter::new();
         let input = b"\x1b[1;31m\x1b[10;5HX\x1b[0m";
         assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn c0_inside_csi_is_executed_and_sequence_continues() {
+        let mut f = PassthroughFilter::new();
+        // Per the VT500 parser, a C0 control inside a CSI is executed while
+        // the sequence continues collecting — the filter must not desync from
+        // the terminal and treat the remainder as plain text.
+        assert_eq!(run(&mut f, b"\x1b[1\rH", 24), b"\r\x1b[1H");
+        // A CSI final smuggled past a C0 still gets rewritten.
+        assert_eq!(run(&mut f, b"\x1b[\rr", 24), b"\r\x1b[1;24r");
+    }
+
+    #[test]
+    fn can_aborts_csi() {
+        let mut f = PassthroughFilter::new();
+        // CAN drops the partial sequence; following bytes are plain text.
+        assert_eq!(run(&mut f, b"\x1b[12\x18X", 24), b"\x18X");
     }
 
     #[test]
@@ -333,10 +627,51 @@ mod tests {
     }
 
     #[test]
+    fn osc_split_across_reads_is_held_until_complete() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        // The output must never end mid-OSC: host writes between reads would
+        // be injected into the string on the real terminal.
+        f.rewrite(b"\x1b]52;c;aGVsbG8", 24, &mut out);
+        assert_eq!(out, b"", "partial OSC must be withheld");
+        f.rewrite(b"\x07after", 24, &mut out);
+        assert_eq!(out, b"\x1b]52;c;aGVsbG8\x07after");
+    }
+
+    #[test]
     fn dcs_payload_passes_through() {
         let mut f = PassthroughFilter::new();
         let input = b"\x1bP1$r0m\x1b\\after";
         assert_eq!(run(&mut f, input, 24), input);
+    }
+
+    #[test]
+    fn dcs_split_across_reads_is_held_until_complete() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        f.rewrite(b"\x1bP1$r0", 24, &mut out);
+        assert_eq!(out, b"", "partial DCS must be withheld");
+        f.rewrite(b"m\x1b\\", 24, &mut out);
+        assert_eq!(out, b"\x1bP1$r0m\x1b\\");
+    }
+
+    #[test]
+    fn utf8_split_across_reads_is_held_until_complete() {
+        let mut f = PassthroughFilter::new();
+        let mut out = Vec::new();
+        // "中" (e4 b8 ad) split across reads: emitting the partial bytes would
+        // let host writes interleave mid-codepoint and render U+FFFD.
+        f.rewrite(b"a\xe4\xb8", 24, &mut out);
+        assert_eq!(out, b"a", "partial codepoint must be withheld");
+        f.rewrite(b"\xadb", 24, &mut out);
+        assert_eq!(out, "a中b".as_bytes());
+    }
+
+    #[test]
+    fn invalid_utf8_is_flushed_verbatim() {
+        let mut f = PassthroughFilter::new();
+        // A lead byte followed by a non-continuation must not swallow bytes.
+        assert_eq!(run(&mut f, b"\xe4Xy", 24), b"\xe4Xy");
     }
 
     #[test]
@@ -364,18 +699,5 @@ mod tests {
         let mut f = PassthroughFilter::new();
         let out = run(&mut f, b"before\x1b[rmiddle\x1b[18tafter", 30);
         assert_eq!(out, b"before\x1b[1;30rmiddleafter");
-    }
-
-    #[test]
-    fn reset_clears_dangling_state() {
-        let mut f = PassthroughFilter::new();
-        let mut out = Vec::new();
-        f.rewrite(b"\x1b[12", 24, &mut out); // partial CSI left dangling
-        f.reset();
-        // After reset, a fresh content byte is emitted as ground, not appended
-        // to the abandoned CSI.
-        out.clear();
-        f.rewrite(b"X", 24, &mut out);
-        assert_eq!(out, b"X");
     }
 }

--- a/devenv-shell/src/passthrough.rs
+++ b/devenv-shell/src/passthrough.rs
@@ -98,8 +98,15 @@ impl PassthroughFilter {
     /// Append the rewritten form of `data` to `out`. `content_rows` is the
     /// number of rows available to the app (the real terminal height minus the
     /// reserved status row).
+    ///
+    /// The Ground and OSC/DCS states copy runs of uninteresting bytes in bulk;
+    /// this runs on every PTY read (mediated batches included, for handoff
+    /// continuity), so plain output must cost a scan, not a per-byte loop.
     pub fn rewrite(&mut self, data: &[u8], content_rows: u16, out: &mut Vec<u8>) {
-        for &b in data {
+        let n = data.len();
+        let mut i = 0;
+        while i < n {
+            let b = data[i];
             match self.state {
                 State::Ground => {
                     if self.utf8_need > 0 {
@@ -111,6 +118,7 @@ impl PassthroughFilter {
                                 self.utf8_len = 0;
                                 self.utf8_need = 0;
                             }
+                            i += 1;
                             continue;
                         }
                         // Malformed continuation: flush what was held and
@@ -119,16 +127,51 @@ impl PassthroughFilter {
                         self.utf8_len = 0;
                         self.utf8_need = 0;
                     }
-                    match b {
-                        0x1b => self.state = State::Esc,
-                        // Multi-byte UTF-8 lead: hold the codepoint back until
-                        // complete so host writes interleaved between reads
-                        // can never split it on the real terminal.
-                        0xc2..=0xdf => self.begin_utf8(b, 2),
-                        0xe0..=0xef => self.begin_utf8(b, 3),
-                        0xf0..=0xf4 => self.begin_utf8(b, 4),
-                        _ => out.push(b),
+                    // Bulk-copy the run of plain bytes up to the next ESC.
+                    // Complete multi-byte UTF-8 codepoints stay inside the
+                    // run (their continuations are verified so a malformed
+                    // sequence cannot swallow an ESC); only a codepoint split
+                    // at the end of `data` is held back, so host writes
+                    // interleaved between reads can never split it on the
+                    // real terminal.
+                    let start = i;
+                    loop {
+                        while i < n && data[i] != 0x1b && !(0xc2..=0xf4).contains(&data[i]) {
+                            i += 1;
+                        }
+                        if i == n || data[i] == 0x1b {
+                            break;
+                        }
+                        let need = Self::utf8_need_of(data[i]);
+                        if i + need <= n
+                            && data[i + 1..i + need]
+                                .iter()
+                                .all(|c| (0x80..=0xbf).contains(c))
+                        {
+                            i += need;
+                            continue;
+                        }
+                        break;
                     }
+                    out.extend_from_slice(&data[start..i]);
+                    if i == n {
+                        break;
+                    }
+                    let b = data[i];
+                    i += 1;
+                    if b == 0x1b {
+                        self.state = State::Esc;
+                    } else {
+                        let need = Self::utf8_need_of(b);
+                        if i + need - 1 <= n {
+                            // Malformed lead (the scan above rejected it):
+                            // emit it verbatim and rescan from the next byte.
+                            out.push(b);
+                        } else {
+                            self.begin_utf8(b, need as u8);
+                        }
+                    }
+                    continue;
                 }
                 State::Esc => match b {
                     b'[' => {
@@ -163,7 +206,31 @@ impl PassthroughFilter {
                     }
                 },
                 State::Csi => {
-                    if b == 0x1b {
+                    // Bulk-collect parameter and intermediate bytes.
+                    let start = i;
+                    while i < n && (0x20..=0x3f).contains(&data[i]) {
+                        i += 1;
+                    }
+                    self.csi.extend_from_slice(&data[start..i]);
+                    if self.csi.len() > MAX_CSI_LEN {
+                        // Runaway length: emit verbatim and resync to ground.
+                        out.extend_from_slice(&self.csi);
+                        self.csi.clear();
+                        self.state = State::Ground;
+                        continue;
+                    }
+                    if i == n {
+                        break;
+                    }
+                    let b = data[i];
+                    i += 1;
+                    if (0x40..=0x7e).contains(&b) {
+                        // Final byte: the CSI is complete.
+                        self.csi.push(b);
+                        rewrite_csi(&self.csi, content_rows, out);
+                        self.csi.clear();
+                        self.state = State::Ground;
+                    } else if b == 0x1b {
                         // Abort the partial CSI (matches terminal behavior) and
                         // start a new sequence.
                         self.csi.clear();
@@ -182,28 +249,33 @@ impl PassthroughFilter {
                     } else if b == 0x7f {
                         // DEL is ignored inside a CSI.
                     } else {
+                        // Invalid byte: emit what we have verbatim and resync
+                        // to ground.
                         self.csi.push(b);
-                        if (0x40..=0x7e).contains(&b) {
-                            // Final byte: the CSI is complete.
-                            rewrite_csi(&self.csi, content_rows, out);
-                            self.csi.clear();
-                            self.state = State::Ground;
-                        } else if !(0x20..=0x3f).contains(&b) || self.csi.len() > MAX_CSI_LEN {
-                            // Invalid byte or runaway length: emit what we
-                            // have verbatim and resync to ground.
-                            out.extend_from_slice(&self.csi);
-                            self.csi.clear();
-                            self.state = State::Ground;
-                        }
+                        out.extend_from_slice(&self.csi);
+                        self.csi.clear();
+                        self.state = State::Ground;
                     }
+                    continue;
                 }
                 State::Osc => {
-                    self.string_buf.push(b);
-                    match b {
-                        0x07 => self.flush_string(out), // BEL terminator
-                        0x1b => self.state = State::OscEsc,
-                        _ => self.spill_oversized_string(out),
+                    // Bulk-buffer the payload up to the next BEL or ESC.
+                    let start = i;
+                    while i < n && data[i] != 0x07 && data[i] != 0x1b {
+                        i += 1;
                     }
+                    self.string_buf.extend_from_slice(&data[start..i]);
+                    if i == n {
+                        self.spill_oversized_string(out);
+                        break;
+                    }
+                    self.string_buf.push(data[i]);
+                    match data[i] {
+                        0x07 => self.flush_string(out), // BEL terminator
+                        _ => self.state = State::OscEsc,
+                    }
+                    i += 1;
+                    continue;
                 }
                 State::OscEsc => {
                     // ESC \ is the ST terminator; anything else aborted the
@@ -213,18 +285,37 @@ impl PassthroughFilter {
                     self.flush_string(out);
                 }
                 State::Dcs => {
-                    self.string_buf.push(b);
-                    if b == 0x1b {
-                        self.state = State::DcsEsc;
-                    } else {
-                        self.spill_oversized_string(out);
+                    // Bulk-buffer the payload up to the next ESC.
+                    let start = i;
+                    while i < n && data[i] != 0x1b {
+                        i += 1;
                     }
+                    self.string_buf.extend_from_slice(&data[start..i]);
+                    if i == n {
+                        self.spill_oversized_string(out);
+                        break;
+                    }
+                    self.string_buf.push(0x1b);
+                    self.state = State::DcsEsc;
+                    i += 1;
+                    continue;
                 }
                 State::DcsEsc => {
                     self.string_buf.push(b);
                     self.flush_string(out);
                 }
             }
+            i += 1;
+        }
+    }
+
+    /// Expected byte length of a UTF-8 sequence with lead byte `b`
+    /// (`0xc2..=0xf4`).
+    fn utf8_need_of(b: u8) -> usize {
+        match b {
+            0xc2..=0xdf => 2,
+            0xe0..=0xef => 3,
+            _ => 4,
         }
     }
 

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -491,6 +491,7 @@ impl Renderer {
         // Snapshot which rows changed since the last frame (and clear the
         // terminal's dirty state) before diffing, so clean rows can be skipped.
         self.refresh_dirty(vt);
+        let mut drew = false;
         for row_idx in 0..rows.min(max_row) {
             // Skip clean rows we already have a baseline for: their cells cannot
             // have changed, so there's no need to read or diff them.
@@ -516,6 +517,7 @@ impl Renderer {
             )?;
             stdout.write_all(self.line_buf.as_bytes())?;
             queue!(stdout, ResetColor)?;
+            drew = true;
             if row_idx >= self.prev_lines.len() {
                 self.prev_lines.resize_with(row_idx + 1, String::new);
             }
@@ -524,7 +526,9 @@ impl Renderer {
             baseline.clear();
             baseline.push_str(&self.line_buf);
         }
-        self.update_cursor(stdout, vt)
+        // Drawing rows moved the physical cursor even when the VT cursor is
+        // unchanged, so force a reposition in that case.
+        self.update_cursor(stdout, vt, drew)
     }
 
     /// Push unflushed VT scrollback lines into native terminal scrollback,
@@ -639,10 +643,18 @@ impl Renderer {
     }
 
     /// Position the real terminal cursor to match the VT cursor.
-    fn update_cursor(&mut self, stdout: &mut impl Write, vt: &Terminal<'_, '_>) -> io::Result<()> {
+    ///
+    /// `force` repositions even when the VT cursor is unchanged — needed after
+    /// row draws, which move the physical cursor behind the diff's back.
+    fn update_cursor(
+        &mut self,
+        stdout: &mut impl Write,
+        vt: &Terminal<'_, '_>,
+        force: bool,
+    ) -> io::Result<()> {
         let offset = self.row_offset as usize;
         let cur = CursorState::from_terminal(vt);
-        if cur != self.prev_cursor {
+        if force || cur != self.prev_cursor {
             if cur.visible && !self.prev_cursor.visible {
                 queue!(stdout, cursor::Show)?;
             } else if !cur.visible && self.prev_cursor.visible {
@@ -688,6 +700,68 @@ impl Renderer {
         }
         self.prev_cursor = CursorState::from_terminal(vt);
     }
+}
+
+/// State for alternate-screen passthrough (see the `passthrough` module).
+///
+/// Owned one level above the event loop so a `?` error escaping the loop can
+/// still release the scroll region — an asserted region outlives the process
+/// on the user's terminal if nothing resets it.
+struct PassthroughState {
+    /// Byte-stream rewriter. Fed every PTY batch — mediated output is
+    /// discarded — so its parse state stays aligned with the stream across
+    /// mediated/passthrough handoffs and a sequence split across the handoff
+    /// is forwarded whole instead of leaking a raw tail.
+    filter: PassthroughFilter,
+    /// The reserved scroll region is currently asserted on the real terminal.
+    region_set: bool,
+    /// Rewritten app bytes for the current batch (reused allocation).
+    out: Vec<u8>,
+    /// Raw bytes fed this batch, for tracing.
+    in_bytes: usize,
+}
+
+impl PassthroughState {
+    fn new() -> Self {
+        Self {
+            filter: PassthroughFilter::new(),
+            region_set: false,
+            out: Vec::new(),
+            in_bytes: 0,
+        }
+    }
+}
+
+/// Release the passthrough scroll region if asserted. Resetting DECSTBM homes
+/// the real cursor as a side effect, so put it back at the VT (== app) cursor.
+fn release_passthrough_region(
+    stdout: &mut impl Write,
+    renderer: &Renderer,
+    vt: &Terminal<'_, '_>,
+    pt: &mut PassthroughState,
+) -> io::Result<()> {
+    if pt.region_set {
+        queue!(stdout, ResetScrollRegion)?;
+        renderer.write_cursor(stdout, vt)?;
+        pt.region_set = false;
+    }
+    Ok(())
+}
+
+/// Re-assert the app's current SGR attributes after host output (status line,
+/// cursor moves) reset them. During passthrough the app's raw stream owns the
+/// terminal's attribute state, and apps cache what they last set — text they
+/// draw after a host reset would otherwise render unstyled.
+fn restore_app_pen(stdout: &mut impl Write, vt: &Terminal<'_, '_>) -> io::Result<()> {
+    let Ok(pen) = vt.cursor_style() else {
+        return Ok(());
+    };
+    if pen != Style::default() {
+        let mut s = String::new();
+        dump_style(&mut s, &pen);
+        stdout.write_all(s.as_bytes())?;
+    }
+    Ok(())
 }
 
 #[derive(Debug, Error)]
@@ -1128,6 +1202,35 @@ impl ShellSession {
         coordinator_tx: &tokio_mpsc::Sender<ShellEvent>,
         stdout: &mut Box<dyn Write + Send>,
     ) -> Result<Option<u32>, SessionError> {
+        // On the alternate screen, a full-screen app's output is forwarded
+        // straight to the real terminal (rewritten to protect the status row)
+        // instead of re-rendering every changed row through the VT. The app
+        // already scrolls and repaints minimally; re-deriving that frame from
+        // the VT each time is what made nested full-screen TUIs lag.
+        let mut pt = PassthroughState::new();
+        let result =
+            self.event_loop_inner(pty, vt, renderer, event_rx, coordinator_tx, stdout, &mut pt);
+        // Normal exits release the region themselves; an error propagating
+        // out of the loop must not leave the user's terminal with a clamped
+        // scroll region. Best effort — don't mask the original error.
+        if pt.region_set {
+            let _ = release_passthrough_region(stdout, renderer, vt, &mut pt);
+            let _ = stdout.flush();
+        }
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn event_loop_inner(
+        &mut self,
+        pty: &Arc<Pty>,
+        vt: &mut Terminal<'static, '_>,
+        renderer: &mut Renderer,
+        event_rx: std::sync::mpsc::Receiver<Event>,
+        coordinator_tx: &tokio_mpsc::Sender<ShellEvent>,
+        stdout: &mut Box<dyn Write + Send>,
+        pt: &mut PassthroughState,
+    ) -> Result<Option<u32>, SessionError> {
         let spinner_interval = Duration::from_millis(SPINNER_INTERVAL_MS);
         let mut scanner = EscapeScanner::new();
         let mut vt_input_filter = VtInputFilter::new();
@@ -1136,18 +1239,6 @@ impl ShellSession {
         let mut resize_pending = false;
         let mut esc_events = Vec::new();
         let mut vt_input = Vec::new();
-
-        // On the alternate screen, a full-screen app's output is forwarded
-        // straight to the real terminal (rewritten to protect the status row)
-        // instead of re-rendering every changed row through the VT. The app
-        // already scrolls and repaints minimally; re-deriving that frame from
-        // the VT each time is what made nested full-screen TUIs lag.
-        let mut passthrough_filter = PassthroughFilter::new();
-        // Whether the reserved scroll region is currently asserted on the real
-        // terminal for the active alt-screen passthrough excursion.
-        let mut passthrough_region_set = false;
-        // Raw PTY bytes accumulated across a batch for passthrough forwarding.
-        let mut frame_bytes: Vec<u8> = Vec::new();
 
         loop {
             // Use select! to handle both events and spinner animation
@@ -1158,14 +1249,8 @@ impl ShellSession {
                 match event_rx.recv_timeout(spinner_interval) {
                     Ok(event) => Some(event),
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                        if self.config.show_status_line {
-                            queue!(stdout, terminal::BeginSynchronizedUpdate)?;
-                            self.status_line
-                                .draw(stdout, self.size.cols, self.size.rows)?;
-                            renderer.write_cursor(stdout, vt)?;
-                            queue!(stdout, terminal::EndSynchronizedUpdate)?;
-                            stdout.flush()?;
-                        }
+                        self.draw_status_overlay(stdout, vt, renderer, &esc, pt)?;
+                        stdout.flush()?;
                         continue;
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => None,
@@ -1175,14 +1260,8 @@ impl ShellSession {
                     Ok(event) => Some(event),
                     Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
                         self.status_line.state_mut().clear_reloaded();
-                        if self.config.show_status_line {
-                            queue!(stdout, terminal::BeginSynchronizedUpdate)?;
-                            self.status_line
-                                .draw(stdout, self.size.cols, self.size.rows)?;
-                            renderer.write_cursor(stdout, vt)?;
-                            queue!(stdout, terminal::EndSynchronizedUpdate)?;
-                            stdout.flush()?;
-                        }
+                        self.draw_status_overlay(stdout, vt, renderer, &esc, pt)?;
+                        stdout.flush()?;
                         continue;
                     }
                     Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => None,
@@ -1234,6 +1313,9 @@ impl ShellSession {
                             self.status_line
                                 .draw(stdout, self.size.cols, self.size.rows)?;
                             renderer.write_cursor(stdout, vt)?;
+                            if pt.region_set {
+                                restore_app_pen(stdout, vt)?;
+                            }
                             stdout.flush()?;
                         }
                         continue;
@@ -1252,29 +1334,38 @@ impl ShellSession {
                     // goes through the mediated path so the transition is drawn.
                     let passthrough = was_in_alt;
                     esc.reset_batch();
-                    if passthrough {
-                        frame_bytes.clear();
-                        frame_bytes.extend_from_slice(&data);
+                    // Cursor position before this batch is applied to the VT,
+                    // for restoring it after the region assert that starts an
+                    // excursion (DECSTBM homes the real cursor).
+                    let entry_cursor =
+                        (passthrough && !pt.region_set).then(|| CursorState::from_terminal(vt));
+                    pt.out.clear();
+                    pt.in_bytes = 0;
+                    let mut sink = io::sink();
+
+                    // Feed the filter on every batch so its parse state spans
+                    // the mediated/passthrough handoff; mediated output is
+                    // drawn from the VT, so its rewritten bytes are dropped.
+                    pt.filter.rewrite(&data, renderer.content_rows, &mut pt.out);
+                    pt.in_bytes += data.len();
+                    if !passthrough {
+                        pt.out.clear();
                     }
-                    // In passthrough, track escape state without forwarding mode
-                    // bytes (the raw stream we forward already carries them); the
-                    // host still answers the text-area query via the PTY.
-                    if passthrough {
+                    {
+                        // Track escape state. In passthrough the raw stream we
+                        // forward already carries mode bytes, so suppress the
+                        // scanner's copies; it still answers the text-area
+                        // query via the PTY either way.
+                        let mut esc_out: &mut dyn Write = if passthrough {
+                            &mut sink
+                        } else {
+                            &mut **stdout
+                        };
                         escape_state_process(
                             &mut scanner,
                             &data,
                             &mut esc,
-                            &mut io::sink(),
-                            pty,
-                            self.pty_size(),
-                            &mut esc_events,
-                        )?;
-                    } else {
-                        escape_state_process(
-                            &mut scanner,
-                            &data,
-                            &mut esc,
-                            stdout,
+                            &mut esc_out,
                             pty,
                             self.pty_size(),
                             &mut esc_events,
@@ -1290,23 +1381,22 @@ impl ShellSession {
                     while let Ok(event) = event_rx.try_recv() {
                         match event {
                             Event::PtyOutput(more) => {
-                                if passthrough {
-                                    frame_bytes.extend_from_slice(&more);
+                                pt.filter.rewrite(&more, renderer.content_rows, &mut pt.out);
+                                pt.in_bytes += more.len();
+                                if !passthrough {
+                                    pt.out.clear();
+                                }
+                                {
+                                    let mut esc_out: &mut dyn Write = if passthrough {
+                                        &mut sink
+                                    } else {
+                                        &mut **stdout
+                                    };
                                     escape_state_process(
                                         &mut scanner,
                                         &more,
                                         &mut esc,
-                                        &mut io::sink(),
-                                        pty,
-                                        self.pty_size(),
-                                        &mut esc_events,
-                                    )?;
-                                } else {
-                                    escape_state_process(
-                                        &mut scanner,
-                                        &more,
-                                        &mut esc,
-                                        stdout,
+                                        &mut esc_out,
                                         pty,
                                         self.pty_size(),
                                         &mut esc_events,
@@ -1317,9 +1407,24 @@ impl ShellSession {
                                 total_scroll += feed_vt(vt, &text);
                             }
                             Event::PtyExit(exit_code) => {
-                                if passthrough_region_set {
-                                    stdout.write_all(b"\x1b[r")?;
+                                if passthrough {
+                                    // Forward the batch accumulated so far —
+                                    // the app's final frame, alt-screen exit,
+                                    // and mode resets. `esc` already tracked
+                                    // these bytes; cleanup below relies on the
+                                    // real terminal having received them, and
+                                    // dropping them would leave it stuck on
+                                    // the alternate screen.
+                                    stdout.write_all(&pt.out)?;
+                                    // The forwarded bytes drove the real
+                                    // terminal directly; adopt the VT as the
+                                    // renderer baseline instead of redrawing,
+                                    // and account for the scrolling the raw
+                                    // bytes already performed.
+                                    renderer.sync(vt);
+                                    renderer.scrollback_flushed = vt.scrollback_rows().unwrap_or(0);
                                 }
+                                release_passthrough_region(stdout, renderer, vt, pt)?;
                                 escape_state_cleanup(&esc, stdout)?;
                                 renderer.render_with_scroll(stdout, vt)?;
                                 return Ok(exit_code);
@@ -1344,50 +1449,56 @@ impl ShellSession {
                         // Alternate-screen passthrough: forward the app's frame,
                         // rewritten so its scrolling and addressing stay above
                         // the reserved status row.
-                        let pt_t0 = std::time::Instant::now();
-                        let content_rows = renderer.content_rows;
-                        let mut out: Vec<u8> = Vec::new();
-                        if !passthrough_region_set {
+                        if !pt.region_set {
                             // Reserve the status row on the real terminal.
-                            out.extend_from_slice(format!("\x1b[1;{content_rows}r").as_bytes());
-                            passthrough_region_set = true;
+                            // DECSTBM homes the real cursor, so put it back
+                            // where the app left it before forwarding bytes
+                            // that may rely on cursor continuity.
+                            queue!(
+                                stdout,
+                                SetScrollRegion {
+                                    top: 1,
+                                    bottom: renderer.content_rows
+                                }
+                            )?;
+                            if let Some(cur) = entry_cursor {
+                                let offset = renderer.row_offset as usize;
+                                queue!(
+                                    stdout,
+                                    cursor::MoveTo(cur.col, (cur.row as usize + offset) as u16)
+                                )?;
+                            }
+                            pt.region_set = true;
                         }
-                        passthrough_filter.rewrite(&frame_bytes, content_rows, &mut out);
-                        stdout.write_all(&out)?;
+                        stdout.write_all(&pt.out)?;
 
                         if !esc.in_alternate_screen {
-                            // The app left the alt screen mid-batch: release the
-                            // reserved region and hand back to the mediated
-                            // renderer, which redraws the restored primary screen
-                            // on the next batch.
-                            stdout.write_all(b"\x1b[r")?;
-                            passthrough_region_set = false;
-                            passthrough_filter.reset();
-                            renderer.invalidate();
+                            // The app left the alt screen mid-batch. The raw
+                            // bytes above already drove the real terminal
+                            // through the exit (restore plus any post-exit
+                            // scrolling), so adopt the VT as the renderer
+                            // baseline instead of redrawing, account for the
+                            // scrollback the raw bytes already pushed out, and
+                            // reset SGR so the mediated renderer starts from
+                            // the default state it assumes.
+                            release_passthrough_region(stdout, renderer, vt, pt)?;
+                            queue!(stdout, ResetColor)?;
+                            renderer.sync(vt);
+                            renderer.scrollback_flushed = vt.scrollback_rows().unwrap_or(0);
                         }
 
                         // The app's forwarded frame already positioned the real
                         // cursor; only touch it if we draw the status line, and
                         // wrap that excursion in a synchronized update so the
                         // cursor never visibly flashes onto the status row.
-                        if self.config.show_status_line {
-                            queue!(stdout, terminal::BeginSynchronizedUpdate)?;
-                            self.status_line
-                                .draw(stdout, self.size.cols, self.size.rows)?;
-                            renderer.write_cursor(stdout, vt)?;
-                            queue!(stdout, terminal::EndSynchronizedUpdate)?;
-                        }
+                        self.draw_status_overlay(stdout, vt, renderer, &esc, pt)?;
                         stdout.flush()?;
-                        tracing::debug!(
-                            in_bytes = frame_bytes.len(),
-                            out_bytes = out.len(),
-                            elapsed_us = pt_t0.elapsed().as_micros() as u64,
+                        tracing::trace!(
+                            in_bytes = pt.in_bytes,
+                            out_bytes = pt.out.len(),
                             "alt passthrough frame"
                         );
                     } else {
-                        if esc.in_alternate_screen {
-                            tracing::debug!("alt mediated render");
-                        }
                         // Begin synchronized output so the terminal buffers
                         // all writes atomically (mode 2026).
                         queue!(stdout, terminal::BeginSynchronizedUpdate)?;
@@ -1445,9 +1556,7 @@ impl ShellSession {
                 }
 
                 Event::PtyExit(exit_code) => {
-                    if passthrough_region_set {
-                        stdout.write_all(b"\x1b[r")?;
-                    }
+                    release_passthrough_region(stdout, renderer, vt, pt)?;
                     self.clear_status_row(stdout, esc.in_alternate_screen)?;
                     escape_state_cleanup(&esc, stdout)?;
                     stdout.flush()?;
@@ -1463,6 +1572,11 @@ impl ShellSession {
                         renderer.render_with_scroll(stdout, vt)?;
                     }
                     self.draw_status_and_cursor(stdout, vt, renderer)?;
+                    if pt.region_set {
+                        // The mediated redraw above reset SGR while the
+                        // passthrough app's raw stream owns attribute state.
+                        restore_app_pen(stdout, vt)?;
+                    }
                     queue!(stdout, terminal::EndSynchronizedUpdate)?;
                     stdout.flush()?;
                 }
@@ -1500,11 +1614,28 @@ impl ShellSession {
                             tracing::warn!("failed to resize terminal: {e}");
                         }
                         renderer.discard_vt_scrollback(vt);
+                        if pt.region_set {
+                            // Terminals reset DECSTBM on resize (and the old
+                            // bounds are stale for the new size anyway):
+                            // re-assert the reserved region for the new
+                            // geometry. The write_cursor below repairs the
+                            // homing side effect.
+                            queue!(
+                                stdout,
+                                SetScrollRegion {
+                                    top: 1,
+                                    bottom: pty_size.rows
+                                }
+                            )?;
+                        }
                         renderer.render_full(stdout, vt)?;
                         if self.config.show_status_line && !esc.in_alternate_screen {
                             self.status_line.draw(stdout, cols, rows)?;
                         }
                         renderer.write_cursor(stdout, vt)?;
+                        if pt.region_set {
+                            restore_app_pen(stdout, vt)?;
+                        }
                         stdout.flush()?;
                         if let Err(e) = coordinator_tx.try_send(ShellEvent::Resize {
                             cols: pty_size.cols,
@@ -1517,9 +1648,7 @@ impl ShellSession {
             }
         }
 
-        if passthrough_region_set {
-            stdout.write_all(b"\x1b[r")?;
-        }
+        release_passthrough_region(stdout, renderer, vt, pt)?;
         self.clear_status_row(stdout, esc.in_alternate_screen)?;
         escape_state_cleanup(&esc, stdout)?;
         stdout.flush()?;
@@ -1586,6 +1715,40 @@ impl ShellSession {
         }
 
         Ok(0)
+    }
+
+    /// Draw the status line inside a synchronized update and restore the
+    /// cursor — and, during a passthrough excursion, the app's SGR pen.
+    ///
+    /// Deferred while origin mode is active or a wrap is pending: the host's
+    /// absolute cursor writes would land in the wrong place (DECOM makes them
+    /// region-relative) or clear the terminal's pending-wrap state the app
+    /// relies on. The next frame or spinner tick retries.
+    ///
+    /// Does not flush.
+    fn draw_status_overlay(
+        &mut self,
+        stdout: &mut impl Write,
+        vt: &Terminal<'_, '_>,
+        renderer: &Renderer,
+        esc: &EscapeState,
+        pt: &PassthroughState,
+    ) -> Result<(), SessionError> {
+        if !self.config.show_status_line {
+            return Ok(());
+        }
+        if pt.region_set && (esc.origin_mode || vt.is_cursor_pending_wrap().unwrap_or(false)) {
+            return Ok(());
+        }
+        queue!(stdout, terminal::BeginSynchronizedUpdate)?;
+        self.status_line
+            .draw(stdout, self.size.cols, self.size.rows)?;
+        renderer.write_cursor(stdout, vt)?;
+        if pt.region_set {
+            restore_app_pen(stdout, vt)?;
+        }
+        queue!(stdout, terminal::EndSynchronizedUpdate)?;
+        Ok(())
     }
 
     /// Draw status line and reposition cursor.

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -25,6 +25,7 @@ use crossterm::{
     style::ResetColor,
     terminal::{self, Clear, ClearType},
 };
+use libghostty_vt::render::{Dirty, RenderState, RowIterator};
 use libghostty_vt::screen::{Cell, CellContentTag, CellWide, GridRef};
 use libghostty_vt::style::{Style, StyleColor, Underline};
 use libghostty_vt::terminal::{Options as TerminalOptions, Point, Terminal};
@@ -305,10 +306,34 @@ struct Renderer {
     scrollback_flushed: usize,
     /// Reusable buffer for SGR line rendering (avoids per-line allocation).
     line_buf: String,
+    /// libghostty render state. Snapshotted each `render` to read per-row dirty
+    /// flags (so clean rows can be skipped) and to clear the terminal's dirty
+    /// state. `None` if it could not be allocated, in which case `render` falls
+    /// back to reading every row.
+    render_state: Option<RenderState<'static>>,
+    /// Reusable iterator over the render-state snapshot's rows, used to read and
+    /// acknowledge each row's dirty flag. Paired with `render_state`; `None`
+    /// disables dirty tracking and forces every row to be read.
+    row_iter: Option<RowIterator<'static>>,
+    /// Per-row dirty flags for the current frame, rebuilt by `refresh_dirty`
+    /// from the render-state snapshot. Empty when dirty tracking is unavailable,
+    /// in which case every row is treated as dirty.
+    dirty_rows: Vec<bool>,
+    /// Number of VT rows whose cells were read from the terminal across this
+    /// renderer's lifetime. Used by tests to assert dirty-row tracking avoids
+    /// re-reading unchanged rows.
+    rows_read: u64,
 }
 
 impl Renderer {
     fn new(content_rows: u16) -> Self {
+        let render_state = RenderState::new().ok();
+        let row_iter = RowIterator::new().ok();
+        if render_state.is_none() || row_iter.is_none() {
+            tracing::debug!(
+                "dirty-row tracking unavailable, renderer will read every row each frame"
+            );
+        }
         Self {
             prev_lines: Vec::new(),
             prev_cursor: CursorState {
@@ -320,6 +345,10 @@ impl Renderer {
             content_rows,
             scrollback_flushed: 0,
             line_buf: String::new(),
+            render_state,
+            row_iter,
+            dirty_rows: Vec::new(),
+            rows_read: 0,
         }
     }
 
@@ -383,15 +412,87 @@ impl Renderer {
         queue!(stdout, ResetColor)
     }
 
+    /// Rebuild `dirty_rows` from a fresh render-state snapshot and consume the
+    /// terminal's dirty state in the same pass.
+    ///
+    /// The snapshot's per-row `dirty()` reflects changes the bare per-row bit
+    /// (`grid_ref(...).row().is_dirty()`) misses — most importantly a viewport
+    /// scroll, which rotates rows and marks dirtiness at the page level without
+    /// setting each shifted row's own bit. `update` only snapshots the dirty
+    /// state; it does not reset the render state's own per-row and global dirty
+    /// layers, so we acknowledge each row (`set_dirty(false)`) and the global
+    /// flag here, or every row would report dirty forever. Leaves `dirty_rows`
+    /// empty when dirty tracking is unavailable, in which case `is_row_dirty`
+    /// treats every row as dirty so `render` reads them all.
+    fn refresh_dirty(&mut self, vt: &Terminal<'static, '_>) {
+        let Self {
+            render_state,
+            row_iter,
+            dirty_rows,
+            ..
+        } = self;
+        dirty_rows.clear();
+        let (Some(rs), Some(row_iter)) = (render_state, row_iter) else {
+            return;
+        };
+        let snapshot = match rs.update(vt) {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                tracing::trace!(error = %e, "render-state update failed, reading all rows");
+                return;
+            }
+        };
+        {
+            let mut iter = match row_iter.update(&snapshot) {
+                Ok(iter) => iter,
+                Err(e) => {
+                    tracing::trace!(error = %e, "row-iterator update failed, reading all rows");
+                    return;
+                }
+            };
+            while let Some(row) = iter.next() {
+                dirty_rows.push(row.dirty().unwrap_or(true));
+                // If clearing the bit ever fails it stays set and the row
+                // reports dirty forever, silently disabling the skip for it.
+                if let Err(e) = row.set_dirty(false) {
+                    tracing::trace!(error = %e, "failed to clear row dirty flag");
+                }
+            }
+        }
+        let _ = snapshot.set_dirty(Dirty::Clean);
+    }
+
+    /// Whether VT row `row_idx` changed since the last `render`.
+    ///
+    /// Returns `true` when dirty tracking is unavailable or the row is beyond
+    /// the snapshot, so callers fall back to reading the row unconditionally.
+    fn is_row_dirty(&self, row_idx: usize) -> bool {
+        self.dirty_rows.get(row_idx).copied().unwrap_or(true)
+    }
+
     /// Render changed VT lines to stdout. Skips lines that haven't changed
     /// and clips rows that would fall outside the visible area.
-    fn render(&mut self, stdout: &mut impl Write, vt: &Terminal<'_, '_>) -> io::Result<()> {
+    ///
+    /// Rows the terminal reports as clean are skipped without reading their
+    /// cells at all, so a nested full-screen app (e.g. an editor) only costs
+    /// per-cell FFI reads for the handful of rows it actually repaints rather
+    /// than the whole screen every frame.
+    fn render(&mut self, stdout: &mut impl Write, vt: &Terminal<'static, '_>) -> io::Result<()> {
         let offset = self.row_offset as usize;
         let max_row = self.visible_rows();
         let rows = vt.rows().unwrap_or(0) as usize;
+        // Snapshot which rows changed since the last frame (and clear the
+        // terminal's dirty state) before diffing, so clean rows can be skipped.
+        self.refresh_dirty(vt);
         for row_idx in 0..rows.min(max_row) {
+            // Skip clean rows we already have a baseline for: their cells cannot
+            // have changed, so there's no need to read or diff them.
+            if row_idx < self.prev_lines.len() && !self.is_row_dirty(row_idx) {
+                continue;
+            }
             let point = active_point(row_idx as u32);
             let cells = cells_in_row(vt, point);
+            self.rows_read += 1;
             if row_idx < self.prev_lines.len() && cells == self.prev_lines[row_idx] {
                 continue;
             }
@@ -419,7 +520,7 @@ impl Renderer {
     fn render_with_scroll(
         &mut self,
         stdout: &mut impl Write,
-        vt: &mut Terminal<'_, '_>,
+        vt: &mut Terminal<'static, '_>,
     ) -> io::Result<()> {
         let vt_scrollback = vt.scrollback_rows().unwrap_or(0);
         let unflushed = vt_scrollback.saturating_sub(self.scrollback_flushed);
@@ -511,7 +612,11 @@ impl Renderer {
     }
 
     /// Full redraw of all VT lines (after resize or initialization).
-    fn render_full(&mut self, stdout: &mut impl Write, vt: &Terminal<'_, '_>) -> io::Result<()> {
+    fn render_full(
+        &mut self,
+        stdout: &mut impl Write,
+        vt: &Terminal<'static, '_>,
+    ) -> io::Result<()> {
         self.invalidate();
         self.render(stdout, vt)
     }
@@ -875,7 +980,10 @@ impl ShellSession {
         std::thread::Builder::new()
             .name("session-pty".into())
             .spawn(move || {
-                let mut buf = [0u8; 4096];
+                // A large read buffer keeps a single PTY-output burst (e.g. a
+                // full-screen TUI repaint) in one read so it feeds the VT and
+                // renders as one frame instead of fragmenting across syscalls.
+                let mut buf = [0u8; 65536];
                 loop {
                     match pty_reader.read(&mut buf) {
                         Ok(0) => {
@@ -996,7 +1104,7 @@ impl ShellSession {
     fn event_loop(
         &mut self,
         pty: &Arc<Pty>,
-        vt: &mut Terminal<'_, '_>,
+        vt: &mut Terminal<'static, '_>,
         renderer: &mut Renderer,
         event_rx: std::sync::mpsc::Receiver<Event>,
         coordinator_tx: &tokio_mpsc::Sender<ShellEvent>,
@@ -1432,6 +1540,128 @@ mod tests {
     fn vt_input_filter_preserves_other_escape_sequences() {
         let filtered = filter_chunks(&[b"hello \x1b[31mred\x1b[0m"]);
         assert_eq!(filtered, b"hello \x1b[31mred\x1b[0m");
+    }
+
+    fn make_vt(cols: u16, rows: u16) -> Terminal<'static, 'static> {
+        Terminal::new(TerminalOptions {
+            cols,
+            rows,
+            max_scrollback: DEFAULT_MAX_SCROLLBACK,
+        })
+        .expect("create terminal")
+    }
+
+    /// A nested full-screen app that repaints a single row must not cost a
+    /// full-screen re-read. Dirty-row tracking should limit per-cell reads to
+    /// the rows that actually changed, which is what keeps `devenv shell` fast
+    /// when running editors like neovim on large terminals.
+    #[test]
+    fn render_reads_only_dirty_rows() {
+        let rows: u16 = 50;
+        let mut vt = make_vt(80, rows);
+        let mut renderer = Renderer::new(rows);
+        assert!(
+            renderer.render_state.is_some(),
+            "dirty tracking requires a render state"
+        );
+        let mut out: Vec<u8> = Vec::new();
+
+        // Fill the screen, then draw the first frame.
+        for i in 0..rows {
+            vt.vt_write(format!("line {i}\r\n").as_bytes());
+        }
+        renderer.render(&mut out, &vt).unwrap();
+        let full_reads = renderer.rows_read;
+        assert!(
+            full_reads >= rows as u64,
+            "first frame should read every row, read {full_reads}"
+        );
+
+        // Repaint a single row in place, like a TUI updating one line.
+        vt.vt_write(b"\x1b[10;1Hchanged");
+        let before = renderer.rows_read;
+        renderer.render(&mut out, &vt).unwrap();
+        let delta = renderer.rows_read - before;
+
+        assert!(
+            delta < rows as u64,
+            "second frame must not re-read the whole screen, read {delta} of {rows} rows"
+        );
+        // Only the edited row, plus at most the cursor's prior and landing
+        // rows, should be re-read.
+        assert!(
+            delta <= 5,
+            "expected only a handful of dirty rows, read {delta}"
+        );
+    }
+
+    /// A frame where nothing changed must read no rows at all.
+    #[test]
+    fn render_skips_all_rows_when_clean() {
+        let rows: u16 = 20;
+        let mut vt = make_vt(80, rows);
+        let mut renderer = Renderer::new(rows);
+        let mut out: Vec<u8> = Vec::new();
+
+        vt.vt_write(b"hello\r\nworld\r\n");
+        renderer.render(&mut out, &vt).unwrap();
+
+        let before = renderer.rows_read;
+        renderer.render(&mut out, &vt).unwrap();
+        assert_eq!(
+            renderer.rows_read, before,
+            "an unchanged frame must not read any rows"
+        );
+    }
+
+    /// Scrolling a full-screen (alternate-screen) app shifts every row's
+    /// on-screen content, but libghostty marks a scroll only at the page level,
+    /// not via each row's own dirty bit. The renderer must read dirty state
+    /// through the render-state snapshot (which reflects the page-level flag) so
+    /// the shifted rows are redrawn; reading the bare row bit skipped them and
+    /// left stale content on screen.
+    #[test]
+    fn render_redraws_scrolled_rows() {
+        let rows: u16 = 6;
+        let mut vt = make_vt(80, rows);
+        let mut renderer = Renderer::new(rows);
+        assert!(
+            renderer.render_state.is_some(),
+            "dirty tracking requires a render state"
+        );
+        let mut out: Vec<u8> = Vec::new();
+
+        // A full-screen app on the alternate screen fills every row.
+        vt.vt_write(b"\x1b[?1049h");
+        vt.vt_write(b"L0\r\nL1\r\nL2\r\nL3\r\nL4\r\nL5");
+        renderer.render(&mut out, &vt).unwrap();
+
+        // Scroll up one line: row 0 now shows "L1", ..., row 4 shows "L5", and a
+        // new bottom line "L6" appears. Every row's content changed.
+        vt.vt_write(b"\r\nL6");
+        let before = renderer.rows_read;
+        let mut out2: Vec<u8> = Vec::new();
+        renderer.render(&mut out2, &vt).unwrap();
+        let frame = String::from_utf8_lossy(&out2);
+
+        for line in ["L1", "L2", "L3", "L4", "L5", "L6"] {
+            assert!(
+                frame.contains(line),
+                "scrolled row {line:?} was not redrawn (stale): {frame:?}"
+            );
+        }
+        // Every row's content shifted, so the snapshot must mark all of them
+        // dirty and `render` must re-read each one. If dirty came from the bare
+        // per-row bit instead of the page-level snapshot flag, the shifted rows
+        // would be skipped without reading (delta < rows) and left stale — this
+        // assertion, not the substring check above, is what guards the
+        // page-level dirty path (a plain content-diff redraw would also satisfy
+        // the substring check).
+        let delta = renderer.rows_read - before;
+        assert_eq!(
+            delta, rows as u64,
+            "every scrolled row must be re-read via the snapshot dirty flag, read {delta} of {rows}"
+        );
     }
 
     /// Regression test for devenv#2845: when the process-wide shutdown token is

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -719,6 +719,10 @@ struct PassthroughState {
     out: Vec<u8>,
     /// Raw bytes fed this batch, for tracing.
     in_bytes: usize,
+    /// An oversized terminal string has reached the real terminal and has not
+    /// terminated yet. This is distinct from the filter's parse state because
+    /// filtered output from mediated batches is intentionally discarded.
+    host_sequence_open: bool,
 }
 
 impl PassthroughState {
@@ -728,8 +732,20 @@ impl PassthroughState {
             region_set: false,
             out: Vec::new(),
             in_bytes: 0,
+            host_sequence_open: false,
         }
     }
+}
+
+/// Return the real terminal to ground before host-controlled output if an
+/// oversized passthrough string has already been partially emitted.
+fn prepare_host_output(stdout: &mut impl Write, pt: &mut PassthroughState) -> io::Result<()> {
+    if pt.host_sequence_open {
+        let _ = pt.filter.abort_for_host_output();
+        stdout.write_all(&[0x18])?;
+        pt.host_sequence_open = false;
+    }
+    Ok(())
 }
 
 /// Release the passthrough scroll region if asserted. Resetting DECSTBM homes
@@ -741,6 +757,7 @@ fn release_passthrough_region(
     pt: &mut PassthroughState,
 ) -> io::Result<()> {
     if pt.region_set {
+        prepare_host_output(stdout, pt)?;
         queue!(stdout, ResetScrollRegion)?;
         renderer.write_cursor(stdout, vt)?;
         pt.region_set = false;
@@ -1301,14 +1318,20 @@ impl ShellSession {
                                 }
                                 error_text.push_str("\r\n");
                                 feed_vt(vt, &error_text);
+                            } else {
+                                pty.write_all(&[0x0C])?;
+                                pty.flush()?;
+                            }
+                            if esc.synchronized_output {
+                                continue;
+                            }
+                            prepare_host_output(stdout, pt)?;
+                            if state.show_error {
                                 if renderer.row_offset > 0 {
                                     renderer.render(stdout, vt)?;
                                 } else {
                                     renderer.render_with_scroll(stdout, vt)?;
                                 }
-                            } else {
-                                pty.write_all(&[0x0C])?;
-                                pty.flush()?;
                             }
                             self.status_line
                                 .draw(stdout, self.size.cols, self.size.rows)?;
@@ -1416,6 +1439,7 @@ impl ShellSession {
                                     // dropping them would leave it stuck on
                                     // the alternate screen.
                                     stdout.write_all(&pt.out)?;
+                                    pt.host_sequence_open = !pt.filter.can_interleave_host_output();
                                     // The forwarded bytes drove the real
                                     // terminal directly; adopt the VT as the
                                     // renderer baseline instead of redrawing,
@@ -1471,6 +1495,7 @@ impl ShellSession {
                             pt.region_set = true;
                         }
                         stdout.write_all(&pt.out)?;
+                        pt.host_sequence_open = !pt.filter.can_interleave_host_output();
 
                         if !esc.in_alternate_screen {
                             // The app left the alt screen mid-batch. The raw
@@ -1499,6 +1524,17 @@ impl ShellSession {
                             "alt passthrough frame"
                         );
                     } else {
+                        // Respect an application-owned synchronized-output
+                        // frame that spans PTY reads. Rendering or drawing the
+                        // status line here would emit `?2026l` and close the
+                        // application's frame prematurely. The VT keeps
+                        // accumulating state; the batch that resets mode 2026
+                        // renders the complete frame.
+                        if esc.synchronized_output {
+                            stdout.flush()?;
+                            continue;
+                        }
+
                         // Begin synchronized output so the terminal buffers
                         // all writes atomically (mode 2026).
                         queue!(stdout, terminal::BeginSynchronizedUpdate)?;
@@ -1565,6 +1601,10 @@ impl ShellSession {
 
                 Event::Command(cmd) => {
                     self.handle_command(cmd, vt)?;
+                    if esc.synchronized_output {
+                        continue;
+                    }
+                    prepare_host_output(stdout, pt)?;
                     queue!(stdout, terminal::BeginSynchronizedUpdate)?;
                     if renderer.row_offset > 0 {
                         renderer.render(stdout, vt)?;
@@ -1614,6 +1654,7 @@ impl ShellSession {
                             tracing::warn!("failed to resize terminal: {e}");
                         }
                         renderer.discard_vt_scrollback(vt);
+                        prepare_host_output(stdout, pt)?;
                         if pt.region_set {
                             // Terminals reset DECSTBM on resize (and the old
                             // bounds are stale for the new size anyway):
@@ -1627,6 +1668,11 @@ impl ShellSession {
                                     bottom: pty_size.rows
                                 }
                             )?;
+                        }
+                        if esc.synchronized_output {
+                            renderer.write_cursor(stdout, vt)?;
+                            stdout.flush()?;
+                            continue;
                         }
                         renderer.render_full(stdout, vt)?;
                         if self.config.show_status_line && !esc.in_alternate_screen {
@@ -1737,7 +1783,14 @@ impl ShellSession {
         if !self.config.show_status_line {
             return Ok(());
         }
-        if pt.region_set && (esc.origin_mode || vt.is_cursor_pending_wrap().unwrap_or(false)) {
+        if esc.synchronized_output {
+            return Ok(());
+        }
+        if pt.region_set
+            && (esc.origin_mode
+                || vt.is_cursor_pending_wrap().unwrap_or(false)
+                || !pt.filter.can_interleave_host_output())
+        {
             return Ok(());
         }
         queue!(stdout, terminal::BeginSynchronizedUpdate)?;

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -8,6 +8,7 @@ use crate::escape_state::{
     EscapeState, cleanup_forwarded_modes as escape_state_cleanup,
     process_escape_events as escape_state_process,
 };
+use crate::passthrough::PassthroughFilter;
 use crate::protocol::{ShellCommand, ShellEvent};
 use crate::pty::{Pty, PtyError, get_terminal_size};
 use crate::status_line::{SPINNER_INTERVAL_MS, StatusLine};
@@ -17,8 +18,7 @@ use crate::terminal_commands::{
 };
 use crate::utf8_accumulator::Utf8Accumulator;
 use crate::vt_utils::{
-    CursorState, DEFAULT_MAX_SCROLLBACK, active_point, cells_in_row, point_with_x, push_cell_text,
-    screen_point,
+    CursorState, DEFAULT_MAX_SCROLLBACK, active_point, point_with_x, screen_point,
 };
 use crossterm::{
     Command, cursor, queue,
@@ -43,23 +43,34 @@ const KEYBIND_TOGGLE_PAUSE: [u8; 2] = [0x1b, 0x04]; // Ctrl-Alt-D
 const KEYBIND_LIST_WATCHED: [u8; 2] = [0x1b, 0x17]; // Ctrl-Alt-W
 const KEYBIND_TOGGLE_ERROR: [u8; 2] = [0x1b, 0x05]; // Ctrl-Alt-E
 
-fn dump_row_from_cells(buf: &mut String, vt: &Terminal<'_, '_>, point: Point, cells: &[Cell]) {
+/// Render a VT row as a string with SGR escape sequences.
+///
+/// Fetches each cell once via a single `grid_ref` per column and reuses that
+/// `GridRef` and the metadata (`wide`/`has_text`/`content_tag`) for the style
+/// and grapheme lookups, instead of pre-collecting the row and re-resolving
+/// every cell through a second `grid_ref`. Output is unchanged; this only
+/// removes redundant per-cell FFI reads.
+fn dump_row(buf: &mut String, vt: &Terminal<'_, '_>, point: Point) {
     // TODO(libghostty-rs): Style::is_default() returns true for RGB-bg-only styles
     // because StyleColor::Rgb is mistagged as NONE in the FFI From conversion.
     // Compare via PartialEq against Style::default() until upstream is fixed.
     let default_style = Style::default();
     let mut cur_style = default_style;
     let mut blank_cells: usize = 0;
-    for (x, cell) in cells.iter().enumerate() {
+    let cols = vt.cols().unwrap_or(0);
+    for x in 0..cols {
+        let Ok(cell_ref) = vt.grid_ref(point_with_x(point, x)) else {
+            continue;
+        };
+        let Ok(cell) = cell_ref.cell() else {
+            continue;
+        };
         if matches!(
             cell.wide().ok(),
             Some(CellWide::SpacerTail | CellWide::SpacerHead)
         ) {
             continue;
         }
-        let Ok(cell_ref) = vt.grid_ref(point_with_x(point, x as u16)) else {
-            continue;
-        };
         let has_text = cell.has_text().unwrap_or(false);
         let has_styling = cell.has_styling().unwrap_or(false);
         let tag = cell.content_tag().ok();
@@ -77,7 +88,7 @@ fn dump_row_from_cells(buf: &mut String, vt: &Terminal<'_, '_>, point: Point, ce
             }
             blank_cells = 0;
         }
-        let new_style = cell_style(cell, &cell_ref, tag, has_styling, default_style);
+        let new_style = cell_style(&cell, &cell_ref, tag, has_styling, default_style);
         if new_style != cur_style {
             if new_style == default_style {
                 buf.push_str("\x1b[0m");
@@ -86,7 +97,22 @@ fn dump_row_from_cells(buf: &mut String, vt: &Terminal<'_, '_>, point: Point, ce
             }
             cur_style = new_style;
         }
-        push_cell_text(buf, cell, &cell_ref);
+        // Emit text reusing the metadata already fetched above (the previous
+        // helper re-queried wide/has_text/content_tag via FFI per cell).
+        if has_text {
+            if tag == Some(CellContentTag::CodepointGrapheme) {
+                let mut grapheme_buf = ['\0'; 32];
+                if let Ok(len) = cell_ref.graphemes(&mut grapheme_buf) {
+                    for ch in &grapheme_buf[..len] {
+                        buf.push(*ch);
+                    }
+                }
+            } else if let Some(ch) = cell.codepoint().ok().and_then(char::from_u32) {
+                buf.push(ch);
+            }
+        } else {
+            buf.push(' ');
+        }
     }
     if cur_style != default_style {
         buf.push_str("\x1b[0m");
@@ -124,12 +150,6 @@ fn cell_style(
         }
         None => default,
     }
-}
-
-/// Render a VT row as a string with SGR escape sequences (fetches cells internally).
-fn dump_row(buf: &mut String, vt: &Terminal<'_, '_>, point: Point) {
-    let cells = cells_in_row(vt, point);
-    dump_row_from_cells(buf, vt, point, &cells);
 }
 
 fn dump_style(s: &mut String, style: &Style) {
@@ -288,8 +308,9 @@ impl VtInputFilter {
 /// line's scroll region), this renderer mediates all terminal output through
 /// the VT state machine — similar to how tmux works.
 struct Renderer {
-    /// Previous frame for diffing — one line of cells per row.
-    prev_lines: Vec<Vec<Cell>>,
+    /// Previous frame for diffing: the SGR-rendered bytes of each row as last
+    /// drawn, so a row is redrawn only when its serialized form changes.
+    prev_lines: Vec<String>,
     /// Previous cursor state.
     prev_cursor: CursorState,
     /// Row offset for the initial phase after TUI handoff.
@@ -398,20 +419,6 @@ impl Renderer {
         queue!(stdout, ResetColor)
     }
 
-    /// Write a row using pre-fetched cells (avoids re-iterating cells via FFI).
-    fn write_row_from_cells(
-        &mut self,
-        stdout: &mut impl Write,
-        vt: &Terminal<'_, '_>,
-        point: Point,
-        cells: &[Cell],
-    ) -> io::Result<()> {
-        self.line_buf.clear();
-        dump_row_from_cells(&mut self.line_buf, vt, point, cells);
-        stdout.write_all(self.line_buf.as_bytes())?;
-        queue!(stdout, ResetColor)
-    }
-
     /// Rebuild `dirty_rows` from a fresh render-state snapshot and consume the
     /// terminal's dirty state in the same pass.
     ///
@@ -490,10 +497,16 @@ impl Renderer {
             if row_idx < self.prev_lines.len() && !self.is_row_dirty(row_idx) {
                 continue;
             }
-            let point = active_point(row_idx as u32);
-            let cells = cells_in_row(vt, point);
+            // Serialize the row once (a single grid_ref per cell) and diff the
+            // rendered bytes against the last drawn line.
+            self.line_buf.clear();
+            dump_row(&mut self.line_buf, vt, active_point(row_idx as u32));
             self.rows_read += 1;
-            if row_idx < self.prev_lines.len() && cells == self.prev_lines[row_idx] {
+            if self
+                .prev_lines
+                .get(row_idx)
+                .is_some_and(|prev| *prev == self.line_buf)
+            {
                 continue;
             }
             queue!(
@@ -501,11 +514,15 @@ impl Renderer {
                 cursor::MoveTo(0, (row_idx + offset) as u16),
                 Clear(ClearType::CurrentLine)
             )?;
-            self.write_row_from_cells(stdout, vt, point, &cells)?;
+            stdout.write_all(self.line_buf.as_bytes())?;
+            queue!(stdout, ResetColor)?;
             if row_idx >= self.prev_lines.len() {
-                self.prev_lines.resize_with(row_idx + 1, Vec::new);
+                self.prev_lines.resize_with(row_idx + 1, String::new);
             }
-            self.prev_lines[row_idx] = cells;
+            // Reuse the stored line's allocation as the new baseline.
+            let baseline = &mut self.prev_lines[row_idx];
+            baseline.clear();
+            baseline.push_str(&self.line_buf);
         }
         self.update_cursor(stdout, vt)
     }
@@ -665,8 +682,9 @@ impl Renderer {
         self.prev_lines.clear();
         let rows = vt.rows().unwrap_or(0);
         for y in 0..rows {
-            let cells = cells_in_row(vt, active_point(y as u32));
-            self.prev_lines.push(cells);
+            let mut line = String::new();
+            dump_row(&mut line, vt, active_point(y as u32));
+            self.prev_lines.push(line);
         }
         self.prev_cursor = CursorState::from_terminal(vt);
     }
@@ -1119,6 +1137,18 @@ impl ShellSession {
         let mut esc_events = Vec::new();
         let mut vt_input = Vec::new();
 
+        // On the alternate screen, a full-screen app's output is forwarded
+        // straight to the real terminal (rewritten to protect the status row)
+        // instead of re-rendering every changed row through the VT. The app
+        // already scrolls and repaints minimally; re-deriving that frame from
+        // the VT each time is what made nested full-screen TUIs lag.
+        let mut passthrough_filter = PassthroughFilter::new();
+        // Whether the reserved scroll region is currently asserted on the real
+        // terminal for the active alt-screen passthrough excursion.
+        let mut passthrough_region_set = false;
+        // Raw PTY bytes accumulated across a batch for passthrough forwarding.
+        let mut frame_bytes: Vec<u8> = Vec::new();
+
         loop {
             // Use select! to handle both events and spinner animation
             let event = if resize_pending {
@@ -1216,16 +1246,40 @@ impl ShellSession {
 
                 Event::PtyOutput(data) => {
                     let was_in_alt = esc.in_alternate_screen;
+                    // Already on the alternate screen at the batch start: forward
+                    // the app's bytes directly instead of re-rendering. The frame
+                    // that *enters* the alt screen (was_in_alt == false) still
+                    // goes through the mediated path so the transition is drawn.
+                    let passthrough = was_in_alt;
                     esc.reset_batch();
-                    escape_state_process(
-                        &mut scanner,
-                        &data,
-                        &mut esc,
-                        stdout,
-                        pty,
-                        self.pty_size(),
-                        &mut esc_events,
-                    )?;
+                    if passthrough {
+                        frame_bytes.clear();
+                        frame_bytes.extend_from_slice(&data);
+                    }
+                    // In passthrough, track escape state without forwarding mode
+                    // bytes (the raw stream we forward already carries them); the
+                    // host still answers the text-area query via the PTY.
+                    if passthrough {
+                        escape_state_process(
+                            &mut scanner,
+                            &data,
+                            &mut esc,
+                            &mut io::sink(),
+                            pty,
+                            self.pty_size(),
+                            &mut esc_events,
+                        )?;
+                    } else {
+                        escape_state_process(
+                            &mut scanner,
+                            &data,
+                            &mut esc,
+                            stdout,
+                            pty,
+                            self.pty_size(),
+                            &mut esc_events,
+                        )?;
+                    }
 
                     // Feed output into VT and track how many lines scrolled off
                     let filtered = vt_input_filter.filter(&data, &mut vt_input);
@@ -1236,20 +1290,36 @@ impl ShellSession {
                     while let Ok(event) = event_rx.try_recv() {
                         match event {
                             Event::PtyOutput(more) => {
-                                escape_state_process(
-                                    &mut scanner,
-                                    &more,
-                                    &mut esc,
-                                    stdout,
-                                    pty,
-                                    self.pty_size(),
-                                    &mut esc_events,
-                                )?;
+                                if passthrough {
+                                    frame_bytes.extend_from_slice(&more);
+                                    escape_state_process(
+                                        &mut scanner,
+                                        &more,
+                                        &mut esc,
+                                        &mut io::sink(),
+                                        pty,
+                                        self.pty_size(),
+                                        &mut esc_events,
+                                    )?;
+                                } else {
+                                    escape_state_process(
+                                        &mut scanner,
+                                        &more,
+                                        &mut esc,
+                                        stdout,
+                                        pty,
+                                        self.pty_size(),
+                                        &mut esc_events,
+                                    )?;
+                                }
                                 let filtered = vt_input_filter.filter(&more, &mut vt_input);
                                 let text = utf8_acc.accumulate(filtered);
                                 total_scroll += feed_vt(vt, &text);
                             }
                             Event::PtyExit(exit_code) => {
+                                if passthrough_region_set {
+                                    stdout.write_all(b"\x1b[r")?;
+                                }
                                 escape_state_cleanup(&esc, stdout)?;
                                 renderer.render_with_scroll(stdout, vt)?;
                                 return Ok(exit_code);
@@ -1270,62 +1340,114 @@ impl ShellSession {
                         }
                     }
 
-                    // Begin synchronized output so the terminal buffers
-                    // all writes atomically (mode 2026).
-                    queue!(stdout, terminal::BeginSynchronizedUpdate)?;
-
-                    // Handle alternate screen transitions
-                    if was_in_alt != esc.in_alternate_screen {
-                        renderer.invalidate();
-                    }
-
-                    // Consume offset if needed: when cursor would land
-                    // off-screen or VT scrolled, push old TUI content
-                    // into native scrollback to make room.
-                    if renderer.row_offset > 0 {
+                    if passthrough {
+                        // Alternate-screen passthrough: forward the app's frame,
+                        // rewritten so its scrolling and addressing stay above
+                        // the reserved status row.
+                        let pt_t0 = std::time::Instant::now();
                         let content_rows = renderer.content_rows;
-                        let visible_rows = renderer.visible_rows();
-                        let cursor_row = vt.cursor_y().map(|r| r as usize).unwrap_or(0);
-                        let cursor_excess = (cursor_row + 1).saturating_sub(visible_rows);
-                        let need = total_scroll.max(cursor_excess);
+                        let mut out: Vec<u8> = Vec::new();
+                        if !passthrough_region_set {
+                            // Reserve the status row on the real terminal.
+                            out.extend_from_slice(format!("\x1b[1;{content_rows}r").as_bytes());
+                            passthrough_region_set = true;
+                        }
+                        passthrough_filter.rewrite(&frame_bytes, content_rows, &mut out);
+                        stdout.write_all(&out)?;
 
-                        let consumed = if esc.in_alternate_screen || esc.erase_display {
-                            // Alternate screen or explicit screen clear (CSI 2J):
-                            // consume the entire offset so the shell owns the
-                            // full visible area.
-                            renderer.row_offset as usize
-                        } else {
-                            need.min(renderer.row_offset as usize)
-                        };
-                        if consumed > 0 {
-                            Renderer::scroll_region(stdout, content_rows, consumed)?;
-                            renderer.row_offset -= consumed as u16;
+                        if !esc.in_alternate_screen {
+                            // The app left the alt screen mid-batch: release the
+                            // reserved region and hand back to the mediated
+                            // renderer, which redraws the restored primary screen
+                            // on the next batch.
+                            stdout.write_all(b"\x1b[r")?;
+                            passthrough_region_set = false;
+                            passthrough_filter.reset();
                             renderer.invalidate();
                         }
-                    }
 
-                    if esc.clear_scrollback {
-                        queue!(stdout, Clear(ClearType::Purge))?;
-                    }
-
-                    if esc.in_alternate_screen || renderer.row_offset > 0 {
-                        renderer.render(stdout, vt)?;
+                        // The app's forwarded frame already positioned the real
+                        // cursor; only touch it if we draw the status line, and
+                        // wrap that excursion in a synchronized update so the
+                        // cursor never visibly flashes onto the status row.
+                        if self.config.show_status_line {
+                            queue!(stdout, terminal::BeginSynchronizedUpdate)?;
+                            self.status_line
+                                .draw(stdout, self.size.cols, self.size.rows)?;
+                            renderer.write_cursor(stdout, vt)?;
+                            queue!(stdout, terminal::EndSynchronizedUpdate)?;
+                        }
+                        stdout.flush()?;
+                        tracing::debug!(
+                            in_bytes = frame_bytes.len(),
+                            out_bytes = out.len(),
+                            elapsed_us = pt_t0.elapsed().as_micros() as u64,
+                            "alt passthrough frame"
+                        );
                     } else {
-                        renderer.render_with_scroll(stdout, vt)?;
-                    }
+                        if esc.in_alternate_screen {
+                            tracing::debug!("alt mediated render");
+                        }
+                        // Begin synchronized output so the terminal buffers
+                        // all writes atomically (mode 2026).
+                        queue!(stdout, terminal::BeginSynchronizedUpdate)?;
 
-                    if self.config.show_status_line {
-                        self.status_line
-                            .draw(stdout, self.size.cols, self.size.rows)?;
-                    }
-                    renderer.write_cursor(stdout, vt)?;
+                        // Handle alternate screen transitions
+                        if was_in_alt != esc.in_alternate_screen {
+                            renderer.invalidate();
+                        }
 
-                    // End synchronized output and flush.
-                    queue!(stdout, terminal::EndSynchronizedUpdate)?;
-                    stdout.flush()?;
+                        // Consume offset if needed: when cursor would land
+                        // off-screen or VT scrolled, push old TUI content
+                        // into native scrollback to make room.
+                        if renderer.row_offset > 0 {
+                            let content_rows = renderer.content_rows;
+                            let visible_rows = renderer.visible_rows();
+                            let cursor_row = vt.cursor_y().map(|r| r as usize).unwrap_or(0);
+                            let cursor_excess = (cursor_row + 1).saturating_sub(visible_rows);
+                            let need = total_scroll.max(cursor_excess);
+
+                            let consumed = if esc.in_alternate_screen || esc.erase_display {
+                                // Alternate screen or explicit screen clear (CSI 2J):
+                                // consume the entire offset so the shell owns the
+                                // full visible area.
+                                renderer.row_offset as usize
+                            } else {
+                                need.min(renderer.row_offset as usize)
+                            };
+                            if consumed > 0 {
+                                Renderer::scroll_region(stdout, content_rows, consumed)?;
+                                renderer.row_offset -= consumed as u16;
+                                renderer.invalidate();
+                            }
+                        }
+
+                        if esc.clear_scrollback {
+                            queue!(stdout, Clear(ClearType::Purge))?;
+                        }
+
+                        if esc.in_alternate_screen || renderer.row_offset > 0 {
+                            renderer.render(stdout, vt)?;
+                        } else {
+                            renderer.render_with_scroll(stdout, vt)?;
+                        }
+
+                        if self.config.show_status_line {
+                            self.status_line
+                                .draw(stdout, self.size.cols, self.size.rows)?;
+                        }
+                        renderer.write_cursor(stdout, vt)?;
+
+                        // End synchronized output and flush.
+                        queue!(stdout, terminal::EndSynchronizedUpdate)?;
+                        stdout.flush()?;
+                    }
                 }
 
                 Event::PtyExit(exit_code) => {
+                    if passthrough_region_set {
+                        stdout.write_all(b"\x1b[r")?;
+                    }
                     self.clear_status_row(stdout, esc.in_alternate_screen)?;
                     escape_state_cleanup(&esc, stdout)?;
                     stdout.flush()?;
@@ -1395,6 +1517,9 @@ impl ShellSession {
             }
         }
 
+        if passthrough_region_set {
+            stdout.write_all(b"\x1b[r")?;
+        }
         self.clear_status_row(stdout, esc.in_alternate_screen)?;
         escape_state_cleanup(&esc, stdout)?;
         stdout.flush()?;

--- a/devenv-shell/src/status_line.rs
+++ b/devenv-shell/src/status_line.rs
@@ -389,9 +389,12 @@ impl StatusLine {
             content.truncate(pos);
         }
 
-        // Move to the last row, clear it, write content
+        // Move to the last row, clear it, write content. Reset SGR before
+        // clearing: with background color erase, a clear inherits the current
+        // background, and a passthrough app's colors may still be active.
         queue!(
             stdout,
+            ResetColor,
             cursor::MoveTo(0, total_rows - 1),
             Clear(ClearType::CurrentLine)
         )?;

--- a/devenv-shell/src/terminal_commands.rs
+++ b/devenv-shell/src/terminal_commands.rs
@@ -61,9 +61,21 @@ pub struct ResetDecMode(pub u16);
 /// DEC origin mode (mode 6).
 pub const ORIGIN_MODE: u16 = 6;
 
+/// DEC autowrap mode (mode 7).
+pub const AUTOWRAP_MODE: u16 = 7;
+
 impl Command for ResetDecMode {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
         write!(f, "\x1b[?{}l", self.0)
+    }
+}
+
+/// Set a DEC private mode (CSI ? mode h).
+pub struct SetDecMode(pub u16);
+
+impl Command for SetDecMode {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x1b[?{}h", self.0)
     }
 }
 

--- a/devenv-shell/src/vt_utils.rs
+++ b/devenv-shell/src/vt_utils.rs
@@ -32,14 +32,6 @@ pub fn screen_point(y: u32) -> Point {
     Point::Screen(PointCoordinate { x: 0, y })
 }
 
-/// Get all cells in a row by iterating columns via grid ref.
-pub fn cells_in_row(vt: &Terminal<'_, '_>, point: Point) -> Vec<Cell> {
-    let cols = vt.cols().unwrap_or(0);
-    (0..cols)
-        .filter_map(|x| vt.grid_ref(point_with_x(point, x)).ok()?.cell().ok())
-        .collect()
-}
-
 /// Push a cell's text content into `buf`, using the grid ref for grapheme clusters.
 ///
 /// Skips spacer-tail cells. Pushes a space for empty cells.

--- a/devenv-shell/src/vt_utils.rs
+++ b/devenv-shell/src/vt_utils.rs
@@ -7,7 +7,7 @@ use libghostty_vt::terminal::{Point, PointCoordinate, Terminal};
 ///
 /// libghostty-vt's `max_scrollback` is byte-sized despite the doc string
 /// in its C header suggesting "lines" (see
-/// https://github.com/ghostty-org/ghostty/discussions/12587). 10 MB matches
+/// <https://github.com/ghostty-org/ghostty/discussions/12587>). 10 MB matches
 /// Ghostty's own `scrollback-limit` default and buys roughly 10k rows of
 /// scrollback at typical column widths.
 pub const DEFAULT_MAX_SCROLLBACK: usize = 10_000_000;

--- a/docs/src/devenv.schema.json
+++ b/docs/src/devenv.schema.json
@@ -214,28 +214,8 @@
             "string",
             "null"
           ]
-        },
-        "cachix_auth_token": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CachixAuthToken"
-            },
-            {
-              "type": "null"
-            }
-          ]
         }
       }
-    },
-    "CachixAuthToken": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "string"
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

`devenv shell` now avoids two major sources of rendering overhead:

- The mediated renderer consumes libghostty dirty-row snapshots and skips rows whose cells have not changed.
- Once an application is already on the alternate screen, its output is forwarded directly to the real terminal instead of reconstructing every frame cell-by-cell. The final status-line row remains reserved and protected.

This substantially reduces work for nested full-screen TUIs such as Neovim and Claude Code, especially on larger terminals, without removing the `devenv shell` status line.

## Root cause

Every PTY batch was previously fed through the VT and then re-read across the visible screen. Even a one-line update therefore scaled with terminal area. Full-screen applications also already emit efficient cursor-addressed updates, so reconstructing their output from VT cells duplicated work and fragmented repaint bursts.

## Passthrough correctness

Direct terminal output is handled by a stateful byte-stream rewriter that:

- clamps cursor rows and scrolling regions to the content area above the status line;
- intercepts terminal-size queries and in-band resize mode where the child must see PTY dimensions;
- buffers split CSI, OSC, DCS, APC, PM, SOS, and UTF-8 sequences so host output cannot be inserted inside them;
- safely cancels oversized terminal strings before unavoidable host output;
- reasserts the protected scroll region after DECSTR/RIS resets;
- tracks origin mode, autowrap, keypad state, synchronized output, and forwarded DEC modes for redraw and exit cleanup;
- defers host overlays while the application owns synchronized-output mode or terminal state makes cursor restoration unsafe.

The branch was rebased onto current `main`, preserving the newer tmux title-filtering path in both single and batched PTY reads.

## Validation

- `devenv shell cargo test --workspace`
- `devenv shell cargo test -p devenv-shell` (187 tests)
- `devenv shell cargo clippy -p devenv-shell --lib -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' devenv shell cargo doc -p devenv-shell --all-features --no-deps`
- `devenv shell cargo fmt --all -- --check`
- `git diff --check`

Regression tests cover dirty-row rendering, full-screen scroll invalidation, split control strings and UTF-8, aborted-string recovery, APC/Kitty graphics boundaries, oversized-string cancellation, DECSTR/RIS state resets, synchronized output, and terminal cleanup.