### PR TITLE
fix(containers): preserve symlinks when copying single-file copyToRoot

### DIFF
--- a/src/modules/containers.nix
+++ b/src/modules/containers.nix
@@ -50,10 +50,15 @@ let
       # Copy the directory's contents into the working directory so that, e.g.,
       # the project root ends up directly under ${homeDir} rather than in a
       # hash-prefixed subdirectory.
-      cp -r ${path}/. $out${homeDir}/
+      cp -rP ${path}/. $out${homeDir}/
     else
       # Copy a single file using its original name, dropping the store hash.
-      cp ${path} "$out${homeDir}/${baseNameOf path}"
+      # Preserve symlinks (-P) rather than following them: paths produced by the
+      # `files` option are symlinks into the store, and their targets are not part
+      # of this source path's closure, so dereferencing would fail to stat them.
+      # Keeping the symlink lets Nix's output scan pull the target into the
+      # closure so it ends up in the image.
+      cp -P ${path} "$out${homeDir}/${baseNameOf path}"
     fi
   '');
 


### PR DESCRIPTION
## Problem

`devenv container build` fails whenever `copyToRoot` points at a **single file**, with:

```
cp: cannot stat '/nix/store/…-test-file.txt': No such file or directory
✖ error: Cannot build '…-devenv-container-home.drv'. builder failed with exit code 1.
```

This is what makes the `container-copytoroot` integration test fail in CI (the directory and multiple-path cases pass; only the single-file case fails).

## Root cause

Files produced by the `files` option are **symlinks into the store** (e.g. `test-file.txt -> /nix/store/…-test-file.txt`). When `copyToRoot = ./test-file.txt` imports such a path, Nix re-imports the *symlink* as a source path. Source-path imports do **not** record references, so the symlink's target is not part of its closure and is never placed in the build sandbox.

The single-file branch of `mkHome` used plain `cp`, which **follows** the command-line symlink and tries to read the (absent) target → "No such file or directory". The directory branch already worked because `cp -r …/.` preserves inner symlinks instead of dereferencing them.

This was a latent issue surfaced by the file-vs-directory branching added in e94869e8 (#2914); the old `cp -r ${path}` had the same flaw for single files.

## Fix

Copy single files **without dereferencing** (`cp -P`), matching the directory branch. Nix's output reference scan then carries the target into the image closure, exactly as it does for the directory case. `baseNameOf path` still yields the original name (it operates on the `./test-file.txt` path before store import), so the file keeps its name without the store hash.

## Verification

Reproduced the failure with a from-source build, applied the fix, and ran the full `container-copytoroot` scenario locally using the same input override as CI (`--override-input devenv path:…/src/modules`):

- ✅ directory `copyToRoot`
- ✅ single-file `copyToRoot` (previously failed)
- ✅ multiple-path `copyToRoot`

No CHANGELOG entry: the regression only ever existed on unreleased `main` (introduced by the unreleased #2914), and that entry already describes the intended final behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)