### PR TITLE
rust: preserve LLD with clang linker driver

### DIFF
--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -206,6 +206,8 @@ This avoids GCC’s ` collect2 ` wrapper, which can hit ` Argument list too long
 in large Nix development environments before the final linker receives
 Rust’s response file\.
 
+On x86_64 Linux (glibc), Clang uses LLD unless another linker is enabled\.
+
 
 
 *Type:*

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -21518,6 +21518,8 @@ This avoids GCC’s ` collect2 ` wrapper, which can hit ` Argument list too long
 in large Nix development environments before the final linker receives
 Rust’s response file.
 
+On x86_64 Linux (glibc), Clang uses LLD unless another linker is enabled.
+
 
 
 *Type:*
@@ -49831,5 +49833,4 @@ list of string
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)
-
 

--- a/docs/src/reference/options.md
+++ b/docs/src/reference/options.md
@@ -25283,7 +25283,7 @@ Allocated port based on ` allocate `
 
 process-compose.yaml specific process attributes.
 
-Example: https://github.com/F1bonacc1/process-compose/blob/main/process-compose.yaml\`
+Example: ` https://github.com/F1bonacc1/process-compose/blob/main/process-compose.yaml `
 
 Only used when using ` process.manager.implementation = "process-compose"; `
 
@@ -49833,4 +49833,5 @@ list of string
 
 *Declared by:*
  - [https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix](https://github.com/cachix/devenv/blob/main/src/modules/top-level.nix)
+
 

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -3,6 +3,23 @@
 let
   cfg = config.languages.rust;
 
+  # Linkers the user can enable explicitly; at most one may be active.
+  explicitLinkers = [ cfg.mold.enable cfg.lld.enable cfg.wild.enable ];
+
+  # Setting an explicit linker driver makes rustc stop adding the default LLD
+  # flags on targets where rustc links with LLD out of the box. Force Clang to
+  # use LLD there unless the user selected a different linker through devenv.
+  forceLldWithClang =
+    cfg.clangLinker.enable
+    && pkgs.stdenv.hostPlatform.rust.rustcTarget == "x86_64-unknown-linux-gnu"
+    && !lib.any lib.id explicitLinkers;
+
+  # Pin the linker path so LLD does not need to be installed on PATH (and a
+  # stray ld.lld earlier on PATH cannot take over).
+  clangLinkerDriver = pkgs.writeShellScript "devenv-rust-linker" ''
+    exec ${lib.getExe pkgs.clang} --ld-path=${pkgs.llvmPackages.bintools}/bin/ld.lld "$@"
+  '';
+
   # The components to actually install in the toolchain. Appends the cranelift
   # codegen backend on top of the user-configured `components` (which keeps its
   # default) rather than overriding them.
@@ -119,6 +136,8 @@ in
         This avoids GCC's `collect2` wrapper, which can hit `Argument list too long`
         in large Nix development environments before the final linker receives
         Rust's response file.
+
+        On x86_64 Linux (glibc), Clang uses LLD unless another linker is enabled.
       '';
     };
 
@@ -304,7 +323,7 @@ in
             '';
           }
           {
-            assertion = lib.count lib.id [ cfg.mold.enable cfg.lld.enable cfg.wild.enable ] <= 1;
+            assertion = lib.count lib.id explicitLinkers <= 1;
             message = ''
               Only one linker can be enabled at a time.
 
@@ -432,7 +451,8 @@ in
           # silently dropping any flags configured there (e.g. `--cfg tracing_unstable`).
           # The per-target linker env var sets the linker without touching rustflags.
           // lib.optionalAttrs cfg.clangLinker.enable {
-            "CARGO_TARGET_${pkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" = "clang";
+            "CARGO_TARGET_${pkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" =
+              if forceLldWithClang then clangLinkerDriver else lib.getExe pkgs.clang;
           };
 
         git-hooks.tools = {

--- a/tests/rust/devenv.nix
+++ b/tests/rust/devenv.nix
@@ -1,8 +1,22 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   # The clang linker driver is only enabled by default on Linux, so the
   # clang-specific assertions below only apply where the module turns it on.
   clangLinker = config.languages.rust.clangLinker.enable;
+
+  # This is intentionally independent of the module's implementation so a
+  # regression in its platform condition cannot silently disable the assertion.
+  expectLld =
+    clangLinker
+    && pkgs.stdenv.hostPlatform.rust.rustcTarget == "x86_64-unknown-linux-gnu";
+
+  # The exact linker value the module configured, asserted against the build log.
+  rustLinker = config.env."CARGO_TARGET_${pkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" or "";
+
+  # Ask the linker to print its version during the regular build so the LLD
+  # assertion below does not need a second compile.
+  rustflags = [ "--cfg" "devenv_custom_cfg" ]
+    ++ lib.optionals expectLld [ "-C" "link-arg=-Wl,-v" ];
 in
 {
   languages.rust.enable = true;
@@ -21,7 +35,7 @@ in
     # linker driver is configured via CARGO_TARGET_<triple>_LINKER, not RUSTFLAGS,
     # so it no longer clobbers these flags (RUSTFLAGS would override them entirely).
     mkdir -p "$workdir/linker-check/.cargo"
-    printf '[build]\nrustflags = ["--cfg", "devenv_custom_cfg"]\n' \
+    printf '[build]\nrustflags = %s\n' '${builtins.toJSON rustflags}' \
       > "$workdir/linker-check/.cargo/config.toml"
 
     # cargo discovers `.cargo/config.toml` from the working directory, so build
@@ -30,8 +44,16 @@ in
     ( cd "$workdir/linker-check" && cargo build -vv ) >"$build_log" 2>&1
 
     ${lib.optionalString clangLinker ''
-      if ! grep -q -- "-C linker=clang" "$build_log"; then
+      if ! grep -qF -- "-C linker=${rustLinker}" "$build_log"; then
         echo "cargo build did not pass the clang linker driver to rustc"
+        cat "$build_log"
+        exit 1
+      fi
+    ''}
+
+    ${lib.optionalString expectLld ''
+      if ! grep -qF -- "linker stdout: LLD" "$build_log"; then
+        echo "the clang linker driver did not use LLD"
         cat "$build_log"
         exit 1
       fi


### PR DESCRIPTION
## Summary

- keep Clang as the default Rust linker driver on Linux, avoiding GCC's `collect2` hop
- preserve Rust's LLD backend on `x86_64-linux` when no explicit `mold`, `lld`, or `wild` linker is selected
- verify the actual linker backend while retaining project-level Cargo rustflags

## Root cause

#2981 configured Clang through Cargo's per-target linker setting to avoid GCC `collect2` hitting `ARG_MAX`. Setting an explicit linker driver, however, makes rustc stop adding the target's default self-contained LLD flags. Clang then falls back to GNU BFD `ld`.

A small Clang driver wrapper now adds `-fuse-ld=lld` on `x86_64-linux`. This retains the original `collect2` fix without setting `RUSTFLAGS`, so project `.cargo/config.toml` flags continue to work. Explicit devenv linker selections remain authoritative.

## User impact

Rust 1.90+ builds in default Linux Rust shells use LLD as intended instead of silently falling back to GNU BFD `ld`, avoiding the slower and substantially more memory-intensive linker behavior seen in parallel Cargo builds.

## Validation

- `devenv shell -- devenv-run-tests run tests --only rust`
- `devenv shell -- devenv-run-tests run tests --only rust-clang-linker-disabled`
- `devenv shell -- nixpkgs-fmt --check src/modules/languages/rust.nix tests/rust/devenv.nix`
- commit hooks (`nixpkgs-fmt`)