### PR TITLE
ci: suggest reviewers on pull requests from forks

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,19 +1,37 @@
 name: Auto Assign Reviewers
 
+# `pull_request_target` runs this workflow from the base branch with a writable
+# token. On a plain `pull_request` event GITHUB_TOKEN is read-only for pull
+# requests from a fork, so the suggestion comment could never be posted there.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   assign-reviewers:
     runs-on: ubuntu-latest
 
     steps:
+      # Check out the base branch, never the pull request's code: this job holds
+      # a writable token and must not run anything the PR author controls.
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0  # Required for git blame
+          persist-credentials: false
 
-      - uses: cachix/git-blame-auto-reviewer@main
+      # Make the PR head available as a git object to diff against. Nothing from
+      # it is checked out or executed.
+      - run: git fetch --no-tags origin +refs/pull/${{ github.event.pull_request.number }}/head
+
+      # Pinned to a commit, not a branch: this job holds a writable token, so a
+      # moving ref would let anyone with push access to the action repo run code
+      # here.
+      - uses: cachix/git-blame-auto-reviewer@d1da8bb0ac7306da98262aec9c58d7d65ae939cc
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max-reviewers: 3


### PR DESCRIPTION
## Problem

The Auto Assign Reviewers job fails on every pull request from a fork, e.g. on #3103:

```
✅ Resolved 1 commits to @domenkozar
...
📬 Creating comment to suggest reviewers: domenkozar, sandydoo
##[error]Action failed: Failed to create/update comment: Resource not accessible by integration
```

The blame analysis is fine. GITHUB_TOKEN is simply read-only for `pull_request` runs from a fork, regardless of the `permissions` key or the repo default, so the comment can never be posted. External contributors get a red check for it.

## Fix

`pull_request_target`, which runs the workflow from the base branch with a writable token, with the usual footguns disarmed:

- the checkout is pinned to `github.event.pull_request.base.sha` with `persist-credentials: false`. The PR's code is never checked out
- the PR head is fetched as a git object only, via `+refs/pull/N/head`, so `git diff base..head` has something to diff against without anything being executed
- only two expressions reach a step, a SHA and the PR number. No attacker-written string touches a shell
- the action is pinned to a commit rather than `@main`, since a moving ref plus a writable token means push access to the action repo is push access here

This depends on cachix/git-blame-auto-reviewer#1, now merged and pinned here. That action used to build git commands as shell strings out of filenames, so a PR adding a file named `harmless$(...)x.txt` ran commands on the runner. Harmless under a read-only token, not something to hand a writable one.

## Verification

Replayed both steps against #3103 in a base-only clone: the head object is absent before the fetch and present after, and blame over the PR's files resolves the same 10 commits the failing run resolved. actionlint clean.

Since `pull_request_target` reads the workflow from the base branch, this fixes #3103 on its next push without the contributor rebasing.

---

Created by Claude Code. GitHub's API has no way to mark this authorship, see https://github.com/cli/cli/issues/13904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)