### PR TITLE
fix: seed port allocations for every command, not just up and tasks run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.2 (unreleased)
 
+### Bug Fixes
+
+- Fixed allocated ports resolving to the declared base port in every command except `devenv up` and `devenv tasks run`. `devenv shell`, `direnv-export` and the other evaluating commands seed port allocations from a running process manager again ([#2710](https://github.com/cachix/devenv/issues/2710)).
+
 ## 2.2.1 (2026-08-02)
 
 ### Bug Fixes

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -2902,12 +2902,26 @@ impl Devenv {
 
         self.port_allocator.set_allow_in_use(false);
 
-        match processes::NativeProcessManager::api_request(
-            &self.native_socket_path(),
-            &processes::ApiRequest::Ports,
+        // Bounded because this runs before every command: a manager whose
+        // socket accepts but never answers must not hang the CLI.
+        let query = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            processes::NativeProcessManager::api_request(
+                &self.native_socket_path(),
+                &processes::ApiRequest::Ports,
+            ),
         )
-        .await
-        {
+        .await;
+
+        let response = match query {
+            Ok(response) => response,
+            Err(_) => {
+                trace!("Timed out querying native manager for ports");
+                return;
+            }
+        };
+
+        match response {
             Ok(processes::ApiResponse::PortAllocations { ports }) => {
                 let seeds: Vec<(String, String, u16)> = ports
                     .into_iter()

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -925,6 +925,11 @@ async fn run_backend(
 
     let devenv = Devenv::new(devenv_options).await?;
 
+    // Seed port allocations from a running process manager before anything
+    // evaluates, so allocated ports resolve for every command rather than only
+    // `up` and `tasks run`. No-op when no manager is running.
+    devenv.reserve_running_ports().await;
+
     // PTY shell hands Devenv off to an owner task; we reclaim it after the session.
     if use_pty && let Commands::Shell { cmd: None, args } = command {
         // Pre-compute shell environment while we still own Devenv directly.

--- a/tests/process-port-allocation-two-repos/.test.sh
+++ b/tests/process-port-allocation-two-repos/.test.sh
@@ -184,6 +184,32 @@ PY
   return 1
 }
 
+runtime_hash() {
+  local dotfile
+  dotfile="$(cd "$1" && pwd -P)/.devenv"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$dotfile" | sha256sum | cut -c1-7
+  else
+    printf '%s' "$dotfile" | shasum -a 256 | cut -c1-7
+  fi
+}
+
+wait_for_manager_pid() {
+  local repo=$1
+  # The manager publishes its PID file only after every process passes its
+  # readiness probe, so `up` returning a bound port does not yet mean the
+  # manager is discoverable. Commands that seed from it must wait for this.
+  local pid_file="${XDG_RUNTIME_DIR:-/tmp}/devenv-$(runtime_hash "$repo")/processes/native-manager.pid"
+  for _ in $(seq 1 300); do
+    if [ -s "$pid_file" ]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "Timed out waiting for $pid_file"
+  return 1
+}
+
 start_repo() {
   local repo=$1
   rm -f "$repo/allocated-port" "$repo/server.pid" "$repo/up.log"
@@ -259,6 +285,18 @@ fi
 
 if [ "$repo1_process_port" = "$repo2_process_port" ]; then
   echo "Expected two running repos to have distinct process ports"
+  exit 1
+fi
+
+# Commands other than `up` must resolve the allocated port too, instead of
+# falling back to the base port that repo1 is holding.
+wait_for_manager_pid repo2 || { cat repo2/up.log; exit 1; }
+repo2_shell_port=$(cd repo2 && devenv --no-tui shell -- printenv ALLOCATED_PORT | tail -n 1 | tr -d '[:space:]')
+echo "repo2 shell port: $repo2_shell_port"
+
+if [ "$repo2_shell_port" != "$repo2_process_port" ]; then
+  echo "Expected devenv shell in repo2 to report its allocated port $repo2_process_port, got $repo2_shell_port"
+  cat repo2/up.log
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

`processes.<name>.ports.<port>.value` resolves to the declared base port in every
command except `devenv up` and `devenv tasks run`, even while a process manager is
running with a different allocation. Env vars derived from it are wrong too.

```nix
{ config, pkgs, ... }:

{
  processes.server = {
    ports.http.allocate = 8080;
    exec = "${pkgs.python3}/bin/python -m http.server ${toString config.processes.server.ports.http.value}";
  };

  env.SERVER_PORT = config.processes.server.ports.http.value;
}
```

Run it in two clones of the project. The first takes the base port:

```console
~/project $ devenv up -d
~/project $ devenv processes list
server    ready restarts: 0 ports: http:8080
```

The second allocates around it, but its shell reports the first clone's port:

```console
~/project2 $ devenv up -d
~/project2 $ devenv processes list
server    ready restarts: 0 ports: http:8081

~/project2 $ devenv shell -- printenv SERVER_PORT
8080
```

## Root cause

`reserve_running_ports()` seeds the allocator from the running native manager,
but is only called from `up()` and `tasks_run()`. `shell` (and therefore
`devenv hook`, which spawns `devenv shell`) and `direnv-export` never seed, so
`allocatePort` is not registered and `.value` falls back to `allocate`.

This is a regression of the #2710 fix rather than a gap in it.
[`88ac631`](https://github.com/cachix/devenv/commit/88ac631cf8b6582ed372b8b22e3bd12240c61f64)
seeded inside `assemble()`, which every evaluating command went through;
[`d0f9c588`](https://github.com/cachix/devenv/commit/d0f9c588df74ee7da8ee990c2a96a5cdae9a4ab8)
("split apart and remove assemble") kept the call only in `up()` and
`tasks_run()`. The example above reports the allocated port at commit
[`6792fc1e`](https://github.com/cachix/devenv/commit/6792fc1e2d9f5869de7ee9d2678150705f51dda0)
and the base port at commit
[`d0f9c588`](https://github.com/cachix/devenv/commit/d0f9c588df74ee7da8ee990c2a96a5cdae9a4ab8),
so that is the commit where it stopped working.

## Fix

Call `reserve_running_ports()` once after `Devenv::new` in `run_backend`, before
anything evaluates. Best-effort: it only seeds when a live-PID manager answers,
so the gating added in #3024 still applies. The socket query gets a 2s timeout,
since it now runs before every command and a socket that accepts but never
answers must not hang the CLI.

The existing calls in `up()` and `tasks_run()` are left in place — they are
redundant for the CLI but still cover direct use of those public methods.

Seeding still requires a live-PID manager, so a command run during a manager's
startup window — between its processes binding their ports and the PID file
being written after the readiness probes — resolves the base port as before.
`tests/process-port-allocation-two-repos` waits for the PID file for that
reason. Closing that window is a separate change.

## Validation

- `devenv-run-tests run --only process-port-allocation-two-repos tests`, extended
  with a `devenv shell` assertion in the second project: fails on v2.2.1, passes
  with the fix
- `devenv-run-tests run --only 'process-*' --only 'tasks-*' tests`: 18 passed
- Two concurrent projects on `x86_64-linux` and `aarch64-darwin`: `devenv shell`,
  `direnv-export` and `devenv processes list` agree on the allocated port
