### PR TITLE
shell: increase PTY read buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Improvements
 
+- Reduced renderer fragmentation in `devenv shell` by reading PTY output in larger batches, lowering syscall and event-allocation overhead during full-screen repaint bursts.
 - `DEVENV_HOME` now overrides where devenv stores all per-user data (GC roots, trust database, cached keys), not just the trust database.
 - `DEVENV_RUNTIME` can now be set to override where a project stores its sockets and other runtime files. To relocate runtime files for all projects at once, prefer `XDG_RUNTIME_DIR`, which keeps each project's directory separate.
 

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -875,7 +875,10 @@ impl ShellSession {
         std::thread::Builder::new()
             .name("session-pty".into())
             .spawn(move || {
-                let mut buf = [0u8; 4096];
+                // Keep a full-screen repaint burst in one PTY read where
+                // possible, reducing syscalls, event allocations, and
+                // fragmented renderer frames.
+                let mut buf = [0u8; 64 * 1024];
                 loop {
                     match pty_reader.read(&mut buf) {
                         Ok(0) => {


### PR DESCRIPTION
## What changed

Increase the `devenv shell` PTY reader buffer from 4 KiB to 64 KiB.

## Why

Full-screen applications often emit repaint bursts larger than 4 KiB. Splitting those bursts across reads creates extra syscalls, `PtyOutput` allocations, channel events, and potentially fragmented renderer frames. A larger buffer allows a complete burst to be processed as one batch more often.

This extracts the read-buffer optimization from `fix/shell-dirty-row-rendering`; it does not include dirty-row rendering or alternate-screen passthrough.

## Validation

- `devenv shell cargo fmt --all -- --check`
- `devenv shell cargo test -p devenv-shell` (143 passed)