### PR TITLE
languages/rust: put cargo subcommands ahead of host rustup proxies

### DIFF
--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -374,6 +374,15 @@ in
             ]
           })
           export PATH="$PATH:$CARGO_INSTALL_ROOT/bin"
+        ''
+        # cargo resolves external subcommands (cargo clippy, cargo fmt, ...)
+        # from $CARGO_HOME/bin *before* $PATH by default, so ~/.cargo/bin's
+        # rustup proxies would shadow this environment's toolchain. Append
+        # $CARGO_HOME/bin to $PATH to flip that precedence (per the cargo
+        # docs) so devenv's toolchain wins, while keeping the shared cache,
+        # credentials and global config in ~/.cargo intact.
+        + ''
+          export PATH="$PATH:''${CARGO_HOME:-$HOME/.cargo}/bin"
         '';
 
         packages =


### PR DESCRIPTION
cargo resolves external subcommands (`cargo clippy`, `cargo fmt`, `cargo miri`, ...) from `$CARGO_HOME/bin` before `$PATH`. On a host with a rustup install, `~/.cargo/bin`'s rustup proxies shadow a devenv-provided Rust toolchain, so `cargo clippy` and friends silently run the host toolchain instead of this environment's, with missing targets and mismatched compiler versions as typical symptoms.

Per the [cargo docs](https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands), appending `$CARGO_HOME/bin` to `$PATH` overrides that precedence so devenv's toolchain wins. This keeps `~/.cargo` shared (crate cache, credentials, global config all intact), unlike isolating `CARGO_HOME`. It is unconditional and side-effect-free, so there is no module option.

Thanks @sandydoo for the PATH-append pointer.