### PR TITLE
nix-backend: fix relocated-store shell activation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `devenv shell` failing with `Failed to parse output store path … is not in the Nix store` when using a relocated/chroot Nix store (e.g. `NIX_REMOTE='local?root=…'` or a bind-mounted store). The realized shell path was translated to its physical location and then fed back into store-path parsing, which only accepts the logical `/nix/store/…` form; the logical path is now recovered before creating the GC root ([#2499](https://github.com/cachix/devenv/issues/2499)).
 - Fixed the TUI crashing on activity names or store paths containing multi-byte characters (e.g. non-ASCII package names or evaluation paths) when shortened for narrow terminals.
 - Fixed the TUI crashing with an arithmetic overflow when a download or task reported progress beyond its expected total.
 - Fixed the quit confirmation prompt overflowing past the right edge on terminals narrower than ~82 columns; the prompt now adapts to the available width.

--- a/devenv-nix-backend/src/backend.rs
+++ b/devenv-nix-backend/src/backend.rs
@@ -208,6 +208,39 @@ fn eval_cache_error_into_miette(e: devenv_eval_cache::Error<miette::Error>) -> m
     }
 }
 
+/// Build the logical `<storedir>/<basename>` store-path string from a path that
+/// may have been `real_path`-translated for a relocated/chroot store.
+///
+/// `Store::parse_store_path` only accepts the logical form (e.g.
+/// `/nix/store/<hash>-<name>`), but several call sites cache the *real* path
+/// returned by [`Store::real_path`], which differs for a relocated store
+/// (e.g. `/srv/nix/store/<hash>-<name>`). The basename is identical between the
+/// two forms, so the logical path is just the store's logical dir joined with
+/// that basename. Returns `None` if the path has no basename. See devenv #2499.
+fn logical_store_path_str(storedir: &str, path: &str) -> Option<String> {
+    let basename = std::path::Path::new(path).file_name()?.to_str()?;
+    Some(format!("{}/{}", storedir.trim_end_matches('/'), basename))
+}
+
+/// Parse a possibly `real_path`-translated store path into its logical
+/// [`StorePath`]. Use instead of `store.parse_store_path` whenever the input may
+/// be a cached real path (gc-root creation). See [`logical_store_path_str`].
+fn parse_logical_store_path(
+    store: &mut Store,
+    path: &str,
+) -> Result<nix_bindings_store::path::StorePath> {
+    let storedir = store
+        .get_storedir()
+        .to_miette()
+        .wrap_err("Failed to get store directory")?;
+    let logical = logical_store_path_str(&storedir, path)
+        .ok_or_else(|| miette!("store path '{}' has no basename", path))?;
+    store
+        .parse_store_path(&logical)
+        .to_miette()
+        .wrap_err("Failed to parse store path")
+}
+
 fn cache_key_for(
     bootstrap_args: &BootstrapArgs,
     port_allocator: &PortAllocator,
@@ -809,10 +842,10 @@ impl NixCBackend {
         };
 
         let mut store = self.cnix_store.inner().clone();
-        let store_path = store
-            .parse_store_path(&out_path_str)
-            .to_miette()
-            .wrap_err("Failed to parse output store path")?;
+        // `out_path_str` is the real_path-translated path, which differs from the
+        // logical store path under a relocated/chroot store; gc-root creation
+        // needs the logical form. See devenv #2499.
+        let store_path = parse_logical_store_path(&mut store, &out_path_str)?;
 
         if gc_root.symlink_metadata().is_ok() {
             std::fs::remove_file(gc_root)
@@ -1338,10 +1371,9 @@ impl Evaluator for NixCBackend {
 
             if let Some(gc_root_base) = &opts.gc_root {
                 let mut store = self.cnix_store.inner().clone();
-                let store_path = store
-                    .parse_store_path(&path_str)
-                    .to_miette()
-                    .wrap_err("Failed to parse store path")?;
+                // `path_str` is real_path-translated; gc-root creation needs the
+                // logical store path (differs under a relocated store). See #2499.
+                let store_path = parse_logical_store_path(&mut store, &path_str)?;
 
                 let sanitized_attr = attr_path.replace('.', "-");
                 let attr_gc_root = gc_root_base.with_file_name(format!(
@@ -1633,7 +1665,7 @@ pub fn apply_nix_settings(nix_settings: &NixSettings) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_key_for, core_config_watch_paths};
+    use super::{cache_key_for, core_config_watch_paths, logical_store_path_str};
     use devenv_core::{PortAllocator, bootstrap_args::BootstrapArgs};
     use serde::Serialize;
     use tempfile::TempDir;
@@ -1672,5 +1704,36 @@ mod tests {
 
         assert_ne!(shell_key.key_hash, up_key.key_hash);
         assert_ne!(up_key.key_hash, strict_key.key_hash);
+    }
+
+    // Regression for devenv #2499: a shell built against a relocated/chroot store
+    // caches the real_path-translated path; gc-root creation must still recover
+    // the logical store path so `parse_store_path` accepts it.
+    #[test]
+    fn logical_store_path_str_recovers_logical_path_from_relocated_real_path() {
+        let name = "rdd4pnr4x9rqc9wgbibhngv217w2xvxl-bash-interactive-5.2p26";
+        let logical = format!("/nix/store/{name}");
+
+        // Real path under a relocated store root maps back to the logical path.
+        let real = format!("/srv/nix/store/{name}");
+        assert_eq!(
+            logical_store_path_str("/nix/store", &real).as_deref(),
+            Some(logical.as_str())
+        );
+
+        // An already-logical path is unchanged.
+        assert_eq!(
+            logical_store_path_str("/nix/store", &logical).as_deref(),
+            Some(logical.as_str())
+        );
+
+        // A trailing slash on the store dir is handled.
+        assert_eq!(
+            logical_store_path_str("/nix/store/", &real).as_deref(),
+            Some(logical.as_str())
+        );
+
+        // A path with no basename yields None rather than a malformed path.
+        assert_eq!(logical_store_path_str("/nix/store", "/"), None);
     }
 }


### PR DESCRIPTION
## What

`devenv shell` against a relocated/chroot Nix store — e.g. `NIX_REMOTE='local?root=…'` or a daemon `store=…?root=…` — failed with:

```
× Failed to parse output store path
 ─▶ error: path '…/nix/store/<hash>-devenv-shell' is not in the Nix store
```

before the shell could activate.

## Why

`build_shell_uncached` / `build_attr_uncached` translate the realized output path to its physical location via `Store::real_path` and cache it. That cached string is then fed back into `Store::parse_store_path` when creating the GC root (`backend.rs` shell build and attr build). `parse_store_path` only accepts the **logical** `/nix/store/<hash>-<name>` form, so the real path of a relocated store (`<root>/nix/store/…`) is rejected.

For a default store `real_path` returns the logical path, so this only bites when the store is relocated.

## Fix

Recover the logical store path before gc-root creation. The basename (`<hash>-<name>`) is identical between the real and logical forms, so the logical path is just the store's logical dir (`get_storedir()`) joined with that basename. Applied at both gc-root sites via a small `parse_logical_store_path` helper.

- No-op for the common (non-relocated) case: `real_path` already returns the logical path, so the helper reproduces the exact same `StorePath` (one extra `get_storedir()` call).
- The cached `out_path` string used for cachix `notify_realized` is left unchanged, so there's no push behaviour change.

## Testing

- New unit test `logical_store_path_str_recovers_logical_path_from_relocated_real_path` (relocated real path, already-logical path, trailing-slash store dir, no-basename → `None`).
- Verified end-to-end against a real chroot store (`local?root=…`): before, `devenv shell` aborted at the parse step; after, it execs the shell and runs `enterShell`.

## Scope / caveat

This removes the **activation crash**. It does **not** by itself make a store mounted at a non-default location fully usable: the built shell environment (PATH, shebangs, task scripts) still references logical `/nix/store` paths, so `/nix/store` must also resolve to that store (e.g. an overlay/union mount of the physical store onto `/nix/store`). See #2499 for that broader scenario — this PR is a prerequisite fix, not a full solution, hence `Refs` rather than `Closes`.

Refs #2499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)