### PR TITLE
fix: use correct `system` reference in flake overlay output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -239,7 +239,7 @@
       };
 
       overlays.default = final: prev: {
-        devenv = self.packages.${prev.system}.default;
+        devenv = self.packages.${prev.stdenv.hostPlatform.system}.default;
       };
     };
 }


### PR DESCRIPTION
Fixes the following Nix evaluation warning:

```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```