### PR TITLE
Improve unfree package diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed `devenv up` intermittently failing to start processes with "Failed to initialize task cache: ... pool timed out while waiting for an open connection", most often in CI. The processes that a non-native process manager (e.g. process-compose) launches each open the same task cache database concurrently and raced to create and migrate it; the database is now initialized once before the processes start ([#2897](https://github.com/cachix/devenv/issues/2897)).
 - Fixed `devenv inputs add` from a subdirectory writing to a stray `devenv.yaml` in the subdir instead of the enclosing project. It now walks up to find `devenv.nix` the same way `devenv shell` does, so the input is added where the rest of devenv reads it.
 - Fixed `devenv gc` failing with "File devenv.nix does not exist" when run outside of a project. Garbage collection operates on the global devenv store and no longer requires a `devenv.nix` ([#2928](https://github.com/cachix/devenv/issues/2928)).
+- Fixed unfree package errors suggesting only generic Nix/NixOS configuration. They now point devenv users to `allow_unfree: true` or `nixpkgs.permitted_unfree_packages` in `devenv.yaml` ([#2850](https://github.com/cachix/devenv/issues/2850)).
 
 ### Improvements
 

--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -54,6 +54,23 @@ rec {
       targetSystem = system;
 
       overlays = lib.flatten (lib.mapAttrsToList getOverlays devenv_inputs);
+      unfreePackageError = pkg:
+        let
+          name = lib.getName pkg;
+        in
+        throw ''
+          devenv: package '${name}' has an unfree license.
+
+          To allow all unfree packages, add this to devenv.yaml:
+
+            allow_unfree: true
+
+          To allow only this package, add this to devenv.yaml:
+
+            nixpkgs:
+              permitted_unfree_packages:
+                - ${name}
+        '';
 
       # Helper to create pkgs for a given system with nixpkgs_config
       mkPkgsForSystem =
@@ -73,9 +90,9 @@ rec {
               if nixpkgs_config.allowUnfree or false then
                 (_: true)
               else if (nixpkgs_config.permittedUnfreePackages or [ ]) != [ ] then
-                (pkg: builtins.elem (lib.getName pkg) (nixpkgs_config.permittedUnfreePackages or [ ]))
+                (pkg: builtins.elem (lib.getName pkg) (nixpkgs_config.permittedUnfreePackages or [ ]) || unfreePackageError pkg)
               else
-                (_: false);
+                unfreePackageError;
           } // lib.optionalAttrs ((nixpkgs_config.allowlistedLicenses or [ ]) != [ ]) {
             allowlistedLicenses = map (name: lib.licenses.${name}) (nixpkgs_config.allowlistedLicenses or [ ]);
           } // lib.optionalAttrs ((nixpkgs_config.blocklistedLicenses or [ ]) != [ ]) {

--- a/devenv-nix-backend/src/backend.rs
+++ b/devenv-nix-backend/src/backend.rs
@@ -1553,14 +1553,31 @@ fn write_nixpkgs_config(nixpkgs_config: &NixpkgsConfig, dotfile_dir: &Path) -> R
         r#"let
   cfg = {base};
   getName = pkg: (builtins.parseDrvName (pkg.name or pkg.pname or "")).name;
+  unfreePackageError = pkg:
+    let
+      name = getName pkg;
+    in
+      throw ''
+        devenv: package '${{name}}' has an unfree license.
+
+        To allow all unfree packages, add this to devenv.yaml:
+
+          allow_unfree: true
+
+        To allow only this package, add this to devenv.yaml:
+
+          nixpkgs:
+            permitted_unfree_packages:
+              - ${{name}}
+      '';
 in cfg // {{
   allowUnfreePredicate =
     if cfg.allowUnfree or false then
       (_: true)
     else if (cfg.permittedUnfreePackages or []) != [] then
-      (pkg: builtins.elem (getName pkg) (cfg.permittedUnfreePackages or []))
+      (pkg: builtins.elem (getName pkg) (cfg.permittedUnfreePackages or []) || unfreePackageError pkg)
     else
-      (_: false);
+      unfreePackageError;
 }}"#,
         base = nixpkgs_config_base
     );
@@ -1653,8 +1670,10 @@ pub fn apply_nix_settings(nix_settings: &NixSettings) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{cache_key_for, core_config_watch_paths, logical_store_path_str};
-    use devenv_core::{PortAllocator, bootstrap_args::BootstrapArgs};
+    use super::{
+        cache_key_for, core_config_watch_paths, logical_store_path_str, write_nixpkgs_config,
+    };
+    use devenv_core::{PortAllocator, bootstrap_args::BootstrapArgs, config::NixpkgsConfig};
     use serde::Serialize;
     use tempfile::TempDir;
 
@@ -1692,6 +1711,18 @@ mod tests {
 
         assert_ne!(shell_key.key_hash, up_key.key_hash);
         assert_ne!(up_key.key_hash, strict_key.key_hash);
+    }
+
+    #[test]
+    fn nixpkgs_config_unfree_predicate_mentions_devenv_yaml_options() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_path = write_nixpkgs_config(&NixpkgsConfig::default(), temp_dir.path()).unwrap();
+        let config = std::fs::read_to_string(config_path).unwrap();
+
+        assert!(config.contains("devenv: package '${name}' has an unfree license."));
+        assert!(config.contains("allow_unfree: true"));
+        assert!(config.contains("permitted_unfree_packages:"));
+        assert!(config.contains("else\n      unfreePackageError;"));
     }
 
     // Regression for devenv #2499: a shell built against a relocated/chroot store

--- a/devenv-nix-backend/tests/test_nix_backend.rs
+++ b/devenv-nix-backend/tests/test_nix_backend.rs
@@ -258,6 +258,61 @@ async fn test_eval_empty_attributes_array() {
 }
 
 #[nix_test]
+async fn test_unfree_package_error_mentions_devenv_yaml_options() {
+    let env = TestEnv::builder()
+        .nix(
+            r#"{ pkgs, ... }: {
+  packages = [ pkgs.terraform ];
+}"#,
+        )
+        .build()
+        .await;
+
+    let err = env
+        .backend
+        .eval(&["shell.drvPath"])
+        .await
+        .expect_err("unfree package should fail without allow_unfree");
+    let message = format!("{err:#}");
+
+    assert!(
+        message.contains("devenv: package 'terraform' has an unfree license."),
+        "{message}"
+    );
+    assert!(message.contains("allow_unfree: true"), "{message}");
+    assert!(message.contains("permitted_unfree_packages:"), "{message}");
+}
+
+#[nix_test]
+async fn test_unfree_package_can_still_be_allowed_by_devenv_yaml_options() {
+    let nix = r#"{ pkgs, ... }: {
+  packages = [ pkgs.terraform ];
+}"#;
+
+    for yaml in [
+        r#"allow_unfree: true
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+"#,
+        r#"nixpkgs:
+  permitted_unfree_packages:
+    - terraform
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+"#,
+    ] {
+        let env = TestEnv::builder().yaml(yaml).nix(nix).build().await;
+
+        env.backend
+            .eval(&["shell.drvPath"])
+            .await
+            .expect("unfree package should be allowed by devenv.yaml");
+    }
+}
+
+#[nix_test]
 async fn test_eval_nonexistent_attribute() {
     let env = TestEnv::new().await;
 


### PR DESCRIPTION
Fixes #2850

## Summary
- add a devenv-specific unfree package error at the nixpkgs config layer
- point users to `allow_unfree: true` or `nixpkgs.permitted_unfree_packages` in `devenv.yaml`
- keep existing allowed paths working for both `allow_unfree` and `permitted_unfree_packages`

I chose the Nix-side predicate path over Rust error post-processing so the diagnostic comes from the actual nixpkgs import layer and does not depend on matching Nixpkgs' rendered error text.

## Tests
- `nix run --accept-flake-config . -- shell -- cargo test -p devenv-nix-backend nixpkgs_config_unfree_predicate_mentions_devenv_yaml_options`
- `nix run --accept-flake-config . -- shell -- cargo test -p devenv-nix-backend unfree_package --features test-nix-store`
- `nix run --accept-flake-config . -- shell -- cargo fmt --check --package devenv-nix-backend`
- `git diff --check`