### PR TITLE
Property-based TUI tests, crash/overflow fixes, and nightly bombadil fuzz

### DIFF
--- a/.github/workflows/tui-fuzz.yml
+++ b/.github/workflows/tui-fuzz.yml
@@ -1,0 +1,95 @@
+name: "TUI fuzz"
+
+# End-to-end fuzzing of the real TUI binary through a PTY using bombadil
+# (experimental, pinned). This complements the deterministic property tests in
+# devenv-tui/tests/tui_proptest.rs, which already run on every PR via the
+# `cargo nextest run --features devenv/test-all` step in build.yml.
+#
+# Runs nightly (and on demand) rather than per-PR: it is slow and the trace it
+# records grows fast. On a property violation it stops early and uploads the
+# reproducer so it can be replayed with `bombadil terminal test --reproduce`.
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # nightly, 03:00 UTC
+  workflow_dispatch:
+    inputs:
+      time-limit:
+        description: "bombadil --time-limit (e.g. 120s, 5m, 1h)"
+        required: false
+        default: "120s"
+
+concurrency:
+  group: tui-fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BOMBADIL_VERSION: v0.6.0
+
+jobs:
+  fuzz:
+    name: bombadil terminal fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@v17
+        with:
+          name: devenv
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build devenv
+        id: build-devenv
+        run: |
+          devenv_path=$(nix build -L --print-out-paths --system x86_64-linux .#devenv)
+          echo "path=$devenv_path" >> "$GITHUB_OUTPUT"
+
+      - name: Build tui-replay (deterministic)
+        run: |
+          "${{ steps.build-devenv.outputs.path }}/bin/devenv" shell -- \
+            cargo build -p devenv-tui --features deterministic-tui --bin tui-replay
+
+      - name: Fetch bombadil ${{ env.BOMBADIL_VERSION }}
+        run: |
+          curl -fsSL -o bombadil \
+            "https://github.com/antithesishq/bombadil/releases/download/${BOMBADIL_VERSION}/bombadil-x86_64-linux"
+          chmod +x bombadil
+          ./bombadil --version
+
+      - name: Run terminal fuzz
+        run: |
+          bin=$(find target -maxdepth 3 -type f -name tui-replay | head -1)
+          echo "Fuzzing $bin"
+          ./bombadil terminal test \
+            --time-limit "${{ github.event.inputs.time-limit || '120s' }}" \
+            --exit-on-violation \
+            --scrollback-lines-max 100 \
+            --specification devenv-tui/bombadil/devenv-tui.spec.ts \
+            --output-path bombadil-out \
+            -- "$bin" --hold --loop 0 devenv-tui/replays/quick-test
+
+      - name: Compress reproducer
+        if: failure()
+        run: |
+          if [ -d bombadil-out ]; then
+            tar -C bombadil-out -cf - . | zstd -19 -T0 -o bombadil-reproducer.tar.zst || true
+          fi
+
+      - name: Upload reproducer
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bombadil-reproducer
+          path: bombadil-reproducer.tar.zst
+          if-no-files-found: ignore
+          retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Bug Fixes
 
+- Fixed the TUI crashing on activity names or store paths containing multi-byte characters (e.g. non-ASCII package names or evaluation paths) when shortened for narrow terminals.
+- Fixed the TUI crashing with an arithmetic overflow when a download or task reported progress beyond its expected total.
+- Fixed the quit confirmation prompt overflowing past the right edge on terminals narrower than ~82 columns; the prompt now adapts to the available width.
+- Fixed the bottom navigation hint bar overflowing the right edge on standard ~80 column terminals when a process was selected; the hints are now more compact on narrower terminals.
 - Fixed editing `enterShell` while a `devenv shell` is running causing a parse error (e.g. `(eval):6: parse error near '\n'`) on reload under zsh and fish. The `enterShell` output was being mixed into the environment data the reload applies; it now goes to the terminal as it does on a fresh shell entry ([#2919](https://github.com/cachix/devenv/issues/2919)).
 - Fixed `devenv up` (and other TUI commands) burning significant CPU while idle — roughly 10-15% per managed process — even when every process was quiet. The foreground UI was recomputing its layout dozens of times per second regardless of whether anything changed, and each idle process woke the whole UI twice a second. The TUI now only redraws when the model actually changes, with a slow heartbeat to keep elapsed timers ticking ([#2915](https://github.com/cachix/devenv/issues/2915)).
 - Fixed `devenv container` placing `copyToRoot` directories under a hash-prefixed subdirectory (e.g. `/env/<hash>-source`) instead of in the working directory. The project root and other directory paths now land directly under the working directory, and single files keep their original name ([#2914](https://github.com/cachix/devenv/issues/2914)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,6 +2158,7 @@ dependencies = [
  "insta",
  "iocraft",
  "libc",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2165,6 +2166,7 @@ dependencies = [
  "tokio-shutdown",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.1.14",
  "url",
 ]
 

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -7565,9 +7565,17 @@ rec {
             features = [ "filters" "json" ];
           }
           {
+            name = "proptest";
+            packageId = "proptest";
+          }
+          {
             name = "tokio";
             packageId = "tokio";
             features = [ "process" "fs" "io-util" "macros" "rt-multi-thread" "sync" "time" "test-util" ];
+          }
+          {
+            name = "unicode-width";
+            packageId = "unicode-width 0.1.14";
           }
         ];
         features = {

--- a/devenv-tui/Cargo.toml
+++ b/devenv-tui/Cargo.toml
@@ -67,6 +67,8 @@ path = "src/bin/tui-replay.rs"
 insta.workspace = true
 devenv-activity = { workspace = true, features = ["test-helpers"] }
 tokio = { workspace = true, features = ["test-util"] }
+proptest.workspace = true
+unicode-width = "0.1"
 
 [features]
 default = []

--- a/devenv-tui/README.md
+++ b/devenv-tui/README.md
@@ -71,6 +71,26 @@ cargo run --bin tui-replay trace.jsonl
 cargo run --bin tui-replay <(zstd -dc trace.jsonl.zst)
 ```
 
+#### Long lived mode (for fuzzing)
+
+`--hold` keeps the TUI running after the trace drains, so the data stream is
+deterministic while the program stays live for input. `--loop N` replays the
+trace N times (0 = forever) for continuous data churn. Together they make a
+stable target for a terminal fuzzer such as `bombadil terminal test`:
+
+```bash
+cargo build -p devenv-tui --features deterministic-tui --bin tui-replay
+bombadil terminal test --time-limit 20s --output-path /tmp/bombadil-out \
+  -- ./target/debug/tui-replay --hold --loop 0 devenv-tui/replays/quick-test
+```
+
+The fuzzer spawns the program in its own PTY and injects random input; the
+process exits only on Ctrl+C or when `--time-limit` is reached. Reproduce a
+failing run with `bombadil terminal test --reproduce /tmp/bombadil-out -- ...`.
+
+Note: the trace at `--output-path` records the full terminal grid per sampled
+state, so it grows fast (multiple GB for a 20s run) — delete it after triage.
+
 ## Views
 
 **Main view**: Shows activity tree with inline log previews. Does not use alternate screen buffer, so terminal scrollback is preserved.

--- a/devenv-tui/bombadil/README.md
+++ b/devenv-tui/bombadil/README.md
@@ -1,0 +1,43 @@
+# Bombadil terminal fuzzing for devenv-tui
+
+End-to-end fuzzing of the real TUI binary through a PTY, using
+[bombadil](https://github.com/antithesishq/bombadil) (v0.6.0, **experimental**).
+
+This complements the in-process property tests in `../tests/tui_proptest.rs`:
+
+| Layer | What it covers | Where |
+|------|----------------|-------|
+| Snapshots | exact rendered output for fixed inputs | `../tests/tui_tests.rs` |
+| Property tests | model + `view()` invariants, no-panic, width-fit | `../tests/tui_proptest.rs` |
+| Bombadil (this) | real PTY: crossterm input decode, ANSI output, SIGWINCH | here |
+
+The property tests are the fast, deterministic gate (run in `cargo nextest`).
+Bombadil is the slow, end-to-end layer and is **not wired into CI** — it needs
+the experimental bombadil binary vendored first.
+
+## Running
+
+```bash
+# 1. Build the long-lived replay harness (deterministic output for reproducers).
+cargo build -p devenv-tui --features deterministic-tui --bin tui-replay
+
+# 2. Fuzz it. --hold keeps the TUI alive for input; --loop 0 replays forever
+#    so there is always a live program under the fuzzer.
+bombadil terminal test --time-limit 60s --output-path /tmp/bombadil-out \
+  --specification devenv-tui/bombadil/devenv-tui.spec.ts \
+  -- ./target/debug/tui-replay --hold --loop 0 devenv-tui/replays/quick-test
+
+# 3. Reproduce a failure.
+bombadil terminal test --reproduce /tmp/bombadil-out \
+  --specification devenv-tui/bombadil/devenv-tui.spec.ts \
+  -- ./target/debug/tui-replay --hold --loop 0 devenv-tui/replays/quick-test
+```
+
+Notes:
+
+- The trace at `--output-path` records the full terminal grid per sampled
+  state and grows fast (several GB per minute). Delete it after triage.
+- `noOverflow` in the spec currently surfaces the known bottom nav/help-bar
+  overflow that the in-process tests also document.
+- To make reproducers sound, keep the harness deterministic: build with
+  `deterministic-tui` (static spinner/time) and use the fixed replay trace.

--- a/devenv-tui/bombadil/devenv-tui.spec.ts
+++ b/devenv-tui/bombadil/devenv-tui.spec.ts
@@ -1,0 +1,106 @@
+// Bombadil terminal specification for devenv-tui.
+//
+// This is the end-to-end layer that complements the deterministic property
+// tests in `tests/tui_proptest.rs`. Those tests drive the model + `view()`
+// in-process; this spec drives the *real binary* through a PTY, exercising
+// crossterm input decoding, ANSI output, and SIGWINCH resize handling that an
+// in-process test cannot reach.
+//
+// Status: EXPERIMENTAL. Pinned to the bombadil v0.6.0 terminal API
+// (`@antithesishq/bombadil/terminal`). The terminal spec API is not yet
+// documented upstream; the names below come from the published npm type
+// definitions. Bombadil discovers exported action generators and properties
+// from this module.
+//
+// Run against the long-lived replay harness (see ../README.md):
+//
+//   cargo build -p devenv-tui --features deterministic-tui --bin tui-replay
+//   bombadil terminal test --time-limit 60s --output-path /tmp/bombadil-out \
+//     --specification devenv-tui/bombadil/devenv-tui.spec.ts \
+//     -- ./target/debug/tui-replay --hold --loop 0 devenv-tui/replays/quick-test
+
+import { always, weighted, actions, integers } from "@antithesishq/bombadil";
+import { extract, type State, type Action } from "@antithesishq/bombadil/terminal";
+import {
+  typeFromSet,
+  CharSets,
+  pasteText,
+} from "@antithesishq/bombadil/terminal/defaults/actions";
+
+// Send raw bytes the app actually reads. crossterm decodes these into key
+// events, so control bytes map to devenv-tui's chords more reliably than
+// PressKey codes.
+const k = (bytes: string): Action => ({ TypeText: { text: bytes } });
+
+// Random resize within the usable range (the in-process tests show iocraft
+// itself cannot fit content below ~30 columns, so there is no point fuzzing
+// narrower).
+const resize = actions((): Action[] => [
+  {
+    Resize: {
+      size: {
+        columns: integers().min(40).max(220).generate(),
+        rows: integers().min(2).max(60).generate(),
+      },
+    },
+  },
+]);
+
+// The driver: weighted toward devenv-tui's real input vocabulary, with a slice
+// of adversarial input for robustness.
+export const drive = weighted<Action>([
+  [8, k("\x1b[A")], // Up
+  [8, k("\x1b[B")], // Down
+  [6, k("j")],
+  [6, k("k")],
+  [6, k("\x05")], // Ctrl+E  expand logs
+  [4, k("\x12")], // Ctrl+R  (re)start process
+  [4, k("\x18")], // Ctrl+X  stop process
+  [4, k("\x08")], // Ctrl+H  toggle hide-stopped
+  [5, k("\x1b")], // Esc     clear selection / back
+  [12, resize],
+  [8, { ScrollUp: {} }],
+  [8, { ScrollDown: {} }],
+  [3, k("\x03")], // Ctrl+C  quit prompt
+  [2, k("c")], // keep running
+  [2, k("q")], // quit
+  [3, typeFromSet(CharSets.CONTROL_ALL)], // input-parser robustness
+  [2, typeFromSet(CharSets.UNICODE_CJK.union(CharSets.UNICODE_EMOTICONS))],
+  [1, actions(() => [pasteText("A".repeat(8000))])], // huge paste
+]);
+
+// --- Properties -----------------------------------------------------------
+
+// Largest non-empty cell column in a row, i.e. the rendered width of that row.
+function rowWidth(s: State, r: number): number {
+  const cells = s.grid.row(r);
+  for (let c = cells.length - 1; c >= 0; c--) {
+    if (cells[c].contents.trim() !== "") return c + 1;
+  }
+  return 0;
+}
+
+// No rendered row may extend past the terminal width. NOTE: this currently
+// surfaces the known bottom nav/help-bar overflow that the in-process tests
+// also document (see `rendered_lines_fit_usable_width`). Once the help bar gets
+// a width budget this becomes a clean invariant.
+const overflow = extract((s: State) => {
+  for (let r = 0; r < s.grid.size.rows; r++) {
+    if (rowWidth(s, r) > s.grid.size.columns) return true;
+  }
+  return false;
+});
+export const noOverflow = always(() => !overflow.current);
+
+// devenv internals must never leak panic/debug text onto the screen.
+const leaked = extract((s: State) => {
+  for (let r = 0; r < s.grid.size.rows; r++) {
+    if (/panicked|RUST_BACKTRACE|\{:\?\}/.test(s.grid.rowText(r))) return true;
+  }
+  return false;
+});
+export const noPanicText = always(() => !leaked.current);
+
+// Crash/abort detection (a debug_assert abort shows up as a signal) and unicode
+// width/decoding correctness come for free from the defaults.
+export { exitSuccess, noReplacementChars } from "@antithesishq/bombadil/terminal/defaults/properties";

--- a/devenv-tui/bombadil/devenv-tui.spec.ts
+++ b/devenv-tui/bombadil/devenv-tui.spec.ts
@@ -61,10 +61,11 @@ export const drive = weighted<Action>([
   [12, resize],
   [8, { ScrollUp: {} }],
   [8, { ScrollDown: {} }],
-  [3, k("\x03")], // Ctrl+C  quit prompt
-  [2, k("c")], // keep running
-  [2, k("q")], // quit
-  [3, typeFromSet(CharSets.CONTROL_ALL)], // input-parser robustness
+  // NB: intentionally no quit keys (Ctrl+C / q) and no CONTROL_ALL (which
+  // includes Ctrl+C). They make the harness exit, which ends the session early
+  // and trips `exitSuccess`. The quit prompt rendering is covered by the
+  // in-process property tests instead; here the run is bounded by --time-limit.
+  [3, typeFromSet(CharSets.CONTROL_NAVIGATION.union(CharSets.CONTROL_ARROWS))], // input-parser robustness
   [2, typeFromSet(CharSets.UNICODE_CJK.union(CharSets.UNICODE_EMOTICONS))],
   [1, actions(() => [pasteText("A".repeat(8000))])], // huge paste
 ]);

--- a/devenv-tui/src/bin/tui-replay.rs
+++ b/devenv-tui/src/bin/tui-replay.rs
@@ -23,6 +23,20 @@ struct Args {
     /// Replay speed multiplier (e.g., 2.0 for 2x speed, 0.5 for half speed)
     #[arg(long, short, default_value = "1.0")]
     speed: f64,
+
+    /// Keep the TUI running after the trace drains instead of exiting.
+    ///
+    /// The trace provides a deterministic data stream while the program stays
+    /// live for input. Intended for fuzzing the input/render path (e.g. with
+    /// `bombadil terminal test`), bounded by the fuzzer's timeout or Ctrl+C.
+    #[arg(long)]
+    hold: bool,
+
+    /// Number of times to replay the trace (0 = repeat forever).
+    ///
+    /// Useful for continuous data churn while fuzzing.
+    #[arg(long = "loop", default_value = "1")]
+    loop_count: u64,
 }
 
 /// Raw trace event as it appears in the JSONL file
@@ -155,6 +169,27 @@ async fn replay_events(
     Ok(())
 }
 
+/// Replays the trace `loop_count` times (0 = forever), reopening the file each
+/// iteration since `TraceStream` consumes it.
+async fn run_replays(
+    path: &PathBuf,
+    tx: &mpsc::UnboundedSender<ActivityEvent>,
+    speed: f64,
+    loop_count: u64,
+) -> Result<()> {
+    let mut iteration: u64 = 0;
+    loop {
+        let file = File::open(path)
+            .with_context(|| format!("Failed to open trace file: {}", path.display()))?;
+        replay_events(TraceStream::new(file), tx, speed).await?;
+
+        iteration += 1;
+        if loop_count != 0 && iteration >= loop_count {
+            return Ok(());
+        }
+    }
+}
+
 async fn ctrl_c() {
     signal::ctrl_c().await.expect("Failed to listen for Ctrl+C");
 }
@@ -170,7 +205,9 @@ async fn main() -> Result<()> {
         bail!("Speed must be greater than 0");
     }
 
-    let file = File::open(&args.trace_file)
+    // Validate the trace file exists before spawning the TUI; run_replays
+    // reopens it (once per loop iteration).
+    File::open(&args.trace_file)
         .with_context(|| format!("Failed to open trace file: {}", args.trace_file.display()))?;
 
     let (tx, rx) = mpsc::unbounded_channel();
@@ -197,16 +234,44 @@ async fn main() -> Result<()> {
 
     info!("Starting trace replay from: {}", args.trace_file.display());
 
-    let stream = TraceStream::new(file);
+    // Run the replay on its own task with a cloned sender. The original `tx`
+    // stays alive in `main` so the activity channel never closes — in hold mode
+    // a closed channel would make the TUI exit (see TuiApp::run).
+    let mut replay_task = tokio::spawn({
+        let replay_tx = tx.clone();
+        let path = args.trace_file.clone();
+        let speed = args.speed;
+        let loop_count = args.loop_count;
+        async move { run_replays(&path, &replay_tx, speed, loop_count).await }
+    });
 
     tokio::select! {
-        result = replay_events(stream, &tx, args.speed) => {
-            if let Err(e) = result {
-                warn!("Replay error: {e}");
+        result = &mut replay_task => {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => warn!("Replay error: {e}"),
+                Err(e) => warn!("Replay task panicked: {e}"),
             }
-            // Signal TUI that replay is done
-            if let Some(tx) = backend_done_tx.take() {
-                let _ = tx.send(());
+
+            if args.hold {
+                // Hold the TUI open for input fuzzing: do NOT signal
+                // backend_done and keep `tx`/`backend_done_tx` alive. Wait for
+                // the TUI to exit on its own or for an interrupt (the fuzzer's
+                // timeout kills the process).
+                info!("Trace drained; holding TUI open (--hold). Ctrl+C to exit.");
+                tokio::select! {
+                    _ = &mut tui_task => info!("TUI exited"),
+                    _ = ctrl_c() => {
+                        info!("Interrupted");
+                        shutdown.shutdown();
+                    }
+                }
+            } else {
+                // Signal TUI that replay is done and let it drain and exit.
+                if let Some(tx) = backend_done_tx.take() {
+                    let _ = tx.send(());
+                }
+                let _ = (&mut tui_task).await;
             }
         }
         _ = &mut tui_task => {

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -492,7 +492,9 @@ impl ProgressBarComponent {
             .saturating_sub(4); // Some padding
         let bar_width = available_width.clamp(10, 100); // Min 10, max 100 chars
 
-        let filled = (bar_width * self.percent as usize) / 100;
+        // Clamp to bar_width: progress can exceed 100% (e.g. reported bytes past
+        // the expected total), which would otherwise underflow `empty`.
+        let filled = ((bar_width * self.percent as usize) / 100).min(bar_width);
         let empty = bar_width - filled;
 
         // Split progress bar into filled and empty parts for coloring
@@ -802,16 +804,21 @@ fn shorten_store_path_aggressive(path: &str) -> String {
         }
     }
 
-    // Fallback: if it still looks like a hash, truncate and add ellipsis
+    // Fallback: if it still looks like a hash, truncate and add ellipsis.
+    // Truncate by characters, not bytes, so multi-byte UTF-8 never panics.
     if path.len() > 15 && path.chars().all(|c| c.is_alphanumeric()) {
         // Looks like just a hash, truncate to first few chars + ellipsis
-        format!("{}…", &path[..4])
+        let prefix: String = path.chars().take(4).collect();
+        format!("{}…", prefix)
     } else if path.len() > 20 {
         // For file paths (like evaluation paths), keep the end and truncate the beginning
         if path.contains('/') {
-            format!("…{}", &path[path.len() - 19..])
+            let chars: Vec<char> = path.chars().collect();
+            let tail: String = chars[chars.len().saturating_sub(19)..].iter().collect();
+            format!("…{}", tail)
         } else {
-            format!("{}…", &path[..19])
+            let prefix: String = path.chars().take(19).collect();
+            format!("{}…", prefix)
         }
     } else {
         path.to_string()

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -973,27 +973,35 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     let hide_stopped_processes = *hide_stopped_processes;
 
     if interrupt_prompt_active {
-        let prompt_text = if terminal_width < 72 {
+        // Pick prompt verbosity so the prompt plus the (non-shrinking) key hints
+        // fit within the terminal width. The full hints occupy ~39 columns, so
+        // the long prompt only fits comfortably on wide terminals.
+        let prompt_text = if terminal_width < 60 {
+            "Quit?"
+        } else if terminal_width < 100 {
             "Quit devenv? Nothing stopped."
         } else {
             "Quit devenv? Nothing has been stopped yet."
         };
+        // Compact, single-spaced hints on narrow terminals so the row never
+        // overflows; verbose hints once there is room.
+        let compact = terminal_width < 72;
 
         return element!(View(
             flex_direction: FlexDirection::Row,
             justify_content: JustifyContent::SpaceBetween,
             width: 100pct
         ) {
-            View(flex_grow: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+            View(flex_grow: 1.0, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
                 Text(content: prompt_text, color: Color::Yellow, weight: Weight::Bold)
             }
-            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0, margin_left: 2) {
+            View(flex_direction: FlexDirection::Row, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
                 Text(content: "c", color: COLOR_INTERACTIVE)
-                Text(content: " keep running • ")
+                Text(content: if compact { ":run " } else { " keep running • " })
                 Text(content: "q", color: COLOR_INTERACTIVE)
-                Text(content: " quit • ")
+                Text(content: if compact { ":quit " } else { " quit • " })
                 Text(content: "Ctrl-C", color: COLOR_INTERACTIVE)
-                Text(content: " quit")
+                Text(content: ":quit")
             }
         })
         .into_any();
@@ -1231,7 +1239,10 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         help_children.push(element!(Text(content: "↓", color: down_arrow_color)).into_any());
         if !use_symbols {
             if use_short_text {
-                help_children.push(element!(Text(content: " nav • ")).into_any());
+                // Compact, single-space separators on narrow terminals (< 100
+                // cols): with several hints (e.g. a process is selected) the
+                // " • " bullets pushed the bar past the right edge.
+                help_children.push(element!(Text(content: " nav ")).into_any());
             } else {
                 help_children.push(element!(Text(content: " navigate • ")).into_any());
             }
@@ -1242,7 +1253,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         if use_symbols {
             help_children.push(element!(Text(content: " ▼ • ")).into_any());
         } else if use_short_text {
-            help_children.push(element!(Text(content: " expand • ")).into_any());
+            help_children.push(element!(Text(content: " expand ")).into_any());
         } else {
             help_children.push(element!(Text(content: " expand logs • ")).into_any());
         }
@@ -1251,21 +1262,25 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
                 help_children
                     .push(element!(Text(content: if use_short_text { "^X" } else { "Ctrl-X" }, color: COLOR_INTERACTIVE)).into_any());
                 if use_short_text {
-                    help_children.push(element!(Text(content: " stop • ")).into_any());
+                    help_children.push(element!(Text(content: " stop ")).into_any());
                 } else {
                     help_children.push(element!(Text(content: " stop process • ")).into_any());
                 }
             }
             help_children.push(element!(Text(content: if use_short_text { "^R" } else { "Ctrl-R" }, color: COLOR_INTERACTIVE)).into_any());
             if use_short_text {
-                help_children.push(element!(Text(content: " (re)start • ")).into_any());
+                help_children.push(element!(Text(content: " restart ")).into_any());
             } else {
                 help_children.push(element!(Text(content: " (re)start process • ")).into_any());
             }
         }
         if show_hide_toggle {
             help_children.push(element!(Text(content: if use_short_text { "^H" } else { "Ctrl-H" }, color: COLOR_INTERACTIVE)).into_any());
-            help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped • " } else { " hide stopped • " })).into_any());
+            if use_short_text {
+                help_children.push(element!(Text(content: if hide_stopped_processes { " show " } else { " hide " })).into_any());
+            } else {
+                help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped • " } else { " hide stopped • " })).into_any());
+            }
         }
         help_children.push(element!(Text(content: "Esc", color: COLOR_INTERACTIVE)).into_any());
         if showing_logs {

--- a/devenv-tui/tests/tui_proptest.rs
+++ b/devenv-tui/tests/tui_proptest.rs
@@ -1,0 +1,540 @@
+#![cfg(feature = "test-all")]
+//! Property-based tests for the TUI.
+//!
+//! Where `tui_tests.rs` pins exact rendered output for fixed inputs, this suite
+//! attacks the *state machine*: it generates random streams of activity events
+//! (every activity type, with adversarial unicode/control-character payloads)
+//! interleaved with random UI commands (navigation, filtering, expand/back,
+//! interrupt prompt, and resizes down to degenerate sizes), then asserts the
+//! invariants that must hold no matter what:
+//!
+//! 1. `view()` must render without panicking at any terminal size.
+//! 2. Model query methods must never panic on any (possibly inconsistent) state.
+//! 3. `select_activity` always lands inside the selectable set.
+//! 4. The total log-line counter never undercounts the buffered lines.
+//! 5. Rendered lines never exceed the terminal width (no overflow / bad wrap).
+//!
+//! Determinism: the `test-all` feature pulls in `deterministic-tui`, so spinner
+//! frames and elapsed times render as fixed placeholders and a failing case
+//! shrinks to a stable, reproducible minimal sequence.
+
+use devenv_activity::test_helpers::*;
+use devenv_activity::{ActivityLevel, ActivityOutcome, FetchKind, ProcessStatus};
+use devenv_tui::view::view;
+use devenv_tui::{ActivityModel, RenderContext, UiState, ViewMode};
+use iocraft::prelude::*;
+use proptest::prelude::*;
+use unicode_width::UnicodeWidthStr;
+
+/// Activity ids are drawn from a small space so that events frequently target
+/// the same activity (parents, logs, completions) instead of always creating
+/// fresh orphans.
+const MAX_ID: u64 = 8;
+
+// ---------------------------------------------------------------------------
+// Strategies for the leaf values shared across event kinds.
+// ---------------------------------------------------------------------------
+
+/// Strings designed to break naive rendering / width / slicing logic.
+fn nasty_string() -> impl Strategy<Value = String> {
+    prop_oneof![
+        Just(String::new()),
+        Just("hello world".to_string()),
+        Just("你好世界".to_string()),             // wide (CJK) glyphs
+        Just("🎉🚀👨‍👩‍👧‍👦".to_string()),               // emoji + ZWJ sequence
+        Just("\u{200b}\u{200b}zero".to_string()), // zero-width
+        Just("\x1b[31mfake-ansi\x1b[0m".to_string()), // embedded escape
+        Just("carriage\rreturn".to_string()),
+        Just("new\nline\r\nbreaks".to_string()),
+        Just("\ttabbed\tcontent".to_string()),
+        Just("\0nul\0byte".to_string()),
+        Just("a".repeat(400)),             // very long single line
+        Just("مرحبا بالعالم".to_string()), // RTL
+        "[a-zA-Z0-9 ._/-]{0,48}",
+        "\\PC{0,24}", // arbitrary non-control unicode
+    ]
+}
+
+fn outcome() -> impl Strategy<Value = ActivityOutcome> {
+    prop_oneof![
+        Just(ActivityOutcome::Success),
+        Just(ActivityOutcome::Failed),
+        Just(ActivityOutcome::Cancelled),
+        Just(ActivityOutcome::Cached),
+        Just(ActivityOutcome::Skipped),
+        Just(ActivityOutcome::DependencyFailed),
+    ]
+}
+
+fn level() -> impl Strategy<Value = ActivityLevel> {
+    prop_oneof![
+        Just(ActivityLevel::Error),
+        Just(ActivityLevel::Warn),
+        Just(ActivityLevel::Info),
+        Just(ActivityLevel::Debug),
+        Just(ActivityLevel::Trace),
+    ]
+}
+
+fn fetch_kind() -> impl Strategy<Value = FetchKind> {
+    prop_oneof![
+        Just(FetchKind::Download),
+        Just(FetchKind::Query),
+        Just(FetchKind::Tree),
+        Just(FetchKind::Copy),
+    ]
+}
+
+fn proc_status_val() -> impl Strategy<Value = ProcessStatus> {
+    prop_oneof![
+        Just(ProcessStatus::NotStarted),
+        Just(ProcessStatus::Waiting),
+        Just(ProcessStatus::Starting),
+        Just(ProcessStatus::Running),
+        Just(ProcessStatus::Ready),
+        Just(ProcessStatus::Restarting),
+        Just(ProcessStatus::Stopping),
+        Just(ProcessStatus::Stopped),
+    ]
+}
+
+fn id() -> impl Strategy<Value = u64> {
+    0..MAX_ID
+}
+
+fn parent() -> impl Strategy<Value = Option<u64>> {
+    prop_oneof![Just(None), (0..MAX_ID).prop_map(Some)]
+}
+
+// ---------------------------------------------------------------------------
+// EvtSpec: a serializable description of one activity event, turned into a real
+// `ActivityEvent` via the test helpers at apply time. Kept as a plain enum so
+// proptest can cheaply clone/shrink it regardless of `ActivityEvent`'s traits.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum EvtSpec {
+    BuildStart(u64, Option<u64>, String),
+    BuildPhase(u64, String),
+    BuildLog(u64, String, bool),
+    BuildComplete(u64, ActivityOutcome),
+    FetchStart(u64, FetchKind, String),
+    FetchProgress(u64, u64, Option<u64>),
+    FetchComplete(u64, ActivityOutcome),
+    TaskSingle(u64, String, Option<u64>, bool, bool),
+    TaskStart(u64),
+    TaskLog(u64, String, bool),
+    TaskProgress(u64, u64, u64),
+    TaskComplete(u64, ActivityOutcome),
+    ProcessStart(u64, String),
+    ProcessStatus(u64, ProcessStatus),
+    ProcessComplete(u64, ActivityOutcome),
+    OperationStart(u64, String),
+    OperationLog(u64, String, bool),
+    OperationProgress(u64, u64, u64),
+    OperationComplete(u64, ActivityOutcome),
+    EvalStart(u64, String, ActivityLevel),
+    EvalLog(u64, String),
+    EvalComplete(u64, ActivityOutcome),
+    CommandStart(u64, String),
+    CommandLog(u64, String, bool),
+    CommandComplete(u64, ActivityOutcome),
+    Msg(ActivityLevel, String),
+}
+
+fn evt_spec() -> impl Strategy<Value = EvtSpec> {
+    prop_oneof![
+        (id(), parent(), nasty_string()).prop_map(|(i, p, n)| EvtSpec::BuildStart(i, p, n)),
+        (id(), nasty_string()).prop_map(|(i, n)| EvtSpec::BuildPhase(i, n)),
+        (id(), nasty_string(), any::<bool>()).prop_map(|(i, l, e)| EvtSpec::BuildLog(i, l, e)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::BuildComplete(i, o)),
+        (id(), fetch_kind(), nasty_string()).prop_map(|(i, k, n)| EvtSpec::FetchStart(i, k, n)),
+        (id(), any::<u64>(), proptest::option::of(any::<u64>()))
+            .prop_map(|(i, c, t)| EvtSpec::FetchProgress(i, c, t)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::FetchComplete(i, o)),
+        (id(), nasty_string(), parent(), any::<bool>(), any::<bool>())
+            .prop_map(|(i, n, p, s, pr)| EvtSpec::TaskSingle(i, n, p, s, pr)),
+        id().prop_map(EvtSpec::TaskStart),
+        (id(), nasty_string(), any::<bool>()).prop_map(|(i, l, e)| EvtSpec::TaskLog(i, l, e)),
+        (id(), any::<u64>(), any::<u64>()).prop_map(|(i, d, e)| EvtSpec::TaskProgress(i, d, e)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::TaskComplete(i, o)),
+        (id(), nasty_string()).prop_map(|(i, n)| EvtSpec::ProcessStart(i, n)),
+        (id(), proc_status_val()).prop_map(|(i, s)| EvtSpec::ProcessStatus(i, s)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::ProcessComplete(i, o)),
+        (id(), nasty_string()).prop_map(|(i, n)| EvtSpec::OperationStart(i, n)),
+        (id(), nasty_string(), any::<bool>()).prop_map(|(i, l, e)| EvtSpec::OperationLog(i, l, e)),
+        (id(), any::<u64>(), any::<u64>())
+            .prop_map(|(i, d, e)| EvtSpec::OperationProgress(i, d, e)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::OperationComplete(i, o)),
+        (id(), nasty_string(), level()).prop_map(|(i, n, l)| EvtSpec::EvalStart(i, n, l)),
+        (id(), nasty_string()).prop_map(|(i, l)| EvtSpec::EvalLog(i, l)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::EvalComplete(i, o)),
+        (id(), nasty_string()).prop_map(|(i, n)| EvtSpec::CommandStart(i, n)),
+        (id(), nasty_string(), any::<bool>()).prop_map(|(i, l, e)| EvtSpec::CommandLog(i, l, e)),
+        (id(), outcome()).prop_map(|(i, o)| EvtSpec::CommandComplete(i, o)),
+        (level(), nasty_string()).prop_map(|(l, t)| EvtSpec::Msg(l, t)),
+    ]
+}
+
+fn build_event(spec: EvtSpec) -> devenv_activity::ActivityEvent {
+    match spec {
+        EvtSpec::BuildStart(i, p, n) => build_start_with(i, n, p),
+        EvtSpec::BuildPhase(i, n) => build_phase(i, n),
+        EvtSpec::BuildLog(i, l, e) => build_log(i, l, e),
+        EvtSpec::BuildComplete(i, o) => build_complete(i, o),
+        EvtSpec::FetchStart(i, k, n) => fetch_start(i, k, n),
+        EvtSpec::FetchProgress(i, c, t) => fetch_progress(i, c, t),
+        EvtSpec::FetchComplete(i, o) => fetch_complete(i, o),
+        EvtSpec::TaskSingle(i, n, p, s, pr) => task_hierarchy_single(i, n, p, s, pr),
+        EvtSpec::TaskStart(i) => task_start(i),
+        EvtSpec::TaskLog(i, l, e) => task_log(i, l, e),
+        EvtSpec::TaskProgress(i, d, e) => task_progress(i, d, e),
+        EvtSpec::TaskComplete(i, o) => task_complete(i, o),
+        EvtSpec::ProcessStart(i, n) => process_start(i, n),
+        EvtSpec::ProcessStatus(i, s) => process_status(i, s),
+        EvtSpec::ProcessComplete(i, o) => process_complete(i, o),
+        EvtSpec::OperationStart(i, n) => operation_start(i, n),
+        EvtSpec::OperationLog(i, l, e) => operation_log(i, l, e),
+        EvtSpec::OperationProgress(i, d, e) => operation_progress(i, d, e),
+        EvtSpec::OperationComplete(i, o) => operation_complete(i, o),
+        EvtSpec::EvalStart(i, n, l) => evaluate_start(i, n, l),
+        EvtSpec::EvalLog(i, l) => evaluate_log(i, l),
+        EvtSpec::EvalComplete(i, o) => evaluate_complete(i, o),
+        EvtSpec::CommandStart(i, n) => command_start(i, n),
+        EvtSpec::CommandLog(i, l, e) => command_log(i, l, e),
+        EvtSpec::CommandComplete(i, o) => command_complete(i, o),
+        EvtSpec::Msg(l, t) => message(l, t),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ops: the full alphabet a session can perform — data events plus the UI
+// commands the key handlers (app.rs) issue against UiState.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum Op {
+    Event(EvtSpec),
+    SelectDown,
+    SelectUp,
+    ToggleHide,
+    Expand,
+    Back,
+    ShowInterrupt,
+    ClearInterrupt,
+    Resize(u16, u16),
+}
+
+/// Sizes weighted toward degenerate extremes (1-cell, single-row, single-column)
+/// where off-by-one and divide-by-width bugs live, plus a broad random range.
+fn size() -> impl Strategy<Value = (u16, u16)> {
+    prop_oneof![
+        Just((1u16, 1u16)),
+        Just((2u16, 1u16)),
+        Just((1u16, 24u16)),
+        Just((3u16, 2u16)),
+        Just((10u16, 1u16)),
+        Just((200u16, 1u16)),
+        Just((1u16, 80u16)),
+        (1u16..=220u16, 1u16..=80u16),
+    ]
+}
+
+fn op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        20 => evt_spec().prop_map(Op::Event),
+        4 => Just(Op::SelectDown),
+        4 => Just(Op::SelectUp),
+        2 => Just(Op::ToggleHide),
+        2 => Just(Op::Expand),
+        2 => Just(Op::Back),
+        1 => Just(Op::ShowInterrupt),
+        1 => Just(Op::ClearInterrupt),
+        4 => size().prop_map(|(w, h)| Op::Resize(w, h)),
+    ]
+}
+
+/// Like [`op`], but resizes stay within usable terminal widths (>= 40). Below
+/// ~30 columns iocraft itself can no longer fit content, so width-fit is only a
+/// meaningful guarantee on terminals a human would actually use.
+fn op_wide() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        20 => evt_spec().prop_map(Op::Event),
+        4 => Just(Op::SelectDown),
+        4 => Just(Op::SelectUp),
+        2 => Just(Op::ToggleHide),
+        2 => Just(Op::Expand),
+        2 => Just(Op::Back),
+        2 => Just(Op::ShowInterrupt),
+        1 => Just(Op::ClearInterrupt),
+        4 => (40u16..=300u16, 1u16..=80u16).prop_map(|(w, h)| Op::Resize(w, h)),
+    ]
+}
+
+fn apply_op(model: &mut ActivityModel, ui: &mut UiState, op: Op) {
+    match op {
+        Op::Event(spec) => {
+            model.apply_activity_event(build_event(spec));
+        }
+        Op::SelectDown => {
+            let selectable = model.get_selectable_activity_ids(ui);
+            ui.select_activity(&selectable, true);
+        }
+        Op::SelectUp => {
+            let selectable = model.get_selectable_activity_ids(ui);
+            ui.select_activity(&selectable, false);
+        }
+        Op::ToggleHide => ui.toggle_hide_stopped_processes(),
+        Op::Expand => {
+            let selectable = model.get_selectable_activity_ids(ui);
+            let target = ui
+                .selected_activity
+                .or_else(|| selectable.first().copied())
+                .unwrap_or(0);
+            ui.view_mode = ViewMode::ExpandedLogs {
+                activity_id: target,
+            };
+        }
+        Op::Back => {
+            ui.selected_activity = None;
+            ui.view_mode = ViewMode::Main;
+        }
+        Op::ShowInterrupt => ui.show_interrupt_prompt(),
+        Op::ClearInterrupt => ui.clear_interrupt_prompt(),
+        Op::Resize(w, h) => ui.set_terminal_size(w, h),
+    }
+}
+
+/// Render the main view and return the plain-text output (no ANSI under
+/// `deterministic-tui`). Panicking here fails the property — that is the point.
+fn render(model: &ActivityModel, ui: &UiState) -> String {
+    let width = ui.terminal_size.width.max(1) as usize;
+    let mut element: AnyElement = view(model, ui, RenderContext::Normal, None, false).into();
+    element.render(Some(width)).to_string()
+}
+
+fn check_invariants(model: &ActivityModel, ui: &UiState) -> Result<(), TestCaseError> {
+    // (2) Query methods must not panic on any state. Calling them is the assertion.
+    let _ = model.calculate_summary();
+    let _ = model.get_active_activities();
+    let _ = model.get_display_activities(ui);
+    let _ = model.get_error_messages();
+    let _ = model.get_total_duration();
+    let selectable = model.get_selectable_activity_ids(ui);
+
+    // (3) Anything in the selectable set must resolve to a real activity.
+    for sel_id in &selectable {
+        prop_assert!(
+            model.get_activity(*sel_id).is_some(),
+            "selectable id {sel_id} has no backing activity"
+        );
+    }
+
+    // (4) The total log counter must never undercount the live buffer.
+    for i in 0..MAX_ID {
+        if let Some(logs) = model.get_build_logs(i) {
+            prop_assert!(
+                model.get_log_line_count(i) >= logs.len(),
+                "log_line_count({i})={} < buffered {}",
+                model.get_log_line_count(i),
+                logs.len()
+            );
+        }
+    }
+
+    // (1) Rendering must not panic. (Width-fit is checked separately, see
+    // `rendered_lines_fit_width` — the codebase does not yet guarantee it.)
+    let _ = render(model, ui);
+    Ok(())
+}
+
+/// Largest display-column width of any rendered line.
+fn max_line_width(out: &str) -> usize {
+    out.lines().map(UnicodeWidthStr::width).max().unwrap_or(0)
+}
+
+/// Regression for the bottom navigation/help bar overflow on standard-width
+/// terminals. The richest short-text state (a process selected, with the
+/// hide-stopped toggle showing) must fit a normal ~80-column terminal.
+///
+/// Scope: this covers the standard short-text tier only. The verbose tier
+/// (>= 100 columns) and very narrow terminals (< ~73 columns) can still overflow
+/// when a process is selected — see `rendered_lines_fit_usable_width`.
+#[test]
+fn navbar_fits_standard_widths() {
+    let mut m = ActivityModel::new();
+    m.apply_activity_event(process_start(1, "web"));
+    m.apply_activity_event(process_status(1, ProcessStatus::Running));
+    // A stopped process makes the hide/show-stopped toggle appear (worst case).
+    m.apply_activity_event(process_start(2, "db"));
+    m.apply_activity_event(process_complete(2, ActivityOutcome::Success));
+
+    for w in 76u16..=99 {
+        let mut ui = UiState::new();
+        ui.set_terminal_size(w, 24);
+        ui.selected_activity = Some(1);
+        let out = render(&m, &ui);
+        let widest = max_line_width(&out);
+        assert!(
+            widest <= w as usize,
+            "nav bar width {widest} exceeds terminal width {w}:\n{out}"
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 128,
+        max_shrink_iters: 4096,
+        ..ProptestConfig::default()
+    })]
+
+    /// The headline property: a TUI driven by any sequence of data events and
+    /// UI commands at any size never panics and preserves the core invariants.
+    #[test]
+    fn tui_survives_random_sessions(ops in prop::collection::vec(op(), 0..160)) {
+        let mut model = ActivityModel::new();
+        let mut ui = UiState::new();
+        ui.set_terminal_size(80, 24);
+
+        for op in ops {
+            apply_op(&mut model, &mut ui, op);
+            check_invariants(&model, &ui)?;
+        }
+    }
+
+    /// `select_activity` contract: against a non-empty selectable set, the
+    /// resulting selection is always a member of that set, regardless of the
+    /// starting selection (stale ids included).
+    #[test]
+    fn select_activity_stays_in_set(
+        set in prop::collection::vec(0u64..16, 1..12),
+        start in proptest::option::of(0u64..20),
+        forward in any::<bool>(),
+    ) {
+        // De-dup while preserving order, mirroring how the model builds the list.
+        let mut seen = std::collections::HashSet::new();
+        let selectable: Vec<u64> = set.into_iter().filter(|x| seen.insert(*x)).collect();
+
+        let mut ui = UiState::new();
+        ui.selected_activity = start;
+        ui.select_activity(&selectable, forward);
+
+        let selected = ui.selected_activity.expect("non-empty set must yield a selection");
+        prop_assert!(
+            selectable.contains(&selected),
+            "selection {selected} not in selectable set {selectable:?}"
+        );
+    }
+
+    /// `select_activity` against an empty set never selects and never panics.
+    #[test]
+    fn select_activity_empty_is_noop(start in proptest::option::of(0u64..20), forward in any::<bool>()) {
+        let mut ui = UiState::new();
+        ui.selected_activity = start;
+        ui.select_activity(&[], forward);
+        prop_assert_eq!(ui.selected_activity, start);
+    }
+
+    /// (5) On usable terminals (>= 40 columns) no rendered line ever exceeds the
+    /// terminal width.
+    ///
+    /// IGNORED — this documents a known, pre-existing cosmetic overflow: the
+    /// bottom navigation/help bar is a fixed row of hint segments with no width
+    /// budget. The common standard-width case is fixed (compact hints; see
+    /// `navbar_fits_standard_widths`), but two cases remain: the verbose tier
+    /// (>= 100 columns) and very narrow terminals (< ~73 columns) can still
+    /// overflow by a few columns when a process is selected, because the verbose
+    /// hint labels have no budget. iocraft does not hard-clip overflowing `Text`
+    /// to the layout width, so a full fix needs progressive disclosure (dropping
+    /// hints to fit), a UX change tracked separately. Activity/log content wraps
+    /// correctly, and the interrupt prompt is covered by
+    /// `interrupt_prompt_fits_usable_widths`.
+    /// Run with `--run-ignored all` to characterize the remaining overflow.
+    #[test]
+    #[ignore = "known nav-bar overflow; see doc comment"]
+    fn rendered_lines_fit_usable_width(ops in prop::collection::vec(op_wide(), 0..120)) {
+        let mut model = ActivityModel::new();
+        let mut ui = UiState::new();
+        ui.set_terminal_size(80, 24);
+
+        for op in ops {
+            apply_op(&mut model, &mut ui, op);
+            let width = ui.terminal_size.width.max(1) as usize;
+            let out = render(&model, &ui);
+            let widest = max_line_width(&out);
+            prop_assert!(
+                widest <= width,
+                "rendered line width {widest} exceeds terminal width {width}\n{out}"
+            );
+        }
+    }
+}
+
+/// Deterministic regression for the interrupt (quit) prompt overflow: the prompt
+/// row must fit every realistic terminal width. (Found by the property tests:
+/// the prompt previously rendered 82 columns wide on an 80-column terminal.)
+#[test]
+fn interrupt_prompt_fits_usable_widths() {
+    let model = populated_model();
+    for w in 40u16..=200 {
+        let mut ui = UiState::new();
+        ui.set_terminal_size(w, 24);
+        ui.show_interrupt_prompt();
+        let out = render(&model, &ui);
+        let widest = max_line_width(&out);
+        assert!(
+            widest <= w as usize,
+            "interrupt prompt width {widest} exceeds terminal width {w}:\n{out}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Explicit degenerate-size regression smoke tests (deterministic, no shrinking
+// needed): a populated model must render at extreme sizes without panicking.
+// ---------------------------------------------------------------------------
+
+fn populated_model() -> ActivityModel {
+    let mut m = ActivityModel::new();
+    m.apply_activity_event(build_start_with(1, "build 你好", None));
+    m.apply_activity_event(build_phase(1, "buildPhase"));
+    m.apply_activity_event(build_log(1, "🎉 emoji log line that is fairly long", false));
+    m.apply_activity_event(fetch_start(2, FetchKind::Download, "nixpkgs"));
+    m.apply_activity_event(fetch_progress(2, 5000, Some(10000)));
+    m.apply_activity_event(task_hierarchy_single(3, "task", None, true, false));
+    m.apply_activity_event(task_start(3));
+    m.apply_activity_event(task_log(3, "task output", false));
+    m.apply_activity_event(message(
+        ActivityLevel::Error,
+        "something failed\nwith detail",
+    ));
+    m
+}
+
+#[test]
+fn renders_at_degenerate_sizes_without_panic() {
+    let model = populated_model();
+    let sizes = [
+        (1u16, 1u16),
+        (2, 1),
+        (1, 2),
+        (3, 3),
+        (10, 1),
+        (1, 40),
+        (200, 1),
+        (40, 200),
+        (300, 100),
+    ];
+    for (w, h) in sizes {
+        let mut ui = UiState::new();
+        ui.set_terminal_size(w, h);
+        // Exercise both view modes and the interrupt overlay.
+        let mut element: AnyElement = view(&model, &ui, RenderContext::Normal, None, false).into();
+        let _ = element.render(Some(w.max(1) as usize)).to_string();
+
+        ui.show_interrupt_prompt();
+        let mut element: AnyElement = view(&model, &ui, RenderContext::Final, None, true).into();
+        let _ = element.render(Some(w.max(1) as usize)).to_string();
+    }
+}


### PR DESCRIPTION
## Summary

Adds extensive automated coverage for `devenv-tui` and fixes the real bugs it surfaced.

Three layers, by design: snapshots pin exact output (existing), property tests are the fast deterministic gate, and bombadil is the slow end-to-end PTY layer.

## Bug fixes (found by the property tests)

- **Crash on multi-byte names/paths**: `shorten_store_path_aggressive` sliced strings at raw byte offsets, panicking the whole TUI on non-ASCII activity names or store paths when shortened for narrow terminals. Now truncates by character.
- **Progress-bar underflow**: the bar underflowed when a download or task reported progress beyond its expected total. Filled width is now clamped.
- **Hint-bar overflow**: the quit prompt (terminals < ~82 cols) and the bottom navigation bar (standard ~80 cols, with a process selected) rendered past the right edge. Both now use compact text that fits.

## Tests

- `devenv-tui/tests/tui_proptest.rs` (gated behind `test-all`, deterministic): drives random streams of every activity event type with adversarial unicode/control payloads, interleaved with random UI commands and resizes down to degenerate sizes. Asserts the TUI never panics, `select_activity` stays in the selectable set, the log counter never undercounts, and rendering fits the terminal width on standard widths.
- These run on every PR via the existing `cargo nextest run --features devenv/test-all` step (the feature propagates to `devenv-tui/test-all`).

## End-to-end fuzzing

- Long-lived mode for `tui-replay` (`--hold` keeps the TUI alive for input, `--loop` replays repeatedly) so a terminal fuzzer always has a live program.
- A grounded bombadil terminal spec under `devenv-tui/bombadil/` (action generator over devenv's real keybindings + resize/scroll, plus overflow/panic-text/exit/unicode properties).
- `.github/workflows/tui-fuzz.yml`: nightly (and manually dispatchable) job that builds `tui-replay`, runs a time-limited bombadil fuzz with `--exit-on-violation`, and uploads the reproducer trace on a violation. Runs nightly rather than per-PR because it is slow and the trace grows fast.

## Known follow-ups (documented, not fixed here)

- The bottom nav bar can still overflow by a few columns in the verbose tier (>= 100 cols) and on very narrow terminals (< ~73 cols) when a process is selected. A full fix needs progressive disclosure of hints; tracked in the `#[ignore]`d `rendered_lines_fit_usable_width` test.
- The nightly fuzz downloads the experimental bombadil binary at run time; vendoring it via a flake input would make it fully reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)