### PR TITLE
nix: auto-load devenv hook for fish and nushell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Cleaned up non-TUI console output: surfaces Nix eval/build progress, hides internal debug noise.
 - Auto-disabling the TUI and switching to quiet output when running inside an AI coding agent now recognizes more agents (Aider, autonomous/cloud agents, and others) via the `detect-coding-agent` crate, not just Claude Code. Set `DEVENV_NO_AI_AGENT=1` to opt out.
 - Added `devenv down` as a shorthand for `devenv processes down`, mirroring `devenv up` ([#2862](https://github.com/cachix/devenv/issues/2862)).
+- `devenv hook fish`/`devenv hook nu` are now loaded automatically by fish and nushell, via `share/fish/vendor_conf.d/devenv.fish` and `share/nushell/vendor/autoload/devenv.nu` respectively. Bash and zsh have no equivalent mechanism, so they still need manual configuration.
 - Bumped secretspec to 0.12, which adds a `[providers]` alias map in `secretspec.toml`, a key prefix for the AWS Secrets Manager provider, audit logging and access reasons for secret reads, and support for custom Bitwarden instances.
 - Added a `--include-envrc` flag to `devenv init` (also settable via `DEVENV_INCLUDE_ENVRC`) to scaffold a direnv `.envrc` file. By default `devenv init` no longer creates an `.envrc` ([#2859](https://github.com/cachix/devenv/pull/2859)).
 

--- a/devenv/hooks/hook.nu
+++ b/devenv/hooks/hook.nu
@@ -1,5 +1,8 @@
 # devenv hook for nushell
-# Usage: Add to your config.nu:
+#
+# Loaded automatically (no config.nu edit needed) when devenv is installed via
+# Nix, which ships this under $nu.vendor-autoload-dirs. If you're running a
+# devenv build that didn't install it there, add it to your own autoload dir:
 #   mkdir ($nu.default-config-dir | path join autoload)
 #   devenv hook nu | save --force ($nu.default-config-dir | path join autoload/devenv-hook.nu)
 

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -868,7 +868,7 @@ pub enum Commands {
 
     #[command(
         about = "Print shell hook for auto-activation on directory change.",
-        long_about = "Print shell hook for auto-activation on directory change.\n\nAdd to your shell config:\n\n  bash:    eval \"$(devenv hook bash)\"     # in ~/.bashrc\n  zsh:     eval \"$(devenv hook zsh)\"      # in ~/.zshrc\n  fish:    devenv hook fish | source       # in ~/.config/fish/config.fish\n  nushell: see devenv hook nu              # in config.nu"
+        long_about = "Print shell hook for auto-activation on directory change.\n\nfish and nushell load this automatically when devenv is installed via Nix.\nIf it doesn't load for you:\n\n  fish:    devenv hook fish | source       # in ~/.config/fish/config.fish\n  nushell: mkdir ($nu.default-config-dir | path join autoload); devenv hook nu | save --force ($nu.default-config-dir | path join autoload/devenv-hook.nu)\n\nBash and zsh have no equivalent, so always add this to your shell config:\n\n  bash:    eval \"$(devenv hook bash)\"     # in ~/.bashrc\n  zsh:     eval \"$(devenv hook zsh)\"      # in ~/.zshrc"
     )]
     Hook {
         #[arg(value_enum)]

--- a/docs/src/auto-activation.md
+++ b/docs/src/auto-activation.md
@@ -8,9 +8,9 @@ devenv includes a built in shell hook that automatically activates your develope
 
 ## Setup
 
-Add one line to your shell configuration file:
-
 === "Bash"
+
+    Add one line to your shell configuration file:
 
     ```bash title="~/.bashrc"
     eval "$(devenv hook bash)"
@@ -18,11 +18,16 @@ Add one line to your shell configuration file:
 
 === "Zsh"
 
+    Add one line to your shell configuration file:
+
     ```bash title="~/.zshrc"
     eval "$(devenv hook zsh)"
     ```
 
 === "Fish"
+
+    Usually nothing to do — devenv installed via Nix ships a snippet that fish loads
+    automatically. If it doesn't load for you, add this instead:
 
     ```fish title="~/.config/fish/config.fish"
     devenv hook fish | source
@@ -30,7 +35,12 @@ Add one line to your shell configuration file:
 
 === "Nushell"
 
-    ```nu title="config.nu"
+    Usually nothing to do — devenv installed via Nix ships a snippet that nu loads
+    automatically. If it doesn't load for you, add this instead:
+
+    Run once, in Nu:
+
+    ```nu
     mkdir ($nu.default-config-dir | path join autoload)
     devenv hook nu | save --force ($nu.default-config-dir | path join autoload/devenv-hook.nu)
     ```

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -97,6 +97,15 @@ let
           --bash $compdir/devenv.bash \
           --fish $compdir/devenv.fish \
           --zsh $compdir/_devenv
+
+        # Make devenv hook load automatically on fish.
+        mkdir -p $out/share/fish/vendor_conf.d
+        echo "$out/bin/devenv hook fish | source" > $out/share/fish/vendor_conf.d/devenv.fish
+
+        # Make devenv hook load automatically on nushell. Unlike fish's
+        # `source`, Nu needs a static file.
+        mkdir -p $out/share/nushell/vendor/autoload
+        devenv hook nu > $out/share/nushell/vendor/autoload/devenv.nu
       '';
 
     meta.mainProgram = "devenv";


### PR DESCRIPTION
Ships a vendor_conf.d snippet (fish) and a vendor-autoload-dirs snippet (nushell) so `devenv hook fish`/`devenv hook nu` load automatically with zero shell-config changes. Bash and zsh have no equivalent mechanism, so they still need the manual `eval` line.

Assisted by Claude Sonnet 5.