### PR TITLE
docs(git-hooks): information about the git-hooks input in the git-hooks page

### DIFF
--- a/docs/src/git-hooks.md
+++ b/docs/src/git-hooks.md
@@ -1,4 +1,5 @@
 ``devenv`` has first-class integration for [pre-commit](https://pre-commit.com/) via [git-hooks.nix](https://github.com/cachix/git-hooks.nix).
+You may need to add the `git-hooks` input to your `devenv.yaml` if this is not already the case, as in [the inputs page](inputs.md).
 
 ## Set up
 
@@ -31,6 +32,8 @@ We recommend a two-step approach for integrating your linters and formatters.
   };
 }
 ```
+
+The full list can be found in the reference.
 
 In action:
 

--- a/docs/src/git-hooks.md
+++ b/docs/src/git-hooks.md
@@ -1,5 +1,12 @@
 ``devenv`` has first-class integration for [pre-commit](https://pre-commit.com/) via [git-hooks.nix](https://github.com/cachix/git-hooks.nix).
-You may need to add the `git-hooks` input to your `devenv.yaml` if this is not already the case, as in [the inputs page](inputs.md).
+This integration _requires_ to have the `git-hooks` input the `devenv.yaml` file, as in [the inputs page](inputs.md).
+
+If this is not already in the file, add it using `devenv inputs add git-hooks github:cachix/git-hooks.nix` or insert it manually:
+```yaml title="devenv.yml snippet"
+inputs:
+  git-hooks:
+    url: github:cachix/git-hooks.nix
+```
 
 ## Set up
 


### PR DESCRIPTION
Without hooks, we may remove (or never add) the git-hooks input. This adds a sentence about it to prevent any build failure.
I had this issue when adding hooks into my project, so I suggest a (very) small modification to avoid anyone to have the same issue. The error message was not clear about the source of the build failure.