### PR TITLE
Update nix profile commands from install to add

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -40,7 +40,7 @@
     === "Nix profiles (requires experimental flags)"
 
         ```
-        nix profile install nixpkgs#bashInteractive
+        nix profile add nixpkgs#bashInteractive
         ```
 
 === "Windows (WSL2)"
@@ -68,7 +68,7 @@
 === "Nix profiles (requires experimental flags)"
 
     ```
-    nix profile install nixpkgs#devenv
+    nix profile add nixpkgs#devenv
     ```
 
 === "NixOS/nix-darwin"


### PR DESCRIPTION
Resolves soft error message when following  guide https://devenv.sh/getting-started/#__tabbed_3_2 . See console snippet below.
```
 nix profile install nixpkgs#devenv
warning: 'install' is a deprecated alias for 'add'
```