### PR TITLE
Preserve hook shell during auto-activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed profiles failing to override package-valued options, such as `languages.python.package`, unless the profile
   used `lib.mkForce`. Automatic profile priorities now apply to derivation values while mergeable package lists
   continue to combine ([#3057](https://github.com/cachix/devenv/issues/3057)).
+- Fixed `devenv hook zsh` and the other shell hooks starting Bash when an editor terminal inherited a valid but stale Bash `$SHELL`. Auto-activation now passes the known outer shell as a non-authoritative hint, below explicit CLI, environment, and `devenv.yaml` shell settings but above ambient `$SHELL` detection ([#2880](https://github.com/cachix/devenv/issues/2880)).
 - Fixed `devenv shell` occasionally losing the exit code of the shell it ran, reporting success for a session that exited nonzero.
 - Fixed `devenv --profile <name> allow` ignoring the selected profile for projects with a local `devenv.nix`. Allowed in-tree projects now persist their auto-activation profiles just like out-of-tree `--from` bindings; explicit `--profile` flags still take priority.
 - Fixed `devenv init` hanging when an existing file differs from the template and there is no terminal to confirm on.

--- a/devenv-core/src/settings.rs
+++ b/devenv-core/src/settings.rs
@@ -270,19 +270,47 @@ impl Default for ShellSettings {
 impl ShellSettings {
     /// Resolve shell settings from options and config sources.
     ///
-    /// Precedence: Options > Config > $SHELL > login shell > Default.
+    /// Precedence: Options > Config > hook hint > $SHELL > login shell > Default.
     pub fn resolve(options: ShellOptions, config: &Config) -> Self {
-        Self::resolve_with_env_and_login_shell(
+        Self::resolve_with_shell_hint(options, config, None)
+    }
+
+    /// Resolve shell settings with a non-authoritative hint from the invoking
+    /// shell integration. Explicit options and project configuration still win.
+    pub fn resolve_with_shell_hint(
+        options: ShellOptions,
+        config: &Config,
+        shell_hint: Option<&str>,
+    ) -> Self {
+        Self::resolve_with_shell_hint_env_and_login_shell(
             options,
             config,
+            shell_hint,
             shell_name_from_env,
             login_shell_name,
         )
     }
 
+    #[cfg(test)]
     fn resolve_with_env_and_login_shell(
         options: ShellOptions,
         config: &Config,
+        env_shell: impl FnOnce() -> Option<String>,
+        login_shell: impl FnOnce() -> Option<(String, std::path::PathBuf)>,
+    ) -> Self {
+        Self::resolve_with_shell_hint_env_and_login_shell(
+            options,
+            config,
+            None,
+            env_shell,
+            login_shell,
+        )
+    }
+
+    fn resolve_with_shell_hint_env_and_login_shell(
+        options: ShellOptions,
+        config: &Config,
+        shell_hint: Option<&str>,
         env_shell: impl FnOnce() -> Option<String>,
         login_shell: impl FnOnce() -> Option<(String, std::path::PathBuf)>,
     ) -> Self {
@@ -320,6 +348,16 @@ impl ShellSettings {
                 );
                 ("bash".to_string(), None, "devenv.yaml (fallback)")
             }
+        } else if let Some(shell) = shell_hint.and_then(supported_shell) {
+            // Preserve the absolute login-shell path when it describes the
+            // hinted dialect. This keeps hook activation working even when
+            // the editor also supplied a stripped PATH.
+            let shell_path = if shell == "bash" {
+                None
+            } else {
+                login_shell().and_then(|(name, path)| (name == shell).then_some(path))
+            };
+            (shell, shell_path, "shell hook")
         } else if let Some(shell) = env_shell().and_then(|shell| supported_shell(&shell)) {
             (shell, None, "$SHELL env")
         } else if let Some((name, path)) = login_shell()
@@ -721,6 +759,78 @@ mod tests {
         };
         let settings = ShellSettings::resolve(options, &config);
         assert_eq!(settings.shell, "zsh");
+    }
+
+    #[test]
+    fn shell_settings_hook_hint_precedes_stale_env_shell() {
+        let settings = ShellSettings::resolve_with_shell_hint_env_and_login_shell(
+            ShellOptions::default(),
+            &Config::default(),
+            Some("zsh"),
+            || Some("bash".to_string()),
+            || {
+                Some((
+                    "zsh".to_string(),
+                    std::path::PathBuf::from("/run/current-system/sw/bin/zsh"),
+                ))
+            },
+        );
+
+        assert_eq!(settings.shell, "zsh");
+        assert_eq!(
+            settings.shell_path,
+            Some(std::path::PathBuf::from("/run/current-system/sw/bin/zsh"))
+        );
+    }
+
+    #[test]
+    fn shell_settings_config_precedes_hook_hint() {
+        let config = Config {
+            shell: Some("fish".into()),
+            ..Default::default()
+        };
+        let settings = ShellSettings::resolve_with_shell_hint_env_and_login_shell(
+            ShellOptions::default(),
+            &config,
+            Some("zsh"),
+            || panic!("config shell should suppress ambient shell lookup"),
+            || panic!("config shell should suppress login shell lookup"),
+        );
+
+        assert_eq!(settings.shell, "fish");
+        assert!(settings.shell_path.is_none());
+    }
+
+    #[test]
+    fn shell_settings_options_precede_hook_hint() {
+        let options = ShellOptions {
+            shell: Some("bash".into()),
+            ..Default::default()
+        };
+        let settings = ShellSettings::resolve_with_shell_hint_env_and_login_shell(
+            options,
+            &Config::default(),
+            Some("zsh"),
+            || panic!("explicit shell should suppress ambient shell lookup"),
+            || panic!("explicit shell should suppress login shell lookup"),
+        );
+
+        assert_eq!(settings.shell, "bash");
+        assert!(settings.shell_path.is_none());
+    }
+
+    #[test]
+    fn shell_settings_unsupported_hook_hint_uses_env_shell() {
+        let settings = ShellSettings::resolve_with_shell_hint_env_and_login_shell(
+            ShellOptions::default(),
+            &Config::default(),
+            Some("tcsh"),
+            || Some("fish".to_string()),
+            || panic!("supported ambient shell should suppress login shell lookup"),
+        );
+
+        assert_eq!(settings.shell, "fish");
+        assert!(settings.shell_path.is_none());
     }
 
     #[test]

--- a/devenv/build.rs
+++ b/devenv/build.rs
@@ -89,12 +89,13 @@ fn assemble_shell_hooks() -> Result<(), Box<dyn std::error::Error>> {
     let posix = fs::read_to_string("hooks/hook.posix.sh")?;
     println!("cargo:rerun-if-changed=hooks/hook.posix.sh");
 
-    for (register_path, out_name) in [
-        ("hooks/hook.bash-register.sh", "hook.sh"),
-        ("hooks/hook.zsh-register.zsh", "hook.zsh"),
+    for (register_path, out_name, shell_name) in [
+        ("hooks/hook.bash-register.sh", "hook.sh", "bash"),
+        ("hooks/hook.zsh-register.zsh", "hook.zsh", "zsh"),
     ] {
         let register = fs::read_to_string(register_path)?;
-        fs::write(out_dir.join(out_name), format!("{posix}\n{register}"))?;
+        let script = posix.replace("@DEVENV_SHELL_HINT@", shell_name);
+        fs::write(out_dir.join(out_name), format!("{script}\n{register}"))?;
         println!("cargo:rerun-if-changed={register_path}");
     }
 

--- a/devenv/hooks/hook.fish
+++ b/devenv/hooks/hook.fish
@@ -56,7 +56,7 @@ function _devenv_hook_activate
     if test -n "$DEVENV_ROOT"
         return
     end
-    env -C $project_dir _DEVENV_HOOK_DIR=$project_dir _DEVENV_CALLER=hook devenv shell
+    env -C $project_dir _DEVENV_HOOK_DIR=$project_dir _DEVENV_CALLER=hook _DEVENV_SHELL_HINT=fish devenv shell
     # If the devenv shell exited due to cd outside the project, follow the user there
     set -l exit_dir_file "$project_dir/.devenv/exit-dir"
     if test -f "$exit_dir_file"

--- a/devenv/hooks/hook.nu
+++ b/devenv/hooks/hook.nu
@@ -65,7 +65,7 @@ def --env _devenv_hook [] {
             # `try` nushell aborts the hook on that non-zero exit and never
             # follows the user to `exit-dir` below.
             try {
-                with-env { _DEVENV_HOOK_DIR: $dir, _DEVENV_CALLER: "hook" } { do { cd $dir; ^devenv shell } }
+                with-env { _DEVENV_HOOK_DIR: $dir, _DEVENV_CALLER: "hook", _DEVENV_SHELL_HINT: "nu" } { do { cd $dir; ^devenv shell } }
             }
             let exit_dir_file = ($dir + "/.devenv/exit-dir")
             if ($exit_dir_file | path exists) {

--- a/devenv/hooks/hook.posix.sh
+++ b/devenv/hooks/hook.posix.sh
@@ -60,7 +60,7 @@ _devenv_hook() {
         # Mark activated before launching so exiting the shell (or a SIGINT/
         # failure inside it) doesn't re-launch on the next prompt redraw.
         _DEVENV_HOOK_ACTIVATED="$PWD"
-        (cd "$project_dir" && _DEVENV_HOOK_DIR="$project_dir" _DEVENV_CALLER=hook devenv shell)
+        (cd "$project_dir" && _DEVENV_HOOK_DIR="$project_dir" _DEVENV_CALLER=hook _DEVENV_SHELL_HINT=@DEVENV_SHELL_HINT@ devenv shell)
         local exit_dir_file="$project_dir/.devenv/exit-dir"
         if [[ -f "$exit_dir_file" ]]; then
             local target_dir

--- a/devenv/src/commands/hook.rs
+++ b/devenv/src/commands/hook.rs
@@ -446,6 +446,26 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_script_passes_shell_hint() {
+        for (shell, expected) in [
+            (HookShell::Bash, "_DEVENV_SHELL_HINT=bash"),
+            (HookShell::Zsh, "_DEVENV_SHELL_HINT=zsh"),
+            (HookShell::Fish, "_DEVENV_SHELL_HINT=fish"),
+            (HookShell::Nu, "_DEVENV_SHELL_HINT: \"nu\""),
+        ] {
+            let script = hook_script(&shell);
+            assert!(
+                script.contains(expected),
+                "{shell:?} hook does not pass its shell hint"
+            );
+            assert!(
+                !script.contains("@DEVENV_SHELL_HINT@"),
+                "{shell:?} hook left an unsubstituted shell hint"
+            );
+        }
+    }
+
+    #[test]
     fn test_allow_and_revoke() {
         let dir = TempDir::new().unwrap();
         let project = dir.path().join("myproject");

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -32,6 +32,7 @@ use tokio_shutdown::Shutdown;
 use tracing::{info, instrument};
 
 const DEVENV_CALLER: &str = "_DEVENV_CALLER";
+const DEVENV_SHELL_HINT: &str = "_DEVENV_SHELL_HINT";
 
 fn main() {
     // Handle shell completion requests (COMPLETE=bash devenv)
@@ -49,7 +50,7 @@ fn main() {
 }
 
 fn main_inner() -> Result<()> {
-    let caller = Caller::from_env();
+    let invocation = Invocation::from_env();
 
     // Retry loop: if the backend discovers secrets need interactive prompting,
     // we prompt the user and re-run the entire command with secrets now available.
@@ -102,9 +103,9 @@ fn main_inner() -> Result<()> {
             _ => {}
         }
 
-        let prepared = prepare_command(cli)?;
+        let prepared = prepare_command(cli, invocation.shell_hint.as_deref())?;
 
-        match run(prepared, caller) {
+        match run(prepared, invocation.caller) {
             Err(err) => match err.downcast::<devenv::SecretsNeedPrompting>() {
                 Ok(secrets_err) => {
                     if !terminal::can_use_stdin_interactively() {
@@ -166,21 +167,45 @@ enum Caller {
     Hook,
 }
 
-impl Caller {
+struct Invocation {
+    caller: Caller,
+    shell_hint: Option<String>,
+}
+
+impl Invocation {
     fn from_env() -> Self {
         let caller = env::var_os(DEVENV_CALLER);
+        let shell_hint = env::var(DEVENV_SHELL_HINT).ok();
         // This runs before devenv starts any threads. Removing the one-shot
-        // marker prevents commands launched by an activated shell from
-        // inheriting the original caller.
-        unsafe { env::remove_var(DEVENV_CALLER) };
-
-        match caller.as_deref().and_then(|value| value.to_str()) {
-            Some("direnv") => Self::Direnv,
-            Some("hook") => Self::Hook,
-            _ => Self::Cli,
+        // invocation metadata prevents commands launched by an activated shell
+        // from inheriting the original caller or its ambient shell hint.
+        unsafe {
+            env::remove_var(DEVENV_CALLER);
+            env::remove_var(DEVENV_SHELL_HINT);
         }
+
+        Self::from_parts(
+            caller.as_deref().and_then(|value| value.to_str()),
+            shell_hint,
+        )
     }
 
+    fn from_parts(caller: Option<&str>, shell_hint: Option<String>) -> Self {
+        let caller = match caller {
+            Some("direnv") => Caller::Direnv,
+            Some("hook") => Caller::Hook,
+            _ => Caller::Cli,
+        };
+        let shell_hint = match caller {
+            Caller::Hook => shell_hint,
+            Caller::Cli | Caller::Direnv => None,
+        };
+
+        Self { caller, shell_hint }
+    }
+}
+
+impl Caller {
     fn as_str(self) -> &'static str {
         match self {
             Self::Cli => "cli",
@@ -310,7 +335,7 @@ fn enter_discovered_project_root() -> Result<()> {
 }
 
 /// Prepare a config-backed CLI command for execution.
-fn prepare_command(mut cli: Cli) -> Result<PreparedCommand> {
+fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCommand> {
     let command = cli.command;
 
     // --- Project discovery and working directory ---
@@ -447,8 +472,11 @@ fn prepare_command(mut cli: Cli) -> Result<PreparedCommand> {
     if matches!(command, Commands::Update { .. }) {
         nix_settings.refresh_fetchers = true;
     }
-    let shell_settings =
-        ShellSettings::resolve(devenv_core::ShellOptions::from(cli.shell_args), &config);
+    let shell_settings = ShellSettings::resolve_with_shell_hint(
+        devenv_core::ShellOptions::from(cli.shell_args),
+        &config,
+        shell_hint,
+    );
     let cache_settings = CacheSettings::resolve(devenv_core::CacheOptions::from(cli.cache_args));
     let secret_settings =
         SecretSettings::resolve(devenv_core::SecretOptions::from(cli.secret_args), &config);
@@ -1576,6 +1604,21 @@ mod tests {
 
     static PROCESS_STATE_LOCK: Mutex<()> = Mutex::new(());
 
+    #[test]
+    fn shell_hint_is_only_accepted_from_hook_invocations() {
+        let hook = Invocation::from_parts(Some("hook"), Some("zsh".to_string()));
+        assert!(matches!(hook.caller, Caller::Hook));
+        assert_eq!(hook.shell_hint.as_deref(), Some("zsh"));
+
+        let cli = Invocation::from_parts(None, Some("zsh".to_string()));
+        assert!(matches!(cli.caller, Caller::Cli));
+        assert!(cli.shell_hint.is_none());
+
+        let direnv = Invocation::from_parts(Some("direnv"), Some("zsh".to_string()));
+        assert!(matches!(direnv.caller, Caller::Direnv));
+        assert!(direnv.shell_hint.is_none());
+    }
+
     struct ProcessStateGuard {
         cwd: PathBuf,
         devenv_home: Option<OsString>,
@@ -1620,11 +1663,11 @@ mod tests {
         commands::hook::allow(&devenv_home, None, &["base".to_string()]).unwrap();
 
         let cli = <Cli as clap::Parser>::parse_from(["devenv", "shell"]);
-        let prepared = prepare_command(cli).unwrap();
+        let prepared = prepare_command(cli, None).unwrap();
         assert_eq!(prepared.backend.devenv.shell_settings.profiles, ["base"]);
 
         let cli = <Cli as clap::Parser>::parse_from(["devenv", "--profile=explicit", "shell"]);
-        let prepared = prepare_command(cli).unwrap();
+        let prepared = prepare_command(cli, None).unwrap();
         assert_eq!(
             prepared.backend.devenv.shell_settings.profiles,
             ["explicit"]
@@ -1632,7 +1675,7 @@ mod tests {
 
         commands::hook::allow(&devenv_home, None, &[]).unwrap();
         let cli = <Cli as clap::Parser>::parse_from(["devenv", "shell"]);
-        let prepared = prepare_command(cli).unwrap();
+        let prepared = prepare_command(cli, None).unwrap();
         assert!(prepared.backend.devenv.shell_settings.profiles.is_empty());
     }
 

--- a/devenv/tests/hook_outer_shell_survives.rs
+++ b/devenv/tests/hook_outer_shell_survives.rs
@@ -226,6 +226,62 @@ fn no_respawn_inside_devenv_shell() {
 }
 
 #[test]
+fn hook_passes_invoking_shell_as_hint() {
+    for (shell, src, path_override) in shells() {
+        let project = fake_project();
+        let shim_dir = tempfile::tempdir().unwrap();
+        let calls = shim_dir.path().join("calls");
+        let shim = shim_dir.path().join("devenv");
+        fs::write(
+            &shim,
+            format!(
+                r#"#!/bin/sh
+case "$1" in
+  hook-should-activate)
+    printf '%s\n' {project:?}
+    ;;
+  shell)
+    printf '%s\n' "${{_DEVENV_SHELL_HINT:-}}" > {calls:?}
+    ;;
+esac
+"#,
+                project = project.path(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let stale_shell = if shell == "fish" {
+            "set -gx SHELL /bin/bash"
+        } else {
+            "export SHELL=/bin/bash"
+        };
+        let clear_markers = if shell == "fish" {
+            "set -e DEVENV_ROOT; set -e _DEVENV_HOOK_DIR"
+        } else {
+            "unset DEVENV_ROOT _DEVENV_HOOK_DIR"
+        };
+        let script = format!(
+            "{clear_markers}\n{stale_shell}\n{src}\ncd {project:?}\n{path_override}\n_devenv_hook\n",
+            project = project.path(),
+            path_override = path_override(shim_dir.path()),
+        );
+        let out = run(shell, &script);
+        assert!(
+            out.status.success(),
+            "[{shell}] hook failed.\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        assert_eq!(
+            fs::read_to_string(&calls).unwrap_or_default().trim(),
+            shell,
+            "[{shell}] hook did not pass the invoking shell as its hint"
+        );
+    }
+}
+
+#[test]
 fn fish_deferred_activation_skips_if_already_active() {
     // Fish defers activation to the next prompt (see the comment on
     // `_devenv_hook` in hook.fish) to avoid spawning inside a PWD event


### PR DESCRIPTION
## Summary

- pass the invoking shell from the bash, zsh, fish, and nushell hooks as a private one-shot hint
- resolve that hint below explicit CLI/environment and project configuration, but above the ambient `$SHELL`
- preserve the absolute login-shell path when it matches the hinted shell
- consume hook invocation metadata before constructing the shell environment
- add precedence, caller-gating, generated-hook, and cross-shell regression tests

## Root cause

The fallback added in #2992 handles an absent or unsupported `$SHELL`, but editor terminals can start zsh while retaining a valid, stale `SHELL=/bin/bash`. The hook already knows which shell is executing it, but that information was discarded before `devenv shell` resolved the target shell.

This change carries that context only for hook-triggered activation. It intentionally does not use `DEVENV_SHELL_TYPE`, because that would incorrectly override project configuration.

## User impact

Hook auto-activation now stays in the user's current shell in VS Code/VSCodium and similar environments, without requiring a per-project workaround. Existing explicit choices via `--shell`, `DEVENV_SHELL_TYPE`, or `devenv.yaml` remain authoritative.

## Validation

- `devenv shell cargo fmt --all -- --check`
- `devenv shell cargo check -p devenv`
- `devenv shell cargo test -p devenv-core` (219 passed)
- `devenv shell cargo test -p devenv test_hook_script_ -- --nocapture`
- `devenv shell cargo test -p devenv --bin devenv shell_hint_is_only_accepted_from_hook_invocations -- --nocapture`
- `devenv shell cargo test -p devenv --test hook_outer_shell_survives -- --nocapture` (bash, zsh, fish, and nushell)
- `nix build -L --no-link .#devenv`
- `git diff --check`

Fixes #2880