### PR TITLE
Skip PostgreSQL port allocation in socket-only mode

### DIFF
--- a/src/modules/services/postgres.nix
+++ b/src/modules/services/postgres.nix
@@ -9,7 +9,10 @@ let
 
   # Port allocation
   basePort = cfg.port;
-  allocatedPort = config.processes.postgres.ports.main.value;
+  allocatedPort =
+    if cfg.listen_addresses == ""
+    then basePort
+    else config.processes.postgres.ports.main.value;
 
   q = lib.escapeShellArg;
 
@@ -448,7 +451,9 @@ in
       };
 
       processes.postgres = {
-        ports.main.allocate = basePort;
+        ports = lib.mkIf (cfg.listen_addresses != "") {
+          main.allocate = basePort;
+        };
         exec = "${startScript}/bin/start-postgres";
 
         ready = {

--- a/tests/postgresql-socket-only/.test.sh
+++ b/tests/postgresql-socket-only/.test.sh
@@ -1,0 +1,4 @@
+set -e
+
+wait_for_processes
+psql postgres -c "SELECT 1" > /dev/null

--- a/tests/postgresql-socket-only/devenv.nix
+++ b/tests/postgresql-socket-only/devenv.nix
@@ -1,0 +1,12 @@
+{ config, ... }:
+
+{
+  services.postgres.enable = true;
+
+  assertions = [
+    {
+      assertion = config.processes.postgres.ports == { };
+      message = "Socket-only PostgreSQL must not allocate a TCP port.";
+    }
+  ];
+}


### PR DESCRIPTION
Fixes #2998

## Summary

- Skip dynamic TCP port allocation when PostgreSQL is configured with an empty `listen_addresses` value.
- Keep the configured `services.postgres.port` value for PostgreSQL settings and client environment variables in socket-only mode.
- Add an integration test that verifies socket-only PostgreSQL declares no process ports and remains usable over its Unix socket.

## Root cause

The PostgreSQL module unconditionally declared `processes.postgres.ports.main.allocate` and read its allocated value, even though the default empty `listen_addresses` disables TCP/IP connections. As a result, evaluation still reserved port 5432 and `devenv up --strict-ports` failed whenever an unrelated host process already occupied that port.

Socket-only mode now follows the existing Redis service pattern: it omits the process port declaration and uses the configured base port only as PostgreSQL's Unix-socket suffix and client port setting. TCP-enabled configurations continue to use dynamic allocation.

## Validation

- [x] Reproduced the original failure on `main` with `nc` listening on port 5432 and `devenv up --strict-ports`.
- [x] `devenv-run-tests run tests --only postgresql-socket-only`
- [x] `devenv-run-tests run tests --only postgresql-localhost`
- [x] `nix build --accept-flake-config .#devenv --no-link --print-out-paths`
- [x] `nix run --accept-flake-config nixpkgs#nixpkgs-fmt -- --check src/modules/services/postgres.nix tests/postgresql-socket-only/devenv.nix`
- [x] `git diff --check`
