### PR TITLE
Add JSON output for tasks list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Improvements
 
 - Cachix now authenticates pulls and pushes without `CACHIX_AUTH_TOKEN` exported in the environment: when the variable is unset, devenv resolves the token from a `CACHIX_AUTH_TOKEN` secretspec secret, then from the auth token stored by the Cachix CLI (`cachix authtoken`) in `~/.config/cachix/cachix.dhall`. The resolved token is passed to the cachix push daemon as well. The secretspec secret name is configurable via `secretspec.cachix_auth_token` in `devenv.yaml` for backends whose policy (e.g. an OpenBao/Vault policy) only grants access to the token under a different name.
+- Added `devenv tasks list --json` for machine-readable task graph inspection ([#2966](https://github.com/cachix/devenv/issues/2966)).
 - `devenv repl` now exposes `inputs` alongside `devenv` and `pkgs`, so you can inspect inputs declared in `devenv.yaml` directly from the REPL (e.g. `inputs.nixpkgs.lib.version`).
 - The TUI now shows each process's state as a status dot whose shape encodes the lifecycle (waiting, starting, running, ready, stopped, failed) instead of an identical spinner on every process. The shape carries the state so it reads without relying on color; transient states gently pulse to signal progress.
 - Cleaned up non-TUI console output: surfaces Nix eval/build progress, hides internal debug noise.

--- a/devenv-tasks/src/config.rs
+++ b/devenv-tasks/src/config.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 pub struct TaskConfig {
     pub name: String,
     #[serde(default)]
+    pub description: String,
+    #[serde(default)]
     pub r#type: TaskType,
     #[serde(default)]
     pub after: Vec<String>,

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -1038,7 +1038,10 @@ pub enum TasksCommand {
         input_json: Option<String>,
     },
     #[command(about = "List all available tasks.")]
-    List {},
+    List {
+        #[arg(long, help = "Print tasks as JSON for machine consumption.")]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Clone)]

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -26,6 +26,7 @@ use nix::unistd::Pid;
 use once_cell::sync::{Lazy, OnceCell as SyncOnceCell};
 use processes::ProcessManager as _;
 use secrecy::ExposeSecret;
+use serde::Serialize;
 use sqlx::SqlitePool;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
@@ -1132,8 +1133,12 @@ impl Devenv {
         Ok(serde_json::to_string(&outputs).expect("parsing of outputs failed"))
     }
 
-    pub async fn tasks_list(&self) -> Result<String> {
+    pub async fn tasks_list(&self, json: bool) -> Result<String> {
         let tasks = self.load_tasks().await?;
+
+        if json {
+            return format_tasks_json(&tasks);
+        }
 
         if tasks.is_empty() {
             return Ok("No tasks defined.".to_string());
@@ -2440,6 +2445,39 @@ fn format_tasks_tree(tasks: &[tasks::TaskConfig]) -> String {
     output
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskListItem<'a> {
+    name: &'a str,
+    description: &'a str,
+    r#type: tasks::TaskType,
+    after: &'a [String],
+    before: &'a [String],
+    has_exec: bool,
+    has_status: bool,
+    cwd: Option<&'a str>,
+    exec_if_modified: &'a [String],
+}
+
+fn format_tasks_json(tasks: &[tasks::TaskConfig]) -> Result<String> {
+    let items: Vec<_> = tasks
+        .iter()
+        .map(|task| TaskListItem {
+            name: &task.name,
+            description: &task.description,
+            r#type: task.r#type,
+            after: &task.after,
+            before: &task.before,
+            has_exec: task.command.is_some(),
+            has_status: task.status.is_some(),
+            cwd: task.cwd.as_deref(),
+            exec_if_modified: &task.exec_if_modified,
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&items).into_diagnostic()
+}
+
 fn build_bootstrap_args(
     config: &NixConfig,
     imports: &[String],
@@ -2694,6 +2732,42 @@ mod tests {
             .unwrap_or_default();
         build_children.sort();
         assert_eq!(build_children, vec!["myapp:setup"]);
+    }
+
+    #[test]
+    fn test_format_tasks_json() {
+        let tasks = vec![tasks::TaskConfig {
+            name: "test:run".to_string(),
+            description: "Run tests".to_string(),
+            r#type: tasks::TaskType::Oneshot,
+            after: vec!["test:build".to_string()],
+            before: vec!["test:report".to_string()],
+            command: Some("cargo test".to_string()),
+            status: Some("test -f target/debug/app".to_string()),
+            cwd: Some("crates/app".to_string()),
+            exec_if_modified: vec!["src/**/*.rs".to_string()],
+            ..Default::default()
+        }];
+
+        let output = format_tasks_json(&tasks).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!([
+                {
+                    "name": "test:run",
+                    "description": "Run tests",
+                    "type": "oneshot",
+                    "after": ["test:build"],
+                    "before": ["test:report"],
+                    "hasExec": true,
+                    "hasStatus": true,
+                    "cwd": "crates/app",
+                    "execIfModified": ["src/**/*.rs"]
+                }
+            ])
+        );
     }
 
     #[test]

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -997,8 +997,8 @@ async fn dispatch_command(
                     .await?;
                 Ok(CommandResult::Print(format!("{output}\n")))
             }
-            TasksCommand::List {} => {
-                let output = devenv.tasks_list().await?;
+            TasksCommand::List { json } => {
+                let output = devenv.tasks_list(json).await?;
                 Ok(CommandResult::Print(format!("{output}\n")))
             }
         },


### PR DESCRIPTION
## What changed

Adds `devenv tasks list --json` for machine-readable task graph inspection.

The JSON output emits one object per task with:

- `name`
- `description`
- `type`
- `after` / `before` dependency edges
- `hasExec`
- `hasStatus`
- `cwd`
- `execIfModified`

The existing human tree output remains unchanged when `--json` is not passed.

Fixes cachix/devenv#2966.

## Why

Automation and editor integrations currently need to parse the human task tree or evaluate internals directly. This gives the CLI a stable structured output path for task graph assertions.

## Validation

Passed:

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p devenv-tasks`
- `cargo test -p devenv-tasks config::tests`

Attempted but blocked locally:

- `cargo test -p devenv test_format_tasks_json`
- `cargo check -p devenv --no-default-features`

Both compile attempts failed before reaching this code because this shell does not have `nix-flake-c.pc` available via `pkg-config`, and `nix` is not installed here to enter the repository devshell.