### PR TITLE
docs: added example for python with CUDA support

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -255,6 +255,33 @@ devenv adds these libraries to `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` 
 
 For more control over library search paths, use the `libraries` option.
 
+### CUDA support
+
+Some Python packages require CUDA support. 
+This is a minimal working example of enabling CUDA support in a Python environment.
+
+```nix
+{
+  packages = [ 
+    # Typical CUDA dependencies
+    pkgs.cudaPackages.cuda_cudart  # Runtime 
+    pkgs.cudaPackages.cudnn        # Deep neural networks 
+    pkgs.cudaPackages.cuda_nvrtc   # Runtime compiler
+    pkgs.cudaPackages.cuda_cupti   # Profiling tools interface
+    pkgs.cudaPackages.cudatoolkit  # Toolkit
+  ];
+
+  languages.python = {
+    enable = true;
+    venv.enable = true;
+    libraries = [
+      # Point CUDA libraries to host CUDA drivers
+      "/run/opengl-driver/lib:/run/opengl-driver-32/lib"
+    ];
+  };
+}
+```
+
 ### Manylinux support
 
 On Linux, some pre-built Python wheels depend on [manylinux](https://github.com/pypa/manylinux) compatibility libraries.


### PR DESCRIPTION
Added dedicated example in the documentation for using Python with CUDA support (common use case, eg. deep learning w/ PyTorch). 

Requires manually injecting the host CUDA driver path in `LD_LIBRARY_PATH` via `libraries` option. 

Maybe we should add a dedicated flag in Python configuration options? 

<img width="789" height="570" alt="Screenshot from 2026-08-03 20-29-41" src="https://github.com/user-attachments/assets/e5173e14-8b95-487c-ae85-765c346c9f46" />

