### PR TITLE
fix: make TUI restart fuzzing lifecycle-aware

### DIFF
--- a/.github/workflows/tui-fuzz.yml
+++ b/.github/workflows/tui-fuzz.yml
@@ -101,6 +101,7 @@ jobs:
       - name: Run terminal fuzz
         run: |
           fixture="$PWD/devenv-tui/replays/processes.jsonl"
+          event_log="$PWD/bombadil-events.jsonl"
           set +e
           "${{ steps.build-bombadil.outputs.path }}/bin/bombadil" terminal test \
             --time-limit "${{ github.event.inputs.time-limit || '120s' }}" \
@@ -110,7 +111,7 @@ jobs:
             --specification devenv-tui/bombadil/devenv-tui.spec.ts \
             --output-path bombadil-out \
             -- "${{ steps.build-tui-replay.outputs.bin }}" \
-              --hold --attached --reactive "$fixture" \
+              --hold --attached --reactive --event-log "$event_log" "$fixture" \
             > bombadil.log 2>&1
           status=$?
           set -e
@@ -132,5 +133,6 @@ jobs:
           path: |
             bombadil-reproducer.tar.zst
             bombadil.log
+            bombadil-events.jsonl
           if-no-files-found: ignore
           retention-days: 14

--- a/devenv-processes/src/manager.rs
+++ b/devenv-processes/src/manager.rs
@@ -17,6 +17,36 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, trace, warn};
 
+fn same_process_command(left: &ProcessCommand, right: &ProcessCommand) -> bool {
+    matches!(
+        (left, right),
+        (ProcessCommand::Restart(left), ProcessCommand::Restart(right))
+            | (ProcessCommand::Stop(left), ProcessCommand::Stop(right))
+            if left == right
+    )
+}
+
+async fn recv_process_command(rx: &mut mpsc::Receiver<FrontendEvent>) -> Option<ProcessCommand> {
+    while let Some(event) = rx.recv().await {
+        if let FrontendEvent::Process(command) = event {
+            return Some(command);
+        }
+    }
+    None
+}
+
+/// Keep only the newest process intent that accumulated while the backend was
+/// busy. Terminal key repeats are input intent, not a queue of work to replay.
+fn latest_queued_process_command(rx: &mut mpsc::Receiver<FrontendEvent>) -> Option<ProcessCommand> {
+    let mut latest = None;
+    while let Ok(event) = rx.try_recv() {
+        if let FrontendEvent::Process(command) = event {
+            latest = Some(command);
+        }
+    }
+    latest
+}
+
 /// Request sent by a client to the native manager API socket.
 ///
 /// Protocol: newline-delimited JSON over a Unix stream socket.
@@ -2619,10 +2649,14 @@ impl NativeProcessManager {
     pub fn start_command_listener(self: &Arc<Self>, mut rx: mpsc::Receiver<FrontendEvent>) {
         let pm = Arc::clone(self);
         tokio::spawn(async move {
-            while let Some(event) = rx.recv().await {
-                if let FrontendEvent::Process(command) = event {
-                    pm.handle_command(command).await;
-                }
+            let mut queued_command = None;
+            while let Some(command) = match queued_command.take() {
+                Some(command) => Some(command),
+                None => recv_process_command(&mut rx).await,
+            } {
+                pm.handle_command(command.clone()).await;
+                queued_command = latest_queued_process_command(&mut rx)
+                    .filter(|queued| !same_process_command(&command, queued));
             }
         });
     }
@@ -2641,6 +2675,7 @@ impl NativeProcessManager {
         );
         info!("Manager event loop started (foreground)");
         let mut saw_processes = false;
+        let mut queued_command = None;
 
         loop {
             tokio::select! {
@@ -2653,13 +2688,20 @@ impl NativeProcessManager {
                     break;
                 }
                 Some(event) = async {
-                    match frontend_event_rx.as_mut() {
-                        Some(rx) => rx.recv().await,
-                        None => std::future::pending().await,
+                    match queued_command.take() {
+                        Some(command) => Some(FrontendEvent::Process(command)),
+                        None => match frontend_event_rx.as_mut() {
+                            Some(rx) => rx.recv().await,
+                            None => std::future::pending().await,
+                        },
                     }
                 } => {
                     if let FrontendEvent::Process(command) = event {
-                        self.handle_command(command).await;
+                        self.handle_command(command.clone()).await;
+                        queued_command = frontend_event_rx
+                            .as_mut()
+                            .and_then(latest_queued_process_command)
+                            .filter(|queued| !same_process_command(&command, queued));
                     }
                 }
                 _ = tokio::time::sleep(Duration::from_millis(100)) => {
@@ -2948,6 +2990,44 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let manager = NativeProcessManager::new(temp_dir.path().to_path_buf());
         assert!(manager.is_ok());
+    }
+
+    #[tokio::test]
+    async fn process_command_queue_keeps_only_the_latest_intent() {
+        let (tx, mut rx) = mpsc::channel(4);
+        tx.send(FrontendEvent::Process(ProcessCommand::Restart(
+            "alpha".to_string(),
+        )))
+        .await
+        .unwrap();
+        tx.send(FrontendEvent::Process(ProcessCommand::Stop(
+            "alpha".to_string(),
+        )))
+        .await
+        .unwrap();
+        tx.send(FrontendEvent::Process(ProcessCommand::Restart(
+            "beta".to_string(),
+        )))
+        .await
+        .unwrap();
+
+        let first = recv_process_command(&mut rx).await.unwrap();
+        let latest = latest_queued_process_command(&mut rx).unwrap();
+
+        assert!(matches!(first, ProcessCommand::Restart(name) if name == "alpha"));
+        assert!(matches!(latest, ProcessCommand::Restart(name) if name == "beta"));
+    }
+
+    #[test]
+    fn repeated_process_command_is_the_same_intent() {
+        assert!(same_process_command(
+            &ProcessCommand::Restart("alpha".to_string()),
+            &ProcessCommand::Restart("alpha".to_string()),
+        ));
+        assert!(!same_process_command(
+            &ProcessCommand::Restart("alpha".to_string()),
+            &ProcessCommand::Stop("alpha".to_string()),
+        ));
     }
 
     #[tokio::test]

--- a/devenv-tui/bombadil/devenv-tui.spec.ts
+++ b/devenv-tui/bombadil/devenv-tui.spec.ts
@@ -121,8 +121,13 @@ const resize = actions((): ActionTemplate[] =>
     : [],
 );
 
+const restartInFlight = () =>
+  Object.values(processStates.current).includes("restarting");
 const restartProcess = actions((): ActionTemplate[] =>
-  mainView() ? [k("\x12")] : [],
+  mainView() && !restartInFlight() ? [k("\x12")] : [],
+);
+const restartBurst = actions((): ActionTemplate[] =>
+  mainView() && !restartInFlight() ? [k("\x12".repeat(64))] : [],
 );
 const stopProcess = actions((): ActionTemplate[] =>
   mainView() ? [k("\x18")] : [],
@@ -147,7 +152,7 @@ export const drive = weighted([
   [4, stopProcess], // Ctrl+X  stop process
   // A valid-input burst must be coalesced or rejected safely while the backend
   // catches up; user-controlled terminal input can never be a panic condition.
-  [2, whenMain(k("\x12".repeat(64)))],
+  [2, restartBurst],
   [4, whenMain(k("\x08"))], // Ctrl+H  toggle hide-stopped
   [5, whenReady(k("\x1b"))], // Esc     clear selection / back
   [12, resize],
@@ -178,13 +183,24 @@ export const noPanicText = always(() => !leaked.current);
 // before any generated input is allowed.
 export const fixtureAppears = eventually(mainView).within(2, "seconds");
 
+const restartTarget: Record<ProcessName, VisibleStatus> = {
+  api: "ready",
+  worker: "running",
+  disabled: "running",
+};
+
 const restartCompletes = (process: ProcessName) =>
   always(
     now(() => processStates.current[process] === "restarting").implies(
-      eventually(() => processStates.current[process] === "ready").within(
-        2,
-        "seconds",
-      ),
+      eventually(() => {
+        const state = processStates.current[process];
+        // The terminal cannot observe a process row while another view is on
+        // screen or Ctrl-H has hidden it. A stop also legitimately supersedes
+        // an in-flight restart and has its own completion property below.
+        return !mainView() || state === null ||
+          state === restartTarget[process] ||
+          state === "stopping" || state === "stopped";
+      }).within(2, "seconds"),
     ),
   );
 

--- a/devenv-tui/src/bin/tui-replay.rs
+++ b/devenv-tui/src/bin/tui-replay.rs
@@ -155,14 +155,63 @@ async fn run_replays(
     }
 }
 
-fn process_ids(events: &[ReplayEvent]) -> BTreeMap<String, u64> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ReactiveProcess {
+    id: u64,
+    stable_status: ProcessStatus,
+}
+
+fn reactive_processes(events: &[ReplayEvent]) -> BTreeMap<String, ReactiveProcess> {
     events
         .iter()
         .filter_map(|event| match &event.activity {
-            ActivityEvent::Process(Process::Start { id, name, .. }) => Some((name.clone(), *id)),
+            ActivityEvent::Process(Process::Start {
+                id,
+                name,
+                ready_probe,
+                ..
+            }) => Some((
+                name.clone(),
+                ReactiveProcess {
+                    id: *id,
+                    stable_status: if ready_probe.is_some() {
+                        ProcessStatus::Ready
+                    } else {
+                        ProcessStatus::Running
+                    },
+                },
+            )),
             _ => None,
         })
         .collect()
+}
+
+fn same_process_command(left: &ProcessCommand, right: &ProcessCommand) -> bool {
+    matches!(
+        (left, right),
+        (ProcessCommand::Restart(left), ProcessCommand::Restart(right))
+            | (ProcessCommand::Stop(left), ProcessCommand::Stop(right))
+            if left == right
+    )
+}
+
+async fn recv_process_command(rx: &mut mpsc::Receiver<FrontendEvent>) -> Option<ProcessCommand> {
+    while let Some(event) = rx.recv().await {
+        if let FrontendEvent::Process(command) = event {
+            return Some(command);
+        }
+    }
+    None
+}
+
+fn latest_queued_process_command(rx: &mut mpsc::Receiver<FrontendEvent>) -> Option<ProcessCommand> {
+    let mut latest = None;
+    while let Ok(event) = rx.try_recv() {
+        if let FrontendEvent::Process(command) = event {
+            latest = Some(command);
+        }
+    }
+    latest
 }
 
 #[derive(Serialize)]
@@ -207,17 +256,19 @@ async fn run_reactive_backend(
     mut rx: mpsc::Receiver<FrontendEvent>,
     activity_tx: mpsc::UnboundedSender<ActivityEvent>,
     renderer_tx: mpsc::Sender<FrontendCommand>,
-    processes: BTreeMap<String, u64>,
+    processes: BTreeMap<String, ReactiveProcess>,
     mut log: Option<File>,
 ) -> Result<()> {
-    while let Some(event) = rx.recv().await {
-        let FrontendEvent::Process(command) = event else {
-            continue;
-        };
+    let mut queued_command = None;
+    while let Some(command) = match queued_command.take() {
+        Some(command) => Some(command),
+        None => recv_process_command(&mut rx).await,
+    } {
+        let handled_command = command.clone();
 
         match command {
             ProcessCommand::Restart(name) => {
-                let id = processes
+                let process = processes
                     .get(&name)
                     .copied()
                     .with_context(|| format!("TUI requested unknown process {name:?}"))?;
@@ -228,12 +279,24 @@ async fn run_reactive_backend(
                         process: &name,
                     },
                 )?;
-                send_status(&activity_tx, &mut log, &name, id, ProcessStatus::Restarting)?;
+                send_status(
+                    &activity_tx,
+                    &mut log,
+                    &name,
+                    process.id,
+                    ProcessStatus::Restarting,
+                )?;
                 sleep(Duration::from_millis(100)).await;
-                send_status(&activity_tx, &mut log, &name, id, ProcessStatus::Ready)?;
+                send_status(
+                    &activity_tx,
+                    &mut log,
+                    &name,
+                    process.id,
+                    process.stable_status,
+                )?;
             }
             ProcessCommand::Stop(name) => {
-                let id = processes
+                let process = processes
                     .get(&name)
                     .copied()
                     .with_context(|| format!("TUI requested unknown process {name:?}"))?;
@@ -244,9 +307,21 @@ async fn run_reactive_backend(
                         process: &name,
                     },
                 )?;
-                send_status(&activity_tx, &mut log, &name, id, ProcessStatus::Stopping)?;
+                send_status(
+                    &activity_tx,
+                    &mut log,
+                    &name,
+                    process.id,
+                    ProcessStatus::Stopping,
+                )?;
                 sleep(Duration::from_millis(100)).await;
-                send_status(&activity_tx, &mut log, &name, id, ProcessStatus::Stopped)?;
+                send_status(
+                    &activity_tx,
+                    &mut log,
+                    &name,
+                    process.id,
+                    ProcessStatus::Stopped,
+                )?;
             }
             ProcessCommand::StopManager => {
                 record(
@@ -256,12 +331,24 @@ async fn run_reactive_backend(
                         process: "*",
                     },
                 )?;
-                for (name, id) in &processes {
-                    send_status(&activity_tx, &mut log, name, *id, ProcessStatus::Stopping)?;
+                for (name, process) in &processes {
+                    send_status(
+                        &activity_tx,
+                        &mut log,
+                        name,
+                        process.id,
+                        ProcessStatus::Stopping,
+                    )?;
                 }
                 sleep(Duration::from_millis(100)).await;
-                for (name, id) in &processes {
-                    send_status(&activity_tx, &mut log, name, *id, ProcessStatus::Stopped)?;
+                for (name, process) in &processes {
+                    send_status(
+                        &activity_tx,
+                        &mut log,
+                        name,
+                        process.id,
+                        ProcessStatus::Stopped,
+                    )?;
                 }
                 renderer_tx
                     .send(FrontendCommand::ExitRenderer)
@@ -269,7 +356,10 @@ async fn run_reactive_backend(
                     .context("TUI closed before process-manager shutdown completed")?;
                 return Ok(());
             }
-        }
+        };
+
+        queued_command = latest_queued_process_command(&mut rx)
+            .filter(|queued| !same_process_command(&handled_command, queued));
     }
 
     Ok(())
@@ -300,7 +390,7 @@ async fn main() -> Result<()> {
 
     // Validation deliberately happens before the TUI enters raw mode.
     let events = load_trace_file(&args.trace_file)?;
-    let processes = process_ids(&events);
+    let processes = reactive_processes(&events);
     if args.reactive && processes.is_empty() {
         bail!("--reactive requires at least one process start event in the trace");
     }
@@ -435,7 +525,13 @@ mod tests {
     #[test]
     fn loads_processes_for_reactive_control() {
         let events = load_trace(Cursor::new(PROCESS)).unwrap();
-        assert_eq!(process_ids(&events).get("web"), Some(&7));
+        assert_eq!(
+            reactive_processes(&events).get("web"),
+            Some(&ReactiveProcess {
+                id: 7,
+                stable_status: ProcessStatus::Ready,
+            })
+        );
     }
 
     #[test]
@@ -443,7 +539,11 @@ mod tests {
         let events =
             load_trace(Cursor::new(include_str!("../../replays/processes.jsonl"))).unwrap();
         assert_eq!(events.len(), 9);
-        assert_eq!(process_ids(&events).len(), 3);
+        let processes = reactive_processes(&events);
+        assert_eq!(processes.len(), 3);
+        assert_eq!(processes["api"].stable_status, ProcessStatus::Ready);
+        assert_eq!(processes["worker"].stable_status, ProcessStatus::Running);
+        assert_eq!(processes["disabled"].stable_status, ProcessStatus::Running);
     }
 
     #[test]
@@ -462,7 +562,13 @@ mod tests {
             event_rx,
             activity_tx,
             renderer_tx,
-            BTreeMap::from([("web".to_string(), 7)]),
+            BTreeMap::from([(
+                "web".to_string(),
+                ReactiveProcess {
+                    id: 7,
+                    stable_status: ProcessStatus::Ready,
+                },
+            )]),
             None,
         ));
 
@@ -486,6 +592,41 @@ mod tests {
 
         drop(event_tx);
         task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn reactive_backend_coalesces_restart_bursts_and_restores_running() {
+        let (event_tx, event_rx) = mpsc::channel(64);
+        for _ in 0..64 {
+            event_tx
+                .send(FrontendEvent::Process(ProcessCommand::Restart(
+                    "web".to_string(),
+                )))
+                .await
+                .unwrap();
+        }
+        drop(event_tx);
+
+        let (activity_tx, mut activity_rx) = mpsc::unbounded_channel();
+        let (renderer_tx, _renderer_rx) = mpsc::channel(1);
+        let task = tokio::spawn(run_reactive_backend(
+            event_rx,
+            activity_tx,
+            renderer_tx,
+            BTreeMap::from([(
+                "web".to_string(),
+                ReactiveProcess {
+                    id: 7,
+                    stable_status: ProcessStatus::Running,
+                },
+            )]),
+            None,
+        ));
+
+        assert_status(activity_rx.recv().await.unwrap(), ProcessStatus::Restarting);
+        assert_status(activity_rx.recv().await.unwrap(), ProcessStatus::Running);
+        task.await.unwrap().unwrap();
+        assert!(activity_rx.recv().await.is_none());
     }
 
     #[tokio::test]

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -40,6 +40,7 @@ command="\"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\"
 # Avoid standalone Esc in this byte-level harness: the emulated terminal reports
 # no keyboard-protocol enhancement, so legacy decoding keeps Esc ambiguous until
 # another input byte arrives.
+# The first restart is a pasted/key-repeat burst; it must remain one user intent.
 "$pty_driver" pty --step-timeout 10 "$transcript" "$command" >/dev/null <<'EOF'
 expect:api
 expect:worker
@@ -48,7 +49,7 @@ send:j
 expect:api
 resize:120x40
 expect:restart
-send:\x12
+send:\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12
 expect:restarting
 expect:ready
 run:test "$(tail -n 1 "$TUI_REPLAY_EVENT_LOG")" = '{"kind":"status","process":"api","status":"ready"}'

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -41,11 +41,16 @@ command="\"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\"
 # no keyboard-protocol enhancement, so legacy decoding keeps Esc ambiguous until
 # another input byte arrives.
 # The first restart is a pasted/key-repeat burst; it must remain one user intent.
+# Wait for the stopped fixture row before navigating: under load, selecting a
+# process while that row is still being inserted can clear or move the selection.
 "$pty_driver" pty --step-timeout 10 "$transcript" "$command" >/dev/null <<'EOF'
 expect:api
 expect:worker
-resize:48x12
+expect:disabled
+expect:stopped
 send:j
+expect:restart
+resize:48x12
 expect:api
 resize:120x40
 expect:restart

--- a/tests/process-attach-interactive/devenv-with-beta.nix
+++ b/tests/process-attach-interactive/devenv-with-beta.nix
@@ -6,7 +6,10 @@
   ];
   process.manager.implementation = "native";
 
-  processes.alpha.exec = "exec python3 -u -m http.server 18641";
+  processes.alpha = {
+    exec = "exec python3 -u -m http.server 18641";
+    ready.exec = "curl -sf -o /dev/null http://127.0.0.1:18641/";
+  };
   processes.beta = {
     exec = "exec python3 -u -m http.server 18642";
     start.enable = false;

--- a/tests/process-attach-interactive/devenv.nix
+++ b/tests/process-attach-interactive/devenv.nix
@@ -6,5 +6,8 @@
   ];
   process.manager.implementation = "native";
 
-  processes.alpha.exec = "exec python3 -u -m http.server 18641";
+  processes.alpha = {
+    exec = "exec python3 -u -m http.server 18641";
+    ready.exec = "curl -sf -o /dev/null http://127.0.0.1:18641/";
+  };
 }


### PR DESCRIPTION
## Summary

- coalesce repeated TUI process commands so key-repeat bursts remain a single user intent
- make the reactive replay restore `ready` only for processes with readiness probes and `running` otherwise
- make Bombadil restart properties account for hidden rows, superseding stops, and in-flight restarts
- promote a Ctrl-R burst into the deterministic PTY corpus
- upload the replay semantic event log with future Bombadil failures

## Root cause

The nightly lifecycle property required every visible `restarting` state to become visibly `ready` within two seconds. That obligation remained active after navigating away, explicitly stopping the process, or issuing further restart input. At the same time, the bounded frontend mailbox accepted many repeated restart commands before applying backpressure, and the replay harness incorrectly used `ready` for processes without readiness probes.

This produced both false-positive liveness violations and unnecessarily long restart queues.

## Impact

Repeated terminal input is now coalesced at sequential process-command receivers, while newer conflicting intent is preserved. The fuzz oracle now follows observable lifecycle semantics instead of requiring an impossible transition.

## Validation

- `devenv shell cargo test -p devenv-tui --features deterministic-tui`
- `devenv shell cargo test -p devenv-processes process_command`
- `bash devenv-tui/tests/replay-pty.sh target/debug/devenv-run-tests target/debug/tui-replay`
- `devenv shell cargo clippy -p devenv-processes -p devenv-tui --features devenv-tui/deterministic-tui --all-targets -- -D warnings -A clippy::too_many_arguments`
- `git diff --check`

The exact pinned Bombadil rerun was not completed locally because Nix stalled while fetching the upstream Boa repository; the deterministic replay and byte-level PTY regression both pass.