### PR TITLE
fix(processes): make the runtime directory independent of TMPDIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed the TUI crashing with an arithmetic overflow when a download or task reported progress beyond its expected total.
 - Fixed the quit confirmation prompt overflowing past the right edge on terminals narrower than ~82 columns; the prompt now adapts to the available width.
 - Fixed the bottom navigation hint bar overflowing the right edge on standard ~80 column terminals when a process was selected; the hints are now more compact on narrower terminals.
+- Fixed devenv invocations with different `$TMPDIR` values resolving different runtime directories and therefore failing to find each other's process manager. Runtime directories now resolve from `$XDG_RUNTIME_DIR`, then `/tmp`; `$TMPDIR` is never used. A daemon still using its previous runtime path may need to be restarted once ([#2923](https://github.com/cachix/devenv/issues/2923)).
 - Fixed edits to local `path:` inputs (e.g. `url: path:../shared-config`) never taking effect: the evaluation cache served the old configuration until `.devenv` was deleted, and `devenv update` did not help. Files from local path inputs are now read directly from disk and tracked by the cache, so changes apply on the next command and direnv reloads when they change.
 - Fixed the evaluation cache missing a `devenv.local.nix` (or any other tracked file) created within the same second as the previous evaluation, which could happen in scripts that run devenv commands back to back.
 - Fixed editing `enterShell` while a `devenv shell` is running causing a parse error (e.g. `(eval):6: parse error near '\n'`) on reload under zsh and fish. The `enterShell` output was being mixed into the environment data the reload applies; it now goes to the terminal as it does on a fresh shell entry ([#2919](https://github.com/cachix/devenv/issues/2919)).
@@ -57,8 +58,6 @@
 
 - Reduced renderer fragmentation in `devenv shell` by reading PTY output in larger batches, lowering syscall and event-allocation overhead during full-screen repaint bursts.
 - `DEVENV_HOME` now overrides where devenv stores all per-user data (GC roots, trust database, cached keys), not just the trust database.
-- `DEVENV_RUNTIME` can now be set to override where a project stores its sockets and other runtime files. To relocate runtime files for all projects at once, prefer `XDG_RUNTIME_DIR`, which keeps each project's directory separate.
-
 - Non-TUI console output is now buffered and flushed in batches, reducing write overhead during verbose evaluation.
 
 - Traces now identify whether devenv was invoked by the CLI, direnv, or the native shell hook with a `devenv.caller` span attribute. Caller information is passed explicitly by integrations, so nested commands are not mistaken for automatic activation ([#2965](https://github.com/cachix/devenv/issues/2965)).

--- a/devenv-core/src/paths.rs
+++ b/devenv-core/src/paths.rs
@@ -2,6 +2,7 @@
 
 use miette::{Result, miette};
 use sha2::{Digest, Sha256};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
@@ -47,23 +48,26 @@ pub fn resolve_home() -> Result<PathBuf> {
 ///
 /// The default is kept short to stay within the unix-domain-socket path length limit.
 ///
-/// Honors the `DEVENV_RUNTIME` environment variable.
-/// Otherwise derives a short, deterministic `devenv-<hash>` path
-/// under `$XDG_RUNTIME_DIR` (falling back to `$TMPDIR`, then `/tmp`) that is
-/// unique to `devenv_dotfile`.
+/// Derives a short, deterministic `devenv-<hash>` path
+/// under `$XDG_RUNTIME_DIR` (falling back to `/tmp`) that is unique to
+/// `devenv_dotfile`. `$TMPDIR` is deliberately ignored because it may differ
+/// between invocations that need to rendezvous on the same runtime directory.
 pub fn resolve_runtime_dir(devenv_dotfile: &Path) -> PathBuf {
-    if let Some(runtime) = std::env::var_os("DEVENV_RUNTIME").filter(|v| !v.is_empty()) {
-        return PathBuf::from(runtime);
-    }
+    resolve_runtime_dir_with(devenv_dotfile, |name| std::env::var_os(name))
+}
 
+fn resolve_runtime_dir_with(
+    devenv_dotfile: &Path,
+    get_env: impl Fn(&str) -> Option<OsString>,
+) -> PathBuf {
     let mut hasher = Sha256::new();
     hasher.update(devenv_dotfile.to_string_lossy().as_bytes());
     let hex = hex::encode(hasher.finalize());
 
-    let runtime_base = PathBuf::from(
-        std::env::var("XDG_RUNTIME_DIR")
-            .unwrap_or_else(|_| std::env::var("TMPDIR").unwrap_or_else(|_| "/tmp".to_string())),
-    );
+    let runtime_base = get_env("XDG_RUNTIME_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
     runtime_base.join(format!("devenv-{}", &hex[..7]))
 }
 
@@ -144,52 +148,80 @@ mod tests {
         assert_eq!(resolve_home().ok(), expected);
     }
 
-    /// Set/unset `DEVENV_RUNTIME` for a test. Safe because cargo nextest runs
-    /// each test in its own process, so there is no concurrent env access.
-    fn set_devenv_runtime(dir: &Path) {
-        unsafe { std::env::set_var("DEVENV_RUNTIME", dir) };
-    }
-
-    fn unset_devenv_runtime() {
-        unsafe { std::env::remove_var("DEVENV_RUNTIME") };
+    fn resolve_runtime_dir_for_test(devenv_dotfile: &Path, vars: &[(&str, &str)]) -> PathBuf {
+        let vars = vars
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), OsString::from(value)))
+            .collect::<std::collections::HashMap<_, _>>();
+        resolve_runtime_dir_with(devenv_dotfile, |name| vars.get(name).cloned())
     }
 
     #[test]
-    fn resolve_runtime_dir_honors_env_override() {
-        let tmp = tempfile::tempdir().unwrap();
-        let runtime = tmp.path().join("custom-runtime");
-        set_devenv_runtime(&runtime);
+    fn resolve_runtime_dir_ignores_devenv_runtime() {
+        let dir = resolve_runtime_dir_for_test(
+            Path::new("/project/.devenv"),
+            &[
+                ("DEVENV_RUNTIME", "/tmp/custom-runtime"),
+                ("XDG_RUNTIME_DIR", "/run/user/1234"),
+            ],
+        );
+        assert_eq!(dir.parent(), Some(Path::new("/run/user/1234")));
+    }
 
-        assert_eq!(resolve_runtime_dir(Path::new("/any/.devenv")), runtime);
+    #[test]
+    fn resolve_runtime_dir_is_independent_of_tmpdir() {
+        let dotfile = Path::new("/project/.devenv");
+        let a = resolve_runtime_dir_for_test(dotfile, &[("TMPDIR", "/tmp/dvA")]);
+        let b = resolve_runtime_dir_for_test(dotfile, &[("TMPDIR", "/tmp/claude-501")]);
+        assert_eq!(a, b);
+        assert_eq!(a.parent(), Some(Path::new("/tmp")));
+    }
 
-        unset_devenv_runtime();
+    #[test]
+    fn resolve_runtime_dir_uses_xdg_runtime_dir() {
+        let dir = resolve_runtime_dir_for_test(
+            Path::new("/project/.devenv"),
+            &[("XDG_RUNTIME_DIR", "/run/user/1234")],
+        );
+        assert_eq!(dir.parent(), Some(Path::new("/run/user/1234")));
+    }
+
+    #[test]
+    fn resolve_runtime_dir_does_not_validate_xdg_runtime_dir() {
+        let dir = resolve_runtime_dir_for_test(
+            Path::new("/project/.devenv"),
+            &[("XDG_RUNTIME_DIR", "relative/runtime")],
+        );
+        assert_eq!(dir.parent(), Some(Path::new("relative/runtime")));
     }
 
     #[test]
     fn resolve_runtime_dir_empty_env_falls_back_to_hash() {
-        // An empty DEVENV_RUNTIME is treated as unset.
-        set_devenv_runtime(Path::new(""));
-
-        let dir = resolve_runtime_dir(Path::new("/project/.devenv"));
+        let dir =
+            resolve_runtime_dir_for_test(Path::new("/project/.devenv"), &[("XDG_RUNTIME_DIR", "")]);
         let name = dir.file_name().unwrap().to_string_lossy();
         assert!(
             name.starts_with("devenv-"),
             "unexpected runtime dir: {dir:?}"
         );
         assert_eq!(name.len(), "devenv-".len() + 7);
-
-        unset_devenv_runtime();
     }
 
     #[test]
     fn resolve_runtime_dir_is_deterministic_per_dotfile() {
-        unset_devenv_runtime();
-
-        let a = resolve_runtime_dir(Path::new("/project/.devenv"));
-        let b = resolve_runtime_dir(Path::new("/project/.devenv"));
-        let c = resolve_runtime_dir(Path::new("/other/.devenv"));
+        let a = resolve_runtime_dir_for_test(Path::new("/project/.devenv"), &[]);
+        let b = resolve_runtime_dir_for_test(Path::new("/project/.devenv"), &[]);
+        let c = resolve_runtime_dir_for_test(Path::new("/other/.devenv"), &[]);
         assert_eq!(a, b);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn resolve_runtime_dir_keeps_profiles_isolated() {
+        let base = resolve_runtime_dir_for_test(Path::new("/project/.devenv"), &[]);
+        let profile =
+            resolve_runtime_dir_for_test(Path::new("/project/.devenv/profiles/prod"), &[]);
+        assert_ne!(base, profile);
     }
 
     #[test]

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -28,10 +28,14 @@ devenv defines and respects the following environment variables:
 ### [`DEVENV_RUNTIME`](#devenv_runtime)
 [added-in:1.0]
 
-A short-lived, per-project directory for sockets and other runtime files (e.g. `$DEVENV_RUNTIME/postgres`), exported into the shell.
-Defaults to a short `devenv-<hash>` directory under `$XDG_RUNTIME_DIR` (then `$TMPDIR`, then `/tmp`).
-Set it to override the directory for a single project.
-To relocate runtime files while keeping projects separate, set [`XDG_RUNTIME_DIR`](#xdg_runtime_dir) instead.
+**Read-only.** A short-lived, per-project directory for sockets and other runtime files (e.g. `$DEVENV_RUNTIME/postgres`), exported into the shell.
+The path is resolved in this order:
+
+1. A short `devenv-<hash>` directory under [`$XDG_RUNTIME_DIR`](#xdg_runtime_dir).
+2. `/tmp/devenv-<hash>`.
+
+`$TMPDIR` is deliberately not used, because it can differ between invocations that need to find the same process-manager socket.
+To relocate runtime files while keeping projects and profiles separate, set `$XDG_RUNTIME_DIR`.
 
 ### [`DEVENV_PROFILE`](#devenv_profile)
 [added-in:0.5]
@@ -117,7 +121,8 @@ Locates your shell rc files and serves as the base for the XDG default paths.
 
 ### [`XDG_RUNTIME_DIR`](#xdg_runtime_dir)
 
-Base directory for `$DEVENV_RUNTIME`. Falls back to `$TMPDIR`, then `/tmp`.
+Base directory for `$DEVENV_RUNTIME`.
+When unset, `$DEVENV_RUNTIME` falls back to `/tmp/devenv-<hash>`.
 
 ### [`XDG_DATA_HOME`](#xdg_data_home)
 
@@ -129,7 +134,8 @@ Locates shell rc files and the Cachix CLI configuration.
 
 ### [`TMPDIR`](#tmpdir)
 
-Base directory for build artifacts and a fallback for `$DEVENV_RUNTIME`.
+Base directory for build artifacts.
+It never affects `$DEVENV_RUNTIME`, so sandboxed commands with a different `$TMPDIR` still find the same running processes.
 
 ### [`CI`](#ci)
 

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -255,19 +255,23 @@ in
         type = types.str;
         internal = true;
         # The path has to be
-        # - unique to each DEVENV_STATE to let multiple devenv environments coexist
+        # - unique to each DEVENV_DOTFILE to let multiple devenv environments coexist
         # - deterministic so that it won't change constantly
         # - short so that unix domain sockets won't hit the path length limit
         # - free to create as an unprivileged user across OSes
         default =
           let
-            hashedRoot = builtins.hashString "sha256" config.devenv.state;
+            # Keep this in sync with resolve_runtime_dir in devenv-core. Profile
+            # dotfiles are distinct, so profiles retain separate runtime dirs.
+            hashedDotfile = builtins.hashString "sha256" config.devenv.dotfile;
             # same length as git's abbreviated commit hashes
-            shortHash = builtins.substring 0 7 hashedRoot;
+            shortHash = builtins.substring 0 7 hashedDotfile;
             # XDG_RUNTIME_DIR is the correct location for runtime files like sockets
             # per the XDG Base Directory Specification
             xdg = builtins.getEnv "XDG_RUNTIME_DIR";
-            base = if xdg != "" then xdg else config.devenv.tmpdir;
+            # TMPDIR may differ between invocations that need to rendezvous on
+            # the same process-manager socket.
+            base = if xdg != "" then xdg else "/tmp";
           in
           "${base}/devenv-${shortHash}";
       };
@@ -347,8 +351,7 @@ in
 
       # Override temp directories that stdenv set to NIX_BUILD_TOP.
       # Only reset those that still point to the Nix build dir; leave
-      # any user/CI-supplied value intact so child processes (e.g.
-      # `devenv processes wait`) compute the same runtime directory.
+      # any user/CI-supplied value intact.
       for var in TMP TMPDIR TEMP TEMPDIR; do
         if [ -n "''${!var-}" ] && [ "''${!var}" = "''${NIX_BUILD_TOP-}" ]; then
           export "$var"=${config.devenv.tmpdir}

--- a/tests/cli-flake-bare/.test.sh
+++ b/tests/cli-flake-bare/.test.sh
@@ -7,9 +7,48 @@ nix flake init --template "${DEVENV_REPO}"
 nix flake update --override-input devenv "${DEVENV_REPO}"
 
 # Test that nix develop works with --no-pure-eval
-nix develop --accept-flake-config --no-pure-eval --command echo nix-develop started successfully 2>&1 | tee ./console
+nix develop --accept-flake-config --no-pure-eval \
+  --override-input devenv "$DEVENV_REPO" \
+  --command echo nix-develop started successfully 2>&1 | tee ./console
 grep -F 'nix-develop started successfully' <./console
 grep -F 'Hello, world!' <./console
+
+# The flakes-integration default must remain independent of TMPDIR.
+project_root="$(pwd -P)"
+mkdir -p "$project_root/tmp-a" "$project_root/tmp-b"
+runtime_a="$(
+  env -u DEVENV_RUNTIME -u XDG_RUNTIME_DIR TMPDIR="$project_root/tmp-a" \
+    nix develop --accept-flake-config --no-pure-eval \
+    --override-input devenv "$DEVENV_REPO" --command \
+    sh -c 'printf "%s\n" "$DEVENV_RUNTIME"' | tail -n 1
+)"
+runtime_b="$(
+  env -u DEVENV_RUNTIME -u XDG_RUNTIME_DIR TMPDIR="$project_root/tmp-b" \
+    nix develop --accept-flake-config --no-pure-eval \
+    --override-input devenv "$DEVENV_REPO" --command \
+    sh -c 'printf "%s\n" "$DEVENV_RUNTIME"' | tail -n 1
+)"
+short_hash="$(printf %s "$project_root/.devenv" | sha256sum | cut -c1-7)"
+expected_runtime="/tmp/devenv-$short_hash"
+test "$runtime_a" = "$runtime_b"
+test "$runtime_a" = "$expected_runtime"
+
+inherited_runtime="$(
+  env -u XDG_RUNTIME_DIR DEVENV_RUNTIME="$project_root/custom-runtime" \
+    nix develop --accept-flake-config --no-pure-eval \
+    --override-input devenv "$DEVENV_REPO" --command \
+    sh -c 'printf "%s\n" "$DEVENV_RUNTIME"' | tail -n 1
+)"
+test "$inherited_runtime" = "$expected_runtime"
+
+xdg_runtime_dir="$project_root/xdg-runtime"
+configured_runtime="$(
+  env XDG_RUNTIME_DIR="$xdg_runtime_dir" DEVENV_RUNTIME="$project_root/custom-runtime" \
+    nix develop --accept-flake-config --no-pure-eval \
+    --override-input devenv "$DEVENV_REPO" --command \
+    sh -c 'printf "%s\n" "$DEVENV_RUNTIME"' | tail -n 1
+)"
+test "$configured_runtime" = "$xdg_runtime_dir/devenv-$short_hash"
 
 # Assert that nix-develop fails in pure mode
 if nix develop --command echo nix-develop started in pure mode 2>&1 | tee ./console


### PR DESCRIPTION
Fixes #2923.

## Problem

`DEVENV_RUNTIME` was derived from `XDG_RUNTIME_DIR || TMPDIR || /tmp`. Although its hash suffix was project-stable, using `$TMPDIR` as the base made the complete path invocation-dependent. Sandboxed tools such as Claude Code, `nix develop`, and some CI environments can change `$TMPDIR`, so two commands for the same project resolved different process-manager sockets and could start duplicate or orphaned process stacks.

Reading the exported `$DEVENV_RUNTIME` back as configuration is not safe either: it leaks through nested shells and makes it ambiguous whether a child invocation should reuse the parent project's or profile's runtime directory. `DEVENV_RUNTIME` therefore remains an output-only variable.

## Changes

- Runtime directories now resolve from `$XDG_RUNTIME_DIR`, falling back to `/tmp`; `$TMPDIR` is never used for runtime rendezvous.
- `$DEVENV_RUNTIME` is ignored as an input. Users who need to relocate runtime files should set `$XDG_RUNTIME_DIR`.
- The Rust resolver and direct-flake Nix default both hash `devenv.dotfile`, so CLI and `nix develop` compute the same path.
- Profiles retain separate runtime directories because each profile has a distinct dotfile path.
- Documentation and the changelog now describe `DEVENV_RUNTIME` as read-only and document the migration behavior.

## User impact

Independent invocations for the same project now find the same process manager even when their `$TMPDIR` values differ. Projects and profiles remain isolated. A daemon still using its previous runtime path may need to be restarted once after upgrading.

## Testing

- `cargo nextest run -p devenv-core` — 204 tests passed.
- `cargo check -p devenv-core -p devenv-processes -p devenv`.
- `devenv-run-tests run tests --only cli-flake-bare`, covering different `$TMPDIR` values, ignored inherited `$DEVENV_RUNTIME`, and an explicit `$XDG_RUNTIME_DIR`.
- Rust formatting, Nix parsing/formatting, shell syntax, and `git diff --check`.