### PR TITLE
fix Darwin profile SDK case collision

### DIFF
--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -10,6 +10,8 @@ let
   # Returns a list of all the entries in a folder
   listEntries = path: map (name: path + "/${name}") (builtins.attrNames (builtins.readDir path));
 
+  isAppleSDK = pkg: pkg ? sdkroot;
+
   drvOrPackageToPaths =
     drvOrPackage:
     let
@@ -29,7 +31,17 @@ let
 
   profile = pkgs.buildEnv {
     name = "devenv-profile";
-    paths = lib.flatten (builtins.map drvOrPackageToPaths config.packages);
+    # Apple SDKs expose a top-level `Library`, which collides with packages
+    # exposing `library` on case-insensitive Darwin filesystems. Keep SDKs as
+    # shell inputs below, but do not link them into the user profile.
+    paths = lib.flatten (
+      builtins.map drvOrPackageToPaths (
+        if pkgs.stdenv.isDarwin then
+          builtins.filter (pkg: !isAppleSDK pkg) config.packages
+        else
+          config.packages
+      )
+    );
     ignoreCollisions = true;
     ignoreSingleFileOutputs = true;
   };
@@ -405,7 +417,7 @@ in
         # so they participate in the SDK version comparison done by stdenv's setup hooks.
         partitioned =
           if pkgs.stdenv.isDarwin then
-            builtins.partition (pkg: pkg ? sdkroot) config.packages
+            builtins.partition isAppleSDK config.packages
           else
             {
               right = [ ];

--- a/tests/macos-apple-sdk-profile/.test-config.yml
+++ b/tests/macos-apple-sdk-profile/.test-config.yml
@@ -1,0 +1,3 @@
+supported_systems:
+  - x86_64-darwin
+  - aarch64-darwin

--- a/tests/macos-apple-sdk-profile/devenv.nix
+++ b/tests/macos-apple-sdk-profile/devenv.nix
@@ -1,0 +1,29 @@
+{ pkgs, ... }:
+
+let
+  lowerCaseLibrary = name: pkgs.runCommand "lowercase-library-${name}" { } ''
+    mkdir -p "$out/library"
+    touch "$out/library/${name}"
+  '';
+in
+{
+  packages = [
+    (lowerCaseLibrary "first")
+    (lowerCaseLibrary "second")
+  ];
+
+  enterTest = ''
+    test -f "$DEVENV_PROFILE/library/first"
+    test -f "$DEVENV_PROFILE/library/second"
+
+    test -n "$DEVELOPER_DIR"
+    test -n "$SDKROOT"
+    test -e "$SDKROOT/usr/include/stdio.h"
+
+    xcrun --find clang >/dev/null
+
+    printf '#include <stdio.h>\nint main(void) { puts("ok"); }\n' \
+      | cc -x c - -o "$DEVENV_STATE/apple-sdk-profile-test"
+    test "$("$DEVENV_STATE/apple-sdk-profile-test")" = "ok"
+  '';
+}


### PR DESCRIPTION
## Summary

- keep Apple SDK packages as Darwin shell inputs while excluding them from the generated user profile
- reuse the SDK predicate for shell input partitioning
- add a Darwin-only regression test that verifies the profile, SDK environment, `xcrun`, and C compilation

## Root cause

Apple SDK packages expose a top-level `Library` directory, while R packages and other packages can expose lowercase `library`. On the case-insensitive filesystem used by macOS Nix stores, `pkgs.buildEnv` cannot represent both paths and fails while creating the devenv profile.

The SDK does not need to be linked into `DEVENV_PROFILE`: it remains a direct shell `buildInput`, so its setup hooks continue to provide `DEVELOPER_DIR`, `SDKROOT`, and `xcrun`.

Fixes https://github.com/cachix/devenv-nixpkgs/issues/32

## Validation

- confirmed the regression test fails against the unpatched module with the original `builder.pl` `//library` error
- confirmed the patched test passes on an aarch64-darwin builder
- verified `SDKROOT` headers are accessible, `xcrun --find clang` succeeds, and a C program compiles and runs
- `nixpkgs-fmt --check`
- `git diff --check`
- confirmed test discovery restricts the test to x86_64-darwin and aarch64-darwin