### PR TITLE
fix: fall back to SQLite DELETE journal mode if shmmap fails on WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fixed `devenv inputs add` from a subdirectory writing to a stray `devenv.yaml` in the subdir instead of the enclosing project. It now walks up to find `devenv.nix` the same way `devenv shell` does, so the input is added where the rest of devenv reads it.
 - Fixed `devenv gc` failing with "File devenv.nix does not exist" when run outside of a project. Garbage collection operates on the global devenv store and no longer requires a `devenv.nix` ([#2928](https://github.com/cachix/devenv/issues/2928)).
 - Fixed unfree package errors suggesting only generic Nix/NixOS configuration. They now point devenv users to `allow_unfree: true` or `nixpkgs.permitted_unfree_packages` in `devenv.yaml` ([#2850](https://github.com/cachix/devenv/issues/2850)).
+- Fixed `devenv shell` failing outright with a SQLite `disk I/O error` on filesystems that don't support shared-memory mmap (seen on virtiofs/9p VM mounts and similar). The eval cache and task cache databases now fall back to a plain rollback-journal mode on these filesystems instead of hard-crashing ([#2947](https://github.com/cachix/devenv/issues/2947)).
 
 ### Improvements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ name = "devenv-cache-core"
 version = "2.1.3"
 dependencies = [
  "blake3",
+ "libsqlite3-sys",
  "miette",
  "serde_json",
  "sqlx",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6674,6 +6674,11 @@ rec {
             packageId = "blake3";
           }
           {
+            name = "libsqlite3-sys";
+            packageId = "libsqlite3-sys";
+            usesDefaultFeatures = false;
+          }
+          {
             name = "miette";
             packageId = "miette";
             features = [ "fancy" ];

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ portable-pty = "0.9.0"
 ignore = "0.4.25"
 proptest = "1.11"
 libc = "0.2"
+libsqlite3-sys = { version = "0.37", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "parsing", "extra-traits"] }

--- a/devenv-cache-core/Cargo.toml
+++ b/devenv-cache-core/Cargo.toml
@@ -13,6 +13,7 @@ sqlx = { workspace = true, features = [
     "migrate",
     "macros",
 ] }
+libsqlite3-sys.workspace = true
 
 # Error handling
 thiserror.workspace = true

--- a/devenv-cache-core/src/db.rs
+++ b/devenv-cache-core/src/db.rs
@@ -1,17 +1,18 @@
 use crate::error::{CacheError, CacheResult};
-use sqlx::migrate::Migrator;
+use libsqlite3_sys::SQLITE_IOERR_SHMMAP;
+use sqlx::migrate::{MigrateError, Migrator};
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteSynchronous,
 };
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use tracing::{error, trace};
+use tracing::{error, trace, warn};
 
 /// Database connection manager
 #[derive(Debug, Clone)]
 pub struct Database {
     pool: SqlitePool,
-    path: PathBuf,
+    _path: PathBuf,
 }
 
 impl Database {
@@ -24,50 +25,60 @@ impl Database {
             std::fs::create_dir_all(parent)?;
         }
 
-        let options = connection_options(&path);
-
-        let pool = SqlitePoolOptions::new()
-            .max_connections(5)
-            .connect_with(options)
-            .await?;
-
-        let db = Self { pool, path };
-
-        // Run migrations
         trace!("Running migrations");
 
-        if let Err(err) = migrator.run(&db.pool).await {
-            error!(error = %err, "Failed to migrate the database. Attempting to recreate the database.");
+        // Try WAL journal mode first, falling back to DELETE (the default) on
+        // SQLITE_IOERR_SHMMAP. WAL is preferred for concurrency, but requires
+        // shared-memory support the VFS doesn't always have (e.g. some
+        // virtiofs/9p/network mounts). See
+        // https://github.com/cachix/devenv/issues/2947.
+        let pool = match open_pool(&path, SqliteJournalMode::Wal).await {
+            Ok(pool) => pool,
+            Err(e) if is_shmmap_error(&e) => fall_back_to_delete_mode(&path, &e).await?,
+            Err(e) => return Err(CacheError::Database(e)),
+        };
 
-            // Close the existing connection
-            db.pool.close().await;
-
-            // Delete the database and associated WAL/SHM files
-            remove_sqlite_files(&db.path);
-
-            // Recreate the database and connection pool
-            let options = connection_options(&db.path);
-            let new_pool = SqlitePoolOptions::new()
-                .max_connections(5)
-                .connect_with(options)
-                .await?;
-
-            // Create a new database instance with the new pool
-            let new_db = Self {
-                pool: new_pool,
-                path: db.path,
+        if let Err(err) = migrator.run(&pool).await {
+            // Same shm-mmap failure, just surfacing during migration instead of
+            // at connect time (SQLite can defer opening the `-shm` file until
+            // the first real transaction).
+            let is_shmmap = match &err {
+                MigrateError::Execute(e) => is_shmmap_error(e),
+                MigrateError::ExecuteMigration(e, _) => is_shmmap_error(e),
+                _ => false,
             };
+            if is_shmmap {
+                pool.close().await;
+                let pool = fall_back_to_delete_mode(&path, &err).await?;
+                migrator
+                    .run(&pool)
+                    .await
+                    .map_err(|e| CacheError::Database(e.into()))?;
+                return Ok(Self { pool, _path: path });
+            }
 
-            // Try migrations again
-            if let Err(e) = migrator.run(&new_db.pool).await {
+            // Some other migration failure (corruption, a partially-applied
+            // prior migration run, etc). Delete and recreate once, retrying
+            // with the same (WAL) journal mode, since this isn't a
+            // filesystem/environment limitation.
+            error!(error = %err, "Failed to migrate the database. Attempting to recreate the database.");
+            pool.close().await;
+            remove_sqlite_files(&path);
+
+            let new_pool = open_pool(&path, SqliteJournalMode::Wal)
+                .await
+                .map_err(CacheError::Database)?;
+            if let Err(e) = migrator.run(&new_pool).await {
                 error!("Migration failed after recreating database: {}", e);
                 return Err(CacheError::Database(e.into()));
             }
-
-            return Ok(new_db);
+            return Ok(Self {
+                pool: new_pool,
+                _path: path,
+            });
         }
 
-        Ok(db)
+        Ok(Self { pool, _path: path })
     }
 
     /// Get a reference to the connection pool
@@ -81,18 +92,46 @@ impl Database {
     }
 }
 
-/// Create SQLite connection options
-fn connection_options(path: &Path) -> SqliteConnectOptions {
-    SqliteConnectOptions::new()
+/// Connections kept open per `Database`. Also referenced by tests that need to
+/// force real contention on the pool.
+const MAX_CONNECTIONS: u32 = 5;
+
+async fn open_pool(
+    path: &Path,
+    journal_mode: SqliteJournalMode,
+) -> Result<SqlitePool, sqlx::Error> {
+    let options = SqliteConnectOptions::new()
         .filename(path)
-        .journal_mode(SqliteJournalMode::Wal)
+        .journal_mode(journal_mode)
         .synchronous(SqliteSynchronous::Normal)
         .busy_timeout(Duration::from_secs(10))
         .create_if_missing(true)
         .foreign_keys(true)
         .pragma("wal_autocheckpoint", "1000")
         .pragma("journal_size_limit", (64 * 1024 * 1024).to_string()) // 64 MB
-        .pragma("cache_size", "2000") // 2000 pages
+        .pragma("cache_size", "2000"); // 2000 pages
+
+    SqlitePoolOptions::new()
+        .max_connections(MAX_CONNECTIONS)
+        .connect_with(options)
+        .await
+}
+
+/// Log the fallback and reopen in DELETE mode. Shared by the connect-time and
+/// migrate-time failure sites, which hit the same class of error.
+async fn fall_back_to_delete_mode(
+    path: &Path,
+    error: impl std::fmt::Display,
+) -> CacheResult<SqlitePool> {
+    warn!(
+        %error,
+        path = %path.display(),
+        "got SQLITE_IOERR_SHMMAP, falling back to DELETE journal mode (reduced concurrency)"
+    );
+    remove_sqlite_files(path);
+    open_pool(path, SqliteJournalMode::Delete)
+        .await
+        .map_err(CacheError::Database)
 }
 
 /// Remove a SQLite database file and its associated WAL/SHM files.
@@ -102,6 +141,17 @@ fn remove_sqlite_files(path: &Path) {
         file.push(suffix);
         let _ = std::fs::remove_file(Path::new(&file));
     }
+}
+
+/// True if this is exactly `SQLITE_IOERR_SHMMAP` -- WAL mode failing to
+/// `mmap(MAP_SHARED)` its `-shm` coordination file. See
+/// https://github.com/cachix/devenv/issues/2947.
+fn is_shmmap_error(error: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(db_err) = error else {
+        return false;
+    };
+
+    db_err.code().and_then(|code| code.parse::<i32>().ok()) == Some(SQLITE_IOERR_SHMMAP)
 }
 
 #[cfg(test)]
@@ -135,21 +185,7 @@ mod tests {
     async fn test_database_creation() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-
-        // Create a test schema directly for testing
-        let test_schema = "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)";
-
-        // Create a test migrator using the built-in migrations system
-        // We'll create a temporary directory and write a migration file to it
-        let migrations_dir = temp_dir.path().join("migrations");
-        std::fs::create_dir_all(&migrations_dir).unwrap();
-
-        // Write a migration file
-        let migration_file = migrations_dir.join("20250507000001_test.sql");
-        std::fs::write(&migration_file, test_schema).unwrap();
-
-        // Create a migrator from the directory
-        let migrator = sqlx::migrate::Migrator::new(migrations_dir).await.unwrap();
+        let migrator = create_migrator(&temp_dir).await;
 
         let db = Database::new(db_path.clone(), &migrator).await.unwrap();
 
@@ -172,7 +208,25 @@ mod tests {
 
         assert_eq!(row.1, "test_value");
 
+        // Guard against the DELETE-mode fallback firing in the common case.
+        let (journal_mode,): (String,) = sqlx::query_as("PRAGMA journal_mode")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+
         // Close database
         db.close().await;
+    }
+
+    async fn create_migrator(temp_dir: &TempDir) -> Migrator {
+        let migrations_dir = temp_dir.path().join("migrations");
+        std::fs::create_dir_all(&migrations_dir).unwrap();
+        std::fs::write(
+            migrations_dir.join("20250507000001_test.sql"),
+            "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)",
+        )
+        .unwrap();
+        Migrator::new(migrations_dir).await.unwrap()
     }
 }


### PR DESCRIPTION
devenv shell hard-crashed with a SQLite disk I/O error on filesystems that can't provide WAL's required mmap(MAP_SHARED) for the -shm file (seen on virtiofs/9p VM mounts and similar). Detect SQLITE_IOERR_SHMMAP at both the initial connect and the migration step, and retry once in DELETE (rollback-journal) mode, which needs no shared memory at all.

Fixes https://github.com/cachix/devenv/issues/2947.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>