### PR TITLE
feat(processes): make port auto-allocation listen-address-aware

### DIFF
--- a/devenv-core/src/ports.rs
+++ b/devenv-core/src/ports.rs
@@ -206,6 +206,27 @@ impl PortAllocator {
     ///
     /// In strict mode, only tries the base port and fails with process info if unavailable.
     pub fn allocate(&self, process_name: &str, port_name: &str, base: u16) -> Result<u16, String> {
+        self.allocate_addr(process_name, port_name, base, None)
+    }
+
+    /// Like [`Self::allocate`], but reserves the port on a specific listen
+    /// address when `listen_addr` names a concrete IP.
+    ///
+    /// This makes allocation listen-address-aware: the same base port can be
+    /// used by several instances as long as each binds a different address
+    /// (e.g. Postgres on `127.0.0.2:5432` and `127.0.0.3:5432`), instead of the
+    /// allocator reserving the port across all interfaces and treating it as
+    /// globally taken — which would silently increment to the next port.
+    ///
+    /// A `None`, wildcard (`""`, `"*"`, `"0.0.0.0"`, `"::"`), or non-IP address
+    /// reserves across all interfaces — the conservative default.
+    pub fn allocate_addr(
+        &self,
+        process_name: &str,
+        port_name: &str,
+        base: u16,
+        listen_addr: Option<&str>,
+    ) -> Result<u16, String> {
         if !self.enabled.load(Ordering::SeqCst) {
             return Ok(base);
         }
@@ -235,7 +256,7 @@ impl PortAllocator {
                 ));
             }
 
-            match reserve_exact_port(base) {
+            match reserve_exact_port(listen_addr, base) {
                 Ok(listeners) => {
                     ports.insert(
                         key,
@@ -270,7 +291,7 @@ impl PortAllocator {
                 continue;
             }
 
-            let Ok(listeners) = reserve_port(port) else {
+            let Ok(listeners) = reserve_port(listen_addr, port) else {
                 continue;
             };
 
@@ -354,10 +375,13 @@ impl PortAllocator {
         let strict = self.strict.load(Ordering::SeqCst);
         let allow_in_use = self.allow_in_use.load(Ordering::SeqCst);
 
+        // Replay re-acquires across all interfaces; if it fails because another
+        // instance holds the port on a different address, the cache is
+        // invalidated and a fresh, listen-address-aware allocation takes over.
         let reserve_result = if strict {
-            reserve_exact_port(port)
+            reserve_exact_port(None, port)
         } else {
-            reserve_port(port)
+            reserve_port(None, port)
         };
 
         match reserve_result {
@@ -468,14 +492,52 @@ impl Default for PortAllocator {
 /// including wildcard bindings. This is critical on macOS/BSD where
 /// `SO_REUSEADDR` would allow both `0.0.0.0:port` and `127.0.0.1:port`
 /// to coexist.
-fn reserve_port(port: u16) -> Result<Vec<TcpListener>, std::io::Error> {
-    reserve_port_with(port, bind_no_reuse, ipv6_socket_available)
+fn reserve_port(listen_addr: Option<&str>, port: u16) -> Result<Vec<TcpListener>, std::io::Error> {
+    match listen_addr.map(str::trim) {
+        // A concrete listen address: reserve the port on that address only, so
+        // the same port is free to be reused on other addresses.
+        Some(addr) if !is_wildcard_addr(addr) => reserve_specific_port(addr, port),
+        // No address, a wildcard, or a hostname: reserve across all interfaces.
+        _ => reserve_port_with(port, bind_no_reuse, ipv6_socket_available),
+    }
 }
 
-fn reserve_exact_port(port: u16) -> Result<Vec<TcpListener>, std::io::Error> {
+/// Listen addresses that mean "all interfaces", for which the port must be
+/// reserved across every interface rather than a single address.
+fn is_wildcard_addr(addr: &str) -> bool {
+    matches!(addr, "" | "*" | "0.0.0.0" | "::" | "[::]" | "::0")
+}
+
+/// Reserve `port` on a single specific address. Falls back to an all-interfaces
+/// reservation when `addr` is not a parseable IP (e.g. a hostname like
+/// `localhost`), preserving the conservative default rather than failing.
+fn reserve_specific_port(addr: &str, port: u16) -> Result<Vec<TcpListener>, std::io::Error> {
+    // `bind_no_reuse` formats the socket address as `{host}:{port}`, so IPv6
+    // literals must be bracketed (`[::1]`) to parse.
+    let (domain, host) = if addr.contains(':') {
+        let bare = addr.trim_start_matches('[').trim_end_matches(']');
+        (socket2::Domain::IPV6, format!("[{bare}]"))
+    } else {
+        (socket2::Domain::IPV4, addr.to_string())
+    };
+    match bind_no_reuse(domain, &host, port) {
+        Ok(listener) => Ok(vec![listener]),
+        // Not a parseable IP (e.g. a hostname like `localhost`): fall back to an
+        // all-interfaces reservation rather than failing the allocation.
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {
+            reserve_port_with(port, bind_no_reuse, ipv6_socket_available)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn reserve_exact_port(
+    listen_addr: Option<&str>,
+    port: u16,
+) -> Result<Vec<TcpListener>, std::io::Error> {
     reserve_exact_port_with(
         port,
-        reserve_port,
+        |p| reserve_port(listen_addr, p),
         lookup_process_using_port,
         std::thread::sleep,
     )
@@ -644,6 +706,60 @@ mod tests {
         allocator.set_enabled(true);
         let port = allocator.allocate("server", "http", 49152).unwrap();
         assert!(port >= 49152);
+    }
+
+    #[test]
+    fn is_wildcard_addr_classifies_special_listen_addresses() {
+        for addr in ["", "*", "0.0.0.0", "::", "[::]", "::0"] {
+            assert!(is_wildcard_addr(addr), "{addr:?} should be all-interfaces");
+        }
+        for addr in ["127.0.0.1", "127.42.0.12", "192.168.1.2", "::1"] {
+            assert!(
+                !is_wildcard_addr(addr),
+                "{addr:?} should be a specific address"
+            );
+        }
+    }
+
+    // Binding distinct 127.0.0.x addresses requires the whole 127.0.0.0/8 to be
+    // loopback, which is automatic on Linux but not macOS (needs `ifconfig lo0
+    // alias`). Gate to Linux so the suite stays portable.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn allocate_addr_is_listen_address_aware() {
+        use std::net::TcpListener;
+
+        // Skip in environments where 127.0.0.2 isn't bindable (e.g. a restricted
+        // build sandbox) rather than failing.
+        let Ok(probe) = TcpListener::bind("127.0.0.2:0") else {
+            eprintln!("skipping: 127.0.0.2 is not bindable in this environment");
+            return;
+        };
+        let base = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        // Hold `base` on 127.0.0.2 — taken on that address (and on the wildcard).
+        let _held = TcpListener::bind(("127.0.0.2", base)).unwrap();
+
+        // Same port on a *different* address is honored, not incremented.
+        let scoped = PortAllocator::new();
+        scoped.set_enabled(true);
+        let got = scoped
+            .allocate_addr("app", "pg", base, Some("127.0.0.3"))
+            .unwrap();
+        assert_eq!(
+            got, base,
+            "port should be reusable on a distinct listen address"
+        );
+
+        // All-interfaces (None) sees the held port and bumps past it.
+        let wildcard = PortAllocator::new();
+        wildcard.set_enabled(true);
+        let bumped = wildcard.allocate_addr("app", "pg", base, None).unwrap();
+        assert_ne!(
+            bumped, base,
+            "all-interfaces reservation must avoid the held port"
+        );
     }
 
     #[test]

--- a/devenv-nix-backend/src/backend.rs
+++ b/devenv-nix-backend/src/backend.rs
@@ -431,21 +431,39 @@ impl NixCBackend {
                 eval_state,
                 PrimOpMeta {
                     name: cstr!("allocatePort"),
-                    doc: cstr!("Allocate a free port starting from base"),
-                    args: [cstr!("processName"), cstr!("portName"), cstr!("basePort")],
+                    doc: cstr!("Allocate a free port from base, scoped to a listen address"),
+                    args: [
+                        cstr!("processName"),
+                        cstr!("portName"),
+                        cstr!("basePort"),
+                        cstr!("listenAddress"),
+                    ],
                 },
-                Box::new(move |es, [process_name, port_name, base_port]| {
-                    let process = es.require_string(process_name)?;
-                    let port_name_str = es.require_string(port_name)?;
-                    let base_raw = es.require_int(base_port)?;
-                    let base = u16::try_from(base_raw).map_err(|_| {
-                        anyhow::anyhow!("basePort must be between 0 and 65535, got {}", base_raw)
-                    })?;
-                    let allocated = port_allocator
-                        .allocate(&process, &port_name_str, base)
-                        .map_err(|e| anyhow::anyhow!("{}", e))?;
-                    es.new_value_int(allocated as i64)
-                }),
+                Box::new(
+                    move |es, [process_name, port_name, base_port, listen_address]| {
+                        let process = es.require_string(process_name)?;
+                        let port_name_str = es.require_string(port_name)?;
+                        let base_raw = es.require_int(base_port)?;
+                        let base = u16::try_from(base_raw).map_err(|_| {
+                            anyhow::anyhow!(
+                                "basePort must be between 0 and 65535, got {}",
+                                base_raw
+                            )
+                        })?;
+                        // Empty string means "no specific address" → reserve across
+                        // all interfaces (the conservative default).
+                        let listen = es.require_string(listen_address)?;
+                        let listen_addr = if listen.is_empty() {
+                            None
+                        } else {
+                            Some(listen.as_str())
+                        };
+                        let allocated = port_allocator
+                            .allocate_addr(&process, &port_name_str, base, listen_addr)
+                            .map_err(|e| anyhow::anyhow!("{}", e))?;
+                        es.new_value_int(allocated as i64)
+                    },
+                ),
             )
             .to_miette()
             .wrap_err("Failed to create allocatePort primop")?;

--- a/src/modules/processes.nix
+++ b/src/modules/processes.nix
@@ -9,8 +9,8 @@ let
   devenvPrimops = config._module.args.devenvPrimops or { };
 
   # Capture primop for use in submodule (specialArgs don't propagate to types.submodule)
-  # Signature: allocatePort processName portName basePort
-  allocatePort = devenvPrimops.allocatePort or (_proc: _port: base: base);
+  # Signature: allocatePort processName portName basePort listenAddress
+  allocatePort = devenvPrimops.allocatePort or (_proc: _port: base: _addr: base);
 
   # Port type factory - needs process name for stable cache key
   mkPortType = processName: types.submodule ({ config, name, ... }: {
@@ -21,13 +21,29 @@ let
         example = 8080;
       };
 
+      listenAddress = lib.mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Listen address this port will be bound to. When set to a concrete IP,
+          auto-allocation is scoped to that address — the same port can be reused
+          on other addresses without being treated as taken (e.g. running several
+          instances on different loopback addresses with identical ports).
+
+          Empty, a wildcard (`*`/`0.0.0.0`/`::`), or a hostname reserves the port
+          across all interfaces (the conservative default).
+        '';
+        example = "127.0.0.1";
+      };
+
       value = lib.mkOption {
         type = types.port;
         readOnly = true;
         description = "Resolved port value (allocated by devenv)";
         defaultText = lib.literalMD "Allocated port based on `allocate`";
-        # Pass process name and port name for stable caching across evaluations
-        default = allocatePort processName name config.allocate;
+        # Pass process name and port name for stable caching across evaluations,
+        # plus the listen address so allocation is scoped to it when concrete.
+        default = allocatePort processName name config.allocate config.listenAddress;
       };
     };
   });

--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -414,6 +414,20 @@ in
             Previously, `pass` without `user` was silently ignored.
           '';
         }
+        {
+          date = "2026-06-26";
+          title = "services.postgres: port allocation is now scoped to listen_addresses";
+          when = cfg.enable;
+          description = ''
+            Port auto-allocation now reserves the configured `port` only on
+            `services.postgres.listen_addresses` when it is a concrete IP, rather
+            than across all interfaces. Several PostgreSQL instances can now share
+            the same `port` as long as each binds a different address (e.g.
+            `127.0.0.1` and `127.0.0.2`) instead of the port being silently
+            incremented. Wildcards (`*`/`0.0.0.0`/`::`), the empty string, and
+            hostnames keep the previous all-interfaces behaviour.
+          '';
+        }
       ];
     }
     (lib.mkIf cfg.enable {
@@ -449,6 +463,11 @@ in
 
       processes.postgres = {
         ports.main.allocate = basePort;
+        # Scope auto-allocation to the address Postgres actually binds, so the
+        # same port can be used on different loopback addresses (e.g. several
+        # instances each on their own 127.0.0.x) without being treated as taken.
+        # The allocator treats "*"/"0.0.0.0"/""/hostnames as all-interfaces.
+        ports.main.listenAddress = cfg.listen_addresses;
         exec = "${startScript}/bin/start-postgres";
 
         ready = {


### PR DESCRIPTION
## Problem

`services.postgres.listen_addresses` lets each instance bind a different
loopback address, so several instances should be able to share `port = 5432`.
But port auto-allocation reserves each port across **all** interfaces (binding
`0.0.0.0` without `SO_REUSEADDR`) and isn't listen-address-aware, so the same
port on a *different* address is treated as taken and silently incremented to
the next free one. `strict_ports` doesn't help — it only turns the silent bump
into a hard error, since the reservation still binds the wildcard.

## Change

Thread an optional listen address through `allocatePort` →
`PortAllocator::allocate_addr` → `reserve_port`:

- A concrete IP reserves the port on **that address only**.
- Wildcards (`*`, `0.0.0.0`, `::`, empty) and non-IP hosts (e.g. `localhost`)
  keep the all-interfaces default.
- The `postgres` service forwards `services.postgres.listen_addresses`, and a new
  `processes.<name>.ports.<name>.listenAddress` option exposes this for any service.

Result: `listen_addresses = "127.0.0.2"` with `port = 5432` now binds
`127.0.0.2:5432` instead of bumping to `5433` when `5432` is held on another
address.

## Tests

Unit tests in `devenv-core` (`cargo test -p devenv-core`):
`allocate_addr_is_listen_address_aware` (same port reused on a distinct address;
the all-interfaces path still bumps) and
`is_wildcard_addr_classifies_special_listen_addresses`.

## Notes

- Backwards compatible: no `listenAddress`, or a wildcard, keeps the previous
  all-interfaces behaviour. A changelog entry is included.
- The eval-cache replay path still re-acquires across all interfaces (falling
  back to re-evaluation if the wildcard bind conflicts). Happy to scope replay
  to the listen address as a follow-up if you'd prefer.

(written by claude)