### PR TITLE
docs: fix devenv build output examples

### DIFF
--- a/docs/src/outputs.md
+++ b/docs/src/outputs.md
@@ -43,8 +43,10 @@ To build all defined outputs, run:
 
 ```shell-session
 $ devenv build
-/nix/store/abc123def456ghi789jkl012mno345pq-rust-app-1.0
-/nix/store/xyz987wvu654tsr321qpo987mnl654ki-python-app-1.0
+{
+  "outputs.rust-app": "/nix/store/abc123def456ghi789jkl012mno345pq-rust-app-1.0",
+  "outputs.python-app": "/nix/store/xyz987wvu654tsr321qpo987mnl654ki-python-app-1.0"
+}
 ```
 
 This command will build all outputs and display their paths in the Nix store.
@@ -53,7 +55,9 @@ To build specific output(s), you can specify them explicitly:
 
 ```shell-session
 $ devenv build outputs.rust-app
-/nix/store/abc123def456ghi789jkl012mno345pq-rust-app-1.0
+{
+  "outputs.rust-app": "/nix/store/abc123def456ghi789jkl012mno345pq-rust-app-1.0",
+}
 ```
 
 This will build only the `rust-app` output, making it easy to consume for installation or distribution.


### PR DESCRIPTION
Problem: `devenv build` is documented to just print nix store paths (like `nix-build`), but actually prints structured JSON.

Solution: adjust documentation.

Related:
- #2828 asks for differently structured JSON.