### PR TITLE
feat: compose devenv.yaml from remote inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.1 (unreleased)
 
+### Improvements
+
+- `devenv.yaml` can now compose configuration from remote input imports using the existing `inputs` and `imports` syntax. Remote YAML imports and their transitive inputs are pinned in the importing project's `devenv.lock`; the root project's input declarations retain precedence, allowing shared configurations to reuse a single `nixpkgs` input ([#2205](https://github.com/cachix/devenv/issues/2205)).
+
 ### Bug Fixes
 
 - Fixed `devenv --profile <name> allow` ignoring the selected profile for projects with a local `devenv.nix`. Allowed in-tree projects now persist their auto-activation profiles just like out-of-tree `--from` bindings; explicit `--profile` flags still take priority.

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -5,13 +5,19 @@ use schematic::ConfigLoader;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     path::{Path, PathBuf},
 };
 
 const YAML_CONFIG: &str = "devenv.yaml";
 const YAML_LOCAL_CONFIG: &str = "devenv.local.yaml";
+
+#[derive(Clone, Copy)]
+struct ImportRoots<'a> {
+    git_root: Option<&'a Path>,
+    input_sources: &'a BTreeMap<String, PathBuf>,
+}
 
 /// Version requirement for the devenv CLI.
 ///
@@ -495,6 +501,19 @@ impl Config {
         Self::load_from_with_source("./", source_dir)
     }
 
+    /// Like [`Config::load_with_source`], with locked filesystem locations for
+    /// input-style imports such as `shared-config/profiles/backend`.
+    ///
+    /// Input sources are resolved by the backend from `devenv.lock`. Keeping
+    /// fetching out of this crate lets the local-only loader remain usable
+    /// without a Nix store.
+    pub fn load_with_source_and_input_sources(
+        source_dir: Option<&Path>,
+        input_sources: &BTreeMap<String, PathBuf>,
+    ) -> Result<Self> {
+        Self::load_from_with_source_and_input_sources("./", source_dir, input_sources)
+    }
+
     /// Loads configuration from a directory path, including all imported configurations.
     ///
     /// This method recursively loads the base `devenv.yaml` file and all configurations
@@ -523,6 +542,20 @@ impl Config {
     /// [`Config::load_from`] with an optional out-of-tree source directory;
     /// see [`Config::load_with_source`] for the source merge semantics.
     pub fn load_from_with_source<P>(path: P, source_dir: Option<&Path>) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        Self::load_from_with_source_and_input_sources(path, source_dir, &BTreeMap::new())
+    }
+
+    /// [`Config::load_from_with_source`] with locked sources for input-style
+    /// imports. The source paths must point at the selected input root (and
+    /// therefore already include a flake reference's `dir` parameter).
+    pub fn load_from_with_source_and_input_sources<P>(
+        path: P,
+        source_dir: Option<&Path>,
+        input_sources: &BTreeMap<String, PathBuf>,
+    ) -> Result<Self>
     where
         P: AsRef<Path>,
     {
@@ -613,7 +646,10 @@ impl Config {
                 Self::collect_import_files(
                     &source_result.config.imports,
                     source_dir,
-                    source_git_root.as_deref(),
+                    ImportRoots {
+                        git_root: source_git_root.as_deref(),
+                        input_sources,
+                    },
                     &mut source_yamls,
                     &mut source_dir_only_imports,
                     &mut visited,
@@ -639,7 +675,9 @@ impl Config {
                             import,
                             source_dir,
                             source_git_root.as_deref(),
-                        )?;
+                            input_sources,
+                        )?
+                        .expect("file imports always resolve");
                         let resolved = resolved.canonicalize().unwrap_or(resolved);
                         source_module_imports.push(format!("path:{}", resolved.display()));
                     }
@@ -665,7 +703,10 @@ impl Config {
         Self::collect_import_files(
             &temp_result.config.imports,
             base_path,
-            git_root.as_deref(),
+            ImportRoots {
+                git_root: git_root.as_deref(),
+                input_sources,
+            },
             &mut imported_yamls,
             &mut dir_only_imports,
             &mut visited,
@@ -802,11 +843,12 @@ impl Config {
                 // the live source tree; emit them absolute so they stay valid
                 // from the project root (relative escapes also break under
                 // lazy-trees).
-                let from_source_side = source_root_canon.as_ref().is_some_and(|root| {
-                    input_dir
-                        .canonicalize()
-                        .is_ok_and(|dir| dir.starts_with(root))
-                });
+                let from_source_side =
+                    source_root_canon.as_ref().is_some_and(|root| {
+                        input_dir
+                            .canonicalize()
+                            .is_ok_and(|dir| dir.starts_with(root))
+                    }) || Self::containing_input_source(input_dir, input_sources).is_some();
                 if from_source_side {
                     if let Some(url) = canonical_url(&resolved, &query_suffix) {
                         input.url = Some(url);
@@ -866,7 +908,8 @@ impl Config {
         // Add all loaded file imports (normalized).
         for yaml_path in &imported_yamls {
             if let Some(import_dir) = yaml_path.parent()
-                && let Some(normalized) = Self::normalize_path(import_dir, base_path)
+                && let Some(normalized) =
+                    Self::normalize_import_path(import_dir, base_path, input_sources)
                 && seen.insert(normalized.clone())
             {
                 final_imports.push(normalized);
@@ -877,7 +920,8 @@ impl Config {
         // devenv.yaml of their own. There's nothing to merge, but their
         // devenv.nix should still be loaded.
         for import_dir in &dir_only_imports {
-            if let Some(normalized) = Self::normalize_path(import_dir, base_path)
+            if let Some(normalized) =
+                Self::normalize_import_path(import_dir, base_path, input_sources)
                 && seen.insert(normalized.clone())
             {
                 final_imports.push(normalized);
@@ -999,6 +1043,56 @@ impl Config {
     /// Checks if an import is a file-based import (relative or absolute path).
     fn is_file_import(import: &str) -> bool {
         import.starts_with("./") || import.starts_with("../") || import.starts_with('/')
+    }
+
+    /// Names of declared inputs referenced by `imports`.
+    ///
+    /// These are the only inputs the backend needs to materialize while
+    /// composing YAML, avoiding an eager fetch of unrelated inputs such as
+    /// nixpkgs.
+    pub fn input_import_names(&self) -> BTreeSet<String> {
+        self.imports
+            .iter()
+            .filter(|import| !Self::is_file_import(import) && !import.starts_with("path:"))
+            .filter_map(|import| import.split('/').next())
+            .filter(|name| self.inputs.contains_key(*name))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// Find the most specific locked input source containing `path`.
+    fn containing_input_source<'a>(
+        path: &Path,
+        input_sources: &'a BTreeMap<String, PathBuf>,
+    ) -> Option<(&'a str, &'a Path)> {
+        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        input_sources
+            .iter()
+            .filter(|(_, root)| canonical_path.starts_with(root))
+            .max_by_key(|(_, root)| root.components().count())
+            .map(|(name, root)| (name.as_str(), root.as_path()))
+    }
+
+    /// Render a resolved module path relative to an input when possible, and
+    /// relative to the project otherwise.
+    fn normalize_import_path(
+        source: &Path,
+        base: &Path,
+        input_sources: &BTreeMap<String, PathBuf>,
+    ) -> Option<String> {
+        if let Some((name, root)) = Self::containing_input_source(source, input_sources) {
+            let source = source
+                .canonicalize()
+                .unwrap_or_else(|_| source.to_path_buf());
+            let relative = source.strip_prefix(root).ok()?;
+            if relative.as_os_str().is_empty() {
+                Some(name.to_string())
+            } else {
+                Some(format!("{name}/{}", relative.display()))
+            }
+        } else {
+            Self::normalize_path(source, base)
+        }
     }
 
     /// Normalizes a path relative to a base directory.
@@ -1217,25 +1311,41 @@ impl Config {
         import: &str,
         base_path: &Path,
         git_root: Option<&Path>,
-    ) -> Result<PathBuf> {
-        let resolved = if import.starts_with('/') {
-            if let Some(root) = git_root {
-                root.join(import.strip_prefix('/').unwrap())
+        input_sources: &BTreeMap<String, PathBuf>,
+    ) -> Result<Option<PathBuf>> {
+        let containing_source = Self::containing_input_source(base_path, input_sources);
+        let (resolved, security_root, security_git_root) = if import.starts_with('/') {
+            if let Some((_, root)) = containing_source {
+                (root.join(import.strip_prefix('/').unwrap()), root, None)
+            } else if let Some(root) = git_root {
+                (root.join(import.strip_prefix('/').unwrap()), root, git_root)
             } else {
                 bail!(
                     "Absolute import path '{}' requires a git repository. Use relative paths (e.g., './' or '../') instead.",
                     import
                 );
             }
+        } else if Self::is_file_import(import) {
+            let security_root = containing_source
+                .map(|(_, root)| root)
+                .unwrap_or_else(|| git_root.unwrap_or(base_path));
+            (
+                base_path.join(import),
+                security_root,
+                containing_source.is_none().then_some(git_root).flatten(),
+            )
         } else {
-            base_path.join(import)
+            let (input_name, subpath) = import.split_once('/').unwrap_or((import, ""));
+            let Some(root) = input_sources.get(input_name) else {
+                return Ok(None);
+            };
+            (root.join(subpath), root.as_path(), None)
         };
 
         // Security check
-        let security_root = git_root.unwrap_or(base_path);
-        Self::validate_within_root(&resolved, security_root, import, git_root)?;
+        Self::validate_within_root(&resolved, security_root, import, security_git_root)?;
 
-        Ok(resolved)
+        Ok(Some(resolved))
     }
 
     /// Recursively collects all import files starting from the given imports list.
@@ -1247,11 +1357,12 @@ impl Config {
     /// # Arguments
     /// * `imports` - List of import paths (directories) to process
     /// * `base_path` - The base directory for resolving relative import paths
-    /// * `git_root` - Optional git repository root for resolving absolute paths and security checks
+    /// * `roots` - Git and locked-input roots used for resolution and security checks
     /// * `yaml_files` - Accumulator for collecting YAML file paths in load order
-    /// * `dir_only_imports` - Accumulator for imported directories that have no `devenv.yaml`
-    ///   of their own. There's nothing to merge or recurse into, but the directory still needs
-    ///   to end up in the final imports list so its `devenv.nix` gets loaded.
+    /// * `dir_only_imports` - Accumulator for imported directories without a
+    ///   `devenv.yaml`, and directly imported Nix files. There's nothing to
+    ///   merge or recurse into, but each module still needs to reach the final
+    ///   imports list.
     /// * `visited` - Set of canonical paths already visited (prevents circular imports)
     /// * `depth` - Current recursion depth (prevents stack overflow)
     ///
@@ -1267,7 +1378,7 @@ impl Config {
     fn collect_import_files(
         imports: &[String],
         base_path: &Path,
-        git_root: Option<&Path>,
+        roots: ImportRoots<'_>,
         yaml_files: &mut Vec<PathBuf>,
         dir_only_imports: &mut Vec<PathBuf>,
         visited: &mut HashSet<PathBuf>,
@@ -1284,7 +1395,13 @@ impl Config {
 
         for import in imports {
             // Resolve and validate the import path
-            let import_path = Self::resolve_import_path(import, base_path, git_root)?;
+            let Some(import_path) =
+                Self::resolve_import_path(import, base_path, roots.git_root, roots.input_sources)?
+            else {
+                // Input-style imports are resolved in a second pass after the
+                // backend materializes their locked sources.
+                continue;
+            };
 
             if import_path.is_dir() {
                 let yaml_path = import_path.join(YAML_CONFIG);
@@ -1328,7 +1445,7 @@ impl Config {
                     Self::collect_import_files(
                         &temp_result.config.imports,
                         &import_path,
-                        git_root,
+                        roots,
                         yaml_files,
                         dir_only_imports,
                         visited,
@@ -1351,6 +1468,22 @@ impl Config {
                     if visited.insert(canonical_dir) {
                         dir_only_imports.push(import_path.clone());
                     }
+                }
+            } else if import_path.is_file() {
+                // A transitive `./module.nix` import has no YAML to merge, but
+                // it still needs to reach the final Nix module list.
+                let canonical_file =
+                    import_path
+                        .canonicalize()
+                        .into_diagnostic()
+                        .wrap_err_with(|| {
+                            format!(
+                                "Failed to canonicalize import path: {}",
+                                import_path.display()
+                            )
+                        })?;
+                if visited.insert(canonical_file) {
+                    dir_only_imports.push(import_path);
                 }
             }
         }
@@ -1683,6 +1816,157 @@ mod tests {
         // The second value should override the first
         let merged_profile = config2.profile.or(config1.profile);
         assert_eq!(merged_profile, Some("override".to_string()));
+    }
+
+    #[test]
+    fn locked_input_source_composes_remote_yaml_graph() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let project = temp_dir.path().join("project");
+        let shared = temp_dir.path().join("shared");
+        let backend = shared.join("profiles/backend");
+        let nested = backend.join("nested");
+        fs::create_dir_all(&project).expect("Failed to create project");
+        fs::create_dir_all(&nested).expect("Failed to create nested remote config");
+        fs::create_dir_all(backend.join("dependency")).expect("Failed to create path input");
+
+        fs::write(
+            project.join("devenv.yaml"),
+            r#"
+inputs:
+  shared:
+    url: github:example/shared
+    flake: false
+  nixpkgs:
+    url: github:NixOS/nixpkgs/root
+imports:
+  - shared/profiles/backend
+strict_ports: false
+"#,
+        )
+        .expect("Failed to write project config");
+        fs::write(
+            backend.join("devenv.yaml"),
+            r#"
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/imported
+  tool:
+    url: github:example/tool
+  local-dependency:
+    url: path:./dependency
+    flake: false
+imports:
+  - ./nested
+  - ./extra.nix
+reload: false
+"#,
+        )
+        .expect("Failed to write remote config");
+        fs::write(backend.join("devenv.nix"), "{ }").expect("Failed to write remote module");
+        fs::write(backend.join("extra.nix"), "{ }").expect("Failed to write remote Nix import");
+        fs::write(
+            nested.join("devenv.yaml"),
+            "inputs:\n  nested-tool:\n    url: github:example/nested-tool\n",
+        )
+        .expect("Failed to write nested config");
+        fs::write(nested.join("devenv.nix"), "{ }").expect("Failed to write nested module");
+
+        let shared = shared
+            .canonicalize()
+            .expect("Failed to canonicalize input source");
+        let input_sources = BTreeMap::from([("shared".to_string(), shared)]);
+        let config =
+            Config::load_from_with_source_and_input_sources(&project, None, &input_sources)
+                .expect("Failed to compose locked input config");
+
+        assert!(config.inputs.contains_key("tool"));
+        assert!(config.inputs.contains_key("nested-tool"));
+        assert_eq!(
+            config.inputs["nixpkgs"].url.as_deref(),
+            Some("github:NixOS/nixpkgs/root"),
+            "the root project must retain precedence over imported inputs"
+        );
+        assert_eq!(
+            config.inputs["local-dependency"].url,
+            Some(format!(
+                "path:{}",
+                backend
+                    .join("dependency")
+                    .canonicalize()
+                    .expect("Failed to canonicalize path input")
+                    .display()
+            ))
+        );
+        assert_eq!(config.reload, Some(false));
+        assert_eq!(config.strict_ports, Some(false));
+        assert!(
+            config
+                .imports
+                .contains(&"shared/profiles/backend".to_string())
+        );
+        assert!(
+            config
+                .imports
+                .contains(&"shared/profiles/backend/nested".to_string())
+        );
+        assert!(
+            config
+                .imports
+                .contains(&"shared/profiles/backend/extra.nix".to_string())
+        );
+    }
+
+    #[test]
+    fn locked_input_source_rejects_import_escape() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let project = temp_dir.path().join("project");
+        let shared = temp_dir.path().join("shared");
+        let profile = shared.join("profiles/backend");
+        fs::create_dir_all(&project).expect("Failed to create project");
+        fs::create_dir_all(&profile).expect("Failed to create remote config");
+        fs::write(
+            project.join("devenv.yaml"),
+            "inputs:\n  shared:\n    url: github:example/shared\nimports:\n  - shared/profiles/backend\n",
+        )
+        .expect("Failed to write project config");
+        fs::write(
+            profile.join("devenv.yaml"),
+            "imports:\n  - ../../../outside\n",
+        )
+        .expect("Failed to write remote config");
+
+        let input_sources = BTreeMap::from([(
+            "shared".to_string(),
+            shared
+                .canonicalize()
+                .expect("Failed to canonicalize input source"),
+        )]);
+        let error = Config::load_from_with_source_and_input_sources(&project, None, &input_sources)
+            .expect_err("an imported config must not escape its locked source");
+        assert!(
+            error.to_string().contains("resolves outside"),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn input_import_names_only_returns_declared_input_targets() {
+        let config = Config {
+            inputs: BTreeMap::from([("shared".to_string(), Input::default())]),
+            imports: vec![
+                "./local".to_string(),
+                "path:/absolute/local".to_string(),
+                "missing/profile".to_string(),
+                "shared/profile".to_string(),
+                "shared/other".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.input_import_names(),
+            BTreeSet::from(["shared".to_string()])
+        );
     }
 
     #[test]

--- a/devenv-nix-backend/bootstrap/resolve-input-paths.nix
+++ b/devenv-nix-backend/bootstrap/resolve-input-paths.nix
@@ -1,0 +1,69 @@
+{ src, names, lockFileJSON }:
+
+let
+  lockFilePath = src + "/devenv.lock";
+  lockFile = builtins.fromJSON lockFileJSON;
+
+  resolveInput =
+    inputSpec:
+    if builtins.isList inputSpec then getInputByPath lockFile.root inputSpec else inputSpec;
+
+  getInputByPath =
+    nodeName: path:
+    if path == [ ] then
+      nodeName
+    else
+      getInputByPath
+        (resolveInput lockFile.nodes.${nodeName}.inputs.${builtins.head path})
+        (builtins.tail path);
+
+  sourcePath =
+    key: node:
+    if key == lockFile.root
+      || (node.locked.type or null == "path" && node.locked.path or null == ".")
+    then
+      src
+    else
+      let
+        locked = node.locked;
+        isRelativePath =
+          path:
+          path != null
+          && (builtins.substring 0 2 path == "./" || builtins.substring 0 3 path == "../");
+        resolvedLocked = locked
+          // (if locked.type or null == "path" && isRelativePath (locked.path or null) then {
+          path = src + "/${locked.path}";
+        } else { })
+          // (if locked.type or null == "git" && isRelativePath (locked.url or null) then {
+          url = src + "/${locked.url}";
+        } else { });
+        fetchedSource = builtins.fetchTree (node.info or { } // removeAttrs resolvedLocked [ "dir" ]);
+        isLivePath =
+          locked.type or null == "path"
+          && !(locked ? narHash)
+          && builtins.substring 0 1 (resolvedLocked.path or "") == "/";
+      in
+      if isLivePath then resolvedLocked.path else fetchedSource.outPath;
+
+  nodePath =
+    key:
+    let
+      node = lockFile.nodes.${key};
+      subdir = node.locked.dir or "";
+    in
+    sourcePath key node + (if subdir == "" then "" else "/${subdir}");
+
+  rootInputs = lockFile.nodes.${lockFile.root}.inputs or { };
+in
+if lockFile.version < 5 || lockFile.version > 7 then
+  throw "lock file '${lockFilePath}' has unsupported version ${toString lockFile.version}"
+else
+  builtins.listToAttrs (map
+    (name:
+    if !(builtins.hasAttr name rootInputs) then
+      throw "input '${name}' is missing from ${lockFilePath}"
+    else {
+      inherit name;
+      value = nodePath (resolveInput rootInputs.${name});
+    })
+    names)

--- a/devenv-nix-backend/src/lib.rs
+++ b/devenv-nix-backend/src/lib.rs
@@ -407,29 +407,14 @@ pub fn validate_lock_file(
         );
     };
 
-    let flake_inputs = create_flake_inputs(fetch_settings, flake_settings, inputs)
-        .context("Failed to create flake inputs")?;
-
-    let source_path = root.join("devenv.nix");
-    let source_path_str = source_path
-        .to_str()
-        .context("Source path contains invalid UTF-8")?;
-
-    // Virtual mode so unlocked local inputs don't fail validation;
-    // we compare the computed lock against the existing one to detect drift.
-    let locker = InputsLocker::new(flake_settings)
-        .with_inputs(flake_inputs)
-        .source_path(source_path_str)
-        .old_lock_file(&old_lock)
-        .mode(LockMode::Virtual)
-        .use_registries(true);
-
-    let lock_result = {
-        let _guard = crate::umask_guard::UmaskGuard::restrictive();
-        locker.lock(fetch_settings, eval_state)
-    };
-
-    let new_lock = lock_result.context("Lock validation failed")?;
+    let new_lock = resolve_lock_file(
+        eval_state,
+        fetch_settings,
+        flake_settings,
+        root,
+        inputs,
+        Some(&old_lock),
+    )?;
     if new_lock.has_changes(&old_lock)? {
         tracing::debug!("Lock validation found changes, writing updated lock");
         // Writing new_lock directly avoids re-fetching every input: it was
@@ -437,6 +422,41 @@ pub fn validate_lock_file(
         write_lock_file(&new_lock, &lock_file_path).context("Failed to write lock file")?;
     }
     Ok(())
+}
+
+/// Resolve `inputs` to a lock graph in memory, using `old_lock` to preserve
+/// existing pins. The caller decides when the graph is complete and should be
+/// written to disk.
+pub(crate) fn resolve_lock_file(
+    eval_state: &EvalState,
+    fetch_settings: &FetchersSettings,
+    flake_settings: &FlakeSettings,
+    root: &Path,
+    inputs: &BTreeMap<String, Input>,
+    old_lock: Option<&LockFile>,
+) -> Result<LockFile> {
+    let flake_inputs = create_flake_inputs(fetch_settings, flake_settings, inputs)
+        .context("Failed to create flake inputs")?;
+    let source_path = root.join("devenv.nix");
+    let source_path_str = source_path
+        .to_str()
+        .context("Source path contains invalid UTF-8")?;
+
+    // Virtual mode lets config composition discover every imported input
+    // before committing the resulting graph to devenv.lock.
+    let mut locker = InputsLocker::new(flake_settings)
+        .with_inputs(flake_inputs)
+        .source_path(source_path_str)
+        .mode(LockMode::Virtual)
+        .use_registries(true);
+    if let Some(old_lock) = old_lock {
+        locker = locker.old_lock_file(old_lock);
+    }
+
+    let _guard = crate::umask_guard::UmaskGuard::restrictive();
+    locker
+        .lock(fetch_settings, eval_state)
+        .context("Lock validation failed")
 }
 
 /// Compute a content fingerprint from all locked inputs' fingerprints.

--- a/devenv-nix-backend/src/lock.rs
+++ b/devenv-nix-backend/src/lock.rs
@@ -1,24 +1,29 @@
 //! Pre-bootstrap lock-file helpers.
 //!
-//! Free functions over an explicit `EvalState` + `Store` + settings.
-//! Lock helpers never open a store; the caller controls eval-state lifecycle.
+//! Most helpers operate on an explicit `EvalState` + `Store` + settings. The
+//! pre-backend [`resolve_config_imports`] entry point creates a transient store
+//! so locked sources can be read before the full configuration is available.
 //! Wrap construction + validation in [`with_lock_scope`] so the lazy
 //! `«nix-internal»/derivation-internal.nix` load nests under the activity.
 
-use std::collections::BTreeMap;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use devenv_activity::{Activity, ActivityLevel, instrument_activity};
-use devenv_core::config::Input;
+use devenv_core::config::{Config, Input};
 use devenv_core::nix_log_bridge::NixLogBridge;
-use miette::{Result, WrapErr};
+use devenv_core::{NixSettings, StoreSettings};
+use miette::{IntoDiagnostic, Result, WrapErr, bail};
 use nix_bindings_expr::eval_state::{EvalState, EvalStateBuilder};
 use nix_bindings_fetchers::FetchersSettings;
-use nix_bindings_flake::{EvalStateBuilderExt, FlakeSettings};
+use nix_bindings_flake::{EvalStateBuilderExt, FlakeSettings, LockFile};
 use nix_bindings_store::store::Store;
 
 use crate::anyhow_ext::AnyhowToMiette;
+
+const RESOLVE_INPUT_PATHS: &str = include_str!("../bootstrap/resolve-input-paths.nix");
+const MAX_CONFIG_IMPORT_PASSES: usize = 100;
 
 /// Build a transient `EvalState` for lock-file work. Drop it when done.
 pub fn build_eval_state(
@@ -81,6 +86,158 @@ pub fn fingerprint(
     let lock_file_path = root.join("devenv.lock");
     let lock_file = crate::load_lock_file(fetchers_settings, &lock_file_path).to_miette()?;
     crate::compute_lock_fingerprint(lock_file.as_ref(), fetchers_settings, store).to_miette()
+}
+
+/// Materialize selected top-level lock inputs and return their source roots.
+///
+/// The resolver understands follows and `dir` references and mirrors the live
+/// path-input behavior used by `bootstrap/resolve-lock.nix`.
+pub fn input_paths(
+    eval_state: &mut EvalState,
+    root: &Path,
+    names: &BTreeSet<String>,
+) -> Result<BTreeMap<String, PathBuf>> {
+    if names.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let lock_path = root.join("devenv.lock");
+    let lock_json = std::fs::read_to_string(&lock_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("Failed to read {}", lock_path.display()))?;
+    input_paths_from_json(eval_state, root, names, &lock_json)
+}
+
+fn input_paths_from_lock(
+    eval_state: &mut EvalState,
+    root: &Path,
+    names: &BTreeSet<String>,
+    lock_file: &LockFile,
+) -> Result<BTreeMap<String, PathBuf>> {
+    let lock_json = lock_file
+        .to_string()
+        .to_miette()
+        .wrap_err("Failed to serialize composed lock file")?;
+    input_paths_from_json(eval_state, root, names, &lock_json)
+}
+
+fn input_paths_from_json(
+    eval_state: &mut EvalState,
+    root: &Path,
+    names: &BTreeSet<String>,
+    lock_json: &str,
+) -> Result<BTreeMap<String, PathBuf>> {
+    if names.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let root = root.canonicalize().into_diagnostic().wrap_err_with(|| {
+        format!(
+            "Failed to canonicalize project root while resolving imports: {}",
+            root.display()
+        )
+    })?;
+    let root_nix = ser_nix::to_string(&root.to_string_lossy().as_ref())
+        .into_diagnostic()
+        .wrap_err("Failed to serialize project root for Nix")?;
+    let names_nix = ser_nix::to_string(&names.iter().collect::<Vec<_>>())
+        .into_diagnostic()
+        .wrap_err("Failed to serialize imported input names for Nix")?;
+    let lock_nix = ser_nix::to_string(&lock_json)
+        .into_diagnostic()
+        .wrap_err("Failed to serialize composed lock file for Nix")?;
+    let expression = format!(
+        "builtins.toJSON (({RESOLVE_INPUT_PATHS}) {{ src = {root_nix}; names = {names_nix}; lockFileJSON = {lock_nix}; }})"
+    );
+
+    let value = eval_state
+        .eval_from_string(&expression, "<devenv-input-imports>")
+        .to_miette()
+        .wrap_err("Failed to resolve imported input sources")?;
+    let json = eval_state
+        .require_string(&value)
+        .to_miette()
+        .wrap_err("Failed to read imported input sources")?;
+    let paths: BTreeMap<String, PathBuf> = serde_json::from_str(&json)
+        .into_diagnostic()
+        .wrap_err("Failed to parse imported input sources")?;
+
+    paths
+        .into_iter()
+        .map(|(name, path)| {
+            let path = path.canonicalize().into_diagnostic().wrap_err_with(|| {
+                format!(
+                    "Failed to canonicalize source for imported input '{name}': {}",
+                    path.display()
+                )
+            })?;
+            Ok((name, path))
+        })
+        .collect()
+}
+
+/// Resolve input-style YAML imports to a fixed point.
+///
+/// `reload` reparses the project with the locked input source map and reapplies
+/// any caller-owned overlays (for example CLI input overrides). The root lock
+/// file remains the single lock graph: imported `devenv.lock` files are not
+/// merged, so existing config precedence also determines input precedence.
+pub fn resolve_config_imports<F>(
+    root: &Path,
+    mut config: Config,
+    nix_settings: &NixSettings,
+    mut reload: F,
+) -> Result<Config>
+where
+    F: FnMut(&BTreeMap<String, PathBuf>) -> Result<Config>,
+{
+    if config.input_import_names().is_empty() {
+        return Ok(config);
+    }
+
+    let _gc_registration = crate::backend::init_nix(nix_settings, &StoreSettings::default())?;
+    let store = crate::backend::open_store(&StoreSettings::default())?;
+    let (flake_settings, fetchers_settings) = crate::backend::build_settings()?;
+    let mut eval_state = build_eval_state(&store, root, &flake_settings)?;
+    let old_lock = crate::load_lock_file(&fetchers_settings, &root.join("devenv.lock"))
+        .to_miette()
+        .wrap_err("Failed to load lock file while resolving remote YAML imports")?;
+
+    for _ in 0..MAX_CONFIG_IMPORT_PASSES {
+        // Build each candidate from the on-disk graph so pins belonging only
+        // to imported YAML survive the initial, root-only config pass. Nothing
+        // is written until the complete import graph has stabilized.
+        let resolved_lock = crate::resolve_lock_file(
+            &eval_state,
+            &fetchers_settings,
+            &flake_settings,
+            root,
+            &config.inputs,
+            old_lock.as_ref(),
+        )
+        .to_miette()
+        .wrap_err("Failed to resolve inputs needed by remote YAML imports")?;
+
+        let sources = input_paths_from_lock(
+            &mut eval_state,
+            root,
+            &config.input_import_names(),
+            &resolved_lock,
+        )?;
+        let next = reload(&sources)?;
+        let import_graph_is_stable = next.inputs == config.inputs && next.imports == config.imports;
+        if import_graph_is_stable {
+            crate::write_lock_file(&resolved_lock, &root.join("devenv.lock"))
+                .to_miette()
+                .wrap_err("Failed to write lock file after composing remote YAML imports")?;
+            return Ok(next);
+        }
+        config = next;
+    }
+
+    bail!(
+        "Remote devenv.yaml imports did not stabilize after {} passes. Check for imports or inputs that change each other recursively.",
+        MAX_CONFIG_IMPORT_PASSES
+    )
 }
 
 /// Lock or update the requested inputs.

--- a/devenv-nix-backend/tests/test_flake_lock.rs
+++ b/devenv-nix-backend/tests/test_flake_lock.rs
@@ -1,11 +1,14 @@
 #![cfg(feature = "test-nix-store")]
 //! Integration tests for flake locking.
 
-use devenv_core::{Config, NixOptions};
-use devenv_nix_backend::load_lock_file;
+use devenv_core::{Config, NixOptions, NixSettings};
+use devenv_nix_backend::{load_lock_file, lock};
 use devenv_nix_backend_macros::nix_test;
 use nix_bindings_fetchers::FetchersSettings;
+use std::collections::BTreeSet;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
 use tempfile::TempDir;
 
 mod common;
@@ -105,6 +108,115 @@ async fn test_full_workflow() {
     let lock = fs::read_to_string(env.path().join("devenv.lock")).expect("read lock");
     assert!(lock.contains("\"nodes\""), "lock should have nodes");
     assert!(lock.contains("nixpkgs"));
+}
+
+#[nix_test]
+async fn test_locked_input_paths_resolve_follows_and_subdirectory() {
+    let remote = TempDir::new().expect("remote temp dir");
+    let remote_url = common::write_local_flake(remote.path(), "remote-config");
+    let config_dir = remote.path().join("config");
+    fs::create_dir(&config_dir).expect("create config dir");
+    fs::create_dir(config_dir.join("tool")).expect("create remote tool dir");
+    fs::write(
+        config_dir.join("devenv.yaml"),
+        "inputs:\n  remote-tool:\n    url: path:./tool\n    flake: false\nreload: false\n",
+    )
+    .expect("write remote yaml");
+    fs::write(config_dir.join("devenv.nix"), "{ }\n").expect("write remote module");
+    fs::write(config_dir.join("tool/marker"), "remote tool\n").expect("write remote tool");
+    let status = Command::new("git")
+        .args([
+            "-c",
+            "user.email=test@devenv",
+            "-c",
+            "user.name=devenv-test",
+            "-c",
+            "commit.gpgsign=false",
+            "-C",
+        ])
+        .arg(remote.path())
+        .args(["add", "config"])
+        .status()
+        .expect("git add remote config");
+    assert!(status.success());
+    let status = Command::new("git")
+        .args([
+            "-c",
+            "user.email=test@devenv",
+            "-c",
+            "user.name=devenv-test",
+            "-c",
+            "commit.gpgsign=false",
+            "-C",
+        ])
+        .arg(remote.path())
+        .args(["commit", "-q", "-m", "add devenv config"])
+        .status()
+        .expect("git commit remote config");
+    assert!(status.success());
+
+    let yaml = format!(
+        r#"inputs:
+  shared:
+    url: {remote_url}?dir=config
+    flake: false
+  shared-alias:
+    follows: shared
+imports:
+  - shared-alias
+"#
+    );
+    let env = TestEnv::builder().yaml(yaml).no_lock().build().await;
+    env.backend
+        .update(&None, &env.config.inputs, &[])
+        .await
+        .expect("lock local remote input");
+
+    let mut eval_state = env.backend.fresh_eval_state().expect("fresh eval state");
+    let paths = lock::input_paths(
+        &mut eval_state,
+        env.path(),
+        &BTreeSet::from(["shared-alias".to_string()]),
+    )
+    .expect("resolve locked input paths");
+    let source = &paths["shared-alias"];
+    assert!(
+        source.starts_with("/nix/store"),
+        "source = {}",
+        source.display()
+    );
+    assert_eq!(
+        fs::read_to_string(source.join("tool/marker")).expect("read resolved source"),
+        "remote tool\n"
+    );
+
+    let compose = || {
+        let config = Config::load_from(env.path()).expect("load root config");
+        lock::resolve_config_imports(
+            env.path(),
+            config,
+            &NixSettings::default(),
+            |input_sources| {
+                Config::load_from_with_source_and_input_sources(env.path(), None, input_sources)
+            },
+        )
+        .expect("compose remote config")
+    };
+
+    let composed = compose();
+    assert!(composed.inputs.contains_key("remote-tool"));
+
+    // A second composition starts from root YAML again. Keep the completed
+    // lock read-only to prove that the discovery pass does not temporarily
+    // prune imported inputs and rewrite the same graph twice.
+    let lock_path = env.path().join("devenv.lock");
+    let mut permissions = fs::metadata(&lock_path)
+        .expect("lock metadata")
+        .permissions();
+    permissions.set_mode(0o444);
+    fs::set_permissions(&lock_path, permissions).expect("make lock read-only");
+    let composed_again = compose();
+    assert!(composed_again.inputs.contains_key("remote-tool"));
 }
 
 /// Regression: relative paths with `..` in the path portion (e.g.

--- a/devenv-run-tests/src/main.rs
+++ b/devenv-run-tests/src/main.rs
@@ -414,24 +414,43 @@ async fn run_tests_in_directory(args: &RunArgs) -> Result<Vec<TestResult>> {
 
         let status: miette::Result<()> = if test_config.use_shell {
             // Now load config from the current directory (which might be temp dir)
-            let mut config = Config::load_from(&devenv_root)?;
-            for input in args.override_inputs.chunks_exact(2) {
+            let devenv_input_url = format!("git+file:{}?dir=src/modules", cwd.display());
+            let apply_test_inputs = |config: &mut Config| -> Result<()> {
+                for input in args.override_inputs.chunks_exact(2) {
+                    config
+                        .override_input_url(&input[0], &input[1])
+                        .wrap_err(format!(
+                            "Failed to override input {} with {}",
+                            &input[0], &input[1]
+                        ))?;
+                }
                 config
-                    .override_input_url(&input[0], &input[1])
-                    .wrap_err(format!(
-                        "Failed to override input {} with {}",
-                        &input[0], &input[1]
-                    ))?;
-            }
+                    .add_input("devenv", &devenv_input_url, &[])
+                    .wrap_err("Failed to add devenv input")?;
+                Ok(())
+            };
 
-            // Override the input for the devenv module
-            config
-                .add_input(
-                    "devenv",
-                    &format!("git+file:{}?dir=src/modules", cwd.display()),
-                    &[],
-                )
-                .wrap_err("Failed to add devenv input")?;
+            let mut config = Config::load_from(&devenv_root)?;
+            apply_test_inputs(&mut config)?;
+
+            let preliminary_nix_settings = NixSettings {
+                backend: config.backend.clone(),
+                ..NixSettings::default()
+            };
+            config = devenv_nix_backend::lock::resolve_config_imports(
+                &devenv_root,
+                config,
+                &preliminary_nix_settings,
+                |input_sources| {
+                    let mut config = Config::load_from_with_source_and_input_sources(
+                        &devenv_root,
+                        None,
+                        input_sources,
+                    )?;
+                    apply_test_inputs(&mut config)?;
+                    Ok(config)
+                },
+            )?;
 
             let nix_settings = NixSettings {
                 backend: config.backend.clone(),

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -407,18 +407,32 @@ fn prepare_command(mut cli: Cli) -> Result<PreparedCommand> {
             fs::canonicalize(&full_path).unwrap_or(full_path)
         });
 
-    let mut config = Config::load_with_source(from_path.as_deref())?;
-    config.check_version(crate_version!())?;
-
     let input_overrides = InputOverrides::from(cli.input_overrides);
-    for chunk in input_overrides.override_inputs.chunks_exact(2) {
-        let [name, url] = chunk else {
-            unreachable!("chunks_exact(2)")
-        };
-        config
-            .override_input_url(name, url)
-            .wrap_err_with(|| format!("Failed to override input {name} with URL {url}"))?;
-    }
+    let mut config = Config::load_with_source(from_path.as_deref())?;
+    apply_input_overrides(&mut config, &input_overrides.override_inputs, true)?;
+
+    // Input-style imports need their locked source before their devenv.yaml
+    // can join the normal local merge. Reloading through the same Config path
+    // keeps precedence and path normalization identical for local and remote
+    // projects. CLI overrides are reapplied because they are intentionally
+    // outside the YAML merge.
+    let preliminary_nix_settings =
+        NixSettings::resolve(devenv_core::NixOptions::from(cli.nix_args.clone()), &config);
+    config = devenv_nix_backend::lock::resolve_config_imports(
+        Path::new("."),
+        config,
+        &preliminary_nix_settings,
+        |input_sources| {
+            let mut config =
+                Config::load_with_source_and_input_sources(from_path.as_deref(), input_sources)?;
+            apply_input_overrides(&mut config, &input_overrides.override_inputs, true)?;
+            Ok(config)
+        },
+    )?;
+    // Missing overrides are errors only after imported YAML has had a chance
+    // to declare the target input.
+    apply_input_overrides(&mut config, &input_overrides.override_inputs, false)?;
+    config.check_version(crate_version!())?;
 
     // A non-path source (flake ref, via --from or a persisted binding) is
     // fetched as the `from` input and its devenv.nix imported from the store.
@@ -512,6 +526,28 @@ fn prepare_command(mut cli: Cli) -> Result<PreparedCommand> {
         test_environment,
         shutdown,
     })
+}
+
+/// Apply flat `[name, url, ...]` overrides, optionally deferring unknown names
+/// until remote YAML imports have been composed.
+fn apply_input_overrides(
+    config: &mut Config,
+    overrides: &[String],
+    defer_unknown: bool,
+) -> Result<()> {
+    for chunk in overrides.chunks_exact(2) {
+        let [name, url] = chunk else {
+            unreachable!("chunks_exact(2)")
+        };
+        let is_known = config.inputs.contains_key(name) || name == "nixpkgs" || name == "devenv";
+        if defer_unknown && !is_known {
+            continue;
+        }
+        config
+            .override_input_url(name, url)
+            .wrap_err_with(|| format!("Failed to override input {name} with URL {url}"))?;
+    }
+    Ok(())
 }
 
 /// The activity sink for a run.

--- a/docs/src/composing-using-imports.md
+++ b/docs/src/composing-using-imports.md
@@ -24,25 +24,39 @@ If you enter the ``frontend`` directory, the environment will activate based on 
 If you enter the top-level project, the environment is combined with what's defined in ``backend/devenv.nix`` and ``frontend/devenv.nix``.
 For example, ``devenv up`` will start both the frontend and backend processes.
 
-!!! note "Added in 1.10"
+!!! note "YAML composition"
 
-    Composing ``devenv.yaml`` files is now supported for local files (relative and absolute paths).
-    Remote inputs are not yet supported for ``devenv.yaml`` imports.
+    Local `devenv.yaml` composition was added in 1.10. Remote input composition
+    is supported in 2.2.1 and later.
 
 ## Sharing configuration from another repository
 
-To keep your devenv configuration in a separate repository, for example when working on a team that doesn't use devenv, declare it as a `path:` input and import it:
+To keep your devenv configuration in a separate repository, declare it as an
+input and import the directory containing its `devenv.yaml` and `devenv.nix`:
 
 ```yaml title="devenv.yaml"
 inputs:
   shared-config:
-    url: path:../shared-config/
+    url: github:my-org/shared-devenv-config
     flake: false
 imports:
-- shared-config
+- shared-config/profiles/backend
 ```
 
-The sibling `shared-config` repository only needs a `devenv.nix` file.
+This uses the existing input import syntax; no additional YAML option is
+required. Imports inside the remote `devenv.yaml` are composed recursively,
+and relative `path:` inputs declared there resolve inside the fetched source.
+
+The importing project's `devenv.lock` is the single lock file for the composed
+environment. A `devenv.lock` in the imported repository is not merged. Input
+declarations use the same precedence as local YAML composition, so a declaration
+in the root project wins when both configurations use the same name. In
+particular, when the shared configuration also declares `nixpkgs`, the root
+project's pinned `nixpkgs` is reused instead of creating a second one. Use
+distinct input names when the versions must remain independent.
+
+For a sibling checkout, use `url: path:../shared-config/` in the same example.
+The shared repository may also contain only a `devenv.nix` file.
 Combine this with [profiles](profiles.md) to define one shared configuration that adapts to each project.
 
 !!! tip "New in version 2.2"

--- a/tests/import-remote/.patch.sh
+++ b/tests/import-remote/.patch.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p remote/profile/tool remote/profile/nested/tool
+
+cat > remote/profile/devenv.yaml <<'EOF'
+inputs:
+  nixpkgs:
+    url: github:NixOS/nixpkgs/this-must-be-overridden-by-the-root
+  remote-tool:
+    url: path:./tool
+    flake: false
+imports:
+  - ./nested
+EOF
+
+cat > remote/profile/devenv.nix <<'EOF'
+{ inputs, ... }:
+{
+  env.REMOTE_MODULE = builtins.replaceStrings [ "\n" ] [ "" ]
+    (builtins.readFile (inputs.remote-tool + /marker));
+}
+EOF
+
+cat > remote/profile/tool/marker <<'EOF'
+remote-tool
+EOF
+
+cat > remote/profile/nested/devenv.yaml <<'EOF'
+inputs:
+  nested-tool:
+    url: path:./tool
+    flake: false
+EOF
+
+cat > remote/profile/nested/devenv.nix <<'EOF'
+{ inputs, ... }:
+{
+  env.REMOTE_NESTED_MODULE = builtins.replaceStrings [ "\n" ] [ "" ]
+    (builtins.readFile (inputs.nested-tool + /marker));
+}
+EOF
+
+cat > remote/profile/nested/tool/marker <<'EOF'
+nested-tool
+EOF
+
+git -C remote init -q --initial-branch=main
+git -C remote add .
+git -C remote \
+  -c user.email=test@devenv \
+  -c user.name=devenv-test \
+  -c commit.gpgsign=false \
+  commit -q -m 'remote devenv config'
+
+remote_url="git+file://$(pwd)/remote?dir=profile"
+sed "s|@REMOTE@|$remote_url|" devenv.yaml > devenv.yaml.new
+mv devenv.yaml.new devenv.yaml

--- a/tests/import-remote/devenv.nix
+++ b/tests/import-remote/devenv.nix
@@ -1,0 +1,19 @@
+{ inputs, ... }:
+
+{
+  assertions = [
+    {
+      assertion = inputs ? remote-tool;
+      message = "remote-tool from the imported devenv.yaml was not merged";
+    }
+    {
+      assertion = inputs ? nested-tool;
+      message = "nested-tool from the transitive remote devenv.yaml was not merged";
+    }
+  ];
+
+  enterTest = ''
+    test "$REMOTE_MODULE" = "remote-tool"
+    test "$REMOTE_NESTED_MODULE" = "nested-tool"
+  '';
+}

--- a/tests/import-remote/devenv.yaml
+++ b/tests/import-remote/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  shared:
+    url: "@REMOTE@"
+    flake: false
+imports:
+  - shared


### PR DESCRIPTION
_The PR was created with GPT-5.6-Sol Max._

Fixes https://github.com/cachix/devenv/issues/2205

## Summary

This PR extends the existing `inputs` and `imports` syntax so projects can compose `devenv.yaml` files from remote repositories:

```yaml
inputs:
  shared-config:
    url: github:my-org/shared-config
    flake: false

imports:
  - shared-config/profiles/backend
```

Remote configuration is loaded recursively using sources resolved from `devenv.lock`. No new YAML options are introduced.

### Locking and input precedence

The importing project’s `devenv.lock` remains the single lock graph for the composed environment. Lockfiles from imported repositories are intentionally not merged.

Imported input declarations use the existing YAML merge semantics:

- The root project retains precedence for duplicate input names.
- Shared configurations that also declare `nixpkgs` reuse the root project’s `nixpkgs`.
- Distinct input names remain independent and can use `follows` when they should share a lock node.
- Only inputs referenced by `imports` are materialized while discovering remote YAML.

Candidate lock graphs are built in memory until the complete import graph stabilizes, then written once. This avoids repeatedly pruning and restoring inputs declared only by remote YAML.

### Additional behavior

- Supports nested remote YAML imports.
- Supports `follows` aliases and input URLs using `dir=`.
- Resolves relative `path:` inputs against the remote repository.
- Prevents imported configurations from escaping their locked source.
- Preserves transitive direct Nix module imports.
- Reapplies CLI input overrides as remote inputs are discovered.

## Testing

- Added unit tests for remote YAML traversal, precedence, relative inputs, and path security.
- Added lock tests covering `follows`, `dir=`, transitive inputs, and lock stability.
- Added an end-to-end remote git repository fixture.
- Verified existing local import and monorepo composition suites.
- Verified first-run lock creation and subsequent operation with an unchanged, read-only lock.