### PR TITLE
fix(tasks): complete dependencies and propagate process failures

### DIFF
--- a/devenv-tasks/src/tasks.rs
+++ b/devenv-tasks/src/tasks.rs
@@ -586,6 +586,23 @@ impl Tasks {
                         }
                     }
                 }
+
+                // A selected dependent may have prerequisites other than the root that
+                // brought it into the schedule. Include those prerequisites without
+                // traversing back out from them, which preserves the no-direction-
+                // bouncing behavior above while ensuring every scheduled task has its
+                // complete dependency closure.
+                to_visit.extend(visited.iter().copied());
+                while let Some(node) = to_visit.pop() {
+                    for neighbor in self
+                        .graph
+                        .neighbors_directed(node, petgraph::Direction::Incoming)
+                    {
+                        if visited.insert(neighbor) {
+                            to_visit.push(neighbor);
+                        }
+                    }
+                }
             }
         }
 

--- a/devenv-tasks/src/tests/mod.rs
+++ b/devenv-tasks/src/tests/mod.rs
@@ -3469,6 +3469,64 @@ async fn test_run_mode_all_excludes_unrelated_entry_points() -> Result<(), Error
     Ok(())
 }
 
+/// RunMode::All must include every prerequisite of a dependent selected from
+/// the root's downstream graph, without pulling in unrelated dependents of a
+/// shared prerequisite.
+#[tokio::test]
+async fn test_run_mode_all_includes_selected_dependents_prerequisites() -> Result<(), Error> {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("tasks.db");
+
+    let tasks = Tasks::builder(
+        Config::try_from(json!({
+            "roots": ["devenv:processes:server"],
+            "run_mode": "all",
+            "tasks": [
+                {
+                    "name": "devenv:processes:server"
+                },
+                {
+                    "name": "web:build"
+                },
+                {
+                    "name": "browser:test",
+                    "after": ["web:build", "devenv:processes:server"]
+                },
+                {
+                    "name": "unrelated:test",
+                    "after": ["web:build"]
+                }
+            ]
+        }))
+        .unwrap(),
+        VerbosityLevel::Verbose,
+        Shutdown::new(),
+    )
+    .with_db_path(db_path)
+    .build()
+    .await?;
+
+    let mut scheduled_task_names = Vec::new();
+    for index in &tasks.tasks_order {
+        scheduled_task_names.push(tasks.graph[*index].read().await.task.name.clone());
+    }
+
+    assert!(
+        scheduled_task_names.contains(&"web:build".to_string()),
+        "the selected browser task's build prerequisite must be scheduled"
+    );
+    assert!(
+        scheduled_task_names.contains(&"browser:test".to_string()),
+        "the process-dependent browser task must be scheduled"
+    );
+    assert!(
+        !scheduled_task_names.contains(&"unrelated:test".to_string()),
+        "an unrelated dependent of the build prerequisite must stay excluded"
+    );
+
+    Ok(())
+}
+
 /// Test that @completed dependency does NOT propagate failure (soft dependency)
 #[tokio::test]
 async fn test_complete_dependency_no_failure_propagation() -> Result<(), Error> {

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -2507,7 +2507,15 @@ impl Devenv {
             let _outputs = tasks_runner
                 .run_with_parent_activity(Arc::new(phase4))
                 .await;
+            let task_status = tasks_runner.get_completion_status().await;
             trace!("devenv.up: process tasks completed");
+
+            if task_status.has_failures() {
+                // A caller such as `devenv test` must not leave successfully
+                // started process siblings behind when another task fails.
+                let _ = tasks_runner.process_manager().stop_all().await;
+                bail!("Process tasks failed");
+            }
 
             // API server is started inside run_internal() so it's available
             // while processes are still starting up.

--- a/tests/process-task-failure/.test-config.yml
+++ b/tests/process-task-failure/.test-config.yml
@@ -1,0 +1,3 @@
+# Run outside the shell because the test invokes `devenv test` itself and
+# verifies its exit code.
+use_shell: false

--- a/tests/process-task-failure/.test.sh
+++ b/tests/process-task-failure/.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The integration harness runs this script directly. If the nested
+# `devenv test` incorrectly reaches its test phase, return successfully so
+# the outer invocation exposes the false-positive exit code.
+recursion_marker=.process-task-failure-running
+if test -f "$recursion_marker"; then
+  echo "UNEXPECTED_TEST_PHASE_RAN"
+  exit 0
+fi
+
+touch "$recursion_marker"
+trap 'rm -f "$recursion_marker"' EXIT
+
+set +e
+output=$(devenv test --no-tui 2>&1)
+status=$?
+set -e
+
+printf '%s\n' "$output"
+
+if test "$status" -eq 0; then
+  echo "FAIL: devenv test reported success after a process-dependent task failed"
+  exit 1
+fi
+
+grep -q "INTENTIONAL_PROCESS_TASK_FAILURE" <<<"$output"
+grep -q "Process tasks failed" <<<"$output"
+
+if grep -q "PROCESS_TASK_PREREQUISITE_MISSING" <<<"$output"; then
+  echo "FAIL: the process-dependent task ran without its prerequisite"
+  exit 1
+fi
+
+marker_dir=.devenv/test-state/process-task-failure
+if ! test -f "$marker_dir/prerequisite.ran"; then
+  echo "FAIL: the process-dependent task's prerequisite was not scheduled"
+  exit 1
+fi
+
+pid_file="$marker_dir/server.pid"
+if test -f "$pid_file" && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+  echo "FAIL: process sibling was left running after task failure"
+  exit 1
+fi

--- a/tests/process-task-failure/devenv.nix
+++ b/tests/process-task-failure/devenv.nix
@@ -7,9 +7,10 @@ in
   processes.server = {
     exec = ''
       mkdir -p ${markerDir}
-      echo "$$" > ${markerDir}/server.pid
+      sleep 300 &
+      echo "$!" > ${markerDir}/server.pid
       touch ${markerDir}/server.ready
-      exec sleep 300
+      wait
     '';
     ready.exec = "test -f ${markerDir}/server.ready";
     restart.on = "never";

--- a/tests/process-task-failure/devenv.nix
+++ b/tests/process-task-failure/devenv.nix
@@ -1,0 +1,41 @@
+{ config, ... }:
+
+let
+  markerDir = "${config.devenv.state}/process-task-failure";
+in
+{
+  processes.server = {
+    exec = ''
+      mkdir -p ${markerDir}
+      echo "$$" > ${markerDir}/server.pid
+      touch ${markerDir}/server.ready
+      exec sleep 300
+    '';
+    ready.exec = "test -f ${markerDir}/server.ready";
+    restart.on = "never";
+  };
+
+  tasks."test:prerequisite" = {
+    exec = ''
+      mkdir -p ${markerDir}
+      touch ${markerDir}/prerequisite.ran
+      echo "PROCESS_TASK_PREREQUISITE_RAN"
+    '';
+  };
+
+  tasks."test:failure" = {
+    exec = ''
+      if [ ! -f ${markerDir}/prerequisite.ran ]; then
+        echo "PROCESS_TASK_PREREQUISITE_MISSING"
+        exit 42
+      fi
+
+      echo "INTENTIONAL_PROCESS_TASK_FAILURE"
+      exit 23
+    '';
+    after = [
+      "test:prerequisite"
+      "devenv:processes:server"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary

- complete the prerequisite closure for dependent tasks selected by `RunMode::All`
- propagate native process-task failures from `devenv up` and `devenv test`
- stop already-started sibling processes when startup tasks fail
- add unit and integration regression coverage

## Background

#2348 split `RunMode::All` into independent incoming and outgoing traversals to avoid direction bouncing through shared prerequisites. That correctly excludes unrelated dependents, but a dependent reached from a process root can have another prerequisite that is never selected.

Separately, the native startup path ignored the task runner's completion status, so a failed process-dependent task could still let `devenv test` exit successfully.

This was observed in https://github.com/waneon/neoseq/actions/runs/32113974737: the browser task started without its web build prerequisite, failed because `apps/client/dist` was absent, and the workflow was reported as successful.

The added closure pass follows only incoming edges from the already-selected set, preserving #2348's no-direction-bouncing behavior.

## Tests

- `cargo test -p devenv-tasks` (142 passed)
- `devenv-run-tests run tests --only process-task-failure`
- `nix build .#devenv`
- `cargo fmt --all -- --check`
- `nixpkgs-fmt --check tests/process-task-failure/devenv.nix`
- `shellcheck tests/process-task-failure/.test.sh`

`cargo clippy -p devenv-tasks --all-targets -- -D warnings` currently stops on the pre-existing `clippy::for-kv-map` warning in `devenv-core/src/cachix.rs:621`.

Developed with Codex.
