### PR TITLE
feat: Add VHDL language support

### DIFF
--- a/src/modules/languages/vhdl.nix
+++ b/src/modules/languages/vhdl.nix
@@ -1,0 +1,51 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.languages.vhdl;
+in {
+  options.languages.vhdl = {
+    enable = lib.mkEnableOption "tools for VHDL Development";
+    backend = lib.mkOption {
+      type = lib.types.enum ["ghdl-gcc" "ghdl-llvm" "ghdl-mcode" "nvc"];
+      default = "ghdl-gcc";
+      description = ''
+        The VHDL compiler backend to use.
+        - ghdl-gcc: GHDL with GCC backend
+        - ghdl-llvm: GHDL with LLVM backend
+        - ghdl-mcode: GHDL with built-in mcode backend
+        - nvc: VHDL compiler and simulator
+      '';
+    };
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.ghdl-gcc;
+      description = "The VHDL package to use (automatically set based on backend).";
+      apply = backend: let
+        packages = {
+          "ghdl-gcc" = pkgs.ghdl-gcc;
+          "ghdl-llvm" = pkgs.ghdl-llvm;
+          "ghdl-mcode" = pkgs.ghdl-mcode;
+          "nvc" = pkgs.nvc;
+        };
+      in
+        packages.${backend} or (throw "Unknown VHDL backend: ${backend}");
+    };
+
+    lsp = {
+      enable = lib.mkEnableOption "VHDL Language Server" // {default = true;};
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.vhdl-ls;
+        defaultText = lib.literalExpression "pkgs.vhdl_ls";
+        description = "The VHDL language server package to use.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    packages = with pkgs; [cfg.package] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
+  };
+}

--- a/src/modules/languages/vhdl.nix
+++ b/src/modules/languages/vhdl.nix
@@ -29,7 +29,7 @@ in {
           "nvc" = pkgs.nvc;
         };
       in
-        packages.${config.languages.vhdl.backend} or pkgs.ghdl-gcc;
+        packages.${cfg.backend} or pkgs.ghdl-gcc;
       description = "The VHDL package to use (automatically set based on backend).";
     };
 

--- a/src/modules/languages/vhdl.nix
+++ b/src/modules/languages/vhdl.nix
@@ -21,9 +21,7 @@ in {
     };
     package = lib.mkOption {
       type = lib.types.package;
-      default = pkgs.ghdl-gcc;
-      description = "The VHDL package to use (automatically set based on backend).";
-      apply = backend: let
+      default = let
         packages = {
           "ghdl-gcc" = pkgs.ghdl-gcc;
           "ghdl-llvm" = pkgs.ghdl-llvm;
@@ -31,7 +29,8 @@ in {
           "nvc" = pkgs.nvc;
         };
       in
-        packages.${backend} or (throw "Unknown VHDL backend: ${backend}");
+        packages.${config.languages.vhdl.backend} or pkgs.ghdl-gcc;
+      description = "The VHDL package to use (automatically set based on backend).";
     };
 
     lsp = {

--- a/src/modules/languages/vhdl.nix
+++ b/src/modules/languages/vhdl.nix
@@ -11,6 +11,10 @@ let
     ghdl-mcode = pkgs.ghdl-mcode;
     nvc = pkgs.nvc;
   };
+  defaultPackageText =
+    if pkgs.stdenv.isDarwin
+    then "pkgs.ghdl-llvm"
+    else "pkgs.ghdl-gcc";
 in
 {
   options.languages.vhdl = {
@@ -32,7 +36,7 @@ in
     package = lib.mkOption {
       type = lib.types.package;
       default = compilerPackages.${cfg.compiler};
-      defaultText = lib.literalExpression "pkgs.\${cfg.compiler}";
+      defaultText = lib.literalExpression defaultPackageText;
       description = "The VHDL package to use (automatically set based on compiler).";
     };
 
@@ -43,7 +47,7 @@ in
         default = pkgs.vhdl-ls;
         defaultText = lib.literalExpression "pkgs.vhdl-ls";
         description = ''
-          The VHDL language server package to use.
+          The VHDL language server package to use (automatically set based on compiler).
 
           You can see this example of [vhdl-ls configuration](https://github.com/VHDL-LS/rust_hdl#example-vhdl_lstoml--quickstart) to start.
         '';

--- a/src/modules/languages/vhdl.nix
+++ b/src/modules/languages/vhdl.nix
@@ -1,18 +1,28 @@
-{
-  pkgs,
-  config,
-  lib,
-  ...
-}: let
+{ pkgs
+, config
+, lib
+, ...
+}:
+let
   cfg = config.languages.vhdl;
-in {
+  compilerPackages = {
+    ghdl-gcc = pkgs.ghdl-gcc;
+    ghdl-llvm = pkgs.ghdl-llvm;
+    ghdl-mcode = pkgs.ghdl-mcode;
+    nvc = pkgs.nvc;
+  };
+in
+{
   options.languages.vhdl = {
     enable = lib.mkEnableOption "tools for VHDL Development";
-    backend = lib.mkOption {
-      type = lib.types.enum ["ghdl-gcc" "ghdl-llvm" "ghdl-mcode" "nvc"];
-      default = "ghdl-gcc";
+    compiler = lib.mkOption {
+      type = lib.types.enum (builtins.attrNames compilerPackages);
+      default =
+        if pkgs.stdenv.isDarwin
+        then "ghdl-llvm"
+        else "ghdl-gcc";
       description = ''
-        The VHDL compiler backend to use.
+        The VHDL compiler to use.
         - ghdl-gcc: GHDL with GCC backend
         - ghdl-llvm: GHDL with LLVM backend
         - ghdl-mcode: GHDL with built-in mcode backend
@@ -21,30 +31,27 @@ in {
     };
     package = lib.mkOption {
       type = lib.types.package;
-      default = let
-        packages = {
-          "ghdl-gcc" = pkgs.ghdl-gcc;
-          "ghdl-llvm" = pkgs.ghdl-llvm;
-          "ghdl-mcode" = pkgs.ghdl-mcode;
-          "nvc" = pkgs.nvc;
-        };
-      in
-        packages.${cfg.backend} or pkgs.ghdl-gcc;
-      description = "The VHDL package to use (automatically set based on backend).";
+      default = compilerPackages.${cfg.compiler};
+      defaultText = lib.literalExpression "pkgs.\${cfg.compiler}";
+      description = "The VHDL package to use (automatically set based on compiler).";
     };
 
     lsp = {
-      enable = lib.mkEnableOption "VHDL Language Server" // {default = true;};
+      enable = lib.mkEnableOption "VHDL Language Server" // { default = true; };
       package = lib.mkOption {
         type = lib.types.package;
         default = pkgs.vhdl-ls;
-        defaultText = lib.literalExpression "pkgs.vhdl_ls";
-        description = "The VHDL language server package to use.";
+        defaultText = lib.literalExpression "pkgs.vhdl-ls";
+        description = ''
+          The VHDL language server package to use.
+
+          You can see this example of [vhdl-ls configuration](https://github.com/VHDL-LS/rust_hdl#example-vhdl_lstoml--quickstart) to start.
+        '';
       };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    packages = with pkgs; [cfg.package] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
+    packages = [ cfg.package ] ++ lib.optional cfg.lsp.enable cfg.lsp.package;
   };
 }

--- a/tests/vhdl-ghdl/adder.vhd
+++ b/tests/vhdl-ghdl/adder.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity adder is
+    port (
+        a : in  std_logic_vector(7 downto 0);
+        b : in  std_logic_vector(7 downto 0);
+        sum : out std_logic_vector(7 downto 0)
+    );
+end entity;
+
+architecture rtl of adder is
+begin
+    sum <= std_logic_vector(unsigned(a) + unsigned(b));
+end architecture;

--- a/tests/vhdl-ghdl/devenv.nix
+++ b/tests/vhdl-ghdl/devenv.nix
@@ -1,0 +1,26 @@
+{
+  languages.vhdl = {
+    enable = true;
+    lsp.enable = false;
+  };
+  enterTest = ''
+    set -euo pipefail
+
+    if ! command -v ghdl >/dev/null; then
+      echo "ghdl is not available"
+      exit 1
+    fi
+
+    workdir="$(mktemp -d)"
+    trap 'rm -rf "$workdir"' EXIT
+
+    cp adder.vhd "$workdir/adder.vhd"
+    cp tb_adder.vhd "$workdir/tb_adder.vhd"
+
+    cd "$workdir"
+
+    ghdl -a --std=08 adder.vhd tb_adder.vhd
+    ghdl -e --std=08 tb_adder
+    ghdl -r --std=08 tb_adder --assert-level=error
+  '';
+}

--- a/tests/vhdl-ghdl/tb_adder.vhd
+++ b/tests/vhdl-ghdl/tb_adder.vhd
@@ -1,0 +1,27 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity tb_adder is
+end entity;
+
+architecture test of tb_adder is
+    signal a : std_logic_vector(7 downto 0) := (others => '0');
+    signal b : std_logic_vector(7 downto 0) := (others => '0');
+    signal sum : std_logic_vector(7 downto 0);
+begin
+    uut: entity work.adder port map (a, b, sum);
+    
+    process
+    begin
+        a <= X"05";
+        b <= X"03";
+        wait for 10 ns;
+        assert sum = X"08" report "Adder failed!" severity error;
+        a <= X"FF";
+        b <= X"01";
+        wait for 10 ns;
+        assert sum = X"00" report "Overflow wrap-around failed!" severity error;
+        report "Test completed successfully";
+        wait;
+    end process;
+end architecture;

--- a/tests/vhdl-nvc/adder.vhd
+++ b/tests/vhdl-nvc/adder.vhd
@@ -1,0 +1,16 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity adder is
+    port (
+        a : in  std_logic_vector(7 downto 0);
+        b : in  std_logic_vector(7 downto 0);
+        sum : out std_logic_vector(7 downto 0)
+    );
+end entity;
+
+architecture rtl of adder is
+begin
+    sum <= std_logic_vector(unsigned(a) + unsigned(b));
+end architecture;

--- a/tests/vhdl-nvc/devenv.nix
+++ b/tests/vhdl-nvc/devenv.nix
@@ -1,0 +1,28 @@
+{
+  languages.vhdl = {
+    enable = true;
+    compiler = "nvc";
+    lsp.enable = false;
+  };
+  enterTest = ''
+    set -euo pipefail
+
+    if ! command -v nvc >/dev/null; then
+      echo "nvc is not available"
+      exit 1
+    fi
+
+    workdir="$(mktemp -d)"
+    trap 'rm -rf "$workdir"' EXIT
+
+    cp adder.vhd "$workdir/adder.vhd"
+    cp tb_adder.vhd "$workdir/tb_adder.vhd"
+
+    cd "$workdir"
+
+    nvc --version
+    nvc -a adder.vhd tb_adder.vhd
+    nvc -e tb_adder
+    nvc -r tb_adder
+  '';
+}

--- a/tests/vhdl-nvc/tb_adder.vhd
+++ b/tests/vhdl-nvc/tb_adder.vhd
@@ -1,0 +1,27 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity tb_adder is
+end entity;
+
+architecture test of tb_adder is
+    signal a : std_logic_vector(7 downto 0) := (others => '0');
+    signal b : std_logic_vector(7 downto 0) := (others => '0');
+    signal sum : std_logic_vector(7 downto 0);
+begin
+    uut: entity work.adder port map (a, b, sum);
+    
+    process
+    begin
+        a <= X"05";
+        b <= X"03";
+        wait for 10 ns;
+        assert sum = X"08" report "Adder failed!" severity error;
+        a <= X"FF";
+        b <= X"01";
+        wait for 10 ns;
+        assert sum = X"00" report "Overflow wrap-around failed!" severity error;
+        report "Test completed successfully";
+        wait;
+    end process;
+end architecture;


### PR DESCRIPTION
This PR adds support for VHDL language in devenv project:

features:
1.  Choose from 4 compilers: `ghdl-gcc`, `ghdl-llvm`, `ghdl-mcode`, or `nvc` (Default compiler `ghdl-gcc`).
2. `vhdl-ls` LSP support for VHDL.