### PR TITLE
build(flake): compile libghostty-vt with ReleaseSafe instead of Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Improvements
 
+- Reduced the size of the devenv binary's closure and container image by no longer bundling a debug build of libghostty-vt, which pulled Zig and LLVM (~1 GiB) into every installation.
 - Bumped secretspec to 0.13. When devenv resolves secrets, a provider outage (e.g. an unreachable vault) is now reported as a provider error instead of the secret appearing as missing.
 - Cachix now authenticates pulls and pushes without `CACHIX_AUTH_TOKEN` exported in the environment: when the variable is unset, devenv resolves the token from a `CACHIX_AUTH_TOKEN` secretspec secret, then from the auth token stored by the Cachix CLI (`cachix authtoken`) in `~/.config/cachix/cachix.dhall`. The resolved token is passed to the cachix push daemon as well. The secretspec secret name is configurable via `secretspec.cachix_auth_token` in `devenv.yaml` for backends whose policy (e.g. an OpenBao/Vault policy) only grants access to the token under a different name.
 - Added `devenv tasks list --json` for machine-readable task graph inspection ([#2966](https://github.com/cachix/devenv/issues/2966)).

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
               };
               nixd = inputs.nixd.packages.${system}.nixd;
               crate2nix = final.callPackage "${inputs.crate2nix}/crate2nix/default.nix" { };
-              libghostty-vt = final.callPackage "${inputs.ghostty}/nix/libghostty-vt.nix" { };
+              libghostty-vt = final.callPackage "${inputs.ghostty}/nix/libghostty-vt.nix" { optimize = "ReleaseSafe"; };
             })
           ];
           pkgs = import nixpkgs { inherit overlays system; };


### PR DESCRIPTION
Reduced the size of the devenv binary's closure and container image by no longer bundling a debug build of libghostty-vt, which pulled Zig and LLVM (~1 GiB) into every installation.

> [!NOTE]
> Combined with https://github.com/nix-community/nixd/pull/854, the closure size shrinks from 1.77 GiB to 346.46 MiB

see #2655