### PR TITLE
Fix POSIX hook sibling activation after cd-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `devenv hook bash`/`zsh` skipping activation for a sibling project after following `.devenv/exit-dir` from a hook-spawned shell that cd'd out of the previous project ([#2944](https://github.com/cachix/devenv/issues/2944)).
 - Fixed misleading evaluation errors where evaluation warnings replaced the real error message, hiding syntax errors and suggestions like `devenv inputs add …` ([#2820](https://github.com/cachix/devenv/issues/2820)).
 - Fixed `devenv shell` failing with `Failed to parse output store path … is not in the Nix store` when using a relocated/chroot Nix store (e.g. `NIX_REMOTE='local?root=…'` or a bind-mounted store). The realized shell path was translated to its physical location and then fed back into store-path parsing, which only accepts the logical `/nix/store/…` form; the logical path is now recovered before creating the GC root ([#2499](https://github.com/cachix/devenv/issues/2499)).
 - Fixed the TUI crashing on activity names or store paths containing multi-byte characters (e.g. non-ASCII package names or evaluation paths) when shortened for narrow terminals.

--- a/devenv/hooks/hook.posix.sh
+++ b/devenv/hooks/hook.posix.sh
@@ -46,7 +46,6 @@ _devenv_hook() {
             rm -f "$exit_dir_file"
             if [[ -d "$target_dir" ]]; then
                 cd "$target_dir"
-                _DEVENV_HOOK_PWD="$PWD"
             fi
         fi
     elif [[ $exit_code -eq 0 ]]; then

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -197,7 +197,8 @@ fn posix_activates_sibling_after_cd_out() {
         fs::create_dir_all(project_b.join(".devenv")).unwrap();
         let (_bin_dir, calls) = sibling_activation_shim(&project_a, &project_b);
         let script = format!(
-            "{src}\n\
+            "unset DEVENV_ROOT _DEVENV_HOOK_DIR\n\
+             {src}\n\
              {po}\n\
              cd {project_a:?}\n\
              _devenv_hook\n\

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -4,6 +4,7 @@
 //! - `outer_shell_survives_cd_out` — #2805
 //! - `inner_shell_exits_on_cd_out` — hook-spawned shell must `exit` + write exit-dir
 //! - `no_respawn_inside_devenv_shell` — follow-up to #2815
+//! - `posix_activates_sibling_after_cd_out` — #2944
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -63,6 +64,17 @@ fn shells() -> Vec<(&'static str, String, fn(&Path) -> String)> {
     .collect()
 }
 
+fn posix_shells() -> Vec<(&'static str, String)> {
+    let bin = devenv_bin();
+    [
+        ("bash", format!(r#"eval "$({bin} hook bash)""#)),
+        ("zsh", format!(r#"eval "$({bin} hook zsh)""#)),
+    ]
+    .into_iter()
+    .filter(|(s, _)| have(s))
+    .collect()
+}
+
 fn posix_path_override(dir: &Path) -> String {
     format!(r#"export PATH="{}:$PATH""#, dir.display())
 }
@@ -73,6 +85,42 @@ fn fish_path_override(dir: &Path) -> String {
 
 fn run(shell: &str, script: &str) -> std::process::Output {
     Command::new(shell).arg("-c").arg(script).output().unwrap()
+}
+
+fn sibling_activation_shim(project_a: &Path, project_b: &Path) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let calls = dir.path().join("calls");
+    let bin = dir.path().join("devenv");
+    fs::write(
+        &bin,
+        format!(
+            r#"#!/bin/sh
+set -eu
+case "$1" in
+  hook-should-activate)
+    if [ -d "$PWD/.devenv" ]; then
+      printf '%s\n' "$PWD"
+    fi
+    ;;
+  shell)
+    printf 'shell %s\n' "$PWD" >> {calls:?}
+    if [ "$PWD" = {project_a:?} ]; then
+      printf '%s' {project_b:?} > {project_a:?}/.devenv/exit-dir
+    fi
+    ;;
+  *)
+    printf '%s\n' "$*" >> {calls:?}
+    ;;
+esac
+"#,
+            calls = calls,
+            project_a = project_a.display().to_string(),
+            project_b = project_b.display().to_string(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, calls)
 }
 
 #[test]
@@ -135,6 +183,45 @@ fn no_respawn_inside_devenv_shell() {
             recorded.is_empty(),
             "[{shell}] hook re-invoked devenv from inside a manually-entered shell.\n\
              Recorded:\n{recorded}",
+        );
+    }
+}
+
+#[test]
+fn posix_activates_sibling_after_cd_out() {
+    for (shell, src) in posix_shells() {
+        let parent = tempfile::tempdir().unwrap();
+        let project_a = parent.path().join("project-a");
+        let project_b = parent.path().join("project-b");
+        fs::create_dir_all(project_a.join(".devenv")).unwrap();
+        fs::create_dir_all(project_b.join(".devenv")).unwrap();
+        let (_bin_dir, calls) = sibling_activation_shim(&project_a, &project_b);
+        let script = format!(
+            "{src}\n\
+             {po}\n\
+             cd {project_a:?}\n\
+             _devenv_hook\n\
+             _devenv_hook\n\
+             printf 'PWD=%s\\n' \"$PWD\"\n",
+            po = posix_path_override(calls.parent().unwrap()),
+        );
+        let out = run(shell, &script);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "[{shell}] sibling activation script failed.\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+        assert!(
+            stdout.contains(&format!("PWD={}", project_b.display())),
+            "[{shell}] parent shell did not follow exit-dir to sibling.\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+        let recorded = fs::read_to_string(&calls).unwrap_or_default();
+        assert!(
+            recorded.contains(&format!("shell {}", project_b.display())),
+            "[{shell}] sibling project was not activated after cd-out.\nRecorded:\n{recorded}\nstdout: {stdout}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
         );
     }
 }


### PR DESCRIPTION
Closes #2944

## Summary

- Stop the POSIX hook from marking the `.devenv/exit-dir` target as already processed after the parent shell follows a hook-spawned cd-out.
- Add a bash/zsh regression test that reproduces the sibling-project activation skip.
- Add an unreleased changelog entry for the user-visible shell hook fix.

## Root cause

When a hook-spawned shell cd'd out of project A into sibling project B, the parent POSIX hook followed `.devenv/exit-dir` into B and then set `_DEVENV_HOOK_PWD="$PWD"`. On the next prompt, the hook treated project B as already processed and skipped `devenv shell`, so B never activated.

## Validation

- [x] `cargo test -p devenv --test hook_outer_shell_survives posix_activates_sibling_after_cd_out -- --nocapture`
- [x] `cargo test -p devenv --test hook_outer_shell_survives -- --nocapture`
- [x] `cargo check -p devenv`
- [x] `bash -n devenv/hooks/hook.posix.sh`
- [x] `cargo fmt --check --package devenv`
- [x] `git diff --check`
