### PR TITLE
fix Zig version input source

### DIFF
--- a/src/modules/languages/zig.nix
+++ b/src/modules/languages/zig.nix
@@ -25,6 +25,15 @@ let
     follows = [ "nixpkgs" ];
   };
 
+  # zig-overlay imports files directly from its nixpkgs input. devenv-nixpkgs
+  # is a wrapper flake, so its source root is not the package set's source.
+  # Import the overlay with the source that produced pkgs instead.
+  zigPackages = import "${zig-overlay.outPath}/default.nix" {
+    inherit pkgs;
+    nixpkgs = pkgs.path;
+    system = pkgs.stdenv.hostPlatform.system;
+  };
+
   zls = config.lib.getInput {
     name = "zls";
     url = "github:zigtools/zls/${zlsVersion}";
@@ -70,7 +79,7 @@ in
 
   config = lib.mkIf cfg.enable {
     languages.zig.package = lib.mkIf (cfg.version != null) (
-      zig-overlay.packages.${pkgs.stdenv.system}.${cfg.version}
+      zigPackages.${cfg.version}
     );
 
     languages.zig.lsp.package = lib.mkIf (cfg.version != null) (

--- a/tests/zig-version/devenv.nix
+++ b/tests/zig-version/devenv.nix
@@ -1,0 +1,11 @@
+{
+  languages.zig = {
+    enable = true;
+    version = "0.16.0";
+    lsp.enable = false;
+  };
+
+  enterTest = ''
+    test "$(zig version)" = "0.16.0"
+  '';
+}

--- a/tests/zig-version/devenv.yaml
+++ b/tests/zig-version/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  zig-overlay:
+    url: github:mitchellh/zig-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
## Summary

- import `zig-overlay` with the active package set and its real Nixpkgs source path
- preserve support for `zig-overlay.inputs.nixpkgs.follows = "nixpkgs"`
- add an end-to-end regression test for Zig 0.16.0

## Root cause

`zig-overlay` imports `pkgs/development/compilers/zig/passthru.nix` directly from its `nixpkgs` input. When that input follows `cachix/devenv-nixpkgs`, the input source is the wrapper repository rather than the Nixpkgs source used to construct `pkgs`, so the imported path does not exist.

Importing `zig-overlay/default.nix` with `nixpkgs = pkgs.path` keeps the package set and its source aligned.

## Impact

Projects using `languages.zig.version` can keep the recommended Nixpkgs follow when their root input is `cachix/devenv-nixpkgs`.

Fixes #3088.

## Validation

- `devenv-run-tests run --only zig-version tests`
- `nixpkgs-fmt --check src/modules/languages/zig.nix tests/zig-version/devenv.nix`
- parsed both changed Nix files with `nix-instantiate --parse`
- parsed the regression fixture with `yaml2json`
- `git diff --check`
