### PR TITLE
Fix examples for current Nixpkgs

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -132,7 +132,13 @@ in
 
         # Enable all languages tooling!
         ${lib.concatStringsSep "\n  " (
-          map (lang: "languages.${lang}.enable = true;") (builtins.attrNames options.languages)
+          map (
+            lang:
+            if lang == "hare" then
+              "languages.hare.enable = pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.hare;"
+            else
+              "languages.${lang}.enable = true;"
+          ) (builtins.attrNames options.languages)
         )}
 
         # If you're missing a language, please contribute it by following examples of other languages <3

--- a/examples/postgres-timescale/devenv.nix
+++ b/examples/postgres-timescale/devenv.nix
@@ -3,7 +3,7 @@
 {
   services.postgres = {
     enable = true;
-    package = pkgs.postgresql_15;
+    package = pkgs.postgresql_16;
     initialDatabases = [{ name = "mydb"; }];
     extensions = extensions: [
       extensions.postgis

--- a/examples/supported-languages/devenv.nix
+++ b/examples/supported-languages/devenv.nix
@@ -19,7 +19,7 @@
   languages.gawk.enable = true;
   languages.gleam.enable = true;
   languages.go.enable = true;
-  languages.hare.enable = true;
+  languages.hare.enable = pkgs.lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.hare;
   languages.haskell.enable = true;
   languages.helm.enable = true;
   languages.idris.enable = true;


### PR DESCRIPTION
## Summary

- move the TimescaleDB example from PostgreSQL 15 to PostgreSQL 16, matching the versions supported by current TimescaleDB
- enable Hare in the supported-languages example only when the Nixpkgs package is available on the host platform
- update the example generator so regeneration preserves the Hare platform gate

## Why

Current Nixpkgs marks TimescaleDB broken with PostgreSQL 15 after upstream removed PostgreSQL 15 support. Hare is intentionally unavailable on Darwin; its macOS implementation is a separate, unofficial port. These baseline example failures surfaced while investigating CI on #3080.

## Impact

The examples continue to include TimescaleDB and Hare on supported platforms while evaluating cleanly against current Nixpkgs on Darwin. No unofficial Hare fork or package metadata override is introduced.

## Validation

- pre-commit `nixpkgs-fmt`
- `nix-instantiate --parse devenv.nix`
- `nix-instantiate --parse examples/supported-languages/devenv.nix`
- confirmed Hare is available on `x86_64-linux` and unavailable on `aarch64-darwin` through `lib.meta.availableOn`
- `git diff --check`
- the focused Timescale example test completed shell evaluation; dependency realization later stalled on the busy local Nix builder and was interrupted