### PR TITLE
ci: stop fetching the pull request head to suggest reviewers

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -17,21 +17,19 @@ jobs:
 
     steps:
       # Check out the base branch, never the pull request's code: this job holds
-      # a writable token and must not run anything the PR author controls.
+      # a writable token and must not run anything the PR author controls. The
+      # action reads the changed lines from the pull request files API, so
+      # nothing from the pull request lands on disk at all.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0  # Required for git blame
           persist-credentials: false
 
-      # Make the PR head available as a git object to diff against. Nothing from
-      # it is checked out or executed.
-      - run: git fetch --no-tags origin +refs/pull/${{ github.event.pull_request.number }}/head
-
       # Pinned to a commit, not a branch: this job holds a writable token, so a
       # moving ref would let anyone with push access to the action repo run code
       # here.
-      - uses: cachix/git-blame-auto-reviewer@d1da8bb0ac7306da98262aec9c58d7d65ae939cc
+      - uses: cachix/git-blame-auto-reviewer@2d112d9bbd60c4feaf2b55e94a058e0e397ab0e0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           max-reviewers: 3


### PR DESCRIPTION
Follow-up to #3105, which landed before this commit was pushed.

#3105 left one step CodeQL objects to, and the alert is now open on `main`:

```
Checkout of untrusted code in a privileged workflow with later potential
execution (event trigger: pull_request_target)   [actions/untrusted-checkout/high]
```

It points at the `git fetch +refs/pull/N/head` step, which existed so the action could run `git diff base..head` locally. Nothing was ever checked out or executed from those objects, so the alert is a false positive in substance, but the step is avoidable.

cachix/git-blame-auto-reviewer#2 makes the action read changed lines from the `patch` field that the pull request files API already returns, so the head is no longer needed anywhere. This drops the fetch step and repins to that commit, `2d112d9`.

The privileged job is now a base-only checkout plus the action, with nothing from the pull request on disk at all.

---

Created by Claude Code. GitHub's API has no way to mark this authorship, see https://github.com/cli/cli/issues/13904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)