### PR TITLE
Add `claude.code` primary `agent` option (and `effort` option as well)

### DIFF
--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -212,6 +212,8 @@ Agents are specialized AI assistants that handle specific tasks with their own c
       description = "Expert code review specialist that checks for quality, security, and best practices";
       proactive = true;  # Claude will use this automatically when appropriate
       tools = [ "Read" "Grep" "TodoWrite" ];
+      model = "opus";
+      effort = "high";
       prompt = ''
         You are an expert code reviewer. When reviewing code, check for:
         - Code readability and maintainability
@@ -253,12 +255,32 @@ Agents are specialized AI assistants that handle specific tasks with their own c
 }
 ```
 
+### Primary Agent
+
+By default, Claude Code's main conversation runs as its built-in general-purpose agent. Set `claude.code.agent` to use a different agent as the primary agent instead:
+
+```nix
+{
+  claude.code.agent = "code-reviewer";
+}
+```
+
+`claude.code.agent` accepts either:
+
+- The name of one of your project's `claude.code.agents.<name>` entries. That agent becomes the primary agent, and is removed from the sub-agents list.
+- The name of a Claude Code built-in agent (e.g. `"general-purpose"`) that isn't defined under `claude.code.agents`. In this case every configured agent is still available as a sub-agent.
+
+This is reflected in `devenv info`, which reports a `Primary agent: <name>` line and, when other agents remain, a `Sub-agents: <names>` line.
+
 ### Properties
 
 - **description**: What the sub-agent does (shown in Claude's agent selection)
 - **proactive**: Whether Claude should use this sub-agent automatically when relevant
 - **tools**: List of tools the sub-agent can use (restricts access for safety)
+- **model**: Override the model for this agent (`opus`, `sonnet`, or `haiku`)
+- **effort**: Override the reasoning effort for this agent (`low`, `medium`, `high`, `xhigh`, or `max`)
 - **prompt**: The system prompt that defines the sub-agent's behavior
+- **permissionMode**: Permission mode for this specific sub-agent (`default`, `acceptEdits`, `plan`, or `bypassPermissions`)
 
 ### Available Tools
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -1501,7 +1501,7 @@ Whether Claude should use this sub-agent automatically
 
 
 *Type:*
-null or boolean
+boolean
 
 
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -1420,6 +1420,30 @@ string
 
 
 
+## claude.code.agents.\<name>.effort
+
+
+
+Override the effort level for this agent.
+
+
+
+*Type:*
+null or one of “low”, “medium”, “high”, “xhigh”, “max”
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
 ## claude.code.agents.\<name>.model
 
 
@@ -2768,8 +2792,6 @@ list of anything
 
 ## containers.\<name>.fromImage
 
-
-
 An existing OCI base image to build on top of, built with nix2container’s pullImage.
 
 
@@ -2791,6 +2813,8 @@ null
 
 
 ## containers.\<name>.isBuilding
+
+
 
 Set to true when the environment is building this container.
 
@@ -6033,8 +6057,6 @@ null or string
 
 ## git-hooks.hooks.autoflake.settings.flags
 
-
-
 Flags passed to autoflake.
 
 
@@ -6056,6 +6078,8 @@ string
 
 
 ## git-hooks.hooks.biome
+
+
 
 biome hook
 
@@ -8306,8 +8330,6 @@ false
 
 ## git-hooks.hooks.isort
 
-
-
 isort hook
 
 
@@ -8321,6 +8343,8 @@ submodule
 
 
 ## git-hooks.hooks.isort.enable
+
+
 
 Whether to enable this pre-commit hook.
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -1312,6 +1312,30 @@ true
 
 
 
+## claude.code.agent
+
+
+
+The agent to use as Claude Code’s primary agent.
+
+
+
+*Type:*
+null or string
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+*Declared by:*
+ - [https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix](https://github.com/cachix/devenv/blob/main/src/modules/integrations/claude.nix)
+
+
+
 ## claude.code.agents
 
 
@@ -2768,8 +2792,6 @@ null
 
 ## containers.\<name>.isBuilding
 
-
-
 Set to true when the environment is building this container.
 
 
@@ -2791,6 +2813,8 @@ false
 
 
 ## containers.\<name>.layers
+
+
 
 The layers to create.
 
@@ -6033,8 +6057,6 @@ string
 
 ## git-hooks.hooks.biome
 
-
-
 biome hook
 
 
@@ -6048,6 +6070,8 @@ submodule
 
 
 ## git-hooks.hooks.biome.enable
+
+
 
 Whether to enable this pre-commit hook.
 
@@ -8298,8 +8322,6 @@ submodule
 
 ## git-hooks.hooks.isort.enable
 
-
-
 Whether to enable this pre-commit hook.
 
 
@@ -8321,6 +8343,8 @@ false
 
 
 ## git-hooks.hooks.isort.settings.flags
+
+
 
 Flags passed to isort. See all available [here](https://pycqa.github.io/isort/docs/configuration/options.html).
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -1477,7 +1477,7 @@ Whether Claude should use this sub-agent automatically
 
 
 *Type:*
-boolean
+null or boolean
 
 
 

--- a/examples/claude-agents/.gitignore
+++ b/examples/claude-agents/.gitignore
@@ -1,0 +1,16 @@
+# acai
+.agents/skills
+
+# JavaScript runtimes
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+bun.lockb
+
+# claude
+**/.claude/settings.local.json
+.claude/settings.json
+.claude/agents
+.mcp.json
+.devcontainer.json

--- a/examples/claude-agents/.test-config.yml
+++ b/examples/claude-agents/.test-config.yml
@@ -1,0 +1,2 @@
+use_shell: false
+use_tmp_dir: false

--- a/examples/claude-agents/.test-config.yml
+++ b/examples/claude-agents/.test-config.yml
@@ -1,2 +1,2 @@
-use_shell: false
+use_shell: true
 use_tmp_dir: false

--- a/examples/claude-agents/.test.sh
+++ b/examples/claude-agents/.test.sh
@@ -2,4 +2,101 @@
 
 set -euo pipefail
 
-devenv shell -- acai skill --install
+acai skill --install
+
+AGENT="assist"
+AGENTS_DIR=".claude/agents"
+SETTINGS=".claude/settings.json"
+LOCK="devenv.lock"
+WORKFLOW_AGENTS=(supervise prepare-tasks implement review-task)
+
+# Every check names the full ACID of the requirement it validates.
+fail() {
+  echo "FAIL [$1] $2" >&2
+  exit 1
+}
+
+pass() {
+  echo "ok   [$1] $2"
+}
+
+# Print the YAML frontmatter of a generated agent definition.
+frontmatter() {
+  awk 'NR == 1 && $0 == "---" { inside = 1; next }
+       inside && $0 == "---" { exit }
+       inside { print }' "$1"
+}
+
+frontmatter_has() {
+  frontmatter "$1" | grep -qxF "$2"
+}
+
+echo "=== claude-agents: querying the generated agent definitions ==="
+
+# generic-agent.TESTS.1
+# The agent, in devenv terms, is the definition the claude module generates.
+# The checks below query that definition directly; they never call out to
+# Claude, so they need no credentials and stay deterministic in CI.
+
+# 2. The agent is registered.
+agent_file="$AGENTS_DIR/$AGENT.md"
+if [ ! -e "$agent_file" ]; then
+  echo "Contents of $AGENTS_DIR:" >&2
+  ls -la "$AGENTS_DIR" >&2 || true
+  fail generic-agent.TESTS.1 "agent '$AGENT' is not registered: $agent_file does not exist"
+fi
+pass generic-agent.TESTS.1 "agent '$AGENT' is registered at $agent_file"
+
+# 3. It is not the primary agent.
+if [ ! -e "$SETTINGS" ]; then
+  fail generic-agent.TESTS.1 "$SETTINGS does not exist"
+fi
+# `|| true` keeps an unmatched grep from aborting the script under `set -euo
+# pipefail`, so the empty-value branch below stays reachable and reports why.
+primary=$(grep -o '"agent"[[:space:]]*:[[:space:]]*"[^"]*"' "$SETTINGS" | head -n 1 | sed 's/.*"\([^"]*\)"$/\1/' || true)
+if [ -z "$primary" ]; then
+  echo "Contents of $SETTINGS:" >&2
+  cat "$SETTINGS" >&2
+  fail generic-agent.TESTS.1 "no primary agent recorded in $SETTINGS"
+fi
+if [ "$primary" = "$AGENT" ]; then
+  fail generic-agent.TESTS.1 "agent '$AGENT' is the primary agent in $SETTINGS, it must not be"
+fi
+if [ "$primary" != "supervise" ]; then
+  fail generic-agent.TESTS.1 "expected the primary agent in $SETTINGS to be 'supervise', found '$primary'"
+fi
+pass generic-agent.TESTS.1 "agent '$AGENT' is not primary; the primary agent is '$primary'"
+
+# 4. It is distinct from the four workflow agents, which are all still intact.
+for workflow_agent in "${WORKFLOW_AGENTS[@]}"; do
+  if [ "$AGENT" = "$workflow_agent" ]; then
+    fail generic-agent.TESTS.1 "agent '$AGENT' must not be one of the workflow agents"
+  fi
+
+  workflow_file="$AGENTS_DIR/$workflow_agent.md"
+  if [ ! -e "$workflow_file" ]; then
+    fail generic-agent.TESTS.1 "workflow agent '$workflow_agent' is missing: $workflow_file does not exist"
+  fi
+  if ! frontmatter_has "$workflow_file" "name: $workflow_agent"; then
+    fail generic-agent.TESTS.1 "workflow agent '$workflow_agent' no longer declares 'name: $workflow_agent'"
+  fi
+done
+pass generic-agent.TESTS.1 "agent '$AGENT' is distinct from ${WORKFLOW_AGENTS[*]}, which are all still present"
+
+# 5. Its tools grant the capabilities of the generic agent.
+# generic-agent.EXAMPLES.1
+for tool in Read Grep Glob Bash WebFetch; do
+  if ! frontmatter_has "$agent_file" "  - $tool"; then
+    echo "Frontmatter of $agent_file:" >&2
+    frontmatter "$agent_file" >&2
+    fail generic-agent.EXAMPLES.1 "agent '$AGENT' is not granted the '$tool' tool"
+  fi
+done
+for tool in Write Edit; do
+  if frontmatter_has "$agent_file" "  - $tool"; then
+    fail generic-agent.EXAMPLES.1 "agent '$AGENT' is granted the authoring tool '$tool', which belongs to the 'implement' agent"
+  fi
+done
+pass generic-agent.EXAMPLES.1 "agent '$AGENT' is granted Read, Grep, Glob, Bash and WebFetch, and no authoring tools"
+
+echo "=== claude-agents: all checks passed ==="

--- a/examples/claude-agents/.test.sh
+++ b/examples/claude-agents/.test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+devenv shell -- acai skill --install

--- a/examples/claude-agents/README.md
+++ b/examples/claude-agents/README.md
@@ -1,0 +1,18 @@
+# Claude Code Agents
+
+Here we demonstrate a `devenv` setting with a number of agents suitable for running a spec-driven example based on [acai.sh](https://acai.sh/). Acai recommends [four types of agents](https://acai.sh/agents#factory-agent-roles):
+
+- [supervise.md](https://acai.sh/agents#agents-supervise-md)
+- [prepare-tasks.md](https://acai.sh/agents#agents-prepare-tasks-md)
+- [implement.md](https://acai.sh/agents#agents-implement-md)
+- [review-task.md](https://acai.sh/agents#agents-review-task-md)
+
+Those agents are mapped in [devenv.nix](./examples/claude-agents/devenv.nix) itself. The `supervise` agent is assigned to the `agent` option, making it the primary agent.
+
+## Feature
+
+The feature is specified in [generic-agent.feature.yaml](features/claude-agents-example/generic-agent.feature.yaml). To get Claude to implement the feature, just say:
+
+> I made changes to the spec - @generic-agent.feature.yaml - please run `acai skill` to learn spec-driven development.
+
+The feature itself is already implemented -- it's the `assist` agent defined in [devenv.nix](./examples/claude-agents/devenv.nix).

--- a/examples/claude-agents/devenv.nix
+++ b/examples/claude-agents/devenv.nix
@@ -1,0 +1,211 @@
+{ config
+, pkgs
+, ...
+}:
+{
+  name = "claude-dev";
+
+  packages = [
+    pkgs.git
+  ];
+
+  languages.javascript = {
+    enable = true;
+    npm.enable = true;
+    pnpm.enable = true;
+    pnpm.install.enable = true;
+  };
+
+  claude.code = {
+    enable = true;
+    agent = "supervise";
+    mcpServers = {
+      # Local devenv MCP server
+      devenv = {
+        type = "stdio";
+        command = "devenv";
+        args = [ "mcp" ];
+        env = {
+          DEVENV_ROOT = config.devenv.root;
+        };
+      };
+    };
+    agents = {
+      supervise = {
+        description = "Coordinates and delegates to prepare-tasks, implement, and review-task agents to run a project end-to-end. Use as the primary agent for this project — it doesn't implement or review code itself, only orchestrates handoffs and git operations.";
+        model = "opus";
+        tools = [
+          "Agent(prepare-tasks, implement, review-task)"
+          "Bash"
+        ];
+        permissionMode = "acceptEdits";
+        effort = "low";
+        proactive = null;
+        prompt = ''
+          You are a Project Supervisor. Your job is to coordinate handoff between agents. We work with the `prepare-tasks` agent, the `implement` agent, and the `review-task` agents.
+
+          ## Before you start (MANDATORY)
+          * [ ] Check your git status. If needed, prepare a root integration branch e.g. `feat/{feature_name}`. Avoid committing to main.
+
+          ## Process
+          Oversee project completion of a project beginning to end, following this sequential process.
+
+          1. Dispatch `prepare-tasks` agent.
+            - `prepare-tasks` agent plans the entire project and breaks the work up into one or more tasks, and writes these to a temporary folder
+          2. Dispatch `implement` agent to a task.
+            - `implement` agent will read the task file, makes code changes, and write tests.
+          3. Dispatch `review-task` agent.
+            - They will determine if the changes on the working task branch are ACCEPTED, or REJECTED.
+            - If accepted, they will notify you and invite you to integrate the work.
+            - If rejected, they will append their review findings to the existing task.md file and notify you.
+          5. (IF REJECTED) Go to 2. Dispatch a new `implement` agent and invite them to respond to new action items appended to the task.md file
+          6. (IF ACCEPTED) Commit and/or merge the work. Assign the next task file (if already prepared) or invite another `prepare-task` agent to prepare more tasks.
+
+          Repeat this process until the `prepare-task` agent tells you that the project has been completed.
+
+          You are responsible for git ops - create and integrate branches as you see fit, ideally to a central feature or impl. branch. Do not touch `main`.
+
+          ### Prompt templates for agent dispatch
+          Please follow these templates. In some cases, you do not need to add any additional information. If there is a relevant feature.yaml file, feel free to reference it.
+
+          **prepare-tasks**
+          > Proceed with task planning and creation. Details are provided below. In response, provide me the task file paths so I can assign them. Or, halt and notify me when the project has reached completion to your satisfaction. Details: <include sufficient context for the planner to plan the next set of tasks, e.g. relevant feature specs, notes to pass along, original prompt, etc.)
+
+          **implement - new assignment**
+          > You can find the task assignment file at path: `<path>`. It should contain everything you need to proceed with implementation.
+
+          **implement - handle review feedback**
+          > Work was done to implement a task, but the work did not pass review and could not be merged. Please pick up where they left off and proceed by resolving issues in the task file `<path>`. Respond when all items have been addressed.
+
+          **review-task**
+          > Code changes are ready for review. You can find the implementation at <path or commit or branch etc.>. The relevant changes for review are: <provide commit, or point to 'unstaged/staged changes in git' etc.>. Record your findings into the task.md file, and report back. Task file is located at `<path>`. If during your review you stumble on important follow-up or ancillary work that is out of scope for the current task, you may choose to write additional task .md files to the .tasks directory, and let me know about them.
+
+          ### Other constraints
+          Don't get hands on, don't read task files, don't read code. Your job is just to coordinate with the other agents, and coordinate git commits and merges. This is how we keep your context window small to keep costs down.
+        '';
+      };
+      prepare-tasks = {
+        description = "Researches the codebase and prepares comprehensive, timestamped task files for sequential developer implementation. Use to plan the next batch of work, break a feature into phases, or when told a project needs task assignments prepared.";
+        model = "opus";
+        effort = "high";
+        proactive = null;
+        tools = [
+          "Read"
+          "Grep"
+          "Glob"
+          "Write"
+          "Edit"
+          "Bash"
+          "WebFetch"
+          "Skill"
+        ];
+        prompt = ''
+          Your job is to research, plan and prepare a discrete, well-packaged task (or tasks) that can be assigned to a developer for sequential implementation.
+
+          ## Before you start
+          * [ ] Identify the current branch, should be `main` or a `feat/` feature branch.
+
+          We use task `.md` files to plan and assigning chunks of work to engineers. The resulting task files must be comprehensive and complete, the developer who reads it should not need any outside resources, and will not need to read the spec themselves.
+
+          **What makes a good task assignment?**
+          - Comprehensive research and exploration of the current codebase. Points the developer to existing tools and components that may be useful for this task
+          - Considers dependant and prerequisite work
+          - Includes clear action items / todo boxes to check
+          - Excludes irrelevant and unrelated details
+          - Doesn't micromanage: avoid deciding new variable names, new components, new file paths, etc. unless taken from spec. Only demonstrate critical concepts and patterns.
+          - Always stay true to the spec
+
+          # Requirements
+          * [ ] Read the acai skill
+          * [ ] If you determine the feature is still blocked or needs prerequisite work that is out of scope for this task, halt and notify the supervisor.
+          * [ ] Output 1 or more task files. If the work is complex, break it into phases - 1 phase per task file.
+          * [ ] Task file is always in `tmp/tasks` dir (from git repo root) and is not git tracked
+          * [ ] Timestamp mandatory e.g. `tmp/tasks/YYYYMMDDHHMMSS_align_my-feature-name_to_spec.md`
+          * [ ] Report back to the supervisor: "I have prepared the following task files, which should be implemented in this order: <paths to files>. Feel free to assign the next task and begin implementation."
+
+          **If no acceptance criteria remain & you believe implementation is already complete, report back to the supervisor: "I believe this project is complete, and I do not have any more tasks to prepare"**
+        '';
+      };
+      implement = {
+        description = "Implements code to complete a predefined task file, or resolves review feedback appended to an existing task file. Use when a task .md file is ready for implementation or needs revisions after review.";
+        model = "opus";
+        tools = [
+          "Read"
+          "Grep"
+          "Glob"
+          "Write"
+          "Edit"
+          "Bash"
+          "WebFetch"
+        ];
+        proactive = null;
+        prompt = ''
+          You are a Developer who has been dispatched to implement code and complete a task, or respond to feedback on previous work.
+
+          Either:
+          A) Starting work on a fresh task, defined in a task .md file
+          B) Resolving feedback or incomplete items (QA, code review etc.), appended to the bottom of an existing task .md file.
+
+          ## Prerequisites
+          * [ ] Read the relevant task .md file before proceeding
+
+          ## Process
+          * [ ] Completion is only reached when all tests are passing, all assigned acceptance criteria are implemented, and your work is committed.
+          * [ ] Upon completion, respond back to the supervisor "<task file> has been implemented and is ready for (re-)review."
+
+          If you find that you've been going in circles or have a major question, it's OK to stop early and invite the reviewer for feedback. They can tell you what to do next.
+        '';
+      };
+      review-task = {
+        description = "Reviews code implementations against a task file's acceptance criteria and decides if work is mergeable, needs revision, or is stuck. Use after implement has completed work on a task, or after re-implementation in response to review feedback.";
+        model = "opus";
+        tools = [
+          "Read"
+          "Grep"
+          "Glob"
+          "Bash"
+          "WebFetch"
+          "Edit"
+        ];
+        prompt = ''
+          # Before you start
+          * [ ] Find and read the task file which defined the goals and acceptance criteria for this batch of work.
+
+          ## Process
+          Assume the role of an experienced, high-ranking, high-standards engineer. Your job is to perform code & review of an implementation, feature or task.
+          * [ ] Identify relevant changes and files for review, and review the work.
+          * [ ] Validate that **all the assigned acceptance criteria in the task have been met and tested**
+          * [ ] Validate that test coverage is sufficient.
+          * [ ] Validate that code quality is of the highest standards for readability, elegance, and simplicity.
+          * [ ] Evaluate performance, and ensure the implementation is well-optimized with regards to data fetching, queries, async operations, and memory.
+          * [ ] Confirm the chosen patterns and tools are readable, concise, idiomatic.
+          * [ ] Perform a security assessment
+
+          Generally, you have high standards, and are not afraid to reject the first pass if you find a major issues, or if the number of nitpicks is very high.
+
+          1. Identify excess assigns or large data structures loaded into socket/conn assigns.
+          2. Identify redundant fetching or repeated lookups during mount/render/handle_event.
+          3. Identify serialized queries that could be consolidated, batched, or moved into a single context call/transaction.
+          4. Identify likely N+1 query risks, including lazy preloads, per-item lookups in templates/helpers, or repeated context calls in loops.
+          5. Distinguish initial page-load costs from interaction/event costs.
+          6. Prefer concrete observations from code over general advice.
+
+          # Output
+          After review completion, based on the results of the review, you must follow 1 of these 3 paths:
+          Always append feedback at the bottom of the task file
+
+          A) The work is ACCEPTED. No major feedback remains unaddressed. In this case, you must:
+           * [ ] Update the task file to note the work as accepted
+           * [ ] Notify the supervisor: "The code for <task file> has passed review and can be merged."
+
+          B) The work is REJECTED
+            * [ ] Add your feedback to the end of the task file, including discrete action items in a todo list.
+            * [ ] Respond by notifying the supervisor "The work was rejected, my feedback has been added to <task file>."
+
+          C) The task is STUCK, meaning it has been reviewed and rejected more than 4 times (abort)
+            * [ ] Respond by notifying the engineer that the work is STUCK and REJECTED, and they must stop until they receive further instructions from the CTO.
+        '';
+      };
+    };
+  };
+}

--- a/examples/claude-agents/devenv.nix
+++ b/examples/claude-agents/devenv.nix
@@ -40,7 +40,6 @@
         ];
         permissionMode = "acceptEdits";
         effort = "low";
-        proactive = null;
         prompt = ''
           You are a Project Supervisor. Your job is to coordinate handoff between agents. We work with the `prepare-tasks` agent, the `implement` agent, and the `review-task` agents.
 
@@ -59,9 +58,9 @@
             - If accepted, they will notify you and invite you to integrate the work.
             - If rejected, they will append their review findings to the existing task.md file and notify you.
           5. (IF REJECTED) Go to 2. Dispatch a new `implement` agent and invite them to respond to new action items appended to the task.md file
-          6. (IF ACCEPTED) Commit and/or merge the work. Assign the next task file (if already prepared) or invite another `prepare-task` agent to prepare more tasks.
+          6. (IF ACCEPTED) Commit and/or merge the work. Assign the next task file (if already prepared) or invite another `prepare-tasks` agent to prepare more tasks.
 
-          Repeat this process until the `prepare-task` agent tells you that the project has been completed.
+          Repeat this process until the `prepare-tasks` agent tells you that the project has been completed.
 
           You are responsible for git ops - create and integrate branches as you see fit, ideally to a central feature or impl. branch. Do not touch `main`.
 
@@ -88,7 +87,6 @@
         description = "Researches the codebase and prepares comprehensive, timestamped task files for sequential developer implementation. Use to plan the next batch of work, break a feature into phases, or when told a project needs task assignments prepared.";
         model = "opus";
         effort = "high";
-        proactive = null;
         tools = [
           "Read"
           "Grep"
@@ -138,7 +136,6 @@
           "Bash"
           "WebFetch"
         ];
-        proactive = null;
         prompt = ''
           You are a Developer who has been dispatched to implement code and complete a task, or respond to feedback on previous work.
 
@@ -204,6 +201,34 @@
 
           C) The task is STUCK, meaning it has been reviewed and rejected more than 4 times (abort)
             * [ ] Respond by notifying the engineer that the work is STUCK and REJECTED, and they must stop until they receive further instructions from the CTO.
+        '';
+      };
+      # generic-agent.EXAMPLES.1
+      assist = {
+        description = "Runs generic errands on behalf of the user — reads and searches code, fetches dependencies and documentation, and executes shell commands. Use for one-off lookups, dependency installs, and command runs that don't belong to a task file.";
+        model = "sonnet";
+        effort = "medium";
+        permissionMode = "default";
+        proactive = true;
+        tools = [
+          "Read"
+          "Grep"
+          "Glob"
+          "Bash"
+          "WebFetch"
+        ];
+        prompt = ''
+          You are a general-purpose assistant for read, fetch and run errands. You have no multi-step protocol to follow: do the one thing you were asked, then report the result.
+
+          ## What you do
+          * Read and search the codebase with `Read`, `Grep` and `Glob` to answer questions about it.
+          * Fetch dependencies with `Bash` (this project uses pnpm, so `pnpm install` and friends), and read documentation over HTTP with `WebFetch`.
+          * Execute commands with `Bash` and report their output, including the exit status when it is non-zero.
+
+          ## What you don't do
+          You are not set up to author code. If a request needs code changes, say so and hand it back rather than writing them through `Bash`.
+
+          Report findings directly in your reply. Keep it short, quote the exact output that matters, and use absolute paths.
         '';
       };
     };

--- a/examples/claude-agents/features/claude-agents-example/generic-agent.feature.yaml
+++ b/examples/claude-agents/features/claude-agents-example/generic-agent.feature.yaml
@@ -1,8 +1,8 @@
 feature:
-  name: proactive-agent
+  name: generic-agent
   product: claude-agents-example
   description: >
-    A proactive agent that is not a primary one and also none of the `supervise`, `prepare-task`, `implement` or `review-task` agents.
+    An agent that is not a primary one and also none of the `supervise`, `prepare-tasks`, `implement` or `review-task` agents.
 
 components:
   EXAMPLES:

--- a/examples/claude-agents/features/claude-agents-example/proactive-agent.feature.yaml
+++ b/examples/claude-agents/features/claude-agents-example/proactive-agent.feature.yaml
@@ -1,0 +1,14 @@
+feature:
+  name: proactive-agent
+  product: claude-agents-example
+  description: >
+    A proactive agent that is not a primary one and also none of the `supervise`, `prepare-task`, `implement` or `review-task` agents.
+
+components:
+  EXAMPLES:
+    requirements:
+      1: This agent is capable of running generic tasks on behalf of the user, reading code, fetching dependencies and executing commands.
+
+  TESTS:
+    requirements:
+      1: Simple sanity checks are performed querying directly this agent.

--- a/examples/claude-agents/package.json
+++ b/examples/claude-agents/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "conan-flake",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "^11.15.0",
+      "onFail": "download"
+    }
+  },
+  "type": "module",
+  "devDependencies": {
+    "@acai.sh/cli": "^0.0.4"
+  }
+}

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -369,6 +369,11 @@ in
               default = null;
               description = "Override the model for this agent.";
             };
+            effort = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "low" "medium" "high" "xhigh" "max" ]);
+              default = null;
+              description = "Override the effort level for this agent.";
+            };
             prompt = lib.mkOption {
               type = lib.types.lines;
               description = "The system prompt for the sub-agent";
@@ -694,6 +699,7 @@ in
                 ${lib.optionalString (agent.proactive != null) "proactive: ${lib.boolToString agent.proactive}"}
                 ${lib.optionalString (agent.tools != []) "tools:\n${lib.concatMapStringsSep "\n" (tool: "  - ${tool}") agent.tools}"}
                 ${lib.optionalString (agent.model != null) "model: ${agent.model}"}
+                ${lib.optionalString (agent.effort != null) "effort: ${agent.effort}"}
                 ${lib.optionalString (agent.permissionMode != null) "permissionMode: ${agent.permissionMode}"}
                 ---
 

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -355,7 +355,7 @@ in
               description = "What the sub-agent does";
             };
             proactive = lib.mkOption {
-              type = lib.types.bool;
+              type = lib.types.nullOr lib.types.bool;
               default = false;
               description = "Whether Claude should use this sub-agent automatically";
             };
@@ -691,7 +691,7 @@ in
                 ---
                 name: ${name}
                 description: ${agent.description}
-                proactive: ${lib.boolToString agent.proactive}
+                ${lib.optionalString (agent.proactive != null) "proactive: ${lib.boolToString agent.proactive}"}
                 ${lib.optionalString (agent.tools != []) "tools:\n${lib.concatMapStringsSep "\n" (tool: "  - ${tool}") agent.tools}"}
                 ${lib.optionalString (agent.model != null) "model: ${agent.model}"}
                 ${lib.optionalString (agent.permissionMode != null) "permissionMode: ${agent.permissionMode}"}
@@ -705,27 +705,47 @@ in
       ];
 
       # Add a message about the integration
-      infoSections."claude" = [
-        ''
-          Claude Code integration is enabled with automatic hooks and commands setup.
-          Settings are configured at: ${cfg.settingsPath}
-          ${lib.optionalString config.git-hooks.enable "- Auto-formatting: enabled via git-hooks (git-hooks-run)"}
-          ${lib.optionalString (cfg.commands != { })
-            "- Project commands: ${
-              lib.concatStringsSep ", " (map (cmd: "/${cmd}") (lib.attrNames cfg.commands))
-            }"
-          }
-          ${lib.optionalString (cfg.agents != { })
-            "- Sub-agents: ${
-              lib.concatStringsSep ", " (lib.attrNames cfg.agents)
-            }"
-          }
-          ${lib.optionalString (cfg.mcpServers != { })
-            "- MCP servers: ${
-              lib.concatStringsSep ", " (lib.attrNames cfg.mcpServers)
-            } (configured at ${config.devenv.root}/.mcp.json)"
-          }
-        ''
+      infoSections."claude" =
+        let
+          primaryAgent = lib.filterAttrs (n: a: a.proactive == null) cfg.agents;
+        in
+        [
+          ''
+            Claude Code integration is enabled with automatic hooks and commands setup.
+            Settings are configured at: ${cfg.settingsPath}
+            ${lib.optionalString config.git-hooks.enable "- Auto-formatting: enabled via git-hooks (git-hooks-run)"}
+            ${lib.optionalString (cfg.commands != { })
+              "- Project commands: ${
+                lib.concatStringsSep ", " (map (cmd: "/${cmd}") (lib.attrNames cfg.commands))
+              }"
+            }
+            ${lib.optionalString (primaryAgent != { })
+              "- Primary agent: ${
+                lib.concatStringsSep ", " (lib.attrNames primaryAgent)
+              }"
+            }
+            ${lib.optionalString (cfg.agents != { })
+              "- Sub-agents: ${
+                lib.concatStringsSep ", " (lib.attrNames (lib.filterAttrs (n: a: a.proactive != null) cfg.agents))
+              }"
+            }
+            ${lib.optionalString (cfg.mcpServers != { })
+              "- MCP servers: ${
+                lib.concatStringsSep ", " (lib.attrNames cfg.mcpServers)
+              } (configured at ${config.devenv.root}/.mcp.json)"
+            }
+          ''
+        ];
+
+      assertions = [
+        {
+          assertion = cfg.agent != null -> (cfg.agents.${cfg.agent} or null) != null;
+          message = "claude.code.agent must be set to one of the claude.code.agents.<NAME>";
+        }
+        {
+          assertion = cfg.agent != null -> cfg.agents.${cfg.agent}.proactive == null;
+          message = "claude.code.agent not null requires claude.code.agents.<NAME>.proactive to be null";
+        }
       ];
     })
 

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -713,7 +713,8 @@ in
       # Add a message about the integration
       infoSections."claude" =
         let
-          primaryAgent = lib.filterAttrs (n: a: a.proactive == null) cfg.agents;
+          primaryAgent = lib.filterAttrs (n: a: n == cfg.agent) cfg.agents;
+          subAgents = lib.filterAttrs (n: a: n != cfg.agent) cfg.agents;
         in
         [
           ''
@@ -730,9 +731,9 @@ in
                 lib.concatStringsSep ", " (lib.attrNames primaryAgent)
               }"
             }
-            ${lib.optionalString (cfg.agents != { })
+            ${lib.optionalString (subAgents != { })
               "- Sub-agents: ${
-                lib.concatStringsSep ", " (lib.attrNames (lib.filterAttrs (n: a: a.proactive != null) cfg.agents))
+                lib.concatStringsSep ", " (lib.attrNames  subAgents)
               }"
             }
             ${lib.optionalString (cfg.mcpServers != { })
@@ -749,8 +750,8 @@ in
           message = "claude.code.agent must be set to one of the claude.code.agents.<NAME>";
         }
         {
-          assertion = cfg.agent != null -> cfg.agents.${cfg.agent}.proactive == null;
-          message = "claude.code.agent not null requires claude.code.agents.<NAME>.proactive to be null";
+          assertion = cfg.agent != null -> (cfg.agents.${cfg.agent}.proactive or null) == null;
+          message = "claude.code.agent = <NAME> requires claude.code.agents.<NAME>.proactive to be null";
         }
       ];
     })

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -228,6 +228,7 @@ let
       ConfigChange = buildHooks "ConfigChange" (groupedHooks.ConfigChange or [ ]);
     };
     inherit (cfg)
+      agent
       apiKeyHelper
       model
       forceLoginMethod
@@ -245,6 +246,12 @@ in
 {
   options.claude.code = {
     enable = lib.mkEnableOption "Claude Code integration with automatic hooks and commands setup";
+
+    agent = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "The agent to use as Claude Code's primary agent.";
+    };
 
     hooks = lib.mkOption {
       type = lib.types.submodule {

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -355,7 +355,7 @@ in
               description = "What the sub-agent does";
             };
             proactive = lib.mkOption {
-              type = lib.types.nullOr lib.types.bool;
+              type = lib.types.bool;
               default = false;
               description = "Whether Claude should use this sub-agent automatically";
             };
@@ -696,7 +696,7 @@ in
                 ---
                 name: ${name}
                 description: ${agent.description}
-                ${lib.optionalString (agent.proactive != null) "proactive: ${lib.boolToString agent.proactive}"}
+                proactive: ${lib.boolToString agent.proactive}
                 ${lib.optionalString (agent.tools != []) "tools:\n${lib.concatMapStringsSep "\n" (tool: "  - ${tool}") agent.tools}"}
                 ${lib.optionalString (agent.model != null) "model: ${agent.model}"}
                 ${lib.optionalString (agent.effort != null) "effort: ${agent.effort}"}
@@ -713,7 +713,8 @@ in
       # Add a message about the integration
       infoSections."claude" =
         let
-          primaryAgent = lib.filterAttrs (n: a: n == cfg.agent) cfg.agents;
+          primaryAgents = lib.filterAttrs (n: a: n == cfg.agent) cfg.agents;
+          primaryAgent = if primaryAgents != { } then builtins.head (lib.attrNames primaryAgents) else cfg.agent;
           subAgents = lib.filterAttrs (n: a: n != cfg.agent) cfg.agents;
         in
         [
@@ -726,14 +727,12 @@ in
                 lib.concatStringsSep ", " (map (cmd: "/${cmd}") (lib.attrNames cfg.commands))
               }"
             }
-            ${lib.optionalString (primaryAgent != { })
-              "- Primary agent: ${
-                lib.concatStringsSep ", " (lib.attrNames primaryAgent)
-              }"
+            ${lib.optionalString (primaryAgent != null)
+              "- Primary agent: ${primaryAgent}"
             }
             ${lib.optionalString (subAgents != { })
               "- Sub-agents: ${
-                lib.concatStringsSep ", " (lib.attrNames  subAgents)
+                lib.concatStringsSep ", " (lib.attrNames subAgents)
               }"
             }
             ${lib.optionalString (cfg.mcpServers != { })
@@ -743,17 +742,6 @@ in
             }
           ''
         ];
-
-      assertions = [
-        {
-          assertion = cfg.agent != null -> (cfg.agents.${cfg.agent} or null) != null;
-          message = "claude.code.agent must be set to one of the claude.code.agents.<NAME>";
-        }
-        {
-          assertion = cfg.agent != null -> (cfg.agents.${cfg.agent}.proactive or null) == null;
-          message = "claude.code.agent = <NAME> requires claude.code.agents.<NAME>.proactive to be null";
-        }
-      ];
     })
 
   ];

--- a/tests/claude-primary-agent-external/.test-config.yml
+++ b/tests/claude-primary-agent-external/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/claude-primary-agent-external/.test.sh
+++ b/tests/claude-primary-agent-external/.test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `claude.code.agent` names a built-in agent that is not among the
+# project-defined agents. `devenv info` should report it as the primary
+# agent and list every configured agent as a sub-agent.
+
+out=$(devenv info)
+
+echo "$out" | grep -qF -- "- Primary agent: general-purpose" \
+  || { echo "expected '- Primary agent: general-purpose' in devenv info output:"; echo "$out"; exit 1; }
+
+echo "$out" | grep -qF -- "- Sub-agents: code-reviewer, docs-writer, test-writer" \
+  || { echo "expected '- Sub-agents: code-reviewer, docs-writer, test-writer' in devenv info output:"; echo "$out"; exit 1; }

--- a/tests/claude-primary-agent-external/devenv.nix
+++ b/tests/claude-primary-agent-external/devenv.nix
@@ -1,0 +1,24 @@
+{ ... }: {
+  claude.code = {
+    enable = true;
+    # "general-purpose" is a built-in Claude Code agent. It is intentionally
+    # not one of the project-defined agents below, so it should be reported
+    # as the primary agent while all project agents show up as sub-agents.
+    agent = "general-purpose";
+
+    agents = {
+      code-reviewer = {
+        description = "Reviews code for quality, security and best practices.";
+        prompt = "You are an expert code reviewer.";
+      };
+      docs-writer = {
+        description = "Writes and maintains project documentation.";
+        prompt = "You are a technical writer.";
+      };
+      test-writer = {
+        description = "Writes comprehensive test suites.";
+        prompt = "You are a test writing specialist.";
+      };
+    };
+  };
+}

--- a/tests/claude-primary-agent-internal/.test-config.yml
+++ b/tests/claude-primary-agent-internal/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/claude-primary-agent-internal/.test.sh
+++ b/tests/claude-primary-agent-internal/.test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `claude.code.agent` names one of the project-defined agents. `devenv info`
+# should report it as the primary agent and list the *other* configured
+# agents as sub-agents, excluding the primary one.
+
+out=$(devenv info)
+
+echo "$out" | grep -qF -- "- Primary agent: code-reviewer" \
+  || { echo "expected '- Primary agent: code-reviewer' in devenv info output:"; echo "$out"; exit 1; }
+
+echo "$out" | grep -qF -- "- Sub-agents: docs-writer, test-writer" \
+  || { echo "expected '- Sub-agents: docs-writer, test-writer' in devenv info output:"; echo "$out"; exit 1; }
+
+if echo "$out" | grep -qF -- "code-reviewer, docs-writer"; then
+  echo "primary agent 'code-reviewer' must not be listed among sub-agents:"
+  echo "$out"
+  exit 1
+fi

--- a/tests/claude-primary-agent-internal/devenv.nix
+++ b/tests/claude-primary-agent-internal/devenv.nix
@@ -1,0 +1,24 @@
+{ ... }: {
+  claude.code = {
+    enable = true;
+    # "code-reviewer" is one of the project-defined agents below, so it
+    # should be reported as the primary agent while the *other* agents
+    # show up as sub-agents.
+    agent = "code-reviewer";
+
+    agents = {
+      code-reviewer = {
+        description = "Reviews code for quality, security and best practices.";
+        prompt = "You are an expert code reviewer.";
+      };
+      docs-writer = {
+        description = "Writes and maintains project documentation.";
+        prompt = "You are a technical writer.";
+      };
+      test-writer = {
+        description = "Writes comprehensive test suites.";
+        prompt = "You are a test writing specialist.";
+      };
+    };
+  };
+}

--- a/tests/claude-primary-agent-only/.test-config.yml
+++ b/tests/claude-primary-agent-only/.test-config.yml
@@ -1,0 +1,1 @@
+use_shell: false

--- a/tests/claude-primary-agent-only/.test.sh
+++ b/tests/claude-primary-agent-only/.test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# No agents are configured, and `claude.code.agent` points at a built-in
+# Claude Code agent that isn't part of this project. `devenv info` should
+# report it as the primary agent and print no "Sub-agents" line.
+
+out=$(devenv info)
+
+echo "$out" | grep -qF -- "- Primary agent: general-purpose" \
+  || { echo "expected '- Primary agent: general-purpose' in devenv info output:"; echo "$out"; exit 1; }
+
+if echo "$out" | grep -q -- "- Sub-agents:"; then
+  echo "did not expect a '- Sub-agents:' line in devenv info output:"
+  echo "$out"
+  exit 1
+fi

--- a/tests/claude-primary-agent-only/devenv.nix
+++ b/tests/claude-primary-agent-only/devenv.nix
@@ -1,0 +1,8 @@
+{ ... }: {
+  claude.code = {
+    enable = true;
+    # "general-purpose" is a built-in Claude Code agent, not one of the
+    # (nonexistent, here) project-defined agents.
+    agent = "general-purpose";
+  };
+}


### PR DESCRIPTION
### Add `claude.code.agent` option to configure the primary agent in `.claude/settings.json`

```json
{
  "agent": <AGENT>
}
```

### Add `claude.code.<AGENT>.effort` option to make it possible to configure the effort property of the agents `.claude/agents/<AGENT>.md`

```yaml
---
name: ...
tools:
  - ...
effort: low
permissionMode: ...
---
```

### Obs

- Change `infoSections."claude"` accordingly
- ~~Add assertions guaranteeing `proactive` isn't defined for any primary agent and such a primary agent is only selected among the agents already defined.~~

### Example

```nix
{
  pkgs,
  lib,
  config,
  inputs,
  ...
}:
{
  name = "claude-dev";
  claude.code = {
    enable = true;
    agent = "supervise";
    agents = {
      supervise = {
        description = "Coordinates and delegates to prepare-tasks, implement, and review-task agents to run a project end-to-end. Use as the primary agent for this project — it doesn't implement or review code itself, only orchestrates handoffs and git operations.";
        model = "opus";
        tools = [
          "Agent(prepare-tasks, implement, review-task)"
          "Bash"
        ];
        permissionMode = "acceptEdits";
        effort = "low";
        prompt = ''
          You are a Project Supervisor. Your job is to coordinate handoff between agents. We work with the `prepare-tasks` agent, the `implement` agent, and the `review-task` agents.
          ## ...
        '';
      };
    };
  };
}
```