### PR TITLE
build(flake): link nixd statically against LLVM to drop libLLVM from the closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### Improvements
 
+- Reduced the size of the devenv closure and container image by ~550 MiB by linking nixd (used by `devenv lsp`) statically against LLVM, so the monolithic LLVM shared library is no longer bundled.
 - Reduced the size of the devenv binary's closure and container image by no longer bundling a debug build of libghostty-vt, which pulled Zig and LLVM (~1 GiB) into every installation.
 - Bumped secretspec to 0.13. When devenv resolves secrets, a provider outage (e.g. an unreachable vault) is now reported as a provider error instead of the secret appearing as missing.
 - Cachix now authenticates pulls and pushes without `CACHIX_AUTH_TOKEN` exported in the environment: when the variable is unset, devenv resolves the token from a `CACHIX_AUTH_TOKEN` secretspec secret, then from the auth token stored by the Cachix CLI (`cachix authtoken`) in `~/.config/cachix/cachix.dhall`. The resolved token is passed to the cachix push daemon as well. The secretspec secret name is configurable via `secretspec.cachix_auth_token` in `devenv.yaml` for backends whose policy (e.g. an OpenBao/Vault policy) only grants access to the token under a different name.

--- a/flake.lock
+++ b/flake.lock
@@ -163,11 +163,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780381423,
-        "narHash": "sha256-S1BIJiQF4lRtJUKak0e97JwNvbe69/LW78YJJuB18Qk=",
+        "lastModified": 1783935112,
+        "narHash": "sha256-IAQ14nteIKXAz4cd75UcZrsHGEVJ7QNrkUwX9rmeZ/Y=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "0e07c08c448a2995e7793d1098437b29bbe80b02",
+        "rev": "a64cd33e53b316b6b092ea0a966640cd2309bf3d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
               nix = inputs.nix.packages.${system}.nix-cli // {
                 inherit (inputs.nix.packages.${system}.nix) libs;
               };
-              nixd = inputs.nixd.packages.${system}.nixd;
+              nixd = inputs.nixd.packages.${system}.nixd.override { llvmStatic = true; };
               crate2nix = final.callPackage "${inputs.crate2nix}/crate2nix/default.nix" { };
               libghostty-vt = final.callPackage "${inputs.ghostty}/nix/libghostty-vt.nix" { optimize = "ReleaseSafe"; };
             })


### PR DESCRIPTION
Reduce the closure size from 884.96 MiB to 346.47 MiB

closes #2655