### PR TITLE
fix: update Nix for GitHub URL rewrites

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -599,11 +599,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1785349663,
-        "narHash": "sha256-JSD8lPe5kalvPKx5X+inX8ZZdGLeXkAbd3Jiv7UDf+I=",
+        "lastModified": 1786294306,
+        "narHash": "sha256-WcqKvA7f7TGrlDVd69T1UXUqVXJ+wfoRbO+mg5L7/Rc=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "f33db89fd6db6edc337d93212f6628ab6d25f407",
+        "rev": "59407321a92f7d34d4a53e38959294007c0bc37a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -136,11 +136,11 @@
         "nixpkgs-regression": []
       },
       "locked": {
-        "lastModified": 1785349663,
-        "narHash": "sha256-JSD8lPe5kalvPKx5X+inX8ZZdGLeXkAbd3Jiv7UDf+I=",
+        "lastModified": 1786294306,
+        "narHash": "sha256-WcqKvA7f7TGrlDVd69T1UXUqVXJ+wfoRbO+mg5L7/Rc=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "f33db89fd6db6edc337d93212f6628ab6d25f407",
+        "rev": "59407321a92f7d34d4a53e38959294007c0bc37a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- update both Nix lock entries to [`cachix/nix@59407321a`](https://github.com/cachix/nix/commit/59407321a92f7d34d4a53e38959294007c0bc37a)
- keep GitHub ref resolution on its intended HTTPS transport when users configure Git `url.*.insteadOf` rewrites
- retain token authentication and support for explicitly supplied SSH URLs

## Root cause

libgit2 1.9.4 applies Git URL rewrites when creating detached remotes. A user-level HTTPS-to-SSH rewrite could therefore redirect Nix's internal GitHub smart-HTTP request to SSH, bypassing the supplied GitHub token and failing when no usable SSH agent was available.

The Nix patch creates that internal remote with `GIT_REMOTE_CREATE_SKIP_INSTEADOF`. It also adds a VM regression test with a hostile HTTPS-to-SSH rewrite configured.

## Validation

- `nix build .#devenv --no-link -L`
- Nix `nix-fetchers` component build with pinned libgit2 1.9.2
- Nix `githubFlakes` VM test with pinned libgit2 1.9.2
- Nix `githubFlakes` VM test overridden to libgit2 1.9.4
- direct libgit2 1.9.4 before/after URL resolution check
- `clang-format`, `nixfmt`, and `git diff --check`
