### PR TITLE
fix(hook): make nushell cd-out actually leave the devenv shell, and re-activate on return

### DIFF
--- a/devenv-shell/src/dialect/mod.rs
+++ b/devenv-shell/src/dialect/mod.rs
@@ -474,6 +474,15 @@ export DEVENV_RELOAD_TEST_VAR=reload_works
             "[nu] hook-spawned rcfile did not exit on cd-out.\nstdout: {stdout}\nstderr: {}",
             String::from_utf8_lossy(&output.stderr),
         );
+        // A bare `exit` from inside a hook throws `ShellError::Exit`, which only
+        // the REPL top level handles: nushell reports it and the shell survives
+        // (issue #3033). Stopping the script early is not the same as leaving
+        // the shell, so assert the error is absent too.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("Exit doesn't catch internally"),
+            "[nu] cd-out aborted with an uncaught `exit` instead of terminating the shell.\nstderr: {stderr}",
+        );
         let exit_dir = std::fs::read_to_string(root.join(".devenv/exit-dir")).unwrap();
         assert_eq!(exit_dir, "/", "exit-dir should record cd target");
 

--- a/devenv-shell/src/dialect/mod.rs
+++ b/devenv-shell/src/dialect/mod.rs
@@ -474,14 +474,21 @@ export DEVENV_RELOAD_TEST_VAR=reload_works
             "[nu] hook-spawned rcfile did not exit on cd-out.\nstdout: {stdout}\nstderr: {}",
             String::from_utf8_lossy(&output.stderr),
         );
-        // A bare `exit` from inside a hook throws `ShellError::Exit`, which only
-        // the REPL top level handles: nushell reports it and the shell survives
-        // (issue #3033). Stopping the script early is not the same as leaving
-        // the shell, so assert the error is absent too.
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(
-            !stderr.contains("Exit doesn't catch internally"),
-            "[nu] cd-out aborted with an uncaught `exit` instead of terminating the shell.\nstderr: {stderr}",
+        // Not reaching the end of the script is necessary but not sufficient: a
+        // bare `exit` from inside a hook throws `ShellError::Exit`, which only
+        // the REPL top level handles. Under `nu -c` that unwinds the script and
+        // exits 0, but a real interactive shell reports "Exit doesn't catch
+        // internally" and stays alive (#3033). Only actually terminating the
+        // process is faithful to what the parent hook waits for, so require
+        // death by signal — which `exit` can never produce.
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(
+            output.status.signal(),
+            Some(15),
+            "[nu] cd-out unwound the script instead of terminating the shell \
+             process (status: {:?}).\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
         );
         let exit_dir = std::fs::read_to_string(root.join(".devenv/exit-dir")).unwrap();
         assert_eq!(exit_dir, "/", "exit-dir should record cd target");

--- a/devenv-shell/src/dialect/nushell.rs
+++ b/devenv-shell/src/dialect/nushell.rs
@@ -288,7 +288,11 @@ if $__devenv_enable_exit_on_cd_out {{
 def _devenv_shell_exit_on_cd_out [] {{
     if not ($env.PWD == $env.DEVENV_ROOT or ($env.PWD | str starts-with ($env.DEVENV_ROOT + "/"))) {{
         $env.PWD | save --force ($env.DEVENV_ROOT + "/.devenv/exit-dir")
-        exit
+        # `exit` throws ShellError::Exit, which nushell only handles at the REPL
+        # top level; from inside a hook it reports "Exit doesn't catch
+        # internally" and the shell survives. Signal ourselves instead so the
+        # process really terminates and the parent hook can follow us.
+        ^kill $nu.pid
     }}
 }}
 

--- a/devenv/hooks/hook.fish
+++ b/devenv/hooks/hook.fish
@@ -66,6 +66,11 @@ function _devenv_hook_activate
             # `builtin cd`, not `cd`: avoids "zoxide: infinite loop detected"
             # when the user overrides `cd` (e.g. `zoxide init --cmd=cd`).
             _devenv_builtin_cd_with_history "$target_dir"
+            # We followed the user out, so the "don't re-spawn" guard in
+            # `_devenv_hook` no longer applies: it only exists for exiting the
+            # shell and staying put. Leaving it set to the project dir would
+            # silently skip activation the next time the user cd's back in.
+            set -g _DEVENV_HOOK_ACTIVATED ""
         end
     end
 end

--- a/devenv/hooks/hook.nu
+++ b/devenv/hooks/hook.nu
@@ -32,7 +32,11 @@ def --env _devenv_hook [] {
         if $_devenv_hook_dir {
             if not ($env.PWD == $env.DEVENV_ROOT or ($env.PWD | str starts-with ($env.DEVENV_ROOT + "/"))) {
                 $env.PWD | save --force ($env.DEVENV_ROOT + "/.devenv/exit-dir")
-                exit
+                # `exit` throws ShellError::Exit, which is only handled at the
+                # REPL top level; from inside a hook nushell reports
+                # "Exit doesn't catch internally" and the shell survives.
+                # Signal ourselves instead so the process really terminates.
+                ^kill $nu.pid
             }
         }
         return
@@ -56,7 +60,13 @@ def --env _devenv_hook [] {
             $env._DEVENV_HOOK_UNTRUSTED = ""
             # Mark activated before launching so exiting the shell doesn't re-launch.
             $env._DEVENV_HOOK_ACTIVATED = $env.PWD
-            with-env { _DEVENV_HOOK_DIR: $dir, _DEVENV_CALLER: "hook" } { do { cd $dir; ^devenv shell } }
+            # `try`: a hook-spawned shell that leaves the project terminates
+            # itself with a signal, so `devenv shell` exits 128+SIGTERM. Without
+            # `try` nushell aborts the hook on that non-zero exit and never
+            # follows the user to `exit-dir` below.
+            try {
+                with-env { _DEVENV_HOOK_DIR: $dir, _DEVENV_CALLER: "hook" } { do { cd $dir; ^devenv shell } }
+            }
             let exit_dir_file = ($dir + "/.devenv/exit-dir")
             if ($exit_dir_file | path exists) {
                 let target_dir = (open $exit_dir_file | str trim)

--- a/devenv/hooks/hook.nu
+++ b/devenv/hooks/hook.nu
@@ -73,6 +73,12 @@ def --env _devenv_hook [] {
                 rm -f $exit_dir_file
                 if ($target_dir | path exists) {
                     cd $target_dir
+                    # We followed the user out, so the "don't re-spawn" guard
+                    # above no longer applies: it only exists for exiting the
+                    # shell and staying put. Leaving it set to the project dir
+                    # would silently skip activation the next time the user
+                    # cd's back in.
+                    $env._DEVENV_HOOK_ACTIVATED = ""
                 }
             }
         } else {

--- a/devenv/hooks/hook.posix.sh
+++ b/devenv/hooks/hook.posix.sh
@@ -68,6 +68,11 @@ _devenv_hook() {
             rm -f "$exit_dir_file"
             if [[ -d "$target_dir" ]]; then
                 cd "$target_dir"
+                # We followed the user out, so the "don't re-spawn" guard above
+                # no longer applies: it only exists for exiting the shell and
+                # staying put. Leaving it set to the project dir would silently
+                # skip activation the next time the user cd's back in.
+                _DEVENV_HOOK_ACTIVATED=""
             fi
         fi
     elif [[ $exit_code -eq 0 ]]; then

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -13,6 +13,7 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -525,18 +526,23 @@ fn nu_inner_shell_exits_on_cd_out() {
         "cd /; _devenv_hook; print SHOULD_NOT_REACH",
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         !stdout.contains("SHOULD_NOT_REACH"),
         "[nu] inner shell did not exit on cd-out.\nstdout: {stdout}",
     );
-    // A bare `exit` from inside a hook throws `ShellError::Exit`, which only
-    // the REPL top level handles: nushell reports it and the shell survives.
-    // Aborting the script is not the same as leaving the shell, so assert the
-    // error is absent rather than just that we stopped early.
-    assert!(
-        !stderr.contains("Exit doesn't catch internally"),
-        "[nu] inner shell aborted with an uncaught `exit` instead of terminating.\nstderr: {stderr}",
+    // Not reaching the end of the script is necessary but not sufficient: a
+    // bare `exit` from inside a hook throws `ShellError::Exit`, which only the
+    // REPL top level handles. Under `nu -c` that unwinds the script and exits
+    // 0, but a real interactive shell reports "Exit doesn't catch internally"
+    // and stays alive (#3033). The parent hook is waiting on the process, so
+    // require death by signal — which `exit` can never produce.
+    assert_eq!(
+        out.status.signal(),
+        Some(15),
+        "[nu] inner shell unwound the script instead of terminating the process \
+         (status: {:?}).\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
     );
     let exit_dir = fs::read_to_string(tmp.path().join(".devenv/exit-dir")).unwrap();
     assert_eq!(exit_dir, "/", "[nu] exit-dir should record cd target");

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -8,6 +8,8 @@
 //! - `fish_deferred_activation_skips_if_already_active` — direnv/devenv double-activation race
 //! - `fish_follow_cd_out_preserves_history_for_cd_dash` — #2853
 //! - `posix_activates_sibling_after_cd_out` — #2944
+//! - `activates_again_after_returning_to_the_same_project` — stale
+//!   `_DEVENV_HOOK_ACTIVATED` after a follow-cd (`nu_` variant for nushell)
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -318,6 +320,113 @@ fn fish_follow_cd_out_preserves_history_for_cd_dash() {
         stdout.contains(&format!("AFTER_CD_DASH={}", project_dir.path().display())),
         "fish `cd -` did not return to the project directory that \
          `_devenv_builtin_cd_with_history` left.\nstdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+/// A shimmed `devenv` whose `shell` records the call and reports that the user
+/// cd'd out to `target`, i.e. the hook-spawned shell left the project.
+fn cd_out_shim(project: &Path, target: &Path) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let calls = dir.path().join("calls");
+    let bin = dir.path().join("devenv");
+    fs::write(
+        &bin,
+        format!(
+            r#"#!/bin/sh
+set -eu
+case "$1" in
+  hook-should-activate)
+    if [ -d "$PWD/.devenv" ]; then
+      printf '%s\n' "$PWD"
+    fi
+    ;;
+  shell)
+    printf 'shell %s\n' "$PWD" >> {calls:?}
+    printf '%s' {target:?} > {project:?}/.devenv/exit-dir
+    ;;
+esac
+"#,
+            calls = calls,
+            project = project.display().to_string(),
+            target = target.display().to_string(),
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, calls)
+}
+
+#[test]
+fn activates_again_after_returning_to_the_same_project() {
+    // Re-entering the project you were just followed out of must activate
+    // again. `_DEVENV_HOOK_ACTIVATED` suppresses a re-spawn only for the case
+    // where you `exit` the shell and stay put; once the hook has followed you
+    // out to `exit-dir` that guard has to be cleared, or cd-ing back in is
+    // silently ignored until you leave and return a second time.
+    let parent = tempfile::tempdir().unwrap();
+    let project = parent.path().join("project");
+
+    for (shell, src) in posix_shells() {
+        fs::create_dir_all(project.join(".devenv")).unwrap();
+        let (_bin_dir, calls) = cd_out_shim(&project, parent.path());
+        let script = format!(
+            "unset DEVENV_ROOT _DEVENV_HOOK_DIR\n\
+             {src}\n\
+             {po}\n\
+             cd {project:?}\n\
+             _devenv_hook\n\
+             cd {project:?}\n\
+             _devenv_hook\n",
+            po = posix_path_override(calls.parent().unwrap()),
+        );
+        let out = run(shell, &script);
+        let recorded = fs::read_to_string(&calls).unwrap_or_default();
+        assert_eq!(
+            recorded.lines().count(),
+            2,
+            "[{shell}] cd-ing back into the project after being followed out did \
+             not re-activate.\nRecorded:\n{recorded}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+}
+
+#[test]
+fn nu_activates_again_after_returning_to_the_same_project() {
+    if !have("nu") {
+        return;
+    }
+    let parent = tempfile::tempdir().unwrap();
+    let project = parent.path().join("project");
+    fs::create_dir_all(project.join(".devenv")).unwrap();
+    let (_bin_dir, calls) = cd_out_shim(&project, parent.path());
+
+    let hook_dir = tempfile::tempdir().unwrap();
+    let hook_path = hook_dir.path().join("hook.nu");
+    let hook_gen = Command::new(devenv_bin())
+        .args(["hook", "nu"])
+        .output()
+        .unwrap();
+    assert!(hook_gen.status.success(), "devenv hook nu failed");
+    fs::write(&hook_path, &hook_gen.stdout).unwrap();
+
+    let script = format!(
+        "hide-env -i DEVENV_ROOT\nhide-env -i _DEVENV_HOOK_DIR\n\
+         source {hook:?}\n\
+         $env.PATH = ($env.PATH | prepend {bin_dir:?})\n\
+         cd {project:?}\n_devenv_hook\n\
+         cd {project:?}\n_devenv_hook\n",
+        hook = hook_path,
+        bin_dir = calls.parent().unwrap(),
+    );
+    let out = Command::new("nu").arg("-c").arg(&script).output().unwrap();
+    let recorded = fs::read_to_string(&calls).unwrap_or_default();
+    assert_eq!(
+        recorded.lines().count(),
+        2,
+        "[nu] cd-ing back into the project after being followed out did not \
+         re-activate.\nRecorded:\n{recorded}\nstderr: {}",
         String::from_utf8_lossy(&out.stderr),
     );
 }

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -416,9 +416,18 @@ fn nu_inner_shell_exits_on_cd_out() {
         "cd /; _devenv_hook; print SHOULD_NOT_REACH",
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         !stdout.contains("SHOULD_NOT_REACH"),
         "[nu] inner shell did not exit on cd-out.\nstdout: {stdout}",
+    );
+    // A bare `exit` from inside a hook throws `ShellError::Exit`, which only
+    // the REPL top level handles: nushell reports it and the shell survives.
+    // Aborting the script is not the same as leaving the shell, so assert the
+    // error is absent rather than just that we stopped early.
+    assert!(
+        !stderr.contains("Exit doesn't catch internally"),
+        "[nu] inner shell aborted with an uncaught `exit` instead of terminating.\nstderr: {stderr}",
     );
     let exit_dir = fs::read_to_string(tmp.path().join(".devenv/exit-dir")).unwrap();
     assert_eq!(exit_dir, "/", "[nu] exit-dir should record cd target");


### PR DESCRIPTION
Fixes #3033.
Fixes #3034.

Two bugs in the shell hooks' cd-out ("follow me out of the project") path. The first is nushell-only and is what #3033 reports; the second (#3034) is latent in every dialect and only becomes observable once the first is fixed.

## 1. `exit` from a nushell hook does not exit the shell

The hook-spawned child shell is supposed to terminate when the user `cd`s outside the project, so the parent hook — blocked on `devenv shell` — resumes and follows via `.devenv/exit-dir`. bash/zsh/fish do that with `exit`.

In nushell `exit` throws `ShellError::Exit`, which is only handled at the REPL top level. Thrown from inside a hook it surfaces as

```
Error: nu::shell::exit
  × Exit doesn't catch internally
```

and the shell survives. The user is left inside the `(devenv)` shell after `cd`-ing out, one error per `cd`, until they `exit` manually. (Not a closure-vs-string-hook distinction — both forms fail the same way.)

The failing call is the one in the generated child `config.nu` (`_devenv_shell_exit_on_cd_out` in `devenv-shell/src/dialect/nushell.rs`, registered on `hooks.env_change.PWD`). `hook.nu`'s identical branch is dead in the Nix flow — `_DEVENV_HOOK_DIR` is hidden before the user's config is sourced — but it is reachable for non-Nix loads, so both are fixed.

Fix: signal ourselves instead, which really does terminate the child.

```nu
$env.PWD | save --force ($env.DEVENV_ROOT + "/.devenv/exit-dir")
^kill $nu.pid          # was: exit
```

That makes the child exit `128+SIGTERM`, and nushell **aborts the enclosing block on a non-zero external exit code** — so the nu parent hook never reached its follow-`cd` (it errored at the `^devenv shell` line with `terminated by SIGTERM (15)`). Wrapped that call in `try`. bash/zsh/fish parents ignore the child's exit status, so only the nu hook needed it.

Trade-offs: the child's exit status is no longer the last command's status (nothing on the follow path uses it; bash's `exit $previous_exit_status` behavior is only observable to the parent, which ignores it), and this depends on an external `kill` on `PATH`.

## 2. Re-entering the project you were just followed out of does not activate

`_DEVENV_HOOK_ACTIVATED` is set to the project dir before spawning, so that exiting the shell and staying put doesn't re-spawn it. The follow-`cd` path never cleared it, so the prompt after the follow still carried the stale flag and the next `cd <project>` hit the guard and returned early — you had to leave and come back a second time to get your environment. Reproducible in bash with a shimmed `devenv`; it was simply unreachable in nushell while cd-out was broken.

Fix: clear the flag as part of a successful follow-`cd`, in `hook.nu`, `hook.posix.sh` and `hook.fish`. The exiting-and-staying-put guard is unaffected (the flag is only cleared when we actually moved).

## Tests

- `activates_again_after_returning_to_the_same_project` (+ `nu_` variant) — new, covers bug 2.
- Both existing nu cd-out tests were passing for the wrong reason: under `nu -c` a bare `exit` unwinds the script and exits 0, which is indistinguishable from the shell actually going away. They now assert the child died by signal (`status.signal() == Some(15)`), which `exit` cannot produce — so they fail against the old code. Asserting on the `Exit doesn't catch internally` stderr string would not work here: `nu -c` is not a REPL and never prints it.
- Checked the other way round too: with `devenv/hooks` and `nushell.rs` reverted to `main`, `activates_again_after_returning_to_the_same_project` (+ `nu_` variant), `nu_inner_shell_exits_on_cd_out` and `nu_rcfile_exits_on_cd_out_when_hook_spawned` all fail.

Verified end to end in a real nushell 0.114.1 terminal on NixOS: entering, `cd`-ing out (clean deactivation, parent follows), and re-entering all behave.

---

*Investigated and implemented with the assistance of Claude Opus 5. Every change here was verified by hand in a real nushell terminal, and the tests were checked against both the fixed and unfixed hooks.*
