### PR TITLE
fix(cli): merge devenv.yaml of a --from flake reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fixed `--from <flake-ref>` ignoring the external project's `devenv.yaml`. Its inputs and imports were dropped, so a project relying on an integration such as treefmt or git-hooks failed to evaluate. Flake references are now fetched before the configuration is read and merged exactly like `--from path:` sources. The reference itself is no longer recorded in `devenv.lock`; pin it with an explicit revision (`--from github:owner/repo/<rev>`) if you need it fixed.
+- Fixed `--from <flake-ref>` ignoring the external project's `devenv.yaml` and `devenv.lock`. Its inputs and imports were dropped, so a project relying on an integration such as treefmt or git-hooks failed to evaluate, and every input resolved afresh instead of using the revisions the source was tested with. Flake references are now fetched before the configuration is read and merged exactly like `--from path:` sources, and a working directory with no lock of its own starts from the source's. The reference itself is no longer recorded in `devenv.lock`; pin it with an explicit revision (`--from github:owner/repo/<rev>`) if you need it fixed.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.3 (unreleased)
 
+### Bug Fixes
+
+- Fixed `--from <flake-ref>` ignoring the external project's `devenv.yaml`. Its inputs and imports were dropped, so a project relying on an integration such as treefmt or git-hooks failed to evaluate. Flake references are now fetched before the configuration is read and merged exactly like `--from path:` sources. The reference itself is no longer recorded in `devenv.lock`; pin it with an explicit revision (`--from github:owner/repo/<rev>`) if you need it fixed.
+
 ### Improvements
 
 - Reduced the size of the devenv closure from 528 MB to 376 MB. It no longer contains duplicate copies of glibc, OpenSSL, curl, Boost, ICU and the Nix libraries, which were pulled in by `cachix` and `nixd` being built against different package sets than devenv itself.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Commands:
 
 Input overrides:
       --from <FROM>
-          Source for devenv.nix.
+          Source for devenv.nix and devenv.yaml.
 
-          Can be either a filesystem path (with path: prefix) or a flake input reference.
+          Can be either a filesystem path (with path: prefix) or a flake input reference. A flake reference is fetched on every run; add a revision to pin it.
 
           Examples:
             --from github:cachix/devenv

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -483,7 +483,8 @@ impl Config {
     }
 
     /// Like [`Config::load`], but additionally merges the configuration of an
-    /// out-of-tree source directory (a `path:` `--from` source).
+    /// out-of-tree source directory (the directory behind `--from`: a `path:`
+    /// source, or a flake reference already fetched into the store).
     ///
     /// The source's `devenv.yaml` import graph merges at the lowest precedence
     /// (the project's own configuration wins), and the source's inputs and

--- a/devenv-nix-backend/src/lib.rs
+++ b/devenv-nix-backend/src/lib.rs
@@ -21,6 +21,8 @@ mod file_limit;
 
 pub mod lock;
 
+pub mod source;
+
 use std::cell::RefCell;
 
 // Ensure Nix/GC is initialized exactly once across all threads

--- a/devenv-nix-backend/src/source.rs
+++ b/devenv-nix-backend/src/source.rs
@@ -1,0 +1,202 @@
+//! Fetching an out-of-tree `--from` source before the configuration is loaded.
+//!
+//! `--from <flake-ref>` names a project that lives outside the working
+//! directory. Its `devenv.yaml` has to be merged by `Config::load`, which reads
+//! from disk, so the reference is fetched into the store first and the
+//! resulting directory is handed to the loader like a `path:` source.
+
+use std::path::PathBuf;
+
+use miette::{Result, WrapErr, bail};
+use nix_bindings_expr::eval_state::EvalStateBuilder;
+use nix_bindings_flake::{EvalStateBuilderExt, FlakeSettings};
+use nix_bindings_store::store::Store;
+use nix_bindings_util::settings;
+use tracing::debug;
+
+use crate::anyhow_ext::AnyhowToMiette;
+use crate::error::format_eval_error;
+
+/// Fetch the source behind a `--from` flake reference and return the directory
+/// that holds its `devenv.nix`.
+///
+/// This runs before the project's Nix settings are resolved (they may come from
+/// the fetched `devenv.yaml`), so it evaluates against the default store with
+/// only the experimental features devenv always enables.
+///
+/// Unlike a `path:` source, the reference is resolved on every run and is not
+/// recorded in `devenv.lock`; pass an explicit revision
+/// (`github:owner/repo/<rev>`) to pin it.
+pub fn fetch(reference: &str) -> Result<PathBuf> {
+    // `dir=` selects a subdirectory of the fetched tree. It is a flake-reference
+    // attribute that `builtins.fetchTree` silently ignores, so apply it here.
+    let (url, subdir) = split_dir_attribute(reference);
+
+    crate::nix_init();
+    crate::gc_register_current_thread()
+        .to_miette()
+        .wrap_err("Failed to register thread with Nix garbage collector")?;
+    settings::set("extra-experimental-features", "flakes nix-command")
+        .to_miette()
+        .wrap_err("Failed to enable experimental features")?;
+
+    let store = Store::open(None, [])
+        .to_miette()
+        .wrap_err("Failed to open Nix store")?;
+    let flake_settings = FlakeSettings::new()
+        .to_miette()
+        .wrap_err("Failed to create flake settings")?;
+    let mut eval_state = EvalStateBuilder::new(store)
+        .to_miette()
+        .wrap_err("Failed to create eval state builder")?
+        .flakes(&flake_settings)
+        .to_miette()
+        .wrap_err("Failed to configure flakes")?
+        .build()
+        .to_miette()
+        .wrap_err("Failed to build eval state")?;
+
+    // The context is discarded because the fetched source is already realised
+    // in the store; only its path is needed.
+    let expr = format!(
+        "builtins.unsafeDiscardStringContext (builtins.fetchTree {}).outPath",
+        nix_string_literal(&url)
+    );
+    let context = format!("Failed to fetch --from source '{reference}'");
+    let value = eval_state
+        .eval_from_string(&expr, "«devenv --from»")
+        .and_then(|value| eval_state.require_string(&value))
+        .map_err(|err| miette::Report::from(format_eval_error(&format!("{err:#}"), &context)))?;
+
+    let mut path = PathBuf::from(value);
+    if let Some(subdir) = subdir {
+        path.push(subdir);
+    }
+    debug!(reference, path = %path.display(), "fetched --from source");
+
+    if !path.join("devenv.nix").exists() {
+        bail!(
+            "--from source '{reference}' has no devenv.nix (looked in {})",
+            path.display()
+        );
+    }
+
+    Ok(path)
+}
+
+/// Split a `dir=` query attribute off a flake reference, returning the
+/// reference without it and the subdirectory it selected.
+fn split_dir_attribute(reference: &str) -> (String, Option<String>) {
+    let Some((base, rest)) = reference.split_once('?') else {
+        return (reference.to_string(), None);
+    };
+    // A fragment (`#attr`) always follows the query, so keep it attached to
+    // whatever query parameters survive.
+    let (query, fragment) = match rest.split_once('#') {
+        Some((query, fragment)) => (query, Some(fragment)),
+        None => (rest, None),
+    };
+
+    let mut dir = None;
+    let mut kept = Vec::new();
+    for param in query.split('&').filter(|param| !param.is_empty()) {
+        match param.split_once('=') {
+            Some(("dir", value)) => dir = Some(value.to_string()),
+            _ => kept.push(param),
+        }
+    }
+
+    let mut url = base.to_string();
+    if !kept.is_empty() {
+        url.push('?');
+        url.push_str(&kept.join("&"));
+    }
+    if let Some(fragment) = fragment {
+        url.push('#');
+        url.push_str(fragment);
+    }
+
+    // A leading or trailing slash would produce `//` or a trailing separator
+    // when joined onto the fetched store path.
+    let dir = dir.map(|dir| dir.trim_matches('/').to_string());
+    (url, dir.filter(|dir| !dir.is_empty()))
+}
+
+/// Quote a string for interpolation into a Nix expression.
+fn nix_string_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for c in value.chars() {
+        match c {
+            '"' | '\\' | '$' => {
+                escaped.push('\\');
+                escaped.push(c);
+            }
+            _ => escaped.push(c),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_dir_attribute_without_query() {
+        assert_eq!(
+            split_dir_attribute("github:cachix/devenv"),
+            ("github:cachix/devenv".to_string(), None)
+        );
+    }
+
+    #[test]
+    fn split_dir_attribute_extracts_dir() {
+        assert_eq!(
+            split_dir_attribute("github:cachix/devenv?dir=examples/simple"),
+            (
+                "github:cachix/devenv".to_string(),
+                Some("examples/simple".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn split_dir_attribute_keeps_other_params() {
+        assert_eq!(
+            split_dir_attribute("github:cachix/devenv?ref=main&dir=examples/simple&narHash=sha256"),
+            (
+                "github:cachix/devenv?ref=main&narHash=sha256".to_string(),
+                Some("examples/simple".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn split_dir_attribute_keeps_fragment() {
+        assert_eq!(
+            split_dir_attribute("github:cachix/devenv?dir=examples#simple"),
+            (
+                "github:cachix/devenv#simple".to_string(),
+                Some("examples".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn split_dir_attribute_trims_slashes() {
+        assert_eq!(
+            split_dir_attribute("github:cachix/devenv?dir=/examples/simple/"),
+            (
+                "github:cachix/devenv".to_string(),
+                Some("examples/simple".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn nix_string_literal_escapes() {
+        assert_eq!(nix_string_literal("a\"b\\c$d"), r#""a\"b\\c\$d""#);
+    }
+}

--- a/devenv/src/cli.rs
+++ b/devenv/src/cli.rs
@@ -685,8 +685,8 @@ pub struct Cli {
         long,
         global = true,
         help_heading = "Input overrides",
-        help = "Source for devenv.nix (flake input reference or path)",
-        long_help = "Source for devenv.nix.\n\nCan be either a filesystem path (with path: prefix) or a flake input reference.\n\nExamples:\n  --from github:cachix/devenv\n  --from github:cachix/devenv?dir=examples/simple\n  --from path:/absolute/path/to/project\n  --from path:./relative/path"
+        help = "Source for devenv.nix and devenv.yaml (flake input reference or path)",
+        long_help = "Source for devenv.nix and devenv.yaml.\n\nCan be either a filesystem path (with path: prefix) or a flake input reference. A flake reference is fetched on every run; add a revision to pin it.\n\nExamples:\n  --from github:cachix/devenv\n  --from github:cachix/devenv?dir=examples/simple\n  --from path:/absolute/path/to/project\n  --from path:./relative/path"
     )]
     pub from: Option<String>,
 

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -125,6 +125,9 @@ pub struct DevenvOptions {
     pub secret_settings: SecretSettings,
     pub input_overrides: InputOverrides,
     pub from_external: bool,
+    /// `devenv.lock` of a `--from` source, used as the starting point for a
+    /// project that has none of its own. See [`Devenv::new`].
+    pub from_lock: Option<PathBuf>,
     pub require_version_match: bool,
     pub devenv_root: Option<PathBuf>,
     pub devenv_dotfile: Option<PathBuf>,
@@ -189,6 +192,7 @@ impl Default for DevenvOptions {
             secret_settings: SecretSettings::default(),
             input_overrides: InputOverrides::default(),
             from_external: false,
+            from_lock: None,
             require_version_match: false,
             devenv_root: None,
             devenv_dotfile: None,
@@ -533,6 +537,25 @@ impl Devenv {
         )
         .await?;
         devenv_core::paths::create_runtime_dir(&devenv_runtime)?;
+
+        // A `--from` source ships the revisions it was tested with. A project
+        // that has no lock of its own starts from those instead of resolving
+        // every input afresh; the seeded lock then belongs to this project, so
+        // `devenv update` moves it independently of the source. Locking runs
+        // next and reconciles it with the merged input set.
+        if let Some(source_lock) = &options.from_lock {
+            let lock = devenv_root.join("devenv.lock");
+            if !lock.exists()
+                && let Err(e) = seed_lock_from_source(source_lock, &lock).await
+            {
+                warn!(
+                    source = %source_lock.display(),
+                    error = %e,
+                    "failed to seed devenv.lock from the --from source, resolving inputs afresh"
+                );
+            }
+        }
+
         // A managed netrc holds the Cachix auth token, and outlives any
         // devenv that was killed before it could clean up after itself.
         devenv_core::cachix::reap_stale_netrc_files(&devenv_runtime);
@@ -3549,6 +3572,15 @@ fn build_bootstrap_args(
     };
 
     BootstrapArgs::from_serializable(&args)
+}
+
+/// Copy a `--from` source's lock file into the project as a starting point.
+///
+/// The contents are rewritten rather than copied so the result is writable even
+/// when the source is a read-only store path.
+async fn seed_lock_from_source(source: &Path, target: &Path) -> std::io::Result<()> {
+    let contents = fs::read(source).await?;
+    fs::write(target, contents).await
 }
 
 fn resolve_secretspec_into(

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -441,6 +441,13 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         _ => from_path,
     };
 
+    // The source's own lock seeds a project that has none, so the environment
+    // starts on the revisions the source was tested with.
+    let from_lock = from_dir
+        .as_deref()
+        .map(|dir| dir.join("devenv.lock"))
+        .filter(|lock| lock.exists());
+
     let mut config = Config::load_with_source(from_dir.as_deref())?;
     config.check_version(crate_version!())?;
 
@@ -503,6 +510,7 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         secret_settings,
         input_overrides,
         from_external: from_source.is_some(),
+        from_lock,
         require_version_match,
         devenv_root: None,
         devenv_dotfile: test_environment

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -432,7 +432,16 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
             fs::canonicalize(&full_path).unwrap_or(full_path)
         });
 
-    let mut config = Config::load_with_source(from_path.as_deref())?;
+    // Any other source (a flake ref, via --from or a persisted binding) is
+    // fetched into the store first, then merged from there like a `path:`
+    // source: its devenv.yaml only reaches the config loader if the source is
+    // already on disk when the config is read.
+    let from_dir = match (&from_source, &from_path) {
+        (Some(from), None) => Some(devenv_nix_backend::source::fetch(from)?),
+        _ => from_path,
+    };
+
+    let mut config = Config::load_with_source(from_dir.as_deref())?;
     config.check_version(crate_version!())?;
 
     let input_overrides = InputOverrides::from(cli.input_overrides);
@@ -443,24 +452,6 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         config
             .override_input_url(name, url)
             .wrap_err_with(|| format!("Failed to override input {name} with URL {url}"))?;
-    }
-
-    // A non-path source (flake ref, via --from or a persisted binding) is
-    // fetched as the `from` input and its devenv.nix imported from the store.
-    // Its devenv.yaml is not merged (that needs a fetch before config load);
-    // `path:` sources get the full merge via Config::load_with_source above.
-    if from_path.is_none()
-        && let Some(from) = &from_source
-    {
-        let from_input = devenv_core::config::Input {
-            url: Some(from.clone()),
-            flake: false,
-            follows: None,
-            inputs: BTreeMap::new(),
-            overlays: Vec::new(),
-        };
-        config.inputs.insert("from".to_string(), from_input);
-        config.imports.push("from".to_string());
     }
 
     // --- Resolved settings ---

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -67,6 +67,20 @@ echo "$out" | grep -q "from-flake-input" || fail "--from flake ref dropped the s
 echo "$out" | grep -q "from-flake-import" || fail "--from flake ref dropped the source's imports"
 ! echo "$out" | grep -q "python3" || fail "--from flake ref leaked local python3"
 
+step "--from seeds devenv.lock from the source"
+# from-flake pins flake-compat to an old revision in its lock while leaving it
+# unpinned in devenv.yaml. A project with no lock of its own starts from the
+# source's, so this must keep that revision instead of resolving the current
+# head of flake-compat.
+from_flake_dir="$(cd from-flake && pwd)"
+pinned_rev=$(sed -n 's/.*"rev": "\([0-9a-f]*\)".*/\1/p' from-flake/devenv.lock)
+[ -n "$pinned_rev" ] || fail "from-flake/devenv.lock has no pinned revision"
+mkdir -p test-from-seed && pushd test-from-seed >/dev/null
+devenv --from "git+file://$from_flake_dir" info >/dev/null
+grep -q "$pinned_rev" devenv.lock || fail "--from didn't seed devenv.lock from the source"
+popd >/dev/null
+rm -rf test-from-seed
+
 step "--from works in a directory without devenv.nix"
 mkdir -p test-from-only && pushd test-from-only >/dev/null
 out=$(devenv --from "path:$from_test_dir" info)

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -55,6 +55,18 @@ for path in "path:$from_test_dir" "path:./from-test"; do
   ! echo "$out" | grep -q "python3" || fail "--from=$path leaked local python3"
 done
 
+step "--from a flake reference merges the source's devenv.yaml"
+# A non-path source is fetched into the store before the config is read, so its
+# devenv.yaml has to survive that round trip: from-flake declares an input its
+# devenv.nix uses and imports a directory that adds another package.
+git -C from-flake init -q --initial-branch=main
+git -C from-flake add -A
+git -C from-flake -c user.email=test@example.com -c user.name=test commit -qm from-flake
+out=$(devenv --from "git+file://$PWD/from-flake" info)
+echo "$out" | grep -q "from-flake-input" || fail "--from flake ref dropped the source's inputs"
+echo "$out" | grep -q "from-flake-import" || fail "--from flake ref dropped the source's imports"
+! echo "$out" | grep -q "python3" || fail "--from flake ref leaked local python3"
+
 step "--from works in a directory without devenv.nix"
 mkdir -p test-from-only && pushd test-from-only >/dev/null
 out=$(devenv --from "path:$from_test_dir" info)

--- a/tests/cli/from-flake/devenv.nix
+++ b/tests/cli/from-flake/devenv.nix
@@ -1,0 +1,5 @@
+{ pkgs, inputs, ... }: {
+  packages = [
+    (pkgs.writeShellScriptBin "from-flake-input" "cat ${inputs.marker}/id.txt")
+  ];
+}

--- a/tests/cli/from-flake/devenv.yaml
+++ b/tests/cli/from-flake/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  marker:
+    url: path:./marker
+    flake: false
+imports:
+  - ./module

--- a/tests/cli/from-flake/devenv.yaml
+++ b/tests/cli/from-flake/devenv.yaml
@@ -2,5 +2,11 @@ inputs:
   marker:
     url: path:./marker
     flake: false
+  # Deliberately unpinned here and pinned to an old revision in devenv.lock, so
+  # a project seeded from this source can be told apart from one that resolved
+  # the input itself. See the "--from seeds devenv.lock" step in .test.sh.
+  flake-compat:
+    url: github:edolstra/flake-compat
+    flake: false
 imports:
   - ./module

--- a/tests/cli/from-flake/marker/id.txt
+++ b/tests/cli/from-flake/marker/id.txt
@@ -1,0 +1,1 @@
+from-flake-marker

--- a/tests/cli/from-flake/module/devenv.nix
+++ b/tests/cli/from-flake/module/devenv.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }: {
+  packages = [
+    (pkgs.writeShellScriptBin "from-flake-import" "true")
+  ];
+}


### PR DESCRIPTION
`--from path:...` merged the source's devenv.yaml, but a flake reference only registered the source as an input named `from` and imported its devenv.nix. The source's inputs and imports were dropped, so a project using an integration such as treefmt or git-hooks failed to evaluate.

Flake references are now fetched into the store before the configuration is read, then merged like a `path:` source, so both forms share one code path. The reference itself is no longer recorded in devenv.lock; pin it with an explicit revision instead.