### PR TITLE
mongodb: only initiate replica-set when not already initialized

### DIFF
--- a/src/modules/services/mongodb.nix
+++ b/src/modules/services/mongodb.nix
@@ -61,9 +61,21 @@ let
         done
 
         if ${lib.boolToString cfg.replication.enable}; then
-            echo "Initialising replica-set"
             rootAuthDatabase="admin"
-            ${pkgs.mongosh}/bin/mongosh ''${mongoShellArgs} "$rootAuthDatabase" --eval 'rs.initiate()' >/dev/null
+            # Only initiate the replica-set if it has not been initialised yet,
+            # otherwise a restart errors with "already initialized".
+            ${pkgs.mongosh}/bin/mongosh ''${mongoShellArgs} "$rootAuthDatabase" --quiet --eval '
+                try {
+                    rs.status();
+                } catch (e) {
+                    if (e.codeName === "NotYetInitialized") {
+                        print("Initialising replica-set");
+                        rs.initiate();
+                    } else {
+                        throw e;
+                    }
+                }
+            ' >/dev/null
         fi
 
         if [ "${cfg.initDatabaseUsername}" ] && [ "${cfg.initDatabasePassword}" ]; then
@@ -72,7 +84,7 @@ let
             ${pkgs.mongosh}/bin/mongosh ''${mongoShellArgs} "$rootAuthDatabase" >/dev/null <<-EOJS
                 db.createUser({
                     user: "${cfg.initDatabaseUsername}",
-                    pwd: "${cfg.initDatabasePassword}",``
+                    pwd: "${cfg.initDatabasePassword}",
                     roles: [ { role: 'root', db: "$rootAuthDatabase" } ]
                 })
     	EOJS


### PR DESCRIPTION
## Problem

Fixes #2934.

Enabling `services.mongodb.replication.enable` works on the first `devenv up`, but on a second run the implicit `mongodb-configure` process restart-loops:

```
Initialising replica-set
Process exited (Failure), restarting
Restarted (attempt 1)
```

The configure script always ran `rs.initiate()`. On the second run the replica-set already exists, so `rs.initiate()` returns an "already initialized" error and the process exits with failure.

## Fix

Check `rs.status()` first and only call `rs.initiate()` when it reports `NotYetInitialized`. Any other error is re-thrown so genuine failures still surface. This makes the configure step idempotent across restarts.

Also removed a stray double-backtick typo in the adjacent user-creation heredoc that would produce invalid JS when `initDatabaseUsername`/`initDatabasePassword` are set.

## Testing

Not verified against a live mongod replica-set restart. Please test:

1. Enable `services.mongodb.enable` and `services.mongodb.replication.enable`.
2. `devenv up`, wait for `mongodb-configure` to finish initialising the replica-set.
3. Stop processes (Ctrl+C + q).
4. `devenv up` again and confirm `mongodb-configure` no longer restart-loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)