### PR TITLE
fix(reload): surface file watcher failures in the TUI instead of hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `devenv shell` appearing to hang under the TUI when the file watcher failed to register a watch — most commonly after reaching the inotify watch limit (`fs.inotify.max_user_watches`). The watcher no longer dies on the first failed watch, and now surfaces a warning in the TUI instead of only logging it under `--verbose --no-tui`.
 - Fixed a task whose `status` command exits nonzero being rendered as a failed `check status` activity, making successful runs look like they contained a failure. A nonzero status is a normal cache miss that runs the task's command; only a failure to spawn the status command itself is now reported as a failure ([#2984](https://github.com/cachix/devenv/issues/2984)).
 - Fixed `devenv processes restart` leaving a restarted process reported as "exited" by `devenv processes list`/`status` even though it was running. When the process had previously exited (restart policy said stop), the restart spawned a fresh job and supervisor but never published a new status, and processes without readiness probes produce no further status events until they exit again. Restarting such a process now also replaces a supervisor parked after exit (kept alive only for file watching), which previously stopped monitoring the restarted job ([#2982](https://github.com/cachix/devenv/issues/2982)).
 - Fixed devenv overriding user-configured experimental features in `nix.conf` ([#2931](https://github.com/cachix/devenv/issues/2931)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,6 +2024,7 @@ name = "devenv-event-sources"
 version = "2.1.3"
 dependencies = [
  "async-priority-channel",
+ "devenv-activity",
  "miette",
  "notify",
  "reqwest 0.13.4",

--- a/devenv-event-sources/Cargo.toml
+++ b/devenv-event-sources/Cargo.toml
@@ -11,6 +11,7 @@ macos-kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
 async-priority-channel.workspace = true
+devenv-activity.workspace = true
 miette.workspace = true
 notify = { workspace = true, optional = true }
 reqwest.workspace = true

--- a/devenv-event-sources/src/fs.rs
+++ b/devenv-event-sources/src/fs.rs
@@ -328,7 +328,38 @@ impl FileWatcher {
         // to avoid spawning its signal, keyboard, action, and error workers
         // that we don't need.
         let (ev_s, ev_r) = async_priority_channel::bounded(4096);
-        let (er_s, _er_r) = mpsc::channel(64);
+        let (er_s, mut er_r) = mpsc::channel(64);
+
+        // Task 0: drain watchexec runtime errors.
+        //
+        // The fs worker reports per-path watch failures (e.g. hitting the
+        // inotify watch limit) as non-fatal runtime errors on this channel.
+        // If nothing keeps the receiver alive, the worker's send fails and it
+        // escalates to a fatal error, exiting and leaving pending watch() calls
+        // waiting on `fs_ready` forever -- which looks like a hang under the TUI.
+        //
+        // Draining keeps the worker alive and lets us surface the failure to the
+        // user through the activity system (visible in the TUI). We report only
+        // the first error to avoid flooding when many watches fail at once, and
+        // trace the rest for developers.
+        let err_name = watch_name.clone();
+        let error_task = tokio::spawn(async move {
+            let mut reported = false;
+            while let Some(e) = er_r.recv().await {
+                if !reported {
+                    reported = true;
+                    devenv_activity::message(
+                        devenv_activity::ActivityLevel::Warn,
+                        format!(
+                            "file watcher for {err_name} failed to register a watch: {e}. \
+                             hot reload may miss changes. this is often caused by reaching \
+                             the inotify watch limit (raise fs.inotify.max_user_watches)."
+                        ),
+                    );
+                }
+                warn!(error = %e, watch = %err_name, "watchexec runtime error");
+            }
+        });
 
         // Task 1: fs worker — watches files via notify, sends raw events.
         let fs_config = wx_config.clone();
@@ -336,6 +367,12 @@ impl FileWatcher {
         let fs_task = tokio::spawn(async move {
             if let Err(e) = watchexec::sources::fs::worker(fs_config, fs_errors, ev_s).await {
                 warn!("fs worker for {} stopped: {}", watch_name, e);
+                devenv_activity::message(
+                    devenv_activity::ActivityLevel::Warn,
+                    format!(
+                        "file watcher for {watch_name} stopped: {e}. hot reload is no longer active."
+                    ),
+                );
             }
         });
 
@@ -398,7 +435,7 @@ impl FileWatcher {
             rx,
             _tx: tx,
             handle,
-            tasks: vec![fs_task, filter_task],
+            tasks: vec![fs_task, filter_task, error_task],
         }
     }
 


### PR DESCRIPTION
When the fs worker failed to register a watch (commonly after reaching the inotify watch limit, fs.inotify.max_user_watches), watchexec reported it as a non-fatal runtime error. But the error receiver was dropped right after FileWatcher::new() returned, so the send failed with "channel closed", which watchexec escalates to a fatal error. The worker exited, its failure was only logged via tracing (visible with --verbose --no-tui), and pending watch() calls waited on fs_ready forever — so devenv shell appeared to hang under the TUI.

Keep the error receiver alive with a drain task so a failed watch stays non-fatal and the worker keeps running, and surface the failure to the user via the activity system so it shows in the TUI. The first error is reported once (to avoid flooding when many watches fail at once) with a hint about the inotify limit; the rest go to tracing.

fixes #2987