### PR TITLE
feat(files): add copy mode for editable files

### DIFF
--- a/docs/src/creating-files.md
+++ b/docs/src/creating-files.md
@@ -132,29 +132,29 @@ This is particularly useful for:
 ## Copying Files Instead of Symlinking
 
 By default, files are symlinked to a read-only path in the Nix store, so they cannot be edited.
-Set the `copy` attribute to materialize an editable file instead:
+Set the `copyMode` attribute to materialize an editable file instead:
 
 ```nix title="devenv.nix"
 {
   # Seed an editable template once; never overwrites the user's edits.
-  files.".env.local".copy = "copy";
+  files.".env.local".copyMode = "seed";
   files.".env.local".text = ''
     API_URL=http://localhost:8080
   '';
 
   # Always overwrite with a fresh writable copy on every shell entry.
-  files."config/generated.toml".copy = "replace";
+  files."config/generated.toml".copyMode = "copy";
   files."config/generated.toml".toml = {
     server.port = 8000;
   };
 }
 ```
 
-The `copy` attribute accepts:
+The `copyMode` attribute accepts:
 
-- `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible.
-- `copy`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched. This is useful for seeding configuration files from templates that the user can then edit to fit their project.
-- `replace`: overwrite the file with a fresh writable copy on every shell entry.
+- `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
+- `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. This is useful for seeding configuration files from templates that the user can then edit to fit their project.
+- `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. This is useful when a tool must write to the file in place but devenv should remain the source of truth.
 
 !!! tip "New in version 2.2"
 

--- a/docs/src/creating-files.md
+++ b/docs/src/creating-files.md
@@ -129,6 +129,35 @@ This is particularly useful for:
 - Custom tooling and utilities
 - Git hooks
 
+## Copying Files Instead of Symlinking
+
+By default, files are symlinked to a read-only path in the Nix store, so they cannot be edited.
+Set the `copy` attribute to materialize an editable file instead:
+
+```nix title="devenv.nix"
+{
+  # Seed an editable template once; never overwrites the user's edits.
+  files.".env.local".copy = "copy";
+  files.".env.local".text = ''
+    API_URL=http://localhost:8080
+  '';
+
+  # Always overwrite with a fresh writable copy on every shell entry.
+  files."config/generated.toml".copy = "replace";
+  files."config/generated.toml".toml = {
+    server.port = 8000;
+  };
+}
+```
+
+The `copy` attribute accepts:
+
+- `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible.
+- `copy`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched. This is useful for seeding configuration files from templates that the user can then edit to fit their project.
+- `replace`: overwrite the file with a fresh writable copy on every shell entry.
+
+!!! tip "New in version 2.2"
+
 ## Creating Files in Subdirectories
 
 Files can be created in nested directories by specifying the path:

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -3827,6 +3827,34 @@ attribute set of (submodule)
 
 
 
+## files.\<name>.copy
+
+
+
+How to materialize the file in the project root:
+
+ - ` symlink ` (default): symlink to the read-only file in the Nix store. Edits are not possible.
+ - ` copy `: copy the file into place once, only if it does not already exist, and make it writable so it can be edited. Existing files are left untouched, which is useful for seeding editable templates.
+ - ` replace `: overwrite the file with a fresh writable copy on every shell entry.
+
+
+
+*Type:*
+one of “symlink”, “copy”, “replace”
+
+
+
+*Default:*
+
+```nix
+"symlink"
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/files.nix](https://github.com/cachix/devenv/blob/main/src/modules/files.nix)
+
+
+
 ## files.\<name>.executable
 
 
@@ -6021,8 +6049,6 @@ false
 
 ## git-hooks.hooks.biome.settings.binPath
 
-
-
 ` biome ` binary path.
 For example, if you want to use the ` biome ` binary from ` node_modules `, use ` "./node_modules/.bin/biome" `.
 Use a string instead of a path to avoid having to Git track the file in projects that use Nix flakes.
@@ -6056,6 +6082,8 @@ null or string or absolute path
 
 
 ## git-hooks.hooks.biome.settings.configPath
+
+
 
 Path to the configuration JSON file
 
@@ -8294,8 +8322,6 @@ string
 
 ## git-hooks.hooks.isort.settings.profile
 
-
-
 Built-in profiles to allow easy interoperability with common projects and code styles.
 
 
@@ -8317,6 +8343,8 @@ one of “”, “black”, “django”, “pycharm”, “google”, “open_s
 
 
 ## git-hooks.hooks.lacheck
+
+
 
 lacheck hook
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -3827,20 +3827,20 @@ attribute set of (submodule)
 
 
 
-## files.\<name>.copy
+## files.\<name>.copyMode
 
 
 
 How to materialize the file in the project root:
 
- - ` symlink ` (default): symlink to the read-only file in the Nix store. Edits are not possible.
- - ` copy `: copy the file into place once, only if it does not already exist, and make it writable so it can be edited. Existing files are left untouched, which is useful for seeding editable templates.
- - ` replace `: overwrite the file with a fresh writable copy on every shell entry.
+ - ` symlink ` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
+ - ` seed `: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. Useful for seeding configuration from templates the user then edits.
+ - ` copy `: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. Useful when a tool must write to the file in place but devenv should remain the source of truth.
 
 
 
 *Type:*
-one of “symlink”, “copy”, “replace”
+one of “symlink”, “seed”, “copy”
 
 
 

--- a/src/modules/files.nix
+++ b/src/modules/files.nix
@@ -53,6 +53,18 @@ let
         default = false;
         description = "Make the file executable";
       };
+
+      copy = mkOption {
+        type = types.enum [ "symlink" "copy" "replace" ];
+        default = "symlink";
+        description = ''
+          How to materialize the file in the project root:
+
+          - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible.
+          - `copy`: copy the file into place once, only if it does not already exist, and make it writable so it can be edited. Existing files are left untouched, which is useful for seeding editable templates.
+          - `replace`: overwrite the file with a fresh writable copy on every shell entry.
+        '';
+      };
     } // (mapAttrs
       (name: format: mkOption {
         type = types.nullOr format.type;
@@ -87,7 +99,7 @@ let
       };
   });
   # Track successfully created files for partial state saving
-  createFileScript = filename: fileOption: ''
+  createSymlinkScript = filename: fileOption: ''
     if [ -L "${filename}" ]; then
       # Only update symlink if target changed (same content = same store path)
       if [ "$(readlink "${filename}")" != "${fileOption.file}" ]; then
@@ -106,6 +118,35 @@ let
       echo "${filename}" >> "$DEVENV_FILES_CREATED"
     fi
   '';
+
+  # Copy the file into place as a writable file the user can edit.
+  # "copy" only seeds the file when missing; "replace" overwrites it every time.
+  createCopyScript = filename: fileOption: ''
+    # Drop a previous devenv-managed symlink into the store so we can seed a writable copy
+    if [ -L "${filename}" ] && [[ "$(readlink "${filename}")" == /nix/store/* ]]; then
+      rm "${filename}"
+    fi
+    ${optionalString (fileOption.copy == "replace") ''
+      if [ -e "${filename}" ] || [ -L "${filename}" ]; then
+        echo "Replacing ${filename}"
+        rm -rf "${filename}"
+      fi
+    ''}
+    if [ -e "${filename}" ]; then
+      echo "Keeping existing ${filename}"
+    else
+      echo "Creating ${filename}"
+      mkdir -p "${dirOf filename}"
+      cp -RL ${fileOption.file} "${filename}"
+      chmod -R u+w "${filename}"
+    fi
+    echo "${filename}" >> "$DEVENV_FILES_CREATED"
+  '';
+
+  createFileScript = filename: fileOption:
+    if fileOption.copy == "symlink"
+    then createSymlinkScript filename fileOption
+    else createCopyScript filename fileOption;
 
   cleanupScript = ''
     # Read previously managed files from state

--- a/src/modules/files.nix
+++ b/src/modules/files.nix
@@ -54,15 +54,15 @@ let
         description = "Make the file executable";
       };
 
-      copy = mkOption {
-        type = types.enum [ "symlink" "copy" "replace" ];
+      copyMode = mkOption {
+        type = types.enum [ "symlink" "seed" "copy" ];
         default = "symlink";
         description = ''
           How to materialize the file in the project root:
 
-          - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible.
-          - `copy`: copy the file into place once, only if it does not already exist, and make it writable so it can be edited. Existing files are left untouched, which is useful for seeding editable templates.
-          - `replace`: overwrite the file with a fresh writable copy on every shell entry.
+          - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
+          - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. Useful for seeding configuration from templates the user then edits.
+          - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. Useful when a tool must write to the file in place but devenv should remain the source of truth.
         '';
       };
     } // (mapAttrs
@@ -120,15 +120,15 @@ let
   '';
 
   # Copy the file into place as a writable file the user can edit.
-  # "copy" only seeds the file when missing; "replace" overwrites it every time.
+  # "seed" only creates the file when missing; "copy" overwrites it every time.
   createCopyScript = filename: fileOption: ''
     # Drop a previous devenv-managed symlink into the store so we can seed a writable copy
     if [ -L "${filename}" ] && [[ "$(readlink "${filename}")" == /nix/store/* ]]; then
       rm "${filename}"
     fi
-    ${optionalString (fileOption.copy == "replace") ''
+    ${optionalString (fileOption.copyMode == "copy") ''
       if [ -e "${filename}" ] || [ -L "${filename}" ]; then
-        echo "Replacing ${filename}"
+        echo "Overwriting ${filename}"
         rm -rf "${filename}"
       fi
     ''}
@@ -144,7 +144,7 @@ let
   '';
 
   createFileScript = filename: fileOption:
-    if fileOption.copy == "symlink"
+    if fileOption.copyMode == "symlink"
     then createSymlinkScript filename fileOption
     else createCopyScript filename fileOption;
 

--- a/tests/files-copy/.gitignore
+++ b/tests/files-copy/.gitignore
@@ -1,0 +1,2 @@
+template.txt
+managed.txt

--- a/tests/files-copy/.patch.sh
+++ b/tests/files-copy/.patch.sh
@@ -22,23 +22,23 @@ cat > devenv.nix << 'EOF'
 { pkgs, ... }: {
   files."template.txt" = {
     text = "default content\n";
-    copy = "copy";
+    copyMode = "seed";
   };
   files."managed.txt" = {
     text = "managed content\n";
-    copy = "replace";
+    copyMode = "copy";
   };
 
   enterTest = ''
-    # copy mode: writable regular file, user edit preserved
+    # seed mode: writable regular file, user edit preserved
     test ! -L "$DEVENV_ROOT/template.txt" || { echo "template.txt should not be a symlink"; exit 1; }
     test -w "$DEVENV_ROOT/template.txt" || { echo "template.txt should be writable"; exit 1; }
     grep -qx "user edit" "$DEVENV_ROOT/template.txt" || { echo "template.txt edit not preserved"; exit 1; }
 
-    # replace mode: writable regular file, overwritten back to the template content
+    # copy mode: writable regular file, overwritten back to the template content
     test ! -L "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should not be a symlink"; exit 1; }
     test -w "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should be writable"; exit 1; }
-    grep -qx "managed content" "$DEVENV_ROOT/managed.txt" || { echo "managed.txt not replaced"; exit 1; }
+    grep -qx "managed content" "$DEVENV_ROOT/managed.txt" || { echo "managed.txt not overwritten"; exit 1; }
   '';
 }
 EOF

--- a/tests/files-copy/.patch.sh
+++ b/tests/files-copy/.patch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+
+# First run: seed both files from their templates
+devenv shell true
+
+# Both files are real writable files, not symlinks into the store
+test -f template.txt && test ! -L template.txt
+test -f managed.txt && test ! -L managed.txt
+test -w template.txt
+test -w managed.txt
+
+# Simulate the user editing both files
+echo "user edit" > template.txt
+echo "user edit" > managed.txt
+
+# Second run re-applies the files
+devenv shell true
+
+# Final config asserts the resulting state during `devenv test`
+cat > devenv.nix << 'EOF'
+{ pkgs, ... }: {
+  files."template.txt" = {
+    text = "default content\n";
+    copy = "copy";
+  };
+  files."managed.txt" = {
+    text = "managed content\n";
+    copy = "replace";
+  };
+
+  enterTest = ''
+    # copy mode: writable regular file, user edit preserved
+    test ! -L "$DEVENV_ROOT/template.txt" || { echo "template.txt should not be a symlink"; exit 1; }
+    test -w "$DEVENV_ROOT/template.txt" || { echo "template.txt should be writable"; exit 1; }
+    grep -qx "user edit" "$DEVENV_ROOT/template.txt" || { echo "template.txt edit not preserved"; exit 1; }
+
+    # replace mode: writable regular file, overwritten back to the template content
+    test ! -L "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should not be a symlink"; exit 1; }
+    test -w "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should be writable"; exit 1; }
+    grep -qx "managed content" "$DEVENV_ROOT/managed.txt" || { echo "managed.txt not replaced"; exit 1; }
+  '';
+}
+EOF

--- a/tests/files-copy/.patch.sh
+++ b/tests/files-copy/.patch.sh
@@ -14,31 +14,6 @@ test -w managed.txt
 echo "user edit" > template.txt
 echo "user edit" > managed.txt
 
-# Second run re-applies the files
+# Second run re-applies the files. enterTest (in devenv.nix) asserts the
+# resulting state when `devenv test` runs after this script.
 devenv shell true
-
-# Final config asserts the resulting state during `devenv test`
-cat > devenv.nix << 'EOF'
-{ pkgs, ... }: {
-  files."template.txt" = {
-    text = "default content\n";
-    copyMode = "seed";
-  };
-  files."managed.txt" = {
-    text = "managed content\n";
-    copyMode = "copy";
-  };
-
-  enterTest = ''
-    # seed mode: writable regular file, user edit preserved
-    test ! -L "$DEVENV_ROOT/template.txt" || { echo "template.txt should not be a symlink"; exit 1; }
-    test -w "$DEVENV_ROOT/template.txt" || { echo "template.txt should be writable"; exit 1; }
-    grep -qx "user edit" "$DEVENV_ROOT/template.txt" || { echo "template.txt edit not preserved"; exit 1; }
-
-    # copy mode: writable regular file, overwritten back to the template content
-    test ! -L "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should not be a symlink"; exit 1; }
-    test -w "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should be writable"; exit 1; }
-    grep -qx "managed content" "$DEVENV_ROOT/managed.txt" || { echo "managed.txt not overwritten"; exit 1; }
-  '';
-}
-EOF

--- a/tests/files-copy/devenv.nix
+++ b/tests/files-copy/devenv.nix
@@ -1,10 +1,10 @@
 { pkgs, ... }: {
   files."template.txt" = {
     text = "default content\n";
-    copy = "copy";
+    copyMode = "seed";
   };
   files."managed.txt" = {
     text = "managed content\n";
-    copy = "replace";
+    copyMode = "copy";
   };
 }

--- a/tests/files-copy/devenv.nix
+++ b/tests/files-copy/devenv.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }: {
+  files."template.txt" = {
+    text = "default content\n";
+    copy = "copy";
+  };
+  files."managed.txt" = {
+    text = "managed content\n";
+    copy = "replace";
+  };
+}

--- a/tests/files-copy/devenv.nix
+++ b/tests/files-copy/devenv.nix
@@ -7,4 +7,16 @@
     text = "managed content\n";
     copyMode = "copy";
   };
+
+  enterTest = ''
+    # seed mode: writable regular file, user edit preserved
+    test ! -L "$DEVENV_ROOT/template.txt" || { echo "template.txt should not be a symlink"; exit 1; }
+    test -w "$DEVENV_ROOT/template.txt" || { echo "template.txt should be writable"; exit 1; }
+    grep -qx "user edit" "$DEVENV_ROOT/template.txt" || { echo "template.txt edit not preserved"; exit 1; }
+
+    # copy mode: writable regular file, overwritten back to the template content
+    test ! -L "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should not be a symlink"; exit 1; }
+    test -w "$DEVENV_ROOT/managed.txt" || { echo "managed.txt should be writable"; exit 1; }
+    grep -qx "managed content" "$DEVENV_ROOT/managed.txt" || { echo "managed.txt not overwritten"; exit 1; }
+  '';
 }


### PR DESCRIPTION
Closes #2123.

Adds a `copyMode` attribute to the `files` option that controls how a file is materialized in the project root.

## Motivation

Today `files` always symlinks to a read-only path in the Nix store, so the materialized files can't be edited. The issue asks for a way to seed configuration files from templates that the user can then edit (e.g. `.env.local`, recipe-style scaffolding), and to support tools that must write to the file in place (e.g. `KUBECONFIG`) where a store symlink breaks them.

## Behavior

```nix
{
  # Seed an editable template once; never overwrites the user's edits.
  files.".env.local".copyMode = "seed";
  files.".env.local".text = "API_URL=http://localhost:8080\n";

  # Always overwrite with a fresh writable copy on every shell entry.
  files."config/generated.toml".copyMode = "copy";
  files."config/generated.toml".toml.server.port = 8000;
}
```

`copyMode` accepts:

- `symlink` (default): symlink to the read-only store path. Unchanged existing behavior; devenv keeps the link pointed at the current contents.
- `seed`: copy the file into place once, only if it does not already exist, made writable. Existing files are left untouched, so user edits survive across shell entries.
- `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry — devenv stays the source of truth, but the file is a real writable file rather than a symlink.

The three values cover the two genuinely distinct decisions: symlink vs writable file, and (for writable files) seed-once vs always-refresh.

## Notes

- A leftover devenv-managed symlink into the store is replaced by a real copy when switching a file to `seed`/`copy`.
- The cleanup task only ever removes symlinks into the store, so copied files (which the user may have edited) are never garbage-collected.

## Naming

Went with `copyMode` rather than `mode` (collides with a unix permission `mode`/`chmod`) or `copy` (redundant as `copy = "copy"`). Values are `symlink`/`seed`/`copy` so the seed-once case reads clearly.

## Tests

Added `tests/files-copy` covering both modes: copied files are writable non-symlinks, `seed` preserves user edits across runs, and `copy` overwrites them back to the template content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)