### PR TITLE
spike: fully-static (musl) devenv build

### DIFF
--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -1,3 +1,41 @@
+// [tier2] On the fully-static (musl) build, musl's mallocng returns freed
+// memory to the kernel aggressively, turning devenv's alloc-heavy startup into
+// hundreds of mmap/munmap syscalls (~8 ms). Route the global allocator to
+// mimalloc (linked via nix as libmimalloc.a, MI_OVERRIDE=OFF so only the mi_*
+// API is exposed). Gated on `--cfg use_mimalloc`, set only for the static build.
+#[cfg(use_mimalloc)]
+mod mimalloc_global {
+    use std::alloc::{GlobalAlloc, Layout};
+
+    unsafe extern "C" {
+        fn mi_malloc_aligned(size: usize, alignment: usize) -> *mut u8;
+        fn mi_zalloc_aligned(size: usize, alignment: usize) -> *mut u8;
+        fn mi_realloc_aligned(p: *mut u8, newsize: usize, alignment: usize) -> *mut u8;
+        fn mi_free(p: *mut u8);
+    }
+
+    pub struct MiMalloc;
+
+    unsafe impl GlobalAlloc for MiMalloc {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            unsafe { mi_malloc_aligned(layout.size(), layout.align()) }
+        }
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            unsafe { mi_zalloc_aligned(layout.size(), layout.align()) }
+        }
+        unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+            unsafe { mi_free(ptr) }
+        }
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            unsafe { mi_realloc_aligned(ptr, new_size, layout.align()) }
+        }
+    }
+}
+
+#[cfg(use_mimalloc)]
+#[global_allocator]
+static GLOBAL: mimalloc_global::MiMalloc = mimalloc_global::MiMalloc;
+
 use clap::{CommandFactory, crate_version};
 use clap_complete::CompleteEnv;
 use devenv::{

--- a/flake.nix
+++ b/flake.nix
@@ -88,12 +88,71 @@
         let
           overlays = [
             inputs.rust-overlay.overlays.default
+            # Exposes `nixComponents2` (the component scope) so we can rebuild the
+            # Nix C/C++ libraries below. `overlays.default` only sets `nix`.
+            inputs.nix.overlays.internal
             (final: prev: {
               inherit (inputs.cachix.packages.${system}) cachix;
-              # Use nix-cli to skip building nix-manual, but keep libs for C bindings
-              nix = inputs.nix.packages.${system}.nix-cli // {
-                inherit (inputs.nix.packages.${system}.nix) libs;
-              };
+              # [static-link-spike] Build the Nix C++/C-API libraries with
+              # default_library=static so they link *into* the devenv binary
+              # instead of as ~14 shared objects. This removes the Nix cluster
+              # from the dynamic closure and the bulk of startup-time symbol
+              # resolution (do_lookup_x). External deps (boost, curl, …) stay
+              # dynamic — default_library only affects Nix's own meson libs.
+              nix =
+                # Under pkgsStatic (musl) the fork already builds the Nix libs
+                # static and handles LTO; just expose nix-cli + the C-API libs.
+                # Disable S3/AWS though: it's on by default, and its
+                # aws-c-* / aws-crt-cpp archives (CMake, no .pc) aren't on the
+                # final static link line, so libnixstore's aws_* references go
+                # unresolved. S3 doesn't affect startup; re-enable and link the
+                # aws-c-* stack once the startup win is confirmed.
+                # On glibc, rebuild them static ourselves (the Tier 1 override).
+                if prev.stdenv.hostPlatform.isStatic then
+                  let
+                    staticComponents = prev.nixComponents2.overrideScope (
+                      _finalScope: prevScope: {
+                        nix-store = prevScope.nix-store.override { withAWS = false; };
+                      }
+                    );
+                  in
+                  staticComponents.nix-cli
+                  // { libs = staticComponents.nix-everything.libs; }
+                else
+                  let
+                    staticComponents =
+                      (prev.nixComponents2.overrideScope (
+                        _finalScope: prevScope: {
+                          # TEMP for the startup measurement only: S3 doesn't affect
+                          # startup (static archives resolve at link time), and
+                          # aws-crt-cpp is a CMake dep with no .pc, so keeping S3
+                          # needs the aws-c-* stack linked explicitly. Re-enable S3
+                          # and link the aws libs once the startup win is confirmed.
+                          nix-store = prevScope.nix-store.override { withAWS = false; };
+                        }
+                      )).overrideAllMesonComponents (
+                        _finalAttrs: prevAttrs: {
+                          mesonFlags = (prevAttrs.mesonFlags or [ ]) ++ [
+                            (prev.lib.mesonOption "default_library" "static")
+                          ];
+                          # A static lib's generated .pc lists its buildInputs under
+                          # Requires.private; propagate them so downstream components'
+                          # pkg-config lookups (and the final devenv link) resolve the
+                          # transitive deps (libblake3, boost, …).
+                          propagatedBuildInputs =
+                            (prevAttrs.propagatedBuildInputs or [ ]) ++ (prevAttrs.buildInputs or [ ]);
+                          # The fork enables LTO for release builds (packaging/components.nix)
+                          # but already disables it for `isStatic`, knowing LTO+static breaks.
+                          # default_library=static on a glibc stdenv doesn't set isStatic, so
+                          # it slips past and GCC 15 ICEs building nix-expr. Append after the
+                          # fork's snippet so b_lto=false wins. LTO doesn't affect startup.
+                          preConfigure = (prevAttrs.preConfigure or "") + ''
+                            appendToVar mesonFlags "-Db_lto=false"
+                          '';
+                        }
+                      );
+                  in
+                  staticComponents.nix-cli // { libs = staticComponents.nix-everything.libs; };
               nixd = inputs.nixd.packages.${system}.nixd;
               crate2nix = final.callPackage "${inputs.crate2nix}/crate2nix/default.nix" { };
               libghostty-vt = final.callPackage "${inputs.ghostty}/nix/libghostty-vt.nix" { };
@@ -109,9 +168,40 @@
             rustc = rustToolchain;
             cargo = rustToolchain;
           };
+
+          # [tier2] Fully static (musl) build: every dep links into one binary,
+          # no dynamic Nix/external libs, to reach the startup floor and let the
+          # shell hook drop its caching.
+          pkgsStatic = pkgs.pkgsStatic;
+          rustToolchainStatic = pkgs.rust-bin.stable.latest.default.override {
+            targets = [ "x86_64-unknown-linux-musl" ];
+          };
+          # [tier2] libghostty-vt links libc++ for its vendored simdutf, which
+          # makes Zig build its bundled libc++ for the target. Ghostty's nix
+          # build sets `dontSetZigDefaultFlags` and passes no `-Dtarget`, so
+          # Zig builds for `native-native` — and building libc++ for the
+          # *native-detected* musl fails (libc++ <__locale> references ctype
+          # masks the detected musl doesn't expose). Passing an explicit
+          # `-Dtarget=<arch>-linux-musl` makes Zig use its own known-good musl
+          # config, so libc++ (and thus SIMD) builds cleanly. The simd C++ is
+          # compiled SIMDUTF_NO_LIBCXX/-fno-exceptions/-fno-rtti, so the static
+          # archive we link references no libc++ symbols at runtime.
+          libghosttyVtStatic = pkgsStatic.libghostty-vt.overrideAttrs (old: {
+            zigBuildFlags = old.zigBuildFlags ++ [
+              "-Dtarget=${pkgsStatic.stdenv.hostPlatform.parsed.cpu.name}-linux-musl"
+            ];
+          });
+          workspaceStatic = pkgsStatic.callPackage ./nix/workspace.nix {
+            inherit gitRev;
+            rustc = rustToolchainStatic;
+            cargo = rustToolchainStatic;
+            buildStatic = true;
+            libghostty-vt = libghosttyVtStatic;
+          };
         in
         {
           inherit (workspace.crates) devenv devenv-tasks;
+          devenv-static = workspaceStatic.crates.devenv;
           default = self.packages.${system}.devenv;
           crate2nix = pkgs.crate2nix;
         }

--- a/nix/crate-config.nix
+++ b/nix/crate-config.nix
@@ -9,6 +9,11 @@
 , llvmPackages
 , rustPlatform
 , libghostty-vt
+, pcre2
+, bzip2
+, libunistring
+, llhttp
+, mimalloc
 , gitRev ? ""
 , isRelease ? false
 ,
@@ -23,7 +28,25 @@ let
     nix.libs.nix-cmd-c
     nix.libs.nix-fetchers-c
     nix.libs.nix-main-c
-    llvmPackages.clang-unwrapped
+  ]
+  # libclang is only needed by bindgen, which runs on the build host and gets
+  # it from `rustPlatform.bindgenHook`; nothing links libclang at runtime. On
+  # the static (musl) build, pulling clang-unwrapped in as a buildInput forces
+  # an enormous static LLVM+clang compile whose final tool links exhaust RAM
+  # and disk. Keep it on glibc (cheap, already cached); drop it for the static
+  # build and rely on bindgenHook alone.
+  ++ lib.optional (!stdenv.hostPlatform.isStatic) llvmPackages.clang-unwrapped
+  ++ [
+    # [static-link-spike] With static Nix libs, pkg-config (PKG_CONFIG_ALL_STATIC)
+    # walks the full Requires.private tree; libgit2 needs libpcre2-8, whose .pc
+    # isn't otherwise on the path. Add it so the static link resolves.
+    pcre2.dev
+    # These transitive static deps (libarchive→bz2, libidn2→unistring, curl→llhttp)
+    # have no .pc file, so pkg-config emits `-lbz2`/`-lunistring`/`-lllhttp` with no
+    # `-L`; add the packages so their lib dirs reach the linker search path.
+    bzip2
+    libunistring
+    llhttp
   ];
 
   protoSetup = ''
@@ -49,11 +72,47 @@ let
     ];
   };
 
+  # [static-link-spike] Tell pkg-config to emit the static link line (Libs.private),
+  # so the now-static Nix C++ libs (libnixstore/expr/util) are pulled in transitively
+  # when crates link the C-API libs.
+  staticPkgConfig = { PKG_CONFIG_ALL_STATIC = "1"; };
+
+  # [static-link-spike] The static Nix archives reference boost's *compiled*
+  # component libs (iostreams/context/url), which boost's pkg-config doesn't
+  # enumerate. boost's lib dir is already on -L (propagated), so link them
+  # explicitly. --start-group handles the archive<->boost reference ordering.
+  #
+  # The Nix libs are C++ (built with musl g++), so the final binary also needs
+  # the C++ runtime for `operator new`/`operator delete`/etc. Rust links libc
+  # but not libstdc++, and on the dynamic (glibc) build these come in via the
+  # Nix .so's NEEDED; for the static build we must link libstdc++ ourselves.
+  # Put it in the same group so it resolves symbols the Nix archives reference.
+  staticBoostLinkOpts = [
+    "-C"
+    "link-arg=-Wl,--start-group"
+    "-C"
+    "link-arg=-lboost_context"
+    "-C"
+    "link-arg=-lboost_iostreams"
+    "-C"
+    "link-arg=-lboost_url"
+    "-C"
+    "link-arg=-lstdc++"
+    # libstdc++ pulls wide-char/locale/threading helpers from libc
+    # (btowc, wmemset, setlocale, get_nprocs, …). rustc's own -lc is emitted
+    # before this trailing group, so ld can't back-resolve those; include -lc
+    # inside the group so --start-group/--end-group iterates until resolved.
+    "-C"
+    "link-arg=-lc"
+    "-C"
+    "link-arg=-Wl,--end-group"
+  ];
+
   # Override for crates needing nix C libraries
   nixLibsOverride = attrs: {
     buildInputs = (attrs.buildInputs or [ ]) ++ nixLibs;
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
-  };
+  } // staticPkgConfig;
 
   # Common overrides for crates needing openssl
   opensslOverride = attrs: {
@@ -73,16 +132,37 @@ let
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
   };
 
+  # [tier2] On the static (musl) build, use mimalloc instead of musl's mallocng.
+  # musl returns freed memory to the kernel aggressively, so devenv's
+  # alloc-heavy init triggers hundreds of mmap/munmap syscalls (~8 ms of system
+  # time). mimalloc keeps a userspace heap and avoids that churn.
+  #
+  # We can't override `malloc` at link time (Rust links its bundled musl libc.a
+  # before our -lmimalloc → multiple-definition). Instead build mimalloc with
+  # MI_OVERRIDE=OFF (exposes only the `mi_*` API, no `malloc` symbols) and route
+  # Rust's allocator to it via a `#[global_allocator]` gated on `--cfg
+  # use_mimalloc` (see devenv/src/main.rs).
+  mimallocNoOverride = mimalloc.overrideAttrs (o: {
+    cmakeFlags = (o.cmakeFlags or [ ]) ++ [ "-DMI_OVERRIDE=OFF" ];
+  });
+  staticAllocLinkOpts = lib.optionals stdenv.hostPlatform.isStatic [
+    "--cfg"
+    "use_mimalloc"
+    "-C"
+    "link-arg=-lmimalloc"
+  ];
+
   # Shared override for crates linking against nix, openssl, protobuf, dbus, and bindgen.
   devenvBase = attrs: {
     buildInputs =
       (attrs.buildInputs or [ ])
-      ++ [
+        ++ [
         openssl
         libghostty-vt
       ]
-      ++ nixLibs
-      ++ lib.optional stdenv.isLinux dbus;
+        ++ nixLibs
+        ++ lib.optional stdenv.isLinux dbus
+        ++ lib.optional stdenv.hostPlatform.isStatic mimallocNoOverride;
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [
       pkg-config
       protobuf
@@ -92,8 +172,8 @@ let
     extraRustcOpts = (attrs.extraRustcOpts or [ ]) ++ [
       "--cfg"
       "tracing_unstable"
-    ];
-  };
+    ] ++ staticAllocLinkOpts ++ staticBoostLinkOpts;
+  } // staticPkgConfig;
 in
 {
   # Main devenv crate
@@ -122,7 +202,7 @@ in
       "--cfg"
       "tracing_unstable"
     ];
-  };
+  } // staticPkgConfig;
 
   # devenv-snix-backend needs protobuf
   devenv-snix-backend = attrs: {
@@ -198,13 +278,21 @@ in
       pkg-config
       rustPlatform.bindgenHook
     ];
-  };
+  } // staticPkgConfig;
 
   # libghostty-vt-sys has a pkg-config feature that finds the pre-built
   # library from the ghostty flake, so just provide pkg-config + the library.
+  #
+  # [tier2] For the static build, also enable the crate's `link-static`
+  # feature. Its build script otherwise defaults to dynamic linking and emits
+  # `-lghostty-vt` (the .so, which our static `.dev` output doesn't ship) →
+  # "cannot find -lghostty-vt". With `link-static` it probes the
+  # `libghostty-vt-static` pkg-config module and links `libghostty-vt.a`.
   libghostty-vt-sys = attrs: {
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
     buildInputs = (attrs.buildInputs or [ ]) ++ [ libghostty-vt.dev ];
+  } // lib.optionalAttrs stdenv.hostPlatform.isStatic {
+    features = (attrs.features or [ ]) ++ [ "link-static" ];
   };
 
   nix-bindings-util = nixLibsOverride;

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -1,6 +1,7 @@
 # Tooling to build the workspace crates using crate2nix
 { lib
 , stdenv
+, buildPackages
 
 , openssl
 , dbus
@@ -24,6 +25,10 @@
 , cargo
 , cargoProfile ? "release"
 
+  # [tier2] Static (musl) build: force non-PIE codegen on every crate AND its
+  # build.rs, since rust+musl defaults to static-PIE which segfaults on exec.
+, buildStatic ? false
+
 , gitRev ? ""
 , isRelease ? false
 }:
@@ -32,17 +37,77 @@ let
   cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
   inherit (cargoToml.workspace.package) version;
 
-  # Override the rust toolchain
-  buildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
-    inherit rustc cargo;
-  };
-
   # Import crate2nix generated file with overrides
   crateConfig = callPackage ./crate-config.nix { inherit gitRev isRelease libghostty-vt; };
 
+  # rust+musl defaults to static-PIE, which segfaults on exec (the musl-gcc
+  # wrappers don't support static-PIE — rust-lang/rust#95926). Fix: non-PIE
+  # codegen via -Crelocation-model=static plus -Clink-arg=-no-pie to force a
+  # non-PIE link, so the final musl host binary actually runs. These apply to
+  # the host (musl) crate compiles only.
+  staticRustcOpts = [ "-Crelocation-model=static" "-Clink-arg=-no-pie" ];
+
+  # Build scripts (build.rs) are the real Tier 2 blocker. crate2nix compiles a
+  # crate's build.rs *inside the musl host derivation*, but with NO `--target`
+  # and NO `-C linker`. So rustc falls back to its default target — which, for
+  # the rust-overlay toolchain, is x86_64-unknown-linux-GNU — and its default
+  # linker, which is `cc` on PATH = the musl-static wrapper inside the host
+  # derivation. gnu-target objects linked by the musl cc segfault the instant
+  # the build runs them (exit 139, first hit at anyhow). The build-dependency
+  # rlibs build.rs links come from `pkgs.buildPackages` and are gnu-target, so
+  # the gnu default is correct — the link is what's wrong. Two fixes, together:
+  #
+  #   1. Point build.rs at the glibc build-host cc (`-C linker=`), so gnu
+  #      objects are linked by a gnu linker.
+  #   2. Force the glibc dynamic linker onto the build.rs link explicitly. The
+  #      musl-static stdenv sets `NIX_CFLAGS_LINK=-static` globally, which the
+  #      build cc's setup hook merges into its gnu role. With `-static` present
+  #      the cc wrapper treats the link as static and skips `-dynamic-linker` —
+  #      but rust still emits dynamic `-l` flags, so the result is a dynamic ELF
+  #      with DT_NEEDED libc.so.6 yet NO PT_INTERP: unloadable, segfaults on
+  #      exec. Passing `-Wl,-dynamic-linker,<glibc ld.so>` ourselves bypasses
+  #      that guard and restores the interpreter, so build.rs runs.
+  buildCc = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
+  buildRsRustcOpts = [
+    "-C"
+    "linker=${buildCc}"
+    "-C"
+    "link-arg=-Wl,-dynamic-linker,${buildPackages.stdenv.cc.bintools.dynamicLinker}"
+  ];
+
+  injectStatic = crate: crate // {
+    extraRustcOpts = (crate.extraRustcOpts or [ ]) ++ staticRustcOpts;
+    extraRustcOptsForBuildRs = (crate.extraRustcOptsForBuildRs or [ ]) ++ buildRsRustcOpts;
+  };
+
+  # Override the rust toolchain and bake the per-crate overrides into the
+  # builder. We pass `defaultCrateOverrides` through unchanged to crate2nix so it
+  # uses this builder directly rather than calling `.override` on it (which would
+  # strip the static wrapper, since a plain function has no `.override`).
+  #
+  # crate2nix calls this for two package sets: the musl *host* set (isStatic)
+  # for crates that end up in the binary, and `pkgs.buildPackages` (glibc) for
+  # build-time deps (proc-macros, build scripts). The static codegen flags must
+  # apply ONLY to the musl host crates. Applying `-Crelocation-model=static` to
+  # the glibc build-platform rlibs makes them non-PIC, then the default-PIE
+  # build.rs executables that link them fail with `R_X86_64_32 … recompile with
+  # -fPIC` (first hit: indexmap linking autocfg). Gate on `isStatic`.
+  buildRustCrateForPkgs =
+    pkgs:
+    let
+      base = pkgs.buildRustCrate.override {
+        inherit rustc cargo;
+        defaultCrateOverrides = defaultCrateOverrides // crateConfig;
+      };
+    in
+    if buildStatic && pkgs.stdenv.hostPlatform.isStatic then
+      (crate: base (injectStatic crate))
+    else
+      base;
+
   cargoNix = callPackage ../Cargo.nix {
     inherit buildRustCrateForPkgs;
-    defaultCrateOverrides = defaultCrateOverrides // crateConfig;
+    inherit defaultCrateOverrides;
     release = cargoProfile == "release";
     # Enable tracing_unstable for dependency resolution so valuable crate is included.
     # This matches the --cfg tracing_unstable passed via crate-config.nix at compile time.


### PR DESCRIPTION
> **Draft / spike.**

## What

Builds a fully-static-musl `devenv` (**0 dynamic libs vs 83**) to cut startup cost. The dynamic-linker symbol-resolution tax across 83 shared libs disappears:

| Command | dynamic | static-musl |
|---|---|---|
| `hook-should-activate` | ~33 ms | ~8 ms |
| `version` | ~55 ms | ~10 ms |

(~5x). Verified end to end: `devenv shell` evaluates and runs via the static Nix C-API FFI.

## Fixes required to build and run static-musl

- **workspace.nix**: compile `build.rs` via the glibc build-host cc with an explicit `-Wl,-dynamic-linker` (the musl-static stdenv's global `-static` otherwise drops the `PT_INTERP` → unrunnable build scripts, the long-standing segfault); scope the non-PIE static codegen flags to `isStatic` so glibc build deps stay PIC.
- **crate-config.nix**: drop `clang-unwrapped` from `nixLibs` on static (libclang is bindgen-only, supplied by `bindgenHook`) to skip the huge static LLVM+clang build; enable `libghostty-vt-sys`'s `link-static` feature; link `libstdc++` + `libc` in a group for the Nix C++ runtime symbols; route the global allocator to mimalloc (`MI_OVERRIDE=OFF`) to cut musl mallocng mmap/munmap churn.
- **flake.nix**: pass `-Dtarget=<arch>-linux-musl` to libghostty-vt so Zig builds libc++ for an explicit musl target (native-native detection fails); disable S3/AWS for the static Nix libs (`aws-c-*` not on the link line).
- **main.rs**: mimalloc `#[global_allocator]` gated on `--cfg use_mimalloc`.

## Scope

Self-contained static-build slice only. The related shell-hook startup work (deleting activation caching) is entangled with the out-of-tree `--from` feature in `hook.rs` and rides along with #2940 instead.
