### PR TITLE
fix(tasks): don't render a status miss as a failed activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed a task whose `status` command exits nonzero being rendered as a failed `check status` activity, making successful runs look like they contained a failure. A nonzero status is a normal cache miss that runs the task's command; only a failure to spawn the status command itself is now reported as a failure ([#2984](https://github.com/cachix/devenv/issues/2984)).
 - Fixed `devenv processes restart` leaving a restarted process reported as "exited" by `devenv processes list`/`status` even though it was running. When the process had previously exited (restart policy said stop), the restart spawned a fresh job and supervisor but never published a new status, and processes without readiness probes produce no further status events until they exit again. Restarting such a process now also replaces a supervisor parked after exit (kept alive only for file watching), which previously stopped monitoring the restarted job ([#2982](https://github.com/cachix/devenv/issues/2982)).
 - Fixed devenv overriding user-configured experimental features in `nix.conf` ([#2931](https://github.com/cachix/devenv/issues/2931)).
 - Fixed `devenv hook bash`/`zsh` skipping activation for a sibling project after following `.devenv/exit-dir` from a hook-spawned shell that cd'd out of the previous project ([#2944](https://github.com/cachix/devenv/issues/2944)).

--- a/devenv-tasks/src/task_state.rs
+++ b/devenv-tasks/src/task_state.rs
@@ -510,10 +510,9 @@ impl TaskState {
 
                 match command.output().await {
                     Ok(output) => {
-                        if !output.status.success() {
-                            status_activity.fail();
-                        }
-
+                        // A nonzero exit is a normal status/cache miss: fall through
+                        // to run the command. Only a spawn/execution error of the
+                        // status probe itself (the `Err` arm below) is a real failure.
                         if output.status.success() {
                             // Start with cached output, merge in any exports from the status command
                             let mut result = cached_output.unwrap_or_else(|| serde_json::json!({}));

--- a/devenv-tasks/src/tests/mod.rs
+++ b/devenv-tasks/src/tests/mod.rs
@@ -286,6 +286,91 @@ echo 'Task 2 is running' && echo 'Task 2 completed'
     Ok(())
 }
 
+/// Regression test for https://github.com/cachix/devenv/issues/2984
+///
+/// When a task's `status` command exits nonzero, that is a normal status/cache
+/// miss and the task's `command` should run. The internal "check status" probe
+/// activity must NOT be rendered as a failed activity in that case: only a
+/// spawn/execution error of the status command is a real probe failure.
+#[tokio::test]
+async fn test_status_miss_not_rendered_as_failed() -> Result<(), Error> {
+    use devenv_activity::{ActivityEvent, ActivityOutcome, Command};
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    // Status exits nonzero -> cache miss -> the command must run.
+    let status_script = create_script("#!/bin/sh\nexit 1")?;
+    let status = status_script.to_str().unwrap().to_string();
+    let command_script = create_script("#!/bin/sh\necho exec-ran")?;
+    let command = command_script.to_str().unwrap();
+
+    let config = Config::try_from(json!({
+        "roots": ["demo:status_miss"],
+        "run_mode": "all",
+        "tasks": [
+            {
+                "name": "demo:status_miss",
+                "command": command,
+                "status": status
+            }
+        ]
+    }))
+    .unwrap();
+
+    // Capture activity events so we can inspect how the status probe is rendered.
+    let (mut activity_rx, handle) = devenv_activity::init();
+    let activity_guard = handle.install();
+
+    let tasks = Tasks::builder(config, VerbosityLevel::Verbose, Shutdown::new())
+        .with_db_path(db_path)
+        .build()
+        .await?;
+    tasks.run(false).await;
+
+    // Stop capturing so the channel closes and the drain below terminates.
+    drop(activity_guard);
+
+    // A nonzero status is a cache miss, so the command must have actually run.
+    match &tasks.graph[tasks.tasks_order[0]].read().await.status {
+        TaskStatus::Completed(TaskCompleted::Success(_, _)) => {}
+        other => panic!("Expected Success status for status-miss task, got: {other:?}"),
+    }
+
+    // Locate the "check status" probe activity for our status command and record
+    // the outcome it completed with. Matching on the command string keeps the
+    // assertion robust even if unrelated activities share the channel.
+    let mut status_activity_id = None;
+    let mut status_outcome = None;
+    while let Ok(event) = activity_rx.try_recv() {
+        match event {
+            ActivityEvent::Command(Command::Start {
+                id, name, command, ..
+            }) if name == "check status" && command.as_deref() == Some(status.as_str()) => {
+                status_activity_id = Some(id);
+            }
+            ActivityEvent::Command(Command::Complete { id, outcome, .. })
+                if Some(id) == status_activity_id =>
+            {
+                status_outcome = Some(outcome);
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        status_activity_id.is_some(),
+        "expected a 'check status' probe activity to be emitted"
+    );
+    assert_eq!(
+        status_outcome,
+        Some(ActivityOutcome::Success),
+        "status miss (nonzero exit) must not be rendered as a failed activity",
+    );
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_status_output_caching() -> Result<(), Error> {
     // Create a unique tempdir for this test


### PR DESCRIPTION
## Problem

When a task's `status` command exits nonzero, devenv correctly treats it as a cache miss and runs the task's `command` — but it also marks the internal `check status` probe activity as **failed**, so successful runs render a misleading failure line:

```text
• Running demo:status-miss
✖ check status in 1.94ms (failed)
exec-ran
✓ Running demo:status-miss in 4.61ms
✓ Running tasks in 4.76ms
```

This is noisy in CI and easy to misread when scanning logs.

Semantically:
- `status` exits `0` → cached, skip `command`
- `status` exits nonzero → not cached, run `command` (a normal cache miss)
- status command spawn/error → real status probe failure

Only the last case should render as a failure.

## Fix

Removed the `status_activity.fail()` call on nonzero status exit in `devenv-tasks/src/task_state.rs`. A nonzero exit now falls through to run the command with the probe activity completing as a normal (non-error) outcome. The genuine spawn-error path (the `Err` arm) is untouched and still reports a failure.

## Regression history

- Regressed in `ff91ff54` ("devenv-tasks: replace tracing_events with devenv-activity"), which translated the status probe reporting into `status_activity.fail()` on any nonzero exit.
- The underlying conflation of a status miss with a failure dates back to `933ed0ff` ("refactor: add task tracing and separate status from UI"), where the probe was first routed through the command completion reporter and emitted a `warn!("Command failed")` (the older symptom of #2529).

## Test

Added `test_status_miss_not_rendered_as_failed`, which captures activity events while running a task whose `status` exits nonzero and asserts the `check status` probe completes with `Success` rather than `Failed`. Confirmed it fails before the fix (`left: Some(Failed)`) and passes after. Full `devenv-tasks` suite: 124/124 pass.

Fixes #2984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)