### PR TITLE
Regenerate Cargo.nix for event sources

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6926,6 +6926,10 @@ rec {
             packageId = "async-priority-channel";
           }
           {
+            name = "devenv-activity";
+            packageId = "devenv-activity";
+          }
+          {
             name = "miette";
             packageId = "miette";
             features = [ "fancy" ];


### PR DESCRIPTION
## Summary

- Add the missing `devenv-activity` crate dependency to the generated `Cargo.nix` entry for `devenv-event-sources`.
- Restores the Nix build path after #2988 added `devenv-activity` to `devenv-event-sources/Cargo.toml` and `Cargo.lock`.

## Root cause

#2988 added `devenv_activity::message` calls in `devenv-event-sources/src/fs.rs` and added the dependency to Cargo metadata, but `Cargo.nix` was not regenerated. The generated Nix build for `devenv-event-sources` therefore invoked `rustc` without `--extern devenv_activity`, causing main branch Release and Generate docs/examples workflows to fail.

## Validation

- `cargo test -p devenv-shell reload_subprocess_does_not_leak_enter_shell_output -- --nocapture`
- `nix build .#devenv --print-out-paths`
- `cargo test -p devenv-event-sources`
- `cargo fmt --check --package devenv-event-sources`
- `git diff --check`
