### PR TITLE
fix: use host platform attributes for stdenv checks

### DIFF
--- a/examples/cockroachdb/devenv.nix
+++ b/examples/cockroachdb/devenv.nix
@@ -2,6 +2,6 @@
 
 {
   services.cockroachdb = {
-    enable = pkgs.stdenv.isLinux;
+    enable = pkgs.stdenv.hostPlatform.isLinux;
   };
 }

--- a/examples/phoenix/devenv.nix
+++ b/examples/phoenix/devenv.nix
@@ -11,7 +11,7 @@
 {
   packages = [
     pkgs.git
-  ] ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.inotify-tools ];
+  ] ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.inotify-tools ];
 
   languages.elixir.enable = true;
 

--- a/examples/rabbitmq/devenv.nix
+++ b/examples/rabbitmq/devenv.nix
@@ -10,7 +10,7 @@
     # `_github-runner` user used by our self-hosted CI). RabbitMQ's default
     # memory monitor shells to `ps` and crashes the `rabbitmq_management_agent`
     # plugin during boot. Use Erlang's allocator accounting instead.
-    configItems = lib.mkIf pkgs.stdenv.isDarwin {
+    configItems = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
       "vm_memory_calculation_strategy" = "allocated";
     };
   };

--- a/examples/ruby/devenv.nix
+++ b/examples/ruby/devenv.nix
@@ -24,5 +24,5 @@
   # part of the Xcode command line developer tools, in which case they can be
   # removed.
   # For more information, see the `--install` flag in `man xcode-select`.
-  ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.libllvm ];
+  ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libllvm ];
 }

--- a/examples/vala/devenv.nix
+++ b/examples/vala/devenv.nix
@@ -8,7 +8,7 @@
 
   languages = {
     vala = {
-      enable = pkgs.stdenv.isLinux;
+      enable = pkgs.stdenv.hostPlatform.isLinux;
       # This is the default package for Vala for the configured channel (see nixpkgs input in devenv.yaml)
       # It can be configured to use a specific version
       # Take a look [here](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=vala) to find out which versions are available

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
           default = self.packages.${system}.devenv;
           crate2nix = pkgs.crate2nix;
         }
-        // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
           devenv-image = import ./containers/devenv/image.nix {
             inherit pkgs;
             inherit (self.packages.${system}) devenv;

--- a/nix/crate-config.nix
+++ b/nix/crate-config.nix
@@ -69,7 +69,7 @@ let
 
   # Override for crates needing dbus (Linux only)
   dbusOverride = attrs: {
-    buildInputs = (attrs.buildInputs or [ ]) ++ lib.optional stdenv.isLinux dbus;
+    buildInputs = (attrs.buildInputs or [ ]) ++ lib.optional stdenv.hostPlatform.isLinux dbus;
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
   };
 
@@ -82,7 +82,7 @@ let
         libghostty-vt
       ]
       ++ nixLibs
-      ++ lib.optional stdenv.isLinux dbus;
+      ++ lib.optional stdenv.hostPlatform.isLinux dbus;
     nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [
       pkg-config
       protobuf

--- a/src/modules/languages/c.nix
+++ b/src/modules/languages/c.nix
@@ -20,7 +20,7 @@ in
     debugger = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
       default =
-        if pkgs.stdenv.isDarwin
+        if pkgs.stdenv.hostPlatform.isDarwin
         then pkgs.lldb
         else if lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.gdb
         then pkgs.gdb
@@ -39,7 +39,7 @@ in
         {
           date = "2026-03-07";
           title = "languages.c.debugger defaults to lldb on macOS";
-          when = cfg.enable && pkgs.stdenv.isDarwin;
+          when = cfg.enable && pkgs.stdenv.hostPlatform.isDarwin;
           description = ''
             The default debugger for `languages.c` on macOS has been changed from `gdb` to `lldb`.
           '';

--- a/src/modules/languages/pascal.nix
+++ b/src/modules/languages/pascal.nix
@@ -15,6 +15,6 @@ in
   config = lib.mkIf cfg.enable {
     packages = with pkgs; [
       fpc
-    ] ++ lib.optional (cfg.lazarus.enable && pkgs.stdenv.isLinux) pkgs.lazarus;
+    ] ++ lib.optional (cfg.lazarus.enable && pkgs.stdenv.hostPlatform.isLinux) pkgs.lazarus;
   };
 }

--- a/src/modules/languages/python/default.nix
+++ b/src/modules/languages/python/default.nix
@@ -344,7 +344,7 @@ in
             ":"
             (lib.makeLibraryPath libraries)
           ]
-          ++ lib.optionals pkgs.stdenv.isDarwin [
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
             "--prefix"
             "DYLD_FALLBACK_LIBRARY_PATH"
             ":"

--- a/src/modules/languages/rust.nix
+++ b/src/modules/languages/rust.nix
@@ -128,8 +128,8 @@ in
 
     clangLinker.enable = lib.mkOption {
       type = lib.types.bool;
-      default = pkgs.stdenv.isLinux;
-      defaultText = lib.literalExpression "pkgs.stdenv.isLinux";
+      default = pkgs.stdenv.hostPlatform.isLinux;
+      defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.isLinux";
       description = ''
         Use Clang as the Rust linker driver on Linux.
 
@@ -332,7 +332,7 @@ in
             '';
           }
           {
-            assertion = cfg.wild.enable -> pkgs.stdenv.isLinux;
+            assertion = cfg.wild.enable -> pkgs.stdenv.hostPlatform.isLinux;
             message = ''
               `languages.rust.wild.enable` is only supported on Linux.
             '';
@@ -409,7 +409,7 @@ in
           ++ lib.optional cfg.lld.enable pkgs.llvmPackages.bintools
           ++ lib.optional cfg.wild.enable pkgs.wild
           ++ lib.optional cfg.clangLinker.enable pkgs.clang
-          ++ lib.optional pkgs.stdenv.isDarwin pkgs.libiconv
+          ++ lib.optional pkgs.stdenv.hostPlatform.isDarwin pkgs.libiconv
           ++ lib.optional cfg.lsp.enable cfg.lsp.package;
 
         # enable compiler tooling by default to expose things like cc
@@ -426,7 +426,7 @@ in
             # on aarch64-linux, so add the flag there (requires nightly on that target).
             wildFlags = lib.optionalString cfg.wild.enable (
               "-C linker-features=-lld -C link-arg=-B${pkgs.wild}/bin"
-              + lib.optionalString pkgs.stdenv.isAarch64 " -Z unstable-options"
+              + lib.optionalString pkgs.stdenv.hostPlatform.isAarch64 " -Z unstable-options"
             );
             linkerFlags = lib.concatStringsSep " " (lib.filter (x: x != "") [ moldFlags lldFlags wildFlags ]);
             optionalEnv = cond: str: if cond then str else null;

--- a/src/modules/process-managers/mprocs.nix
+++ b/src/modules/process-managers/mprocs.nix
@@ -46,7 +46,7 @@ in
         ${(lib.cli.toCommandLineShellGNU or lib.cli.toGNUCommandLineShell) { } config.process.manager.args}
     '';
 
-    packages = [ cfg.package ] ++ lib.optionals pkgs.stdenv.isDarwin
+    packages = [ cfg.package ] ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin
       [ (makeImpurePackage "/usr/bin/pbcopy") ];
 
     process.managers.mprocs = {

--- a/src/modules/top-level.nix
+++ b/src/modules/top-level.nix
@@ -139,7 +139,7 @@ in
       # Allow users to specify an optional SDK in `apple.sdk`.
       apply =
         stdenv:
-        if stdenv.isDarwin then
+        if stdenv.hostPlatform.isDarwin then
           stdenv.override
             (prev: {
               extraBuildInputs = builtins.filter (x: !(x ? sdkroot)) prev.extraBuildInputs;
@@ -157,8 +157,8 @@ in
 
           If set to `null`, the system SDK can be used if the shell allows access to external environment variables.
         '';
-        default = if pkgs.stdenv.isDarwin then pkgs.apple-sdk else null;
-        defaultText = lib.literalExpression "if pkgs.stdenv.isDarwin then pkgs.apple-sdk else null";
+        default = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.apple-sdk else null;
+        defaultText = lib.literalExpression "if pkgs.stdenv.hostPlatform.isDarwin then pkgs.apple-sdk else null";
         example = lib.literalExpression "pkgs.apple-sdk_15";
       };
     };
@@ -405,7 +405,7 @@ in
       fi
 
       # set path to locales on non-NixOS Linux hosts
-      ${lib.optionalString (pkgs.stdenv.isLinux && (pkgs.glibcLocalesUtf8 != null)) ''
+      ${lib.optionalString (pkgs.stdenv.hostPlatform.isLinux && (pkgs.glibcLocalesUtf8 != null)) ''
         if [ -z "''${LOCALE_ARCHIVE-}" ]; then
           export LOCALE_ARCHIVE=${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive
         fi
@@ -438,7 +438,7 @@ in
         # On macOS, route apple-sdk packages (identified by `passthru.sdkroot`) into `buildInputs`
         # so they participate in the SDK version comparison done by stdenv's setup hooks.
         partitioned =
-          if pkgs.stdenv.isDarwin then
+          if pkgs.stdenv.hostPlatform.isDarwin then
             builtins.partition (pkg: pkg ? sdkroot) config.packages
           else
             {

--- a/tests/macos-custom-apple-sdk/devenv.nix
+++ b/tests/macos-custom-apple-sdk/devenv.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 
-lib.mkIf pkgs.stdenv.isDarwin {
+lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
   apple.sdk = pkgs.apple-sdk;
 
   packages = [

--- a/tests/macos-no-default-sdk/devenv.nix
+++ b/tests/macos-no-default-sdk/devenv.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, ... }:
 
-lib.mkIf pkgs.stdenv.isDarwin {
+lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
   apple.sdk = null;
 
   # Test that there is no default SDK set on macOS.


### PR DESCRIPTION
## Summary

- replace deprecated `stdenv.is*` platform checks with `stdenv.hostPlatform.is*`
- update module defaults, examples, tests, and build expressions consistently
- preserve existing platform behavior while avoiding evaluation warnings with current nixpkgs

Fixes #3109.

## Testing

- `nix flake check --no-build`
- `devenv shell -- devenv-run-tests run tests --only 'macos-*-sdk'` (2 passed)
- `devenv shell -- devenv-run-tests run examples --only cockroachdb --only phoenix --only rabbitmq --only ruby --only vala --only rust --only python --only modern-c` (8 passed)
- `devenv shell -- devenv-run-tests run tests --only rust` (1 passed)
- parsed all 15 changed Nix files with `nix-instantiate --parse`
- `nixpkgs-fmt --check` reported `0 / 15 would have been reformatted`
- reproduced the warning with current `nixos-unstable`, then evaluated the same project using these modules and confirmed no deprecated `stdenv.is*` warnings remain