### PR TITLE
fix: ship one copy of each package in the devenv closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.3 (unreleased)
 
+### Improvements
+
+- Reduced the size of the devenv closure from 528 MB to 376 MB. It no longer contains duplicate copies of glibc, OpenSSL, curl, Boost, ICU and the Nix libraries, which were pulled in by `cachix` and `nixd` being built against different package sets than devenv itself.
+
 ## 2.2.2 (2026-08-13)
 
 ### Bug Fixes

--- a/flake.lock
+++ b/flake.lock
@@ -9,7 +9,9 @@
         "git-hooks": [
           "git-hooks"
         ],
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1777487137,
@@ -175,18 +177,21 @@
       }
     },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "lastModified": 1782132010,
+        "narHash": "sha256-ZnAVHdVrotp80iIMm5CSR1fdxPlw7Uwmwxb+O/wsgZ8=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "12866ae2dddbc0ab8b329915f8072bb9c75bde89",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
         "type": "github"
       }
     },
@@ -207,25 +212,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "inputs": {
-        "nixpkgs-src": "nixpkgs-src"
-      },
-      "locked": {
-        "lastModified": 1782132010,
-        "narHash": "sha256-ZnAVHdVrotp80iIMm5CSR1fdxPlw7Uwmwxb+O/wsgZ8=",
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "12866ae2dddbc0ab8b329915f8072bb9c75bde89",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "cachix": "cachix",
@@ -236,7 +222,7 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixd": "nixd",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
   inputs.cachix = {
     url = "github:cachix/cachix/latest";
     inputs = {
+      nixpkgs.follows = "nixpkgs";
       flake-compat.follows = "flake-compat";
       git-hooks.follows = "git-hooks";
       devenv.follows = "";
@@ -93,7 +94,19 @@
               nix = inputs.nix.packages.${system}.nix-cli // {
                 inherit (inputs.nix.packages.${system}.nix) libs;
               };
-              nixd = inputs.nixd.packages.${system}.nixd.override { llvmStatic = true; };
+              # Build nixd against the same nix components as devenv, otherwise
+              # it drags a second copy of the nix libraries into the closure.
+              nixd =
+                let
+                  nixdPkgs = inputs.nixd.packages.${system};
+                  nixComponents = final.nix.libs;
+                in
+                nixdPkgs.nixd.override {
+                  llvmStatic = true;
+                  inherit nixComponents;
+                  nixf = nixdPkgs.nixf.override { inherit (nixComponents) nix-expr; };
+                  nixt = nixdPkgs.nixt.override { inherit nixComponents; };
+                };
               crate2nix = final.callPackage "${inputs.crate2nix}/crate2nix/default.nix" { };
               libghostty-vt = final.callPackage "${inputs.ghostty}/nix/libghostty-vt.nix" {
                 optimize = "ReleaseSafe";

--- a/tests/closure-size/.test-config.yml
+++ b/tests/closure-size/.test-config.yml
@@ -1,0 +1,3 @@
+# Runs in the repository, not a temp copy: the test inspects our own flake outputs.
+use_shell: false
+use_tmp_dir: false

--- a/tests/closure-size/.test.sh
+++ b/tests/closure-size/.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Ratchet on the size of the devenv closure, which is what dominates the size of
+# the container image we publish. The limit is meant to come down over time;
+# raising it should be a deliberate decision, not a silent one.
+set -euo pipefail
+
+MAX_MB=400
+
+repo=$(cd ../.. && pwd)
+
+echo "Building devenv..."
+devenv_path=$(nix build --no-link --print-out-paths "$repo#devenv")
+
+bytes=$(nix path-info --closure-size "$devenv_path" | awk '{print $2}')
+mb=$((bytes / 1000 / 1000))
+
+echo "devenv closure: $mb MB (limit $MAX_MB MB)"
+
+if [ "$mb" -gt "$MAX_MB" ]; then
+  cat >&2 <<EOF
+❌ The devenv closure grew to $mb MB, past its limit of $MAX_MB MB.
+
+See what is taking up the space with:
+  nix path-info -rS $repo#devenv | sort -k2 -n | tail -20
+
+A common cause is a flake input without \`nixpkgs.follows\`, which drags a second
+copy of glibc, OpenSSL, curl and friends into the closure. Track an offender
+back to its source with:
+  nix why-depends --precise $repo#devenv <store-path>
+EOF
+  exit 1
+fi
+
+echo "✅ devenv closure is within budget"


### PR DESCRIPTION
The `cachix` input had no `nixpkgs.follows`, so it was built against its own nixpkgs pin, and `nixd` follows our nixpkgs but is evaluated by its own flake without our overlay, so it linked nixpkgs' nix instead of the one devenv uses. Between them the closure carried two copies of glibc, OpenSSL, curl, Boost, ICU, sqlite and the Nix libraries.

Closure 528 MB -> 376 MB, container image 234 MB -> 179 MB.

cachix still links the nix version nixpkgs pins for hercules-ci-cnix-store, whose cabal file declares `nix-store < 2.34`; that accounts for the ~10 MB that remains duplicated.

Add tests/closure-size as a ratchet so the closure cannot creep back up unnoticed.