### PR TITLE
fix(profiles): prioritize package-valued options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug Fixes
 
+- Fixed profiles failing to override package-valued options, such as `languages.python.package`, unless the profile
+  used `lib.mkForce`. Automatic profile priorities now apply to derivation values while mergeable package lists
+  continue to combine ([#3057](https://github.com/cachix/devenv/issues/3057)).
 - Fixed `devenv shell` occasionally losing the exit code of the shell it ran, reporting success for a session that exited nonzero.
 - Fixed `devenv --profile <name> allow` ignoring the selected profile for projects with a local `devenv.nix`. Allowed in-tree projects now persist their auto-activation profiles just like out-of-tree `--from` bindings; explicit `--profile` flags still take priority.
 - Fixed `devenv init` hanging when an existing file differs from the template and there is no terminal to confirm on.

--- a/devenv-nix-backend/bootstrap/bootstrapLib.nix
+++ b/devenv-nix-backend/bootstrap/bootstrapLib.nix
@@ -393,10 +393,10 @@ rec {
                     config: optionPath:
                     if lib.isAttrs config && config ? _type then
                       config
-                    else if lib.isAttrs config then
-                      lib.mapAttrs (name: value: applyOverrideRecursive value (optionPath ++ [ name ])) config
                     else if pathNeedsOverride optionPath then
                       lib.mkOverride profilePriority config
+                    else if lib.isAttrs config then
+                      lib.mapAttrs (name: value: applyOverrideRecursive value (optionPath ++ [ name ])) config
                     else
                       config;
 

--- a/tests/profile-package-priority/.test-config.yml
+++ b/tests/profile-package-priority/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/profile-package-priority/.test.sh
+++ b/tests/profile-package-priority/.test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base=$(devenv eval profilePriorityTest.package.pname)
+echo "$base" | grep -Eq '"profilePriorityTest.package.pname"[[:space:]]*:[[:space:]]*"hello"'
+
+profile=$(devenv --profile package-override eval profilePriorityTest.package.pname)
+echo "$profile" | grep -Eq '"profilePriorityTest.package.pname"[[:space:]]*:[[:space:]]*"curl"'

--- a/tests/profile-package-priority/devenv.nix
+++ b/tests/profile-package-priority/devenv.nix
@@ -1,0 +1,15 @@
+{ lib, pkgs, ... }:
+
+{
+  options.profilePriorityTest.package = lib.mkOption {
+    type = lib.types.package;
+  };
+
+  config = {
+    profilePriorityTest.package = pkgs.hello;
+
+    profiles.package-override.module = {
+      profilePriorityTest.package = pkgs.curl;
+    };
+  };
+}


### PR DESCRIPTION
Fixes #3057.

`applyOverrideRecursive` previously recursed into attribute-set values before checking the declared option path. Because derivations are attribute sets, `types.package` values bypassed automatic profile priority.

This checks the option path first, after preserving explicit `_type` constructs such as `mkForce` and `mkIf`. Mergeable options remain unchanged.

A focused regression test covers a singular package-valued option set by both the base configuration and a profile. The existing profile suite continues to verify package-list merging and explicit override behavior.

Validation:

- `nix build .#devenv`
- `devenv-run-tests run tests --only profile-package-priority`
- `devenv-run-tests run tests --only profiles`
- `nixpkgs-fmt --check` on the changed Nix files
- `bash -n tests/profile-package-priority/.test.sh`
- Pinned and current-main reproductions before and after the fix
