### PR TITLE
Preserve SecretSpec provider fallback chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `devenv mcp` ignoring termination signals. A single SIGTERM or SIGINT now shuts the server down immediately, without waiting for further input on stdin; previously it kept running until it was killed forcefully or its client closed stdin ([#3065](https://github.com/cachix/devenv/issues/3065)).
 - Fixed `devenv mcp` ignoring most of the session's configuration; it previously fell back to default Nix, cache, and shell settings for everything except inputs and imports.
+- Fixed devenv exporting an inferred SecretSpec provider into the development shell when no provider override was configured, which replaced per-secret provider fallback chains for commands run inside the shell.
 
 ## 2.2.1 (2026-08-02)
 

--- a/devenv-core/src/nix_args.rs
+++ b/devenv-core/src/nix_args.rs
@@ -306,8 +306,8 @@ pub struct SecretspecData {
     /// The profile that was used to load secrets
     pub profile: String,
 
-    /// The provider that was used to load secrets
-    pub provider: String,
+    /// An explicit provider override selected through devenv
+    pub provider: Option<String>,
 
     /// Map of secret names to their values
     pub secrets: BTreeMap<String, String>,
@@ -495,6 +495,25 @@ mod tests {
     /// Matches pattern: key = value (with possible whitespace variation)
     fn contains_key_value(output: &str, key: &str, value: &str) -> bool {
         output.contains(&format!("{} = {}", key, value))
+    }
+
+    #[test]
+    fn secretspec_provider_override_serializes_as_optional() {
+        let without_override = SecretspecData {
+            profile: "production".to_string(),
+            provider: None,
+            secrets: BTreeMap::new(),
+        };
+        let with_override = SecretspecData {
+            provider: Some("sops".to_string()),
+            ..without_override.clone()
+        };
+
+        let serialized = ser_nix::to_string(&without_override).unwrap();
+        assert!(contains_key_value(&serialized, "provider", "null"));
+
+        let serialized = ser_nix::to_string(&with_override).unwrap();
+        assert!(contains_key_value(&serialized, "provider", "\"sops\""));
     }
 
     // Nixpkgs upstream output contract: NixpkgsConfigForNix serializes as

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -556,6 +556,15 @@ impl Devenv {
 
         let mut secretspec_cell: OnceCell<ResolvedSecrets> = OnceCell::new();
         resolve_secretspec_into(&devenv_root, &secret_settings, &mut secretspec_cell)?;
+        let secretspec_provider_override = secret_settings
+            .secretspec
+            .as_ref()
+            .and_then(|config| config.provider.as_deref());
+        let secretspec_data = secretspec_cell.get().map(|resolved| SecretspecData {
+            profile: resolved.profile.clone(),
+            provider: secretspec_provider_override.map(str::to_owned),
+            secrets: resolved.secrets.clone().into_iter().collect(),
+        });
 
         // Create the cachix manager after secretspec so a secretspec secret
         // can authenticate pulls (netrc) and pushes (daemon env) even when
@@ -656,7 +665,7 @@ impl Devenv {
                     options.from_external,
                     options.require_version_match,
                     options.is_testing,
-                    secretspec_cell.get(),
+                    secretspec_data.as_ref(),
                     &fingerprint,
                 )?);
 
@@ -686,7 +695,7 @@ impl Devenv {
                     options.from_external,
                     options.require_version_match,
                     options.is_testing,
-                    secretspec_cell.get(),
+                    secretspec_data.as_ref(),
                     "",
                 )?);
 
@@ -3464,7 +3473,7 @@ fn build_bootstrap_args(
     from_external: bool,
     require_version_match: bool,
     is_testing: bool,
-    secretspec: Option<&ResolvedSecrets>,
+    secretspec: Option<&SecretspecData>,
     lock_fingerprint: &str,
 ) -> Result<BootstrapArgs> {
     let paths = &config.paths;
@@ -3483,12 +3492,6 @@ fn build_bootstrap_args(
             .expect("dotfile has filename")
             .to_string_lossy()
     ));
-
-    let secretspec_data: Option<SecretspecData> = secretspec.map(|resolved| SecretspecData {
-        profile: resolved.profile.clone(),
-        provider: resolved.provider.clone(),
-        secrets: resolved.secrets.clone().into_iter().collect(),
-    });
 
     let cli_options = CliOptionsConfig(parse_cli_options(
         &config.input_overrides.nix_module_options,
@@ -3514,7 +3517,7 @@ fn build_bootstrap_args(
         hostname: hostname.as_deref(),
         username: username.as_deref(),
         git_root: paths.git_root.as_deref(),
-        secretspec: secretspec_data.as_ref(),
+        secretspec,
         devenv_inputs: &config.inputs,
         devenv_imports: imports,
         impure: nix.impure,

--- a/docs/src/integrations/secretspec.md
+++ b/docs/src/integrations/secretspec.md
@@ -22,9 +22,17 @@ $ secretspec run -- npm start
 
 The `secretspec` command is included with devenv, so no separate installation is
 needed. When the integration is enabled, devenv also exports the resolved profile
-and provider as `SECRETSPEC_PROFILE` and `SECRETSPEC_PROVIDER`. Consequently,
-`secretspec run` uses the same configuration that devenv used while evaluating
-`devenv.nix`.
+as `SECRETSPEC_PROFILE`. If you explicitly select a provider through devenv, it
+also exports that override as `SECRETSPEC_PROVIDER`. Consequently,
+`secretspec run` uses the same explicit overrides that devenv used while evaluating
+`devenv.nix`. When no provider override is selected, SecretSpec commands remain
+free to use the per-secret provider routes from `secretspec.toml`.
+
+!!! tip "New in version 2.2.2"
+
+    devenv no longer infers `SECRETSPEC_PROVIDER` from the provider that happened
+    to resolve secrets during evaluation. It only exports an explicitly selected
+    provider override, preserving per-secret provider and fallback chains.
 
 This approach:
 
@@ -62,9 +70,11 @@ secretspec:
 
 CLI flags take precedence over `devenv.yaml` values.
 
-The selected profile and provider apply both while evaluating `devenv.nix` and
-to `secretspec` commands run inside the development shell. You can access the
-resolved secrets in `devenv.nix`:
+The resolved profile applies both while evaluating `devenv.nix` and to
+`secretspec` commands run inside the development shell. An explicitly selected
+provider does too. If you omit the provider, SecretSpec uses the provider
+configuration in `secretspec.toml` for both. You can access the resolved secrets
+in `devenv.nix`:
 
 ```nix title="devenv.nix"
 { config, ... }:

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -167,6 +167,12 @@ Authentication token for pulling from and pushing to Cachix binary caches.
 Override the provider for the [secretspec integration](../integrations/secretspec.md).
 Mirrored by the `--secretspec-provider` flag.
 
+!!! tip "New in version 2.2.2"
+
+    devenv exports this variable into the development shell only when a provider
+    override was explicitly configured. Otherwise, commands use the provider
+    routes from `secretspec.toml`.
+
 ### [`SECRETSPEC_PROFILE`](#secretspec_profile)
 
 Override the profile for the [secretspec integration](../integrations/secretspec.md).

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -26553,7 +26553,7 @@ null
 
 
 
-The secretspec provider that was used to load secrets (read-only)
+The explicit secretspec provider override selected through devenv, if any (read-only)
 
 
 

--- a/src/modules/integrations/secretspec.nix
+++ b/src/modules/integrations/secretspec.nix
@@ -38,7 +38,7 @@ in
       type = lib.types.nullOr lib.types.str;
       default = if secretspecData != null then secretspecData.provider else null;
       readOnly = true;
-      description = "The secretspec provider that was used to load secrets (read-only)";
+      description = "The explicit secretspec provider override selected through devenv, if any (read-only)";
     };
 
     secrets = lib.mkOption {

--- a/tests/secretspec/devenv.nix
+++ b/tests/secretspec/devenv.nix
@@ -7,7 +7,7 @@
   # Test that secrets are available in Nix
   enterShell = ''
     test "$SECRETSPEC_PROFILE" = "test"
-    test "$SECRETSPEC_PROVIDER" = "dotenv"
+    test -z "$SECRETSPEC_PROVIDER"
 
     # Expected JSON structure based on .env values
     expected_json='{"TEST_API_KEY":"test-api-key-123","TEST_DATABASE_URL":"postgresql://test:test@localhost/testdb","TEST_OPTIONAL":"optional-value"}'

--- a/tests/secretspec/devenv.yaml
+++ b/tests/secretspec/devenv.yaml
@@ -1,4 +1,3 @@
 secretspec:
   enable: true
-  provider: dotenv
   profile: test

--- a/tests/secretspec/secretspec.toml
+++ b/tests/secretspec/secretspec.toml
@@ -2,7 +2,14 @@
 name = "secretspec-test"
 revision = "1.0"
 
+[providers]
+missing = "dotenv://.env.missing"
+local = "dotenv://.env"
+
 [profiles.test]
 TEST_API_KEY = { description = "Test API key", required = true }
 TEST_DATABASE_URL = { description = "Test database URL", required = true }
 TEST_OPTIONAL = { description = "Optional test secret", required = false }
+
+[profiles.test.defaults]
+providers = ["missing", "local"]


### PR DESCRIPTION
## Summary

- export `SECRETSPEC_PROVIDER` only when a provider override was explicitly selected through devenv
- leave provider selection to `secretspec.toml` when no devenv override is configured, preserving per-secret providers and fallback chains
- keep exporting the resolved profile and preserve explicit provider override behavior
- update the integration documentation, environment-variable reference, and changelog for 2.2.2

## Root cause

devenv serialized SecretSpec's resolved provider label into its Nix bootstrap data even when the user had not configured a provider override. The Nix integration then exported that label as `SECRETSPEC_PROVIDER`, turning resolution metadata into a whole-resolution override for later SecretSpec commands in the development shell.

## User impact

Commands such as `secretspec check --profile prod` run inside `devenv shell` can now use provider routes and fallback chains declared per secret or profile in `secretspec.toml`. Users who explicitly configure a provider through `devenv.yaml`, CLI flags, or the environment retain the previous override behavior.

## Validation

- `devenv shell -- cargo nextest run -p devenv-core` (220 passed)
- `devenv shell -- cargo nextest run -p devenv` (150 passed)
- `devenv shell -- devenv-run-tests run tests --only secretspec`
- Rust and Nix formatting hooks
- standard clippy for `devenv-core` and `devenv`

The SecretSpec integration fixture now resolves secrets through a two-provider fallback chain while asserting that no `SECRETSPEC_PROVIDER` override is exported.