### PR TITLE
fix(processes): report fresh status when restarting an exited process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `devenv processes restart` leaving a restarted process reported as "exited" by `devenv processes list`/`status` even though it was running. When the process had previously exited (restart policy said stop), the restart spawned a fresh job and supervisor but never published a new status, and processes without readiness probes produce no further status events until they exit again. Restarting such a process now also replaces a supervisor parked after exit (kept alive only for file watching), which previously stopped monitoring the restarted job ([#2982](https://github.com/cachix/devenv/issues/2982)).
 - Fixed devenv overriding user-configured experimental features in `nix.conf` ([#2931](https://github.com/cachix/devenv/issues/2931)).
 - Fixed `devenv hook bash`/`zsh` skipping activation for a sibling project after following `.devenv/exit-dir` from a hook-spawned shell that cd'd out of the previous project ([#2944](https://github.com/cachix/devenv/issues/2944)).
 - Fixed misleading evaluation errors where evaluation warnings replaced the real error message, hiding syntax errors and suggestions like `devenv inputs add …` ([#2820](https://github.com/cachix/devenv/issues/2820)).

--- a/devenv-processes/src/manager.rs
+++ b/devenv-processes/src/manager.rs
@@ -180,6 +180,19 @@ impl From<crate::supervisor_state::SupervisorPhase> for ProcessPhase {
     }
 }
 
+/// Gets initial process state, processes with no readiness mechanism are 
+// immediately `Ready`, everything else is `Starting` until a probe or notify fires.
+fn initial_phase(config: &ProcessConfig) -> crate::supervisor_state::SupervisorPhase {
+    let has_notify = config.ready.as_ref().is_some_and(|r| r.notify);
+    let has_ready_config = config.ready.is_some();
+    let has_tcp_probe = (!config.listen.is_empty() || !config.ports.is_empty()) && !has_notify;
+    if !has_notify && !has_ready_config && !has_tcp_probe {
+        crate::supervisor_state::SupervisorPhase::Ready
+    } else {
+        crate::supervisor_state::SupervisorPhase::Starting
+    }
+}
+
 /// Collect the names of all active (supervised) processes from the map.
 fn active_names(processes: &HashMap<String, ProcessEntry>) -> Vec<String> {
     processes
@@ -735,23 +748,13 @@ impl NativeProcessManager {
         let stderr_tailer =
             crate::log_tailer::spawn_file_tailer(proc_cmd.stderr_log, activity.ref_handle(), true);
 
-        // Create status channel for supervisor state observation
+        // Create status channel for supervisor state observation. 
+        // Processes with no readiness mechanism are reported Ready right away.
         let initial_status = crate::supervisor_state::JobStatus {
-            phase: crate::supervisor_state::SupervisorPhase::Starting,
+            phase: initial_phase(config),
             restart_count: 0,
         };
         let (status_tx, status_rx) = tokio::sync::watch::channel(initial_status);
-
-        // If no readiness mechanism is configured, mark process as immediately ready
-        let has_notify = config.ready.as_ref().is_some_and(|r| r.notify);
-        let has_ready_config = config.ready.is_some();
-        let has_tcp_probe = (!config.listen.is_empty() || !config.ports.is_empty()) && !has_notify;
-        if !has_notify && !has_ready_config && !has_tcp_probe {
-            let _ = status_tx.send(crate::supervisor_state::JobStatus {
-                phase: crate::supervisor_state::SupervisorPhase::Ready,
-                restart_count: 0,
-            });
-        }
 
         let resources = ProcessResources {
             config: config.clone(),
@@ -1113,16 +1116,34 @@ impl NativeProcessManager {
             ),
         ));
 
-        // Check if supervisor task has exited (e.g., due to max restarts)
-        if handle.supervisor_task.is_finished() {
-            // Supervisor has exited — start fresh with new supervision.
+        // Check if the old supervision still monitors the job. It doesn't when
+        // the supervisor task has exited (e.g., due to max restarts), or when
+        // it is parked in the Exited phase (kept alive only to react to file
+        // changes — its job-wait arm is disabled).
+        let supervisor_finished = handle.supervisor_task.is_finished();
+        let supervisor_parked =
+            handle.status_rx.borrow().phase == crate::supervisor_state::SupervisorPhase::Exited;
+        if supervisor_finished || supervisor_parked {
+            // Start fresh with new supervision.
             // Order matters: start job first, then spawn supervisor (like start_command does).
             // This gives the process a fresh restart quota (restart_count = 0).
             info!(
-                "Supervisor for {} has exited, starting fresh with new supervision",
+                "Supervisor for {} no longer monitors the job, starting fresh with new supervision",
                 name
             );
+            if !supervisor_finished {
+                handle.supervisor_task.abort();
+            }
             handle.resources.job.start().await;
+
+            // Publish a fresh status (needed for processes without readiness probe)
+            let _ = handle
+                .resources
+                .status_tx
+                .send(crate::supervisor_state::JobStatus {
+                    phase: initial_phase(&handle.resources.config),
+                    restart_count: 0,
+                });
             handle.supervisor_task =
                 crate::supervisor::spawn_supervisor(&handle.resources, self.shutdown.clone());
         } else {

--- a/devenv-processes/tests/restart_policy.rs
+++ b/devenv-processes/tests/restart_policy.rs
@@ -272,6 +272,86 @@ async fn test_max_restarts_limit() {
     .expect("Test timed out");
 }
 
+/// Manual restart of an exited process must publish a fresh status.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_manual_restart_after_exit_reports_fresh_status() {
+    timeout(TEST_TIMEOUT, async {
+        let ctx = TestContext::new();
+        // First run exits cleanly; the run after restart() keeps running.
+        let marker = ctx.temp_path().join("first-run-done");
+        let script = ctx
+            .create_script(
+                "exit_then_run.sh",
+                &format!(
+                    "#!/bin/sh\nif [ -f {m} ]; then sleep 30; else touch {m}; exit 0; fi\n",
+                    m = marker.display()
+                ),
+            )
+            .await;
+
+        let config = ProcessConfig {
+            name: "restart-status".to_string(),
+            exec: script.to_string_lossy().to_string(),
+            args: vec![],
+            restart: RestartConfig {
+                on: RestartPolicy::OnFailure,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let manager = ctx.create_manager();
+        manager
+            .start_command(&config, None)
+            .await
+            .expect("Failed to start");
+
+        // Wait until the clean exit is reported (supervisor stops monitoring).
+        let exited = wait_for_condition(
+            || async {
+                manager
+                    .job_state("restart-status")
+                    .await
+                    .is_some_and(|s| s.phase == SupervisorPhase::Exited)
+            },
+            RESTART_TIMEOUT,
+        )
+        .await;
+        assert!(exited, "Process should report Exited after a clean exit");
+
+        manager
+            .restart("restart-status")
+            .await
+            .expect("Failed to restart");
+
+        // The restarted process has no readiness mechanism, so it must be
+        // reported Ready with a fresh restart quota — not the stale Exited.
+        let ready = wait_for_condition(
+            || async {
+                manager
+                    .job_state("restart-status")
+                    .await
+                    .is_some_and(|s| s.phase == SupervisorPhase::Ready && s.restart_count == 0)
+            },
+            RESTART_TIMEOUT,
+        )
+        .await;
+        assert!(
+            ready,
+            "Restarted process should report Ready, not the stale Exited phase"
+        );
+
+        // And it must stay Ready while the process keeps running.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let status = manager.job_state("restart-status").await.unwrap();
+        assert_eq!(status.phase, SupervisorPhase::Ready);
+
+        manager.stop_all().await.expect("Failed to stop");
+    })
+    .await
+    .expect("Test timed out");
+}
+
 /// Test that max_restarts=None allows unlimited restarts (with manual stop)
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unlimited_restarts() {


### PR DESCRIPTION
The status watch channel backing 'devenv processes list'/'status' is only written by the supervisor task. When a process exits and its restart policy says stop, the supervisor publishes Exited and finishes. A subsequent 'devenv processes restart' started a fresh job and supervisor, but never published a new status — and a fresh supervisor only sends on events, which a process without readiness probes doesn't produce until it exits again. The result: a running, freshly-restarted process (e.g. a 'docker run' wrapper with no ready config) was reported as "exited" indefinitely.

restart() now publishes a fresh JobStatus (with a reset restart quota) when it replaces supervision, using the same no-readiness-mechanism-means-Ready logic as initial startup, now shared via initial_phase().

It also treats a supervisor parked in the Exited phase (kept alive only to react to file changes) like a finished one: the parked loop has its job-wait arm disabled, so it would never monitor the restarted job. The old task is aborted and fresh supervision is spawned instead.

Fixes #2982