### PR TITLE
devcontainer: add Zed extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,11 @@
       "extensions": [
         "jnoortheen.nix-ide"
       ]
+    },
+    "zed": {
+      "extensions": [
+        "nix"
+      ]
     }
   },
   "image": "ghcr.io/cachix/devenv/devcontainer:latest",

--- a/devenv.nix
+++ b/devenv.nix
@@ -114,7 +114,10 @@ in
 
   devcontainer = {
     enable = true;
-    settings.customizations.vscode.extensions = [ "jnoortheen.nix-ide" ];
+    settings.customizations = {
+      vscode.extensions = [ "jnoortheen.nix-ide" ];
+      zed.extensions = [ "nix" ];
+    };
   };
 
   difftastic.enable = true;

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -3422,6 +3422,30 @@ list of string
 
 
 
+## devcontainer.settings.customizations.zed.extensions
+
+
+
+A list of pre-installed Zed extensions.
+
+
+
+*Type:*
+list of string
+
+
+
+*Default:*
+
+```nix
+[ ]
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/devcontainer.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/devcontainer.nix)
+
+
+
 ## devcontainer.settings.image
 
 
@@ -6025,8 +6049,6 @@ submodule
 
 ## git-hooks.hooks.biome.enable
 
-
-
 Whether to enable this pre-commit hook.
 
 
@@ -6048,6 +6070,8 @@ false
 
 
 ## git-hooks.hooks.biome.settings.binPath
+
+
 
 ` biome ` binary path.
 For example, if you want to use the ` biome ` binary from ` node_modules `, use ` "./node_modules/.bin/biome" `.
@@ -8298,8 +8322,6 @@ false
 
 ## git-hooks.hooks.isort.settings.flags
 
-
-
 Flags passed to isort. See all available [here](https://pycqa.github.io/isort/docs/configuration/options.html).
 
 
@@ -8321,6 +8343,8 @@ string
 
 
 ## git-hooks.hooks.isort.settings.profile
+
+
 
 Built-in profiles to allow easy interoperability with common projects and code styles.
 

--- a/src/modules/integrations/devcontainer.nix
+++ b/src/modules/integrations/devcontainer.nix
@@ -42,6 +42,14 @@ in
             A list of pre-installed VS Code extensions.
           '';
         };
+
+        options.customizations.zed.extensions = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = ''
+            A list of pre-installed Zed extensions.
+          '';
+        };
       };
 
       default = { };


### PR DESCRIPTION
The `settings` is basically a free-form JSON, but initially I have thought that Zed extensions are not supported syntactically.

Therefore:
- Add the Zed section, so that also shows up in the docs
- Add `nix` Zed extension to the devenv definition of the project
  - Regenerate the devcontainer.json given the previous change