### PR TITLE
tests: fix a failing macOS file-watcher test (FSEvents false positive on chmod)

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6926,6 +6926,10 @@ rec {
             packageId = "async-priority-channel";
           }
           {
+            name = "devenv-activity";
+            packageId = "devenv-activity";
+          }
+          {
             name = "miette";
             packageId = "miette";
             features = [ "fancy" ];
@@ -6965,6 +6969,12 @@ rec {
           }
         ];
         devDependencies = [
+          {
+            name = "notify";
+            packageId = "notify";
+            usesDefaultFeatures = false;
+            features = [ "macos_kqueue" ];
+          }
           {
             name = "tempfile";
             packageId = "tempfile";

--- a/devenv-event-sources/Cargo.toml
+++ b/devenv-event-sources/Cargo.toml
@@ -7,6 +7,8 @@ description = "Reusable event sources for devenv (file watcher, TCP probe, notif
 
 [features]
 default = []
+# For consumers' tests (e.g. devenv-processes/test-file-watcher); this
+# crate's own tests get kqueue via the dev-dependency below instead.
 macos-kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
@@ -23,6 +25,13 @@ watchexec-filterer-globset.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+# macOS FSEvents can bundle a bare chmod with a stale Create/Data(Content)
+# event for the same path (verified, not a race -- see commit message).
+# kqueue reports it precisely, but opens 1 fd per watched path, so it can
+# exhaust the process's fd limit at scale (limit varies by system/config,
+# so no fixed number here); that's why it stays test-only, not a prod
+# default.
+notify = { workspace = true, features = ["macos_kqueue"] }
 
 [package.metadata.cargo-machete]
 ignored = ["notify"]

--- a/devenv-processes/tests/file_watching.rs
+++ b/devenv-processes/tests/file_watching.rs
@@ -13,21 +13,16 @@
 //! watcher is live. This replaces fixed sleeps and handles the asynchronous
 //! nature of FSEvents on macOS.
 
-#[cfg(feature = "test-file-watcher")]
+#![cfg(feature = "test-file-watcher")]
+
 mod common;
 
-#[cfg(feature = "test-file-watcher")]
 use common::*;
-#[cfg(feature = "test-file-watcher")]
 use devenv_processes::ProcessConfig;
-#[cfg(feature = "test-file-watcher")]
 use std::time::Duration;
-#[cfg(feature = "test-file-watcher")]
 use tokio::time::timeout;
 
-#[cfg(feature = "test-file-watcher")]
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
-#[cfg(feature = "test-file-watcher")]
 const WATCH_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ============================================================================
@@ -35,7 +30,6 @@ const WATCH_TIMEOUT: Duration = Duration::from_secs(30);
 // ============================================================================
 
 /// Test that process restarts when a watched file changes
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_restart_on_file_change() {
     timeout(TEST_TIMEOUT, async {
@@ -104,7 +98,6 @@ sleep 3600
 }
 
 /// Test watching a directory for changes
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_watch_directory() {
     timeout(TEST_TIMEOUT, async {
@@ -179,7 +172,6 @@ sleep 3600
 // ============================================================================
 
 /// Test that ignored files don't trigger restart
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ignore_patterns() {
     timeout(TEST_TIMEOUT, async {
@@ -260,7 +252,6 @@ sleep 3600
 }
 
 /// Test ignoring hidden files and directories
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ignore_hidden_files() {
     timeout(TEST_TIMEOUT, async {
@@ -340,7 +331,6 @@ sleep 3600
 }
 
 /// Test that extension filter only triggers on matching extensions
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_extension_filter() {
     timeout(TEST_TIMEOUT, async {
@@ -424,7 +414,6 @@ sleep 3600
 // ============================================================================
 
 /// Test watching multiple paths
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_multiple_watch_paths() {
     timeout(TEST_TIMEOUT, async {
@@ -528,7 +517,6 @@ sleep 3600
 // ============================================================================
 
 /// Test that empty watch paths doesn't set up a watcher
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_watch_paths_no_watcher() {
     timeout(TEST_TIMEOUT, async {
@@ -602,7 +590,6 @@ sleep 3600
 /// Without the fix the watcher is gone after the first (immediate) exit, so
 /// `wait_for_watcher_ready` can never observe a re-run and `baseline` stays 1,
 /// failing the assertion below.
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_oneshot_reruns_on_file_change() {
     timeout(TEST_TIMEOUT, async {
@@ -673,7 +660,6 @@ echo "started" >> {}
 }
 
 /// Test rapid file changes (debouncing behavior)
-#[cfg(feature = "test-file-watcher")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rapid_file_changes_debounced() {
     timeout(TEST_TIMEOUT, async {


### PR DESCRIPTION
Enabled dev-only `macos_kqueue` feature in `notify` for the `devenv-event-sources` crate to fix a failing test.

`fs::tests::test_metadata_only_chmod_does_not_emit_change_event` failed on macOS because FSEvents backend bundled a bare chmod with stale `Create`/`Data(Content)` events on the same path. This isn't fixed by a sleep, but is fixed by using kqueue, which is more precise.

We can't use kqueue in prod since it's too easy to cause fd exhaustion with it, since it opens a fd per path whereas fsevents doesn't, so only use it in tests.

This was the only test which failed with `cargo nextest run`, so all tests now pass on macOS.

---

Along the way, made a change in `devenv-processes/tests/file_watching.rs`. Replaced 16 occurences of`#[cfg(feature = "test-file-watcher")]` with one top-level `#![cfg(feature = "test-file-watcher")]`.

This is consistent with how we do it at https://github.com/cachix/devenv/blob/main/devenv-shell/tests/session_tests.rs and is simpler and makes it harder to make a mistake.