### PR TITLE
Fix typo in containers.md

### DIFF
--- a/docs/src/containers.md
+++ b/docs/src/containers.md
@@ -17,7 +17,7 @@ To use 'containers' command, add the following dependencies:
 
 ```shell-session
 $ devenv inputs add nix2container github:nlewo/nix2container --follows nixpkgs
-$ devenv inputs add mk-shell-bin github:rrbutani/nix-mk-shell-bi
+$ devenv inputs add mk-shell-bin github:rrbutani/nix-mk-shell-bin
 ```
 
 Use `devenv container build <name>` to generate an [OCI container](https://opencontainers.org/) from your development environment.


### PR DESCRIPTION
Fix for typo in git repo name introduced by commit https://github.com/cachix/devenv/commit/27e43fdaef174fc4f252aad0d43a56c65114db58
`rrbutani/nix-mk-shell-bi` -> `rrbutani/nix-mk-shell-bin`