### PR TITLE
docs: use `nix profile add` instead of deprecated `install`

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -40,7 +40,7 @@
     === "Nix profiles (requires experimental flags)"
 
         ```
-        nix profile install nixpkgs#bashInteractive
+        nix profile add nixpkgs#bashInteractive
         ```
 
 === "Windows (WSL2)"
@@ -68,7 +68,7 @@
 === "Nix profiles (requires experimental flags)"
 
     ```
-    nix profile install nixpkgs#devenv
+    nix profile add nixpkgs#devenv
     ```
 
 === "NixOS/nix-darwin"


### PR DESCRIPTION
`nix profile install` was renamed to `nix profile add` in Nix 2.30 (July 2025). Use `nix profile add` in getting-started.md so users don't see a deprecation warning.