### PR TITLE
Use clang as Rust linker driver for Rust shells

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -109,6 +109,19 @@ in
       '';
     };
 
+    clangLinker.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = pkgs.stdenv.isLinux;
+      defaultText = lib.literalExpression "pkgs.stdenv.isLinux";
+      description = ''
+        Use Clang as the Rust linker driver on Linux.
+
+        This avoids GCC's `collect2` wrapper, which can hit `Argument list too long`
+        in large Nix development environments before the final linker receives
+        Rust's response file.
+      '';
+    };
+
     cranelift = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -367,6 +380,7 @@ in
           lib.optional cfg.mold.enable pkgs.mold-wrapped
           ++ lib.optional cfg.lld.enable pkgs.llvmPackages.bintools
           ++ lib.optional cfg.wild.enable pkgs.wild
+          ++ lib.optional cfg.clangLinker.enable pkgs.clang
           ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv
           ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
@@ -375,6 +389,7 @@ in
 
         env =
           let
+            clangLinkerFlags = lib.optionalString cfg.clangLinker.enable "-C linker=clang";
             moldFlags = lib.optionalString cfg.mold.enable "-C link-arg=-fuse-ld=mold";
             lldFlags = lib.optionalString cfg.lld.enable "-C link-arg=-fuse-ld=lld";
             # TODO: Work around rustc's default lld selection and missing native GCC Wild support;
@@ -386,7 +401,7 @@ in
               "-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin"
               + lib.optionalString pkgs.stdenv.isAarch64 " -Z unstable-options"
             );
-            linkerFlags = lib.concatStringsSep " " (lib.filter (x: x != "") [ moldFlags lldFlags wildFlags ]);
+            linkerFlags = lib.concatStringsSep " " (lib.filter (x: x != "") [ clangLinkerFlags moldFlags lldFlags wildFlags ]);
             optionalEnv = cond: str: if cond then str else null;
           in
           {

--- a/tests/rust-clang-linker-disabled/devenv.nix
+++ b/tests/rust-clang-linker-disabled/devenv.nix
@@ -1,0 +1,14 @@
+{
+  languages.rust = {
+    enable = true;
+    clangLinker.enable = false;
+  };
+
+  enterTest = ''
+    if [ -n "''${RUSTFLAGS+x}" ]; then
+      echo "RUSTFLAGS is set, but it should not be"
+      echo "RUSTFLAGS=$RUSTFLAGS"
+      exit 1
+    fi
+  '';
+}

--- a/tests/rust/devenv.nix
+++ b/tests/rust/devenv.nix
@@ -3,8 +3,28 @@
   # TODO: what are we testing here? the mold feature?
   languages.rust.mold.enable = false;
   enterTest = ''
-    if [ -n "''${RUSTFLAGS+x}" ]; then
-      echo "RUSTFLAGS is set, but it should not be"
+    case "$RUSTFLAGS" in
+      *"-C linker=clang"*)
+        ;;
+      *)
+        echo "RUSTFLAGS should configure clang as the linker driver"
+        echo "RUSTFLAGS=$RUSTFLAGS"
+        exit 1
+        ;;
+    esac
+
+    if ! command -v clang >/dev/null; then
+      echo "clang linker driver is not available"
+      exit 1
+    fi
+
+    workdir=$(mktemp -d)
+    cargo new --bin "$workdir/linker-check" >/dev/null
+    build_log="$workdir/build.log"
+    cargo build --manifest-path "$workdir/linker-check/Cargo.toml" -vv >"$build_log" 2>&1
+    if ! grep -q -- "-C linker=clang" "$build_log"; then
+      echo "cargo build did not pass the clang linker driver to rustc"
+      cat "$build_log"
       exit 1
     fi
   '';


### PR DESCRIPTION
Fixes #2977

## Summary

- Use Clang as the Rust linker driver by default on Linux Rust shells via `-C linker=clang`.
- Add `languages.rust.clangLinker.enable` so projects can opt out and keep the previous driver behavior.
- Add coverage for the Linux default, a real Cargo build receiving the linker flag, and the opt-out path.

## Root cause

The reported build fails while Rust is linking early build scripts through the `cc` driver. On current Rust toolchains that can still mean GCC is the process that launches the final linker, even when `-fuse-ld=lld` is present.

In large Nix development environments, the inherited environment and linker arguments can be big enough that GCC's `collect2` spawn hits `ARG_MAX` first:

```console
gcc: fatal error: cannot execute '.../collect2': posix_spawn: Argument list too long
```

Using Clang as the Rust linker driver avoids that GCC `collect2` hop while keeping the existing Rust linker flag composition in `RUSTFLAGS`.

## Validation

- [x] `devenv-run-tests run tests --only rust`
- [x] `devenv-run-tests run tests --only rust-clang-linker-disabled`
- [x] `devenv-run-tests run tests --only rust-toolchain-file`
- [x] `nix build --accept-flake-config .#devenv --no-link --print-out-paths`
- [x] `nix run --accept-flake-config nixpkgs#nixpkgs-fmt -- --check src/modules/languages/rust.nix tests/rust/devenv.nix tests/rust-clang-linker-disabled/devenv.nix`
- [x] `git diff --check`

Attempted separately:

- A temporary devenv using the package set from #2977 plus a small Rust crate with `quote`/`serde` build dependencies did not reach the shell after several minutes of rolling-input Nix evaluation, so I stopped that run rather than treating it as proof.
