### PR TITLE
Handle tmux window-title escapes in devenv shell

### DIFF
--- a/devenv-shell/src/escape/mod.rs
+++ b/devenv-shell/src/escape/mod.rs
@@ -1,8 +1,8 @@
 //! Stateful byte-level scanner for escape sequences in raw PTY output.
 //!
-//! Detects DEC private mode sequences, CSI queries, DCS sequences, and
-//! OSC queries so they can be forwarded to the real terminal (the VT backend
-//! consumes them internally).
+//! Detects DEC private mode sequences, CSI queries, DCS sequences, screen/tmux
+//! title sequences, and OSC queries so they can be forwarded to the real
+//! terminal (the VT backend consumes them internally).
 
 mod dec_mode;
 mod osc;
@@ -124,6 +124,10 @@ pub enum SequenceEvent {
     ForwardDcs {
         raw_bytes: Vec<u8>,
     },
+    /// screen/tmux title sequence (`ESC k ... ST`) forwarded verbatim.
+    ForwardScreenTitle {
+        raw_bytes: Vec<u8>,
+    },
     /// `ESC =` (DECKPAM) or `ESC >` (DECKPNM) — keypad application/numeric mode.
     /// Part of `smkx`/`rmkx` terminfo capabilities alongside DECCKM.
     KeypadMode {
@@ -151,8 +155,8 @@ pub enum SequenceEvent {
 const MAX_CSI_PARAMS: usize = 16;
 /// Maximum number of CSI intermediate bytes.
 const MAX_CSI_INTERMEDIATES: usize = 2;
-/// Maximum DCS payload size before giving up.
-const MAX_DCS_PAYLOAD: usize = 4096;
+/// Maximum string control payload size before giving up.
+const MAX_STRING_PAYLOAD: usize = 4096;
 
 /// Classification result for a complete CSI sequence.
 enum CsiClass {
@@ -244,6 +248,10 @@ enum RouterState {
     Dcs,
     /// ESC seen while in DCS — could be ST or start of new sequence.
     DcsEsc,
+    /// screen/tmux title sequence accumulator (`ESC k ... ST`).
+    ScreenTitle,
+    /// ESC seen while in screen/tmux title — could be ST or start of new sequence.
+    ScreenTitleEsc,
 }
 
 /// Full CSI parameter accumulator.
@@ -336,8 +344,9 @@ impl CsiParamState {
 
 /// Byte-level scanner that detects escape sequences in raw PTY output.
 ///
-/// Routes `ESC [` to the CSI parameter accumulator, `ESC ]` to the
-/// OSC parser, and `ESC P` to the DCS accumulator.
+/// Routes `ESC [` to the CSI parameter accumulator, `ESC ]` to the OSC parser,
+/// `ESC P` to the DCS accumulator, and `ESC k` to the screen/tmux title
+/// accumulator.
 /// State persists across calls to handle sequences split across buffer boundaries.
 pub struct EscapeScanner {
     state: RouterState,
@@ -412,6 +421,9 @@ impl EscapeScanner {
                         }
                         b'P' => {
                             self.state = RouterState::Dcs;
+                        }
+                        b'k' => {
+                            self.state = RouterState::ScreenTitle;
                         }
                         b'=' | b'>' => {
                             // DECKPAM (ESC =) / DECKPNM (ESC >)
@@ -571,7 +583,7 @@ impl EscapeScanner {
                     self.seq_bytes.push(byte);
                     if byte == 0x1b {
                         self.state = RouterState::DcsEsc;
-                    } else if self.seq_bytes.len() > MAX_DCS_PAYLOAD {
+                    } else if self.seq_bytes.len() > MAX_STRING_PAYLOAD {
                         self.reset();
                     }
                 }
@@ -606,6 +618,59 @@ impl EscapeScanner {
                             }
                             b'P' => {
                                 self.state = RouterState::Dcs;
+                            }
+                            b'k' => {
+                                self.state = RouterState::ScreenTitle;
+                            }
+                            _ => {
+                                self.reset();
+                            }
+                        }
+                    }
+                }
+
+                RouterState::ScreenTitle => {
+                    self.seq_bytes.push(byte);
+                    if byte == 0x1b {
+                        self.state = RouterState::ScreenTitleEsc;
+                    } else if self.seq_bytes.len() > MAX_STRING_PAYLOAD {
+                        self.reset();
+                    }
+                }
+
+                RouterState::ScreenTitleEsc => {
+                    if byte == b'\\' {
+                        // ST (ESC \) terminates the title string
+                        self.seq_bytes.push(byte);
+                        let raw_bytes = std::mem::take(&mut self.seq_bytes);
+                        events.push(SequenceEvent::ForwardScreenTitle { raw_bytes });
+                        self.state = RouterState::Ground;
+                    } else if byte == 0x1b {
+                        // Another ESC — abort title string, start new sequence
+                        self.seq_bytes.clear();
+                        self.seq_bytes.push(byte);
+                        self.state = RouterState::Esc;
+                    } else {
+                        // ESC wasn't ST — abort title string. The ESC + this byte
+                        // could be a new escape sequence.
+                        self.seq_bytes.clear();
+                        self.seq_bytes.push(0x1b);
+                        self.seq_bytes.push(byte);
+                        match byte {
+                            b'[' => {
+                                self.state = RouterState::Csi;
+                                self.dec_parser.reset();
+                                self.csi_params.reset();
+                            }
+                            b']' => {
+                                self.state = RouterState::Osc;
+                                self.osc_parser.reset();
+                            }
+                            b'P' => {
+                                self.state = RouterState::Dcs;
+                            }
+                            b'k' => {
+                                self.state = RouterState::ScreenTitle;
                             }
                             _ => {
                                 self.reset();
@@ -1524,6 +1589,61 @@ mod tests {
         let mut scanner = EscapeScanner::new();
         // ESC P starts DCS, then ESC [ starts a CSI — DCS is aborted
         let events = scanner.scan(b"\x1bPdata\x1b[c");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], SequenceEvent::ForwardCsi { .. }));
+    }
+
+    // -- screen/tmux title tests --
+
+    #[test]
+    fn detects_screen_title() {
+        let mut scanner = EscapeScanner::new();
+        let events = scanner.scan(b"\x1bkls\x1b\\");
+        assert_eq!(events.len(), 1);
+        let SequenceEvent::ForwardScreenTitle { ref raw_bytes } = events[0] else {
+            panic!("expected ForwardScreenTitle, got {:?}", events[0]);
+        };
+        assert_eq!(raw_bytes, b"\x1bkls\x1b\\");
+    }
+
+    #[test]
+    fn screen_title_split_across_buffers() {
+        let mut scanner = EscapeScanner::new();
+
+        let events1 = scanner.scan(b"\x1bkec");
+        assert!(events1.is_empty());
+
+        let events2 = scanner.scan(b"ho hello\x1b\\");
+        assert_eq!(events2.len(), 1);
+        let SequenceEvent::ForwardScreenTitle { ref raw_bytes } = events2[0] else {
+            panic!("expected ForwardScreenTitle, got {:?}", events2[0]);
+        };
+        assert_eq!(raw_bytes, b"\x1bkecho hello\x1b\\");
+    }
+
+    #[test]
+    fn screen_title_split_at_every_byte() {
+        let mut scanner = EscapeScanner::new();
+        let seq = b"\x1bkecho hello\x1b\\";
+        for (i, &byte) in seq.iter().enumerate() {
+            let events = scanner.scan(&[byte]);
+            if i < seq.len() - 1 {
+                assert!(events.is_empty());
+            } else {
+                assert_eq!(events.len(), 1);
+                assert!(matches!(
+                    events[0],
+                    SequenceEvent::ForwardScreenTitle { .. }
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn screen_title_esc_mid_sequence_restarts() {
+        let mut scanner = EscapeScanner::new();
+        // ESC k starts a title string, then ESC [ starts a CSI — title is aborted
+        let events = scanner.scan(b"\x1bkcommand\x1b[c");
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], SequenceEvent::ForwardCsi { .. }));
     }

--- a/devenv-shell/src/escape_state.rs
+++ b/devenv-shell/src/escape_state.rs
@@ -164,6 +164,9 @@ pub fn process_escape_events(
             SequenceEvent::ForwardDcs { raw_bytes } => {
                 stdout.write_all(&raw_bytes)?;
             }
+            SequenceEvent::ForwardScreenTitle { raw_bytes } => {
+                stdout.write_all(&raw_bytes)?;
+            }
             SequenceEvent::KittyKeyboard {
                 raw_bytes,
                 stack_delta,

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -202,6 +202,85 @@ fn feed_vt(vt: &mut Terminal<'_, '_>, text: &str) -> usize {
     total_after.saturating_sub(total_before)
 }
 
+#[derive(Debug, Default)]
+struct VtInputFilter {
+    state: VtInputFilterState,
+    pending: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+enum VtInputFilterState {
+    #[default]
+    Ground,
+    Esc,
+    TmuxTitle,
+    TmuxTitleEsc,
+}
+
+impl VtInputFilter {
+    fn new() -> Self {
+        Self {
+            state: VtInputFilterState::Ground,
+            pending: Vec::new(),
+        }
+    }
+
+    fn filter<'a>(&mut self, data: &'a [u8], output: &'a mut Vec<u8>) -> &'a [u8] {
+        output.clear();
+
+        for &byte in data {
+            match self.state {
+                VtInputFilterState::Ground => {
+                    if byte == 0x1b {
+                        self.pending.clear();
+                        self.pending.push(byte);
+                        self.state = VtInputFilterState::Esc;
+                    } else {
+                        output.push(byte);
+                    }
+                }
+
+                VtInputFilterState::Esc => {
+                    self.pending.push(byte);
+                    if byte == b'k' {
+                        self.pending.clear();
+                        self.state = VtInputFilterState::TmuxTitle;
+                    } else if byte == 0x1b {
+                        self.pending.clear();
+                        self.pending.push(byte);
+                    } else {
+                        output.extend_from_slice(&self.pending);
+                        self.pending.clear();
+                        self.state = VtInputFilterState::Ground;
+                    }
+                }
+
+                VtInputFilterState::TmuxTitle => {
+                    if byte == 0x1b {
+                        self.state = VtInputFilterState::TmuxTitleEsc;
+                    }
+                }
+
+                VtInputFilterState::TmuxTitleEsc => {
+                    if byte == b'\\' {
+                        self.state = VtInputFilterState::Ground;
+                    } else if byte == 0x1b {
+                        self.state = VtInputFilterState::Esc;
+                        self.pending.clear();
+                        self.pending.push(byte);
+                    } else {
+                        self.state = VtInputFilterState::Ground;
+                        output.push(0x1b);
+                        output.push(byte);
+                    }
+                }
+            }
+        }
+
+        output
+    }
+}
+
 /// Differential renderer that draws VT state to a bounded terminal region.
 ///
 /// Instead of passing raw PTY output to stdout (which conflicts with the status
@@ -925,10 +1004,12 @@ impl ShellSession {
     ) -> Result<Option<u32>, SessionError> {
         let spinner_interval = Duration::from_millis(SPINNER_INTERVAL_MS);
         let mut scanner = EscapeScanner::new();
+        let mut vt_input_filter = VtInputFilter::new();
         let mut utf8_acc = Utf8Accumulator::new();
         let mut esc = EscapeState::new();
         let mut resize_pending = false;
         let mut esc_events = Vec::new();
+        let mut vt_input = Vec::new();
 
         loop {
             // Use select! to handle both events and spinner animation
@@ -1039,7 +1120,8 @@ impl ShellSession {
                     )?;
 
                     // Feed output into VT and track how many lines scrolled off
-                    let text = utf8_acc.accumulate(&data);
+                    let filtered = vt_input_filter.filter(&data, &mut vt_input);
+                    let text = utf8_acc.accumulate(filtered);
                     let mut total_scroll = feed_vt(vt, &text);
 
                     // Batch: drain any additional pending PtyOutput events
@@ -1055,7 +1137,8 @@ impl ShellSession {
                                     self.pty_size(),
                                     &mut esc_events,
                                 )?;
-                                let text = utf8_acc.accumulate(&more);
+                                let filtered = vt_input_filter.filter(&more, &mut vt_input);
+                                let text = utf8_acc.accumulate(filtered);
                                 total_scroll += feed_vt(vt, &text);
                             }
                             Event::PtyExit(exit_code) => {
@@ -1319,6 +1402,37 @@ impl Default for ShellSession {
 mod tests {
     use super::*;
     use portable_pty::CommandBuilder;
+
+    fn filter_chunks(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut filter = VtInputFilter::new();
+        let mut output = Vec::new();
+        let mut combined = Vec::new();
+
+        for chunk in chunks {
+            let filtered = filter.filter(chunk, &mut output);
+            combined.extend_from_slice(filtered);
+        }
+
+        combined
+    }
+
+    #[test]
+    fn vt_input_filter_strips_tmux_title_sequence() {
+        let filtered = filter_chunks(&[b"hello \x1bkecho hello\x1b\\world"]);
+        assert_eq!(filtered, b"hello world");
+    }
+
+    #[test]
+    fn vt_input_filter_strips_tmux_title_sequence_across_chunks() {
+        let filtered = filter_chunks(&[b"hello \x1bkec", b"ho hello", b"\x1b\\world"]);
+        assert_eq!(filtered, b"hello world");
+    }
+
+    #[test]
+    fn vt_input_filter_preserves_other_escape_sequences() {
+        let filtered = filter_chunks(&[b"hello \x1b[31mred\x1b[0m"]);
+        assert_eq!(filtered, b"hello \x1b[31mred\x1b[0m");
+    }
 
     /// Regression test for devenv#2845: when the process-wide shutdown token is
     /// cancelled (e.g. from the SIGHUP/SIGINT/SIGTERM handler), the inner shell


### PR DESCRIPTION
Fixes #2975

## Summary

- Handle the tmux/screen window-title escape that oh-my-zsh writes before each command inside tmux: `\ek<command>\e\\`.
- Forward that title update to the real terminal so tmux can consume it normally.
- Strip the same bytes before feeding output into the embedded Ghostty VT renderer, so the command name does not get rendered as stdout.
- Add regressions for complete and split title sequences, plus renderer-input filtering.

## Root cause

`devenv shell` does not stream PTY output straight to the terminal. It scans the raw PTY bytes, forwards selected terminal controls, then feeds the output through `libghostty_vt` for rendering.

The scanner already handled CSI, OSC, DCS, and keypad mode sequences, but not the tmux/screen title form that starts with escape + `k`. In tmux, oh-my-zsh uses that form to set the pane/window title to the command being run.

Because devenv did not recognize that title update, the command name could fall through into the VT render path and appear as real output. In the reported case, running `ls` could render like this:

```console
~/src/myproject ❯ ls
lsAGENTS.md  README.md  devenv.nix  ...
```

The leading `ls` on the file-listing line is the bug. It is the title payload being rendered, not output from `ls`.

This patch treats that title update the same way as the other terminal control strings: pass it through to the outer terminal, but keep it out of the rendered shell contents.

## Validation

- [x] Installed the missing Zig toolchain needed by `libghostty-vt-sys` (`zig0.15`, because Ghostty requires Zig 0.15.2).
- [x] `PATH=/usr/lib/zig0.15/bin:$PATH cargo test -p devenv-shell vt_input_filter --lib`
- [x] `PATH=/usr/lib/zig0.15/bin:$PATH cargo test -p devenv-shell escape:: --lib`
- [x] `PATH=/usr/lib/zig0.15/bin:$PATH cargo test -p devenv-shell --lib`
- [x] `PATH=/usr/lib/zig0.15/bin:$PATH cargo test -p devenv-shell`
- [x] `PATH=/usr/lib/zig0.15/bin:$PATH cargo check -p devenv-shell`
- [x] `cargo fmt --check --package devenv-shell`
- [x] `git diff --check`
- [x] tmux smoke check: wrote `\ekecho hello\e\\visible-line` inside a detached tmux session and confirmed the captured pane only showed `visible-line`.
