### PR TITLE
feat: Tui ux improvements

### DIFF
--- a/devenv-run-tests/src/pty.rs
+++ b/devenv-run-tests/src/pty.rs
@@ -99,18 +99,17 @@ pub fn run(transcript: &Path, command: &str, step_timeout: Duration) -> Result<i
     let (chunk_tx, chunk_rx) = mpsc::channel::<Vec<u8>>();
     let terminal_writer = Arc::clone(&writer);
     let reader_thread = thread::spawn(move || {
-        // Crossterm probes for the Kitty keyboard protocol before entering its
-        // event loop. A bare PTY has no terminal emulator to answer it, which
-        // leaves startup dependent on a timeout and can race scripted input.
+        // Crossterm probes for the Kitty keyboard protocol whenever an iocraft
+        // event loop starts. A bare PTY has no terminal emulator to answer it,
+        // which leaves startup dependent on a timeout and can race scripted input.
         // Reply only to the primary-device-attributes query: this explicitly
         // selects legacy key decoding, matching a terminal without keyboard
         // enhancement support.
         const KEYBOARD_PROBE: &[u8] = b"\x1b[?u\x1b[c";
         const PRIMARY_DEVICE_ATTRIBUTES: &[u8] = b"\x1b[?1;2c";
         let mut probe_output = Vec::new();
-        let mut answered_probe = false;
         let mut buf = [0u8; 4096];
-        loop {
+        'read: loop {
             // Linux raises EIO once the slave side is closed; macOS returns EOF.
             match reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
@@ -118,26 +117,21 @@ pub fn run(transcript: &Path, command: &str, step_timeout: Duration) -> Result<i
                     if out.write_all(&buf[..n]).is_err() {
                         break;
                     }
-                    if !answered_probe {
-                        probe_output.extend_from_slice(&buf[..n]);
-                        if find(&probe_output, KEYBOARD_PROBE).is_some() {
-                            let Ok(mut writer) = terminal_writer.lock() else {
-                                break;
-                            };
-                            if writer.write_all(PRIMARY_DEVICE_ATTRIBUTES).is_err()
-                                || writer.flush().is_err()
-                            {
-                                break;
-                            }
-                            answered_probe = true;
-                        } else {
-                            // Keep only enough output to recognize a probe split
-                            // across two reads.
-                            let keep = KEYBOARD_PROBE.len().saturating_sub(1);
-                            if probe_output.len() > keep {
-                                probe_output.drain(..probe_output.len() - keep);
-                            }
+                    probe_output.extend_from_slice(&buf[..n]);
+                    while let Some(pos) = find(&probe_output, KEYBOARD_PROBE) {
+                        let Ok(mut writer) = terminal_writer.lock() else {
+                            break 'read;
+                        };
+                        if writer.write_all(PRIMARY_DEVICE_ATTRIBUTES).is_err()
+                            || writer.flush().is_err()
+                        {
+                            break 'read;
                         }
+                        probe_output.drain(..pos + KEYBOARD_PROBE.len());
+                    }
+                    let keep = KEYBOARD_PROBE.len().saturating_sub(1);
+                    if probe_output.len() > keep {
+                        probe_output.drain(..probe_output.len() - keep);
                     }
                     let _ = chunk_tx.send(buf[..n].to_vec());
                 }

--- a/devenv-tui/README.md
+++ b/devenv-tui/README.md
@@ -115,9 +115,9 @@ triage.
 
 ## Views
 
-**Main view**: Shows a stable activity tree with log previews collapsed by default. Does not use alternate screen buffer, so terminal scrollback is preserved.
+**Main view**: Shows a stable activity tree. Process logs are previewed automatically when the complete tree fits in the terminal and can always be opened or hidden explicitly. The main view does not use the alternate screen buffer, so terminal scrollback is preserved.
 
-**Expanded logs**: Fullscreen view of logs for a single activity.
+**Expanded logs**: Fullscreen view of logs for a single activity with follow mode, scrolling, selection, and clipboard copy.
 
 ## Activity Types
 
@@ -137,7 +137,9 @@ triage.
 
 ### Main View
 - `↑/↓` or `j/k`: Navigate activities
-- `Enter`: Toggle an inline log preview for the selected activity
+- `Enter`: Toggle the selected activity or process log preview
+- `→` or `l`: Expand the selected activity or show its process log preview
+- `←` or `h`: Collapse the selected activity or hide process log previews
 - `Ctrl+E`: Expand logs for selected activity
 - `/`: Search managed processes by name; use `↑/↓` to move through matches
 - `Ctrl+R`: Restart the selected managed process
@@ -151,7 +153,9 @@ Long lines wrap onto continuation rows so their full content stays readable.
 
 - `↑/↓` or `j/k`: Scroll one line
 - `PgUp/PgDn` or `Space`: Scroll page
-- `g/G`: Jump to top/bottom
+- `g` or `Home`: Jump to the top and pause following
+- `G` or `End`: Jump to the bottom and resume following
+- `y`: Copy the selection, or the complete retained log when nothing is selected
 - `Ctrl+C`: Copy the current selection, or show the quit prompt when no selection is active
 - `c` or `Esc`: Keep running and clear the prompt
 - `q` or `Ctrl+C`: Quit from the interrupt prompt

--- a/devenv-tui/README.md
+++ b/devenv-tui/README.md
@@ -115,7 +115,7 @@ triage.
 
 ## Views
 
-**Main view**: Shows activity tree with inline log previews. Does not use alternate screen buffer, so terminal scrollback is preserved.
+**Main view**: Shows a stable activity tree with log previews collapsed by default. Does not use alternate screen buffer, so terminal scrollback is preserved.
 
 **Expanded logs**: Fullscreen view of logs for a single activity.
 
@@ -137,12 +137,14 @@ triage.
 
 ### Main View
 - `↑/↓` or `j/k`: Navigate activities
+- `Enter`: Toggle an inline log preview for the selected activity
 - `Ctrl+E`: Expand logs for selected activity
+- `/`: Search managed processes by name; use `↑/↓` to move through matches
 - `Ctrl+R`: Restart the selected managed process
 - `Ctrl+C`: Show the quit prompt without stopping managed processes
 - `c` or `Esc`: Keep running and clear the prompt
 - `q` or `Ctrl+C`: Quit from the interrupt prompt
-- `Esc`: Clear selection
+- `Esc`: Close the inline preview, clear the selection, or cancel search
 
 ### Expanded Logs
 Long lines wrap onto continuation rows so their full content stays readable.

--- a/devenv-tui/README.md
+++ b/devenv-tui/README.md
@@ -137,12 +137,15 @@ triage.
 
 ### Main View
 - `↑/↓` or `j/k`: Navigate activities
+- `Ctrl+D/Ctrl+U`: Navigate half a page
 - `Enter`: Toggle the selected activity or process log preview
 - `→` or `l`: Expand the selected activity or show its process log preview
 - `←` or `h`: Collapse the selected activity or hide process log previews
 - `Ctrl+E`: Expand logs for selected activity
 - `/`: Search managed processes by name; use `↑/↓` to move through matches
 - `Ctrl+R`: Restart the selected managed process
+- `Ctrl+X`: Stop the selected managed process
+- `Ctrl+H`: Hide or show stopped processes
 - `Ctrl+C`: Show the quit prompt without stopping managed processes
 - `c` or `Esc`: Keep running and clear the prompt
 - `q` or `Ctrl+C`: Quit from the interrupt prompt
@@ -152,9 +155,12 @@ triage.
 Long lines wrap onto continuation rows so their full content stays readable.
 
 - `↑/↓` or `j/k`: Scroll one line
+- `Ctrl+D/Ctrl+U`: Scroll half a page
+- `Ctrl+F/Ctrl+B`: Scroll a full page
 - `PgUp/PgDn` or `Space`: Scroll page
 - `g` or `Home`: Jump to the top and pause following
 - `G` or `End`: Jump to the bottom and resume following
+- `/`: Search logs; use `n/N` to move through matches
 - `y`: Copy the selection, or the complete retained log when nothing is selected
 - `Ctrl+C`: Copy the current selection, or show the quit prompt when no selection is active
 - `c` or `Esc`: Keep running and clear the prompt

--- a/devenv-tui/bombadil/devenv-tui.spec.ts
+++ b/devenv-tui/bombadil/devenv-tui.spec.ts
@@ -147,6 +147,8 @@ export const drive = weighted([
   [8, whenReady(k("\x1b[B"))], // Down
   [6, whenReady(k("j"))],
   [6, whenReady(k("k"))],
+  [4, whenMain(k("/api\r"))],
+  [4, whenMain(k("\r"))],
   [6, whenMain(k("\x05"))], // Ctrl+E  expand logs
   [4, restartProcess], // Ctrl+R  (re)start process
   [4, stopProcess], // Ctrl+X  stop process

--- a/devenv-tui/bombadil/devenv-tui.spec.ts
+++ b/devenv-tui/bombadil/devenv-tui.spec.ts
@@ -74,7 +74,7 @@ const processStates = extract((s: State): Record<ProcessName, VisibleStatus> => 
 type View = "main" | "expanded" | "prompt" | "unknown";
 const currentView = (): View => {
   const markers: [View, number][] = [
-    ["main", screen.current.lastIndexOf("↑↓ nav")],
+    ["main", screen.current.lastIndexOf("↑↓ j/k")],
     ["expanded", screen.current.lastIndexOf("j/k:line")],
     ["prompt", screen.current.lastIndexOf("Detach or stop")],
   ];

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -591,6 +591,22 @@ fn rendered_activity_height(
     }
 }
 
+fn activity_navigation_action(
+    key_event: &KeyEvent,
+    viewport_height: usize,
+) -> Option<(bool, usize)> {
+    let control = key_event.modifiers.contains(KeyModifiers::CONTROL);
+    let half_page = viewport_height.div_ceil(2).max(1);
+
+    match key_event.code {
+        KeyCode::Down | KeyCode::Char('j') => Some((true, 1)),
+        KeyCode::Up | KeyCode::Char('k') => Some((false, 1)),
+        KeyCode::Char('d') if control => Some((true, half_page)),
+        KeyCode::Char('u') if control => Some((false, half_page)),
+        _ => None,
+    }
+}
+
 /// Scroll the viewport so the selected activity is visible.
 fn scroll_selected_into_view(
     handle: &mut ScrollViewHandle,
@@ -1019,16 +1035,24 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                 collapse_selected_activity(&model, &mut ui);
                             }
                         }
-                        KeyCode::Down | KeyCode::Char('j') | KeyCode::Up | KeyCode::Char('k') => {
+                        _ if activity_navigation_action(
+                            &key_event,
+                            terminal_height.saturating_sub(SUMMARY_BAR_HEIGHT) as usize,
+                        )
+                        .is_some() =>
+                        {
                             if let Ok(model) = activity_model.read()
                                 && let Ok(mut ui) = ui_state.write()
                             {
                                 let display = model.get_display_activities(&ui);
                                 let selectable =
                                     model.get_selectable_activity_ids_from_display(&display, &ui);
-                                let forward =
-                                    matches!(key_event.code, KeyCode::Down | KeyCode::Char('j'));
-                                ui.select_activity(&selectable, forward);
+                                let (forward, steps) = activity_navigation_action(
+                                    &key_event,
+                                    terminal_height.saturating_sub(SUMMARY_BAR_HEIGHT) as usize,
+                                )
+                                .unwrap();
+                                ui.select_activity_by(&selectable, steps, forward);
                                 ui.inline_logs_activity = None;
                                 if let Some(selected_id) = ui.selected_activity
                                     && *scroll_view_active.read()
@@ -1259,6 +1283,33 @@ mod tests {
     };
     use devenv_activity::{ActivityLevel, ActivityOutcome};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn activity_navigation_supports_arrow_vim_and_half_page_keys() {
+        let action = |code, control| {
+            let mut event = KeyEvent::new(KeyEventKind::Press, code);
+            if control {
+                event.modifiers = KeyModifiers::CONTROL;
+            }
+            activity_navigation_action(&event, 21)
+        };
+
+        assert_eq!(action(KeyCode::Down, false), Some((true, 1)));
+        assert_eq!(action(KeyCode::Up, false), Some((false, 1)));
+        assert_eq!(action(KeyCode::Char('j'), false), Some((true, 1)));
+        assert_eq!(action(KeyCode::Char('k'), false), Some((false, 1)));
+        assert_eq!(action(KeyCode::Char('d'), true), Some((true, 11)));
+        assert_eq!(action(KeyCode::Char('u'), true), Some((false, 11)));
+        assert_eq!(action(KeyCode::Char('d'), false), None);
+
+        let selectable: Vec<_> = (1..=20).collect();
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(10);
+        ui_state.select_activity_by(&selectable, 6, true);
+        assert_eq!(ui_state.selected_activity, Some(16));
+        ui_state.select_activity_by(&selectable, 50, false);
+        assert_eq!(ui_state.selected_activity, Some(1));
+    }
 
     #[test]
     fn test_request_interrupt_prompt_requires_native_process_manager() {

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -1,7 +1,10 @@
 use crate::{
     expanded_view::ExpandedLogView,
     model::{ActivityModel, RenderContext, UiState, ViewMode},
-    view::{ActivityHeights, SUMMARY_BAR_HEIGHT, ScrollState, process_previews_fit, view},
+    view::{
+        ActivityHeights, SUMMARY_BAR_HEIGHT, ScrollState, activity_shows_inline_logs,
+        process_previews_fit, view,
+    },
 };
 use crossterm::{
     cursor, event, execute,
@@ -570,12 +573,33 @@ fn activity_height(heights: &std::collections::HashMap<u64, i32>, id: u64) -> i3
     heights.get(&id).copied().unwrap_or(1)
 }
 
+fn rendered_activity_height(
+    heights: &std::collections::HashMap<u64, i32>,
+    model: &ActivityModel,
+    ui_state: &UiState,
+    display: &crate::model::DisplayActivity,
+    previews_fit: bool,
+) -> i32 {
+    if matches!(
+        display.activity.variant,
+        crate::model::ActivityVariant::Process(_)
+    ) && !activity_shows_inline_logs(model, ui_state, display.activity.id, previews_fit)
+    {
+        1
+    } else {
+        activity_height(heights, display.activity.id)
+    }
+}
+
 /// Scroll the viewport so the selected activity is visible.
 fn scroll_selected_into_view(
     handle: &mut ScrollViewHandle,
     heights: &std::collections::HashMap<u64, i32>,
+    model: &ActivityModel,
+    ui_state: &UiState,
     display_activities: &[crate::model::DisplayActivity],
     selected_id: u64,
+    previews_fit: bool,
 ) {
     let Some(position) = display_activities
         .iter()
@@ -586,9 +610,12 @@ fn scroll_selected_into_view(
 
     let offset: i32 = display_activities[..position]
         .iter()
-        .map(|da| activity_height(heights, da.activity.id))
+        .map(|display| rendered_activity_height(heights, model, ui_state, display, previews_fit))
         .sum();
-    let target_height = activity_height(heights, selected_id);
+    let target_height = display_activities
+        .get(position)
+        .map(|display| rendered_activity_height(heights, model, ui_state, display, previews_fit))
+        .unwrap_or(1);
 
     let vp = handle.viewport_height() as i32;
     let current = handle.scroll_offset();
@@ -599,7 +626,11 @@ fn scroll_selected_into_view(
     }
 }
 
-fn update_process_search_selection(model: &ActivityModel, ui_state: &mut UiState) {
+fn update_process_search_selection(
+    model: &ActivityModel,
+    display: &[crate::model::DisplayActivity],
+    ui_state: &mut UiState,
+) {
     let Some(query) = ui_state
         .process_search
         .as_ref()
@@ -607,7 +638,7 @@ fn update_process_search_selection(model: &ActivityModel, ui_state: &mut UiState
     else {
         return;
     };
-    let matches = model.get_matching_process_activity_ids(ui_state, &query);
+    let matches = model.get_matching_process_activity_ids_from_display(display, &query);
     if !ui_state
         .selected_activity
         .is_some_and(|id| matches.contains(&id))
@@ -619,12 +650,12 @@ fn update_process_search_selection(model: &ActivityModel, ui_state: &mut UiState
 fn handle_process_search_key(
     key_event: &KeyEvent,
     model: &ActivityModel,
+    display: &[crate::model::DisplayActivity],
     ui_state: &mut UiState,
 ) -> bool {
     if ui_state.process_search.is_none() {
         return false;
     }
-
     match key_event.code {
         KeyCode::Esc => {
             ui_state.cancel_process_search();
@@ -649,7 +680,7 @@ fn handle_process_search_key(
             if let Some(search) = &mut ui_state.process_search {
                 search.query.pop();
             }
-            update_process_search_selection(model, ui_state);
+            update_process_search_selection(model, display, ui_state);
         }
         KeyCode::Down | KeyCode::Up => {
             let query = ui_state
@@ -657,7 +688,7 @@ fn handle_process_search_key(
                 .as_ref()
                 .map(|search| search.query.as_str())
                 .unwrap_or_default();
-            let matches = model.get_matching_process_activity_ids(ui_state, query);
+            let matches = model.get_matching_process_activity_ids_from_display(display, query);
             if !ui_state
                 .selected_activity
                 .is_some_and(|id| matches.contains(&id))
@@ -674,7 +705,7 @@ fn handle_process_search_key(
             if let Some(search) = &mut ui_state.process_search {
                 search.query.push(character);
             }
-            update_process_search_selection(model, ui_state);
+            update_process_search_selection(model, display, ui_state);
         }
         _ => {}
     }
@@ -682,12 +713,22 @@ fn handle_process_search_key(
     true
 }
 
-fn activate_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
+fn activate_selected_activity(model: &ActivityModel, ui_state: &mut UiState, previews_fit: bool) {
     if let Some(activity_id) = ui_state.selected_activity
         && model.is_activity_collapsible(activity_id, ui_state)
     {
         ui_state.toggle_activity_expansion(activity_id);
         ui_state.inline_logs_activity = None;
+    } else if let Some(activity_id) = ui_state.selected_activity
+        && model.get_activity(activity_id).is_some_and(|activity| {
+            matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+        })
+    {
+        if activity_shows_inline_logs(model, ui_state, activity_id, previews_fit) {
+            ui_state.hide_process_previews();
+        } else {
+            ui_state.focus_inline_logs(activity_id);
+        }
     } else {
         ui_state.toggle_inline_logs();
     }
@@ -703,7 +744,7 @@ fn expand_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
     } else if model.get_activity(activity_id).is_some_and(|activity| {
         matches!(activity.variant, crate::model::ActivityVariant::Process(_))
     }) {
-        ui_state.inline_logs_activity = Some(activity_id);
+        ui_state.focus_inline_logs(activity_id);
     }
 }
 
@@ -717,8 +758,29 @@ fn collapse_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
     } else if model.get_activity(activity_id).is_some_and(|activity| {
         matches!(activity.variant, crate::model::ActivityVariant::Process(_))
     }) {
+        ui_state.hide_process_previews();
+    }
+}
+
+fn hide_selected_preview(
+    model: &ActivityModel,
+    ui_state: &mut UiState,
+    previews_fit: bool,
+) -> bool {
+    let Some(activity_id) = ui_state.selected_activity else {
+        return false;
+    };
+    if !activity_shows_inline_logs(model, ui_state, activity_id, previews_fit) {
+        return false;
+    }
+    if model.get_activity(activity_id).is_some_and(|activity| {
+        matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+    }) {
+        ui_state.hide_process_previews();
+    } else {
         ui_state.inline_logs_activity = None;
     }
+    true
 }
 
 /// Main TUI component (inline mode)
@@ -788,19 +850,24 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 debug!("Key event: {:?}", key_event);
                 let search_handled = if let Ok(model) = activity_model.read()
                     && let Ok(mut ui) = ui_state.write()
+                    && ui.process_search.is_some()
                 {
-                    let handled = handle_process_search_key(&key_event, &model, &mut ui);
+                    let display = model.get_display_activities(&ui);
+                    let handled = handle_process_search_key(&key_event, &model, &display, &mut ui);
                     if handled
                         && let Some(selected_id) = ui.selected_activity
                         && *scroll_view_active.read()
                     {
-                        let display = model.get_display_activities(&ui);
+                        let previews_fit = process_previews_fit(&model, &display, ui.terminal_size);
                         let heights = activity_heights.read();
                         scroll_selected_into_view(
                             &mut scroll_handle.write(),
                             &heights,
+                            &model,
+                            &ui,
                             &display,
                             selected_id,
+                            previews_fit,
                         );
                     }
                     handled
@@ -902,17 +969,22 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                 && let Ok(mut ui) = ui_state.write()
                             {
                                 ui.start_process_search();
-                                update_process_search_selection(&model, &mut ui);
+                                let display = model.get_display_activities(&ui);
+                                update_process_search_selection(&model, &display, &mut ui);
                                 if let Some(selected_id) = ui.selected_activity
                                     && *scroll_view_active.read()
                                 {
-                                    let display = model.get_display_activities(&ui);
+                                    let previews_fit =
+                                        process_previews_fit(&model, &display, ui.terminal_size);
                                     let heights = activity_heights.read();
                                     scroll_selected_into_view(
                                         &mut scroll_handle.write(),
                                         &heights,
+                                        &model,
+                                        &ui,
                                         &display,
                                         selected_id,
+                                        previews_fit,
                                     );
                                 }
                             }
@@ -921,17 +993,26 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             if let Ok(model) = activity_model.read()
                                 && let Ok(mut ui) = ui_state.write()
                             {
-                                activate_selected_activity(&model, &mut ui);
+                                let display = model.get_display_activities(&ui);
+                                let previews_fit =
+                                    process_previews_fit(&model, &display, ui.terminal_size);
+                                activate_selected_activity(&model, &mut ui, previews_fit);
                             }
                         }
-                        KeyCode::Right | KeyCode::Char('l') => {
+                        KeyCode::Right | KeyCode::Char('l')
+                            if !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+                        {
                             if let Ok(model) = activity_model.read()
                                 && let Ok(mut ui) = ui_state.write()
                             {
                                 expand_selected_activity(&model, &mut ui);
                             }
                         }
-                        KeyCode::Left | KeyCode::Char('h') => {
+                        KeyCode::Left | KeyCode::Char('h')
+                            if !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+                        {
                             if let Ok(model) = activity_model.read()
                                 && let Ok(mut ui) = ui_state.write()
                             {
@@ -942,7 +1023,9 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             if let Ok(model) = activity_model.read()
                                 && let Ok(mut ui) = ui_state.write()
                             {
-                                let selectable = model.get_selectable_activity_ids(&ui);
+                                let display = model.get_display_activities(&ui);
+                                let selectable =
+                                    model.get_selectable_activity_ids_from_display(&display, &ui);
                                 let forward =
                                     matches!(key_event.code, KeyCode::Down | KeyCode::Char('j'));
                                 ui.select_activity(&selectable, forward);
@@ -950,22 +1033,29 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                 if let Some(selected_id) = ui.selected_activity
                                     && *scroll_view_active.read()
                                 {
-                                    let display = model.get_display_activities(&ui);
+                                    let previews_fit =
+                                        process_previews_fit(&model, &display, ui.terminal_size);
                                     let heights = activity_heights.read();
                                     scroll_selected_into_view(
                                         &mut scroll_handle.write(),
                                         &heights,
+                                        &model,
+                                        &ui,
                                         &display,
                                         selected_id,
+                                        previews_fit,
                                     );
                                 }
                             }
                         }
                         KeyCode::Esc => {
-                            if let Ok(mut ui) = ui_state.write() {
-                                if ui.inline_logs_activity.is_some() {
-                                    ui.inline_logs_activity = None;
-                                } else {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                let display = model.get_display_activities(&ui);
+                                let previews_fit =
+                                    process_previews_fit(&model, &display, ui.terminal_size);
+                                if !hide_selected_preview(&model, &mut ui, previews_fit) {
                                     ui.selected_activity = None;
                                 }
                             }
@@ -1010,8 +1100,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let is_shutting_down = shutdown.is_cancelled();
     let rendered = if let Ok(model_guard) = activity_model.read() {
         let display = model_guard.get_display_activities(&ui);
-        let auto_expand_process_logs = ui.inline_logs_activity.is_none()
-            && process_previews_fit(&model_guard, &display, ui.terminal_size);
+        let previews_fit = process_previews_fit(&model_guard, &display, ui.terminal_size);
 
         // Prune stale entries and compute total content height in a single lock
         let total_content_height: i32 = {
@@ -1021,18 +1110,8 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             heights.retain(|id, _| active_ids.contains(id));
             display
                 .iter()
-                .map(|da| {
-                    let process_is_expanded =
-                        auto_expand_process_logs || ui.inline_logs_activity == Some(da.activity.id);
-                    if matches!(
-                        da.activity.variant,
-                        crate::model::ActivityVariant::Process(_)
-                    ) && !process_is_expanded
-                    {
-                        1
-                    } else {
-                        activity_height(&heights, da.activity.id)
-                    }
+                .map(|display| {
+                    rendered_activity_height(&heights, &model_guard, &ui, display, previews_fit)
                 })
                 .sum()
         };
@@ -1049,7 +1128,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         element! {
             ContextProvider(value: iocraft::Context::owned(activity_heights)) {
                 View(width: terminal_width) {
-                    #(vec![view(&model_guard, &ui, RenderContext::Normal, Some(ScrollState { handle: scroll_handle_opt, display_activities: display }), is_shutting_down).into()])
+                    #(vec![view(&model_guard, &ui, RenderContext::Normal, Some(ScrollState { handle: scroll_handle_opt, display_activities: display, process_previews_fit: previews_fit }), is_shutting_down).into()])
                 }
             }
         }
@@ -1273,10 +1352,16 @@ mod tests {
         let mut ui_state = UiState::new();
         ui_state.selected_activity = Some(1);
         ui_state.start_process_search();
-        update_process_search_selection(&model, &mut ui_state);
+        let display = model.get_display_activities(&ui_state);
+        update_process_search_selection(&model, &display, &mut ui_state);
 
         let e = KeyEvent::new(KeyEventKind::Press, KeyCode::Char('e'));
-        assert!(handle_process_search_key(&e, &model, &mut ui_state));
+        assert!(handle_process_search_key(
+            &e,
+            &model,
+            &display,
+            &mut ui_state
+        ));
         assert_eq!(ui_state.selected_activity, Some(2));
         assert_eq!(
             ui_state
@@ -1287,7 +1372,12 @@ mod tests {
         );
 
         let escape = KeyEvent::new(KeyEventKind::Press, KeyCode::Esc);
-        assert!(handle_process_search_key(&escape, &model, &mut ui_state));
+        assert!(handle_process_search_key(
+            &escape,
+            &model,
+            &display,
+            &mut ui_state
+        ));
         assert_eq!(ui_state.selected_activity, Some(1));
         assert!(ui_state.process_search.is_none());
     }
@@ -1300,15 +1390,26 @@ mod tests {
 
         let mut ui_state = UiState::new();
         ui_state.start_process_search();
-        update_process_search_selection(&model, &mut ui_state);
+        let display = model.get_display_activities(&ui_state);
+        update_process_search_selection(&model, &display, &mut ui_state);
         assert_eq!(ui_state.selected_activity, Some(1));
 
         let down = KeyEvent::new(KeyEventKind::Press, KeyCode::Down);
-        assert!(handle_process_search_key(&down, &model, &mut ui_state));
+        assert!(handle_process_search_key(
+            &down,
+            &model,
+            &display,
+            &mut ui_state
+        ));
         assert_eq!(ui_state.selected_activity, Some(2));
 
         let up = KeyEvent::new(KeyEventKind::Press, KeyCode::Up);
-        assert!(handle_process_search_key(&up, &model, &mut ui_state));
+        assert!(handle_process_search_key(
+            &up,
+            &model,
+            &display,
+            &mut ui_state
+        ));
         assert_eq!(ui_state.selected_activity, Some(1));
     }
 
@@ -1331,11 +1432,11 @@ mod tests {
         ui_state.selected_activity = Some(1);
         ui_state.inline_logs_activity = Some(1);
 
-        activate_selected_activity(&model, &mut ui_state);
+        activate_selected_activity(&model, &mut ui_state, false);
         assert!(ui_state.expanded_activities.contains(&1));
         assert_eq!(ui_state.inline_logs_activity, None);
 
-        activate_selected_activity(&model, &mut ui_state);
+        activate_selected_activity(&model, &mut ui_state, false);
         assert!(!ui_state.expanded_activities.contains(&1));
     }
 
@@ -1389,5 +1490,55 @@ mod tests {
         ui_state.inline_logs_activity = Some(3);
         collapse_selected_activity(&model, &mut ui_state);
         assert_eq!(ui_state.inline_logs_activity, None);
+        assert!(ui_state.process_previews_hidden);
+    }
+
+    #[test]
+    fn automatic_process_preview_can_be_hidden_and_focused_again() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(process_start(1, "api"));
+        model.apply_activity_event(devenv_activity::test_helpers::process_log(
+            1, "ready", false,
+        ));
+
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        assert!(activity_shows_inline_logs(&model, &ui_state, 1, true));
+
+        assert!(hide_selected_preview(&model, &mut ui_state, true));
+        assert_eq!(ui_state.selected_activity, Some(1));
+        assert!(ui_state.process_previews_hidden);
+        assert!(!activity_shows_inline_logs(&model, &ui_state, 1, true));
+
+        expand_selected_activity(&model, &mut ui_state);
+        assert!(ui_state.process_previews_hidden);
+        assert!(activity_shows_inline_logs(&model, &ui_state, 1, true));
+
+        collapse_selected_activity(&model, &mut ui_state);
+        assert!(!activity_shows_inline_logs(&model, &ui_state, 1, true));
+
+        expand_selected_activity(&model, &mut ui_state);
+        assert!(activity_shows_inline_logs(&model, &ui_state, 1, true));
+    }
+
+    #[test]
+    fn collapsed_process_uses_row_height_before_the_next_render() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(process_start(1, "api"));
+        let display = model.get_display_activities(&UiState::new()).remove(0);
+        let heights = std::collections::HashMap::from([(1, 11)]);
+
+        let mut ui_state = UiState::new();
+        ui_state.process_previews_hidden = true;
+        assert_eq!(
+            rendered_activity_height(&heights, &model, &ui_state, &display, true),
+            1
+        );
+
+        ui_state.focus_inline_logs(1);
+        assert_eq!(
+            rendered_activity_height(&heights, &model, &ui_state, &display, true),
+            11
+        );
     }
 }

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -1,7 +1,7 @@
 use crate::{
     expanded_view::ExpandedLogView,
     model::{ActivityModel, RenderContext, UiState, ViewMode},
-    view::{ActivityHeights, SUMMARY_BAR_HEIGHT, ScrollState, view},
+    view::{ActivityHeights, SUMMARY_BAR_HEIGHT, ScrollState, process_previews_fit, view},
 };
 use crossterm::{
     cursor, event, execute,
@@ -682,6 +682,45 @@ fn handle_process_search_key(
     true
 }
 
+fn activate_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
+    if let Some(activity_id) = ui_state.selected_activity
+        && model.is_activity_collapsible(activity_id, ui_state)
+    {
+        ui_state.toggle_activity_expansion(activity_id);
+        ui_state.inline_logs_activity = None;
+    } else {
+        ui_state.toggle_inline_logs();
+    }
+}
+
+fn expand_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
+    let Some(activity_id) = ui_state.selected_activity else {
+        return;
+    };
+    if model.is_activity_collapsible(activity_id, ui_state) {
+        ui_state.expanded_activities.insert(activity_id);
+        ui_state.inline_logs_activity = None;
+    } else if model.get_activity(activity_id).is_some_and(|activity| {
+        matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+    }) {
+        ui_state.inline_logs_activity = Some(activity_id);
+    }
+}
+
+fn collapse_selected_activity(model: &ActivityModel, ui_state: &mut UiState) {
+    let Some(activity_id) = ui_state.selected_activity else {
+        return;
+    };
+    if model.is_activity_collapsible(activity_id, ui_state) {
+        ui_state.expanded_activities.remove(&activity_id);
+        ui_state.inline_logs_activity = None;
+    } else if model.get_activity(activity_id).is_some_and(|activity| {
+        matches!(activity.variant, crate::model::ActivityVariant::Process(_))
+    }) {
+        ui_state.inline_logs_activity = None;
+    }
+}
+
 /// Main TUI component (inline mode)
 #[component]
 fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
@@ -879,8 +918,24 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             }
                         }
                         KeyCode::Enter => {
-                            if let Ok(mut ui) = ui_state.write() {
-                                ui.toggle_inline_logs();
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                activate_selected_activity(&model, &mut ui);
+                            }
+                        }
+                        KeyCode::Right | KeyCode::Char('l') => {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                expand_selected_activity(&model, &mut ui);
+                            }
+                        }
+                        KeyCode::Left | KeyCode::Char('h') => {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                collapse_selected_activity(&model, &mut ui);
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') | KeyCode::Up | KeyCode::Char('k') => {
@@ -930,7 +985,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 // prompt), which iocraft cannot observe on its own. Wake the
                 // render loop so the change is painted promptly instead of
                 // waiting for the idle heartbeat (#2915).
-                notify.notify_waiters();
+                notify.notify_one();
             }
         }
     });
@@ -955,6 +1010,8 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let is_shutting_down = shutdown.is_cancelled();
     let rendered = if let Ok(model_guard) = activity_model.read() {
         let display = model_guard.get_display_activities(&ui);
+        let auto_expand_process_logs = ui.inline_logs_activity.is_none()
+            && process_previews_fit(&model_guard, &display, ui.terminal_size);
 
         // Prune stale entries and compute total content height in a single lock
         let total_content_height: i32 = {
@@ -964,7 +1021,19 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             heights.retain(|id, _| active_ids.contains(id));
             display
                 .iter()
-                .map(|da| activity_height(&heights, da.activity.id))
+                .map(|da| {
+                    let process_is_expanded =
+                        auto_expand_process_logs || ui.inline_logs_activity == Some(da.activity.id);
+                    if matches!(
+                        da.activity.variant,
+                        crate::model::ActivityVariant::Process(_)
+                    ) && !process_is_expanded
+                    {
+                        1
+                    } else {
+                        activity_height(&heights, da.activity.id)
+                    }
+                })
                 .sum()
         };
 
@@ -1105,7 +1174,11 @@ async fn run_view(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use devenv_activity::test_helpers::process_start;
+    use devenv_activity::test_helpers::{
+        build_complete, build_start_with, evaluate_complete, evaluate_start_with,
+        operation_complete, operation_start, process_start,
+    };
+    use devenv_activity::{ActivityLevel, ActivityOutcome};
     use tokio::sync::mpsc;
 
     #[test]
@@ -1237,5 +1310,84 @@ mod tests {
         let up = KeyEvent::new(KeyEventKind::Press, KeyCode::Up);
         assert!(handle_process_search_key(&up, &model, &mut ui_state));
         assert_eq!(ui_state.selected_activity, Some(1));
+    }
+
+    #[test]
+    fn enter_toggles_completed_shell_summary() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(operation_start(1, "Building shell"));
+        model.apply_activity_event(evaluate_start_with(
+            2,
+            "Evaluating Nix",
+            ActivityLevel::Info,
+            Some(1),
+        ));
+        model.apply_activity_event(build_start_with(3, "hello", Some(2)));
+        model.apply_activity_event(build_complete(3, ActivityOutcome::Success));
+        model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+        model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        ui_state.inline_logs_activity = Some(1);
+
+        activate_selected_activity(&model, &mut ui_state);
+        assert!(ui_state.expanded_activities.contains(&1));
+        assert_eq!(ui_state.inline_logs_activity, None);
+
+        activate_selected_activity(&model, &mut ui_state);
+        assert!(!ui_state.expanded_activities.contains(&1));
+    }
+
+    #[test]
+    fn directional_open_expands_shell_and_process() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(operation_start(1, "Building shell"));
+        model.apply_activity_event(evaluate_start_with(
+            2,
+            "Evaluating Nix",
+            ActivityLevel::Info,
+            Some(1),
+        ));
+        model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+        model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+        model.apply_activity_event(process_start(3, "api"));
+
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        expand_selected_activity(&model, &mut ui_state);
+        expand_selected_activity(&model, &mut ui_state);
+        assert!(ui_state.expanded_activities.contains(&1));
+
+        ui_state.selected_activity = Some(3);
+        expand_selected_activity(&model, &mut ui_state);
+        assert_eq!(ui_state.inline_logs_activity, Some(3));
+    }
+
+    #[test]
+    fn directional_close_collapses_shell_and_process() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(operation_start(1, "Building shell"));
+        model.apply_activity_event(evaluate_start_with(
+            2,
+            "Evaluating Nix",
+            ActivityLevel::Info,
+            Some(1),
+        ));
+        model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+        model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+        model.apply_activity_event(process_start(3, "api"));
+
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        ui_state.expanded_activities.insert(1);
+        collapse_selected_activity(&model, &mut ui_state);
+        collapse_selected_activity(&model, &mut ui_state);
+        assert!(!ui_state.expanded_activities.contains(&1));
+
+        ui_state.selected_activity = Some(3);
+        ui_state.inline_logs_activity = Some(3);
+        collapse_selected_activity(&model, &mut ui_state);
+        assert_eq!(ui_state.inline_logs_activity, None);
     }
 }

--- a/devenv-tui/src/app.rs
+++ b/devenv-tui/src/app.rs
@@ -599,6 +599,89 @@ fn scroll_selected_into_view(
     }
 }
 
+fn update_process_search_selection(model: &ActivityModel, ui_state: &mut UiState) {
+    let Some(query) = ui_state
+        .process_search
+        .as_ref()
+        .map(|search| search.query.clone())
+    else {
+        return;
+    };
+    let matches = model.get_matching_process_activity_ids(ui_state, &query);
+    if !ui_state
+        .selected_activity
+        .is_some_and(|id| matches.contains(&id))
+    {
+        ui_state.selected_activity = matches.first().copied();
+    }
+}
+
+fn handle_process_search_key(
+    key_event: &KeyEvent,
+    model: &ActivityModel,
+    ui_state: &mut UiState,
+) -> bool {
+    if ui_state.process_search.is_none() {
+        return false;
+    }
+
+    match key_event.code {
+        KeyCode::Esc => {
+            ui_state.cancel_process_search();
+            if ui_state
+                .selected_activity
+                .is_some_and(|id| !model.is_selectable(id, ui_state))
+            {
+                ui_state.selected_activity = None;
+            }
+        }
+        KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
+            ui_state.cancel_process_search();
+            if ui_state
+                .selected_activity
+                .is_some_and(|id| !model.is_selectable(id, ui_state))
+            {
+                ui_state.selected_activity = None;
+            }
+        }
+        KeyCode::Enter => ui_state.finish_process_search(),
+        KeyCode::Backspace => {
+            if let Some(search) = &mut ui_state.process_search {
+                search.query.pop();
+            }
+            update_process_search_selection(model, ui_state);
+        }
+        KeyCode::Down | KeyCode::Up => {
+            let query = ui_state
+                .process_search
+                .as_ref()
+                .map(|search| search.query.as_str())
+                .unwrap_or_default();
+            let matches = model.get_matching_process_activity_ids(ui_state, query);
+            if !ui_state
+                .selected_activity
+                .is_some_and(|id| matches.contains(&id))
+            {
+                ui_state.selected_activity = None;
+            }
+            let forward = matches!(key_event.code, KeyCode::Down);
+            ui_state.select_activity(&matches, forward);
+        }
+        KeyCode::Char(character)
+            if !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            if let Some(search) = &mut ui_state.process_search {
+                search.query.push(character);
+            }
+            update_process_search_selection(model, ui_state);
+        }
+        _ => {}
+    }
+
+    true
+}
+
 /// Main TUI component (inline mode)
 #[component]
 fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
@@ -664,7 +747,34 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 && key_event.kind != KeyEventKind::Release
             {
                 debug!("Key event: {:?}", key_event);
-                if !handle_interrupt_prompt_key(&key_event, &ui_state, &shutdown, event_tx.as_ref())
+                let search_handled = if let Ok(model) = activity_model.read()
+                    && let Ok(mut ui) = ui_state.write()
+                {
+                    let handled = handle_process_search_key(&key_event, &model, &mut ui);
+                    if handled
+                        && let Some(selected_id) = ui.selected_activity
+                        && *scroll_view_active.read()
+                    {
+                        let display = model.get_display_activities(&ui);
+                        let heights = activity_heights.read();
+                        scroll_selected_into_view(
+                            &mut scroll_handle.write(),
+                            &heights,
+                            &display,
+                            selected_id,
+                        );
+                    }
+                    handled
+                } else {
+                    false
+                };
+                if !search_handled
+                    && !handle_interrupt_prompt_key(
+                        &key_event,
+                        &ui_state,
+                        &shutdown,
+                        event_tx.as_ref(),
+                    )
                 {
                     match key_event.code {
                         KeyCode::Char('c')
@@ -741,7 +851,36 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                     && !model.is_selectable(id, &ui)
                                 {
                                     ui.selected_activity = None;
+                                    ui.inline_logs_activity = None;
                                 }
+                            }
+                        }
+                        KeyCode::Char('/')
+                            if !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                                && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+                        {
+                            if let Ok(model) = activity_model.read()
+                                && let Ok(mut ui) = ui_state.write()
+                            {
+                                ui.start_process_search();
+                                update_process_search_selection(&model, &mut ui);
+                                if let Some(selected_id) = ui.selected_activity
+                                    && *scroll_view_active.read()
+                                {
+                                    let display = model.get_display_activities(&ui);
+                                    let heights = activity_heights.read();
+                                    scroll_selected_into_view(
+                                        &mut scroll_handle.write(),
+                                        &heights,
+                                        &display,
+                                        selected_id,
+                                    );
+                                }
+                            }
+                        }
+                        KeyCode::Enter => {
+                            if let Ok(mut ui) = ui_state.write() {
+                                ui.toggle_inline_logs();
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') | KeyCode::Up | KeyCode::Char('k') => {
@@ -752,6 +891,7 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                                 let forward =
                                     matches!(key_event.code, KeyCode::Down | KeyCode::Char('j'));
                                 ui.select_activity(&selectable, forward);
+                                ui.inline_logs_activity = None;
                                 if let Some(selected_id) = ui.selected_activity
                                     && *scroll_view_active.read()
                                 {
@@ -768,9 +908,17 @@ fn MainView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         }
                         KeyCode::Esc => {
                             if let Ok(mut ui) = ui_state.write() {
-                                ui.selected_activity = None;
+                                if ui.inline_logs_activity.is_some() {
+                                    ui.inline_logs_activity = None;
+                                } else {
+                                    ui.selected_activity = None;
+                                }
                             }
-                            if *scroll_view_active.read() {
+                            if ui_state
+                                .read()
+                                .is_ok_and(|ui| ui.selected_activity.is_none())
+                                && *scroll_view_active.read()
+                            {
                                 scroll_handle.write().scroll_to_bottom();
                             }
                         }
@@ -957,6 +1105,7 @@ async fn run_view(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use devenv_activity::test_helpers::process_start;
     use tokio::sync::mpsc;
 
     #[test]
@@ -1040,5 +1189,53 @@ mod tests {
             rx.try_recv(),
             Ok(FrontendEvent::Process(ProcessCommand::StopManager))
         ));
+    }
+
+    #[test]
+    fn process_search_updates_selection_and_can_be_cancelled() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(process_start(1, "alpha"));
+        model.apply_activity_event(process_start(2, "beta"));
+
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        ui_state.start_process_search();
+        update_process_search_selection(&model, &mut ui_state);
+
+        let e = KeyEvent::new(KeyEventKind::Press, KeyCode::Char('e'));
+        assert!(handle_process_search_key(&e, &model, &mut ui_state));
+        assert_eq!(ui_state.selected_activity, Some(2));
+        assert_eq!(
+            ui_state
+                .process_search
+                .as_ref()
+                .map(|search| search.query.as_str()),
+            Some("e")
+        );
+
+        let escape = KeyEvent::new(KeyEventKind::Press, KeyCode::Esc);
+        assert!(handle_process_search_key(&escape, &model, &mut ui_state));
+        assert_eq!(ui_state.selected_activity, Some(1));
+        assert!(ui_state.process_search.is_none());
+    }
+
+    #[test]
+    fn process_search_arrows_cycle_matching_processes() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(process_start(1, "scope-api"));
+        model.apply_activity_event(process_start(2, "scope-consumer"));
+
+        let mut ui_state = UiState::new();
+        ui_state.start_process_search();
+        update_process_search_selection(&model, &mut ui_state);
+        assert_eq!(ui_state.selected_activity, Some(1));
+
+        let down = KeyEvent::new(KeyEventKind::Press, KeyCode::Down);
+        assert!(handle_process_search_key(&down, &model, &mut ui_state));
+        assert_eq!(ui_state.selected_activity, Some(2));
+
+        let up = KeyEvent::new(KeyEventKind::Press, KeyCode::Up);
+        assert!(handle_process_search_key(&up, &model, &mut ui_state));
+        assert_eq!(ui_state.selected_activity, Some(1));
     }
 }

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -253,11 +253,17 @@ pub fn format_elapsed_time(elapsed: Duration, high_resolution: bool) -> String {
 /// Only used for nested items (depth > 0). Top-level items don't need hierarchy rendering.
 pub struct HierarchyPrefixComponent {
     pub depth: usize,
+    pub ancestor_continuations: Vec<bool>,
+    pub is_last_sibling: bool,
 }
 
 impl HierarchyPrefixComponent {
-    pub fn new(depth: usize) -> Self {
-        Self { depth }
+    pub fn new(depth: usize, ancestor_continuations: &[bool], is_last_sibling: bool) -> Self {
+        Self {
+            depth,
+            ancestor_continuations: ancestor_continuations.to_vec(),
+            is_last_sibling,
+        }
     }
 
     /// Renders the hierarchy prefix: `[indent][branch]`
@@ -267,15 +273,16 @@ impl HierarchyPrefixComponent {
             return vec![];
         }
 
-        // Indentation: 2 spaces for status indicator width + 2 spaces per additional nesting level
-        let status_indicator_offset = 2;
-        let nesting_indent = "  ".repeat(self.depth - 1);
-        let total_indent = format!("{}{}", " ".repeat(status_indicator_offset), nesting_indent);
+        let mut total_indent = "  ".to_string();
+        for continues in &self.ancestor_continuations {
+            total_indent.push_str(if *continues { "│ " } else { "  " });
+        }
+        let branch = if self.is_last_sibling { "└" } else { "├" };
 
         vec![
-            element!(Text(content: total_indent)).into_any(),
+            element!(Text(content: total_indent, color: COLOR_HIERARCHY)).into_any(),
             element!(View(margin_right: 1) {
-                Text(content: "└", color: COLOR_HIERARCHY)
+                Text(content: branch, color: COLOR_HIERARCHY)
             })
             .into_any(),
         ]
@@ -554,6 +561,8 @@ pub struct DownloadActivityComponent<'a> {
     pub completed: Option<bool>,
     /// Whether this activity's result was cached
     pub cached: bool,
+    pub ancestor_continuations: Vec<bool>,
+    pub is_last_sibling: bool,
 }
 
 impl<'a> DownloadActivityComponent<'a> {
@@ -564,7 +573,19 @@ impl<'a> DownloadActivityComponent<'a> {
             is_selected,
             completed: None,
             cached: false,
+            ancestor_continuations: Vec::new(),
+            is_last_sibling: true,
         }
+    }
+
+    pub fn with_hierarchy(
+        mut self,
+        ancestor_continuations: &[bool],
+        is_last_sibling: bool,
+    ) -> Self {
+        self.ancestor_continuations = ancestor_continuations.to_vec();
+        self.is_last_sibling = is_last_sibling;
+        self
     }
 
     pub fn with_completed(mut self, completed: Option<bool>) -> Self {
@@ -591,7 +612,12 @@ impl<'a> DownloadActivityComponent<'a> {
         let mut elements = vec![];
 
         // First line: activity name with hierarchy prefix and status indicator
-        let mut prefix = HierarchyPrefixComponent::new(self.depth).render();
+        let mut prefix = HierarchyPrefixComponent::new(
+            self.depth,
+            &self.ancestor_continuations,
+            self.is_last_sibling,
+        )
+        .render();
         prefix.push(
             element!(View(margin_right: 1) {
                 StatusIndicator(completed: self.completed, show_spinner: true)

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -961,10 +961,14 @@ impl<'a> ExpandedContentComponent<'a> {
             return lines;
         };
 
-        // Left margin + border + the leading content space + right margin.
-        let width = terminal_width
-            .saturating_sub(self.border_indent() + 3)
-            .max(1);
+        let occupied_width = self.line_prefix.as_ref().map_or_else(
+            || self.border_indent() + 3,
+            |prefix| {
+                use unicode_width::UnicodeWidthStr;
+                prefix.width() + 3
+            },
+        );
+        let width = terminal_width.saturating_sub(occupied_width).max(1);
         lines
             .into_iter()
             .flat_map(|line| hard_wrap(&line, width))
@@ -990,7 +994,7 @@ impl<'a> ExpandedContentComponent<'a> {
                         element! {
                             View(flex_direction: FlexDirection::Row, padding_right: 1) {
                                 Text(content: prefix.clone(), color: COLOR_HIERARCHY)
-                                Text(content: line, color: Color::Reset)
+                                Text(content: format!("  {line}"), color: Color::AnsiValue(245))
                             }
                         }
                         .into_any()
@@ -1014,7 +1018,7 @@ impl<'a> ExpandedContentComponent<'a> {
                 .into_iter()
                 .map(|line| {
                     element! {
-                        Text(content: format!(" {line}"), color: Color::Reset)
+                        Text(content: format!(" {line}"), color: Color::AnsiValue(245))
                     }
                     .into_any()
                 })
@@ -1052,7 +1056,7 @@ impl<'a> ExpandedContentComponent<'a> {
                 element! {
                     View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
                         Text(content: prefix.clone(), color: COLOR_HIERARCHY)
-                        Text(content: empty_message, color: Color::Reset)
+                        Text(content: format!("  {empty_message}"), color: Color::AnsiValue(245))
                     }
                 }
                 .into_any(),
@@ -1060,7 +1064,7 @@ impl<'a> ExpandedContentComponent<'a> {
         }
         vec![element! {
             View(height: 1, flex_direction: FlexDirection::Column, padding_left: indent as u32, padding_right: 1) {
-                Text(content: empty_message, color: Color::Reset)
+                Text(content: empty_message, color: Color::AnsiValue(245))
             }
         }
         .into_any()]

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -295,6 +295,7 @@ pub struct ActivityTextComponent {
     pub name: String,
     pub suffix: Option<String>,
     pub is_selected: bool,
+    pub is_dimmed: bool,
     pub elapsed: String,
     pub is_completed: bool,
     pub variant: ActivityVariant,
@@ -307,6 +308,7 @@ impl ActivityTextComponent {
             name,
             suffix: None,
             is_selected: false,
+            is_dimmed: false,
             elapsed,
             is_completed: false,
             variant,
@@ -329,9 +331,35 @@ impl ActivityTextComponent {
         self
     }
 
+    pub fn with_dimmed(mut self, is_dimmed: bool) -> Self {
+        self.is_dimmed = is_dimmed;
+        self
+    }
+
     pub fn with_completed(mut self, completed: bool) -> Self {
         self.is_completed = completed;
         self
+    }
+
+    fn colors(&self, depth: usize) -> (Color, Color, Color, Option<Color>) {
+        if self.is_selected {
+            (
+                Color::AnsiValue(232),
+                Color::AnsiValue(238),
+                Color::AnsiValue(238),
+                Some(Color::AnsiValue(250)),
+            )
+        } else if self.is_dimmed {
+            (COLOR_HIERARCHY, COLOR_HIERARCHY, COLOR_HIERARCHY, None)
+        } else if self.is_completed && depth == 0 {
+            (Color::Reset, COLOR_SECONDARY, COLOR_HIERARCHY, None)
+        } else if self.is_completed {
+            (COLOR_ACTIVE_NESTED, COLOR_SECONDARY, COLOR_HIERARCHY, None)
+        } else if depth == 0 || matches!(self.variant, ActivityVariant::Process(_)) {
+            (COLOR_ACTIVE, COLOR_SECONDARY, COLOR_HIERARCHY, None)
+        } else {
+            (COLOR_ACTIVE_NESTED, COLOR_SECONDARY, COLOR_HIERARCHY, None)
+        }
     }
 
     pub fn render(
@@ -359,24 +387,7 @@ impl ActivityTextComponent {
             depth,
         );
 
-        // Colors: blue when active, green when completed
-        // Selected rows get inverted colors
-        let (name_color, suffix_color, elapsed_color, bg_color) = if self.is_selected {
-            (
-                Color::AnsiValue(232),       // Near-black text
-                Color::AnsiValue(238),       // Dark gray for suffix
-                Color::AnsiValue(238),       // Dark gray for elapsed
-                Some(Color::AnsiValue(250)), // Light gray background
-            )
-        } else if self.is_completed && depth == 0 {
-            (Color::Reset, COLOR_SECONDARY, COLOR_HIERARCHY, None)
-        } else if self.is_completed {
-            (COLOR_ACTIVE_NESTED, COLOR_SECONDARY, COLOR_HIERARCHY, None)
-        } else if depth == 0 || matches!(self.variant, ActivityVariant::Process(_)) {
-            (COLOR_ACTIVE, COLOR_SECONDARY, COLOR_HIERARCHY, None)
-        } else {
-            (COLOR_ACTIVE_NESTED, COLOR_SECONDARY, COLOR_HIERARCHY, None)
-        };
+        let (name_color, suffix_color, elapsed_color, bg_color) = self.colors(depth);
 
         let mut final_prefix = prefix_children;
 
@@ -1130,6 +1141,34 @@ pub type BuildLogsComponent<'a> = ExpandedContentComponent<'a>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dimmed_activity_uses_hierarchy_colors() {
+        let component = ActivityTextComponent::name_only(
+            "email-worker".to_string(),
+            "1.0s".to_string(),
+            ActivityVariant::Process(crate::model::ProcessActivity {
+                status: ProcessStatus::Ready,
+                ports: vec![],
+                ready_probe: None,
+            }),
+        )
+        .with_dimmed(true);
+
+        assert_eq!(
+            component.colors(1),
+            (COLOR_HIERARCHY, COLOR_HIERARCHY, COLOR_HIERARCHY, None)
+        );
+        assert_eq!(
+            component.with_selection(true).colors(1),
+            (
+                Color::AnsiValue(232),
+                Color::AnsiValue(238),
+                Color::AnsiValue(238),
+                Some(Color::AnsiValue(250))
+            )
+        );
+    }
 
     #[test]
     fn process_status_dot_covers_every_lifecycle_phase() {

--- a/devenv-tui/src/components.rs
+++ b/devenv-tui/src/components.rs
@@ -892,6 +892,8 @@ pub struct ExpandedContentComponent<'a> {
     pub max_lines: usize,
     pub depth: usize,
     pub terminal_width: Option<usize>,
+    border_indent: Option<usize>,
+    line_prefix: Option<String>,
 }
 
 impl<'a> ExpandedContentComponent<'a> {
@@ -902,6 +904,8 @@ impl<'a> ExpandedContentComponent<'a> {
             max_lines: LOG_VIEWPORT_COLLAPSED,
             depth: 0,
             terminal_width: None,
+            border_indent: None,
+            line_prefix: None,
         }
     }
 
@@ -925,6 +929,20 @@ impl<'a> ExpandedContentComponent<'a> {
         self
     }
 
+    pub fn with_border_indent(mut self, indent: usize) -> Self {
+        self.border_indent = Some(indent);
+        self
+    }
+
+    pub fn with_line_prefix(mut self, prefix: String) -> Self {
+        self.line_prefix = Some(prefix);
+        self
+    }
+
+    fn border_indent(&self) -> usize {
+        self.border_indent.unwrap_or(2 + self.depth * 2)
+    }
+
     /// The last `max_lines` logical log lines, preserving chronological order.
     /// Long unbroken strings are hard-wrapped here because a `Text` child's
     /// intrinsic width can otherwise expand its parent beyond the terminal.
@@ -944,23 +962,59 @@ impl<'a> ExpandedContentComponent<'a> {
         };
 
         // Left margin + border + the leading content space + right margin.
-        let width = terminal_width.saturating_sub(2 + self.depth * 2 + 3).max(1);
+        let width = terminal_width
+            .saturating_sub(self.border_indent() + 3)
+            .max(1);
         lines
             .into_iter()
             .flat_map(|line| hard_wrap(&line, width))
             .collect()
     }
 
+    pub fn visual_height(&self) -> usize {
+        self.visible_lines()
+            .len()
+            .max(1)
+            .min(INLINE_LOG_MAX_VISUAL_ROWS.saturating_sub(1) as usize)
+    }
+
     pub fn render(&self) -> Vec<AnyElement<'static>> {
-        let indent = 2 + (self.depth * 2);
+        let indent = self.border_indent();
 
         let lines = self.visible_lines();
         if !lines.is_empty() {
+            if let Some(prefix) = &self.line_prefix {
+                let line_elements: Vec<AnyElement<'static>> = lines
+                    .into_iter()
+                    .map(|line| {
+                        element! {
+                            View(flex_direction: FlexDirection::Row, padding_right: 1) {
+                                Text(content: prefix.clone(), color: COLOR_HIERARCHY)
+                                Text(content: line, color: Color::Reset)
+                            }
+                        }
+                        .into_any()
+                    })
+                    .collect();
+
+                return vec![
+                    element! {
+                    View(
+                        flex_direction: FlexDirection::Column,
+                        overflow: Overflow::Hidden,
+                    ) {
+                        #(line_elements)
+                        }
+                    }
+                    .into_any(),
+                ];
+            }
+
             let line_elements: Vec<AnyElement<'static>> = lines
                 .into_iter()
                 .map(|line| {
                     element! {
-                        Text(content: format!(" {line}"), color: Color::AnsiValue(245))
+                        Text(content: format!(" {line}"), color: Color::Reset)
                     }
                     .into_any()
                 })
@@ -975,7 +1029,7 @@ impl<'a> ExpandedContentComponent<'a> {
                         margin_right: 1,
                         border_style: BorderStyle::Single,
                         border_edges: Edges::Left,
-                        border_color: Color::AnsiValue(245),
+                        border_color: COLOR_HIERARCHY,
                     ) {
                         #(line_elements)
                     }
@@ -993,9 +1047,20 @@ impl<'a> ExpandedContentComponent<'a> {
                 hard_wrap(self.empty_message, budget).into_iter().next()
             })
             .unwrap_or_else(|| self.empty_message.to_string());
+        if let Some(prefix) = &self.line_prefix {
+            return vec![
+                element! {
+                    View(height: 1, flex_direction: FlexDirection::Row, padding_right: 1) {
+                        Text(content: prefix.clone(), color: COLOR_HIERARCHY)
+                        Text(content: empty_message, color: Color::Reset)
+                    }
+                }
+                .into_any(),
+            ];
+        }
         vec![element! {
             View(height: 1, flex_direction: FlexDirection::Column, padding_left: indent as u32, padding_right: 1) {
-                Text(content: empty_message, color: Color::AnsiValue(245))
+                Text(content: empty_message, color: Color::Reset)
             }
         }
         .into_any()]
@@ -1356,5 +1421,21 @@ mod tests {
             "expected URL to appear intact in wrapped output:\n{}",
             out
         );
+    }
+
+    #[test]
+    fn expanded_content_supports_explicit_border_alignment() {
+        let logs = VecDeque::from(["one".to_string()]);
+        let elements = ExpandedContentComponent::new(Some(&logs))
+            .with_border_indent(2)
+            .render();
+        let mut element = element! {
+            View(width: 40u32, flex_direction: FlexDirection::Column) {
+                #(elements)
+            }
+        };
+        let rendered = element.render(Some(40)).to_string();
+
+        assert!(rendered.contains("  │ one"), "{rendered}");
     }
 }

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -9,7 +9,7 @@ use crate::TuiConfig;
 use crate::app::{
     ExitFlag, ProcessCommandSender, handle_interrupt_prompt_key, request_interrupt_prompt,
 };
-use crate::components::COLOR_COMPLETED;
+use crate::components::{COLOR_COMPLETED, COLOR_INTERACTIVE};
 use crate::model::{ActivityModel, UiState, ViewMode};
 use base64::Engine;
 use crossterm::event::MouseButton;
@@ -1337,6 +1337,10 @@ fn search_result_text(search: LogSearchView<'_>) -> String {
     }
 }
 
+fn expanded_footer_piece(content: impl Into<String>, color: Color) -> AnyElement<'static> {
+    element!(Text(content: content.into(), color: color)).into_any()
+}
+
 /// Render the expanded view UI
 fn render_expanded_view(
     state: &ExpandedViewState,
@@ -1383,23 +1387,54 @@ fn render_expanded_view(
     };
 
     let footer = if interrupt_prompt_active {
-        let footer_text = if interrupt_prompt_attached {
-            format!(
-                "{} \u{2502} {} \u{2502} Detach or stop the process manager?  Ctrl-C:detach  s:stop manager  Esc:keep watching",
-                follow_status, progress
-            )
-        } else if width < 88 {
-            format!(
-                "{} \u{2502} {} \u{2502} Quit devenv?  c:keep running  q/Ctrl-C:quit",
-                follow_status, progress
-            )
+        let mut footer_children = vec![expanded_footer_piece(
+            format!("{} \u{2502} {} \u{2502} ", follow_status, progress),
+            Color::AnsiValue(245),
+        )];
+        if interrupt_prompt_attached {
+            footer_children.push(expanded_footer_piece(
+                "Detach or stop the process manager?  ",
+                Color::AnsiValue(245),
+            ));
+            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":detach  ", Color::AnsiValue(245)));
+            footer_children.push(expanded_footer_piece("s", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(
+                ":stop manager  ",
+                Color::AnsiValue(245),
+            ));
+            footer_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(
+                ":keep watching",
+                Color::AnsiValue(245),
+            ));
         } else {
-            format!(
-                "{} \u{2502} {} \u{2502} Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  Ctrl-C:quit",
-                follow_status, progress
-            )
-        };
-        element!(Text(content: footer_text, color: Color::AnsiValue(245))).into_any()
+            footer_children.push(expanded_footer_piece(
+                if width < 88 {
+                    "Quit devenv?  "
+                } else {
+                    "Quit devenv? Nothing has been stopped yet  "
+                },
+                Color::AnsiValue(245),
+            ));
+            footer_children.push(expanded_footer_piece("c", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(
+                ":keep running  ",
+                Color::AnsiValue(245),
+            ));
+            footer_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":quit  ", Color::AnsiValue(245)));
+            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":quit", Color::AnsiValue(245)));
+        }
+        element!(View(
+            flex_direction: FlexDirection::Row,
+            width: 100pct,
+            overflow: Overflow::Hidden,
+        ) {
+            #(footer_children)
+        })
+        .into_any()
     } else if let Some(search) = ui.search.filter(|search| search.editing) {
         let prompt = format!("Search logs: /{}", search.query);
         let result = search_result_text(search);
@@ -1417,8 +1452,12 @@ fn render_expanded_view(
             View(flex_grow: 1.0, flex_shrink: 0.0, min_width: 0, overflow: Overflow::Hidden) {
                 Text(content: prompt, color: prompt_color, weight: Weight::Bold)
             }
-            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
-                Text(content: format!("{result}  Enter:select Esc:cancel"), color: Color::AnsiValue(245))
+            View(flex_direction: FlexDirection::Row, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
+                Text(content: format!("{result}  "), color: Color::AnsiValue(245))
+                Text(content: "Enter", color: COLOR_INTERACTIVE)
+                Text(content: ":select ", color: Color::AnsiValue(245))
+                Text(content: "Esc", color: COLOR_INTERACTIVE)
+                Text(content: ":cancel", color: Color::AnsiValue(245))
             }
         }).into_any()
     } else if let Some(notice) = ui.copy_notice {
@@ -1440,17 +1479,30 @@ fn render_expanded_view(
         } else {
             Color::AnsiValue(220)
         };
-        let search_text = if width < 90 {
-            format!(
-                "/{query}  {result}  n/N  /:new  Esc:clear",
-                query = search.query
-            )
-        } else {
-            format!(
-                "/{query}  {result}  n/N:match  /:new search  Esc:clear  q:back",
-                query = search.query
-            )
-        };
+        let mut search_children = vec![
+            expanded_footer_piece(format!("/{}", search.query), search_color),
+            expanded_footer_piece(format!("  {result}  "), Color::AnsiValue(245)),
+            expanded_footer_piece("n/N", COLOR_INTERACTIVE),
+            expanded_footer_piece(
+                if width < 90 { "  " } else { ":match  " },
+                Color::AnsiValue(245),
+            ),
+            expanded_footer_piece("/", COLOR_INTERACTIVE),
+            expanded_footer_piece(
+                if width < 90 {
+                    ":new  "
+                } else {
+                    ":new search  "
+                },
+                Color::AnsiValue(245),
+            ),
+            expanded_footer_piece("Esc", COLOR_INTERACTIVE),
+            expanded_footer_piece(":clear", Color::AnsiValue(245)),
+        ];
+        if width >= 90 {
+            search_children.push(expanded_footer_piece("  q", COLOR_INTERACTIVE));
+            search_children.push(expanded_footer_piece(":back", Color::AnsiValue(245)));
+        }
         element!(View(
             flex_direction: FlexDirection::Row,
             justify_content: JustifyContent::SpaceBetween,
@@ -1463,32 +1515,61 @@ fn render_expanded_view(
                     color: Color::AnsiValue(245)
                 )
             }
-            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
-                Text(content: search_text, color: search_color, weight: Weight::Bold)
+            View(flex_direction: FlexDirection::Row, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
+                #(search_children)
             }
         })
         .into_any()
     } else {
-        let copy_hint = if ui.selection.is_some() {
-            "y:copy  Ctrl-C:copy"
+        let mut footer_children = vec![expanded_footer_piece(
+            format!("{} \u{2502} {} \u{2502} ", follow_status, progress),
+            Color::AnsiValue(245),
+        )];
+        if ui.selection.is_some() {
+            footer_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
+            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
         } else {
-            "y:copy all"
-        };
-        let footer_text = if width < 90 {
-            format!(
-                "{} \u{2502} {} \u{2502} {}  j/k  ^D/^U  ^F/^B  /  g/G  q",
-                follow_status, progress, copy_hint
-            )
-        } else {
-            format!(
-                "{} \u{2502} {} \u{2502} {}  j/k:line  ^D/^U:half  ^F/^B:page  /:search  g/G:top/follow  q:back",
-                follow_status, progress, copy_hint
-            )
-        };
-        element!(Text(
-            content: footer_text,
-            color: Color::AnsiValue(245)
-        ))
+            footer_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
+            footer_children.push(expanded_footer_piece(":copy all  ", Color::AnsiValue(245)));
+        }
+        footer_children.push(expanded_footer_piece("↑↓ j/k", COLOR_INTERACTIVE));
+        footer_children.push(expanded_footer_piece(
+            if width < 90 { "  " } else { ":line  " },
+            Color::AnsiValue(245),
+        ));
+        footer_children.push(expanded_footer_piece("^D/^U", COLOR_INTERACTIVE));
+        footer_children.push(expanded_footer_piece(
+            if width < 90 { "  " } else { ":half  " },
+            Color::AnsiValue(245),
+        ));
+        footer_children.push(expanded_footer_piece("^F/^B", COLOR_INTERACTIVE));
+        footer_children.push(expanded_footer_piece(
+            if width < 90 { "  " } else { ":page  " },
+            Color::AnsiValue(245),
+        ));
+        footer_children.push(expanded_footer_piece("/", COLOR_INTERACTIVE));
+        footer_children.push(expanded_footer_piece(
+            if width < 90 { "  " } else { ":search  " },
+            Color::AnsiValue(245),
+        ));
+        footer_children.push(expanded_footer_piece("g/G", COLOR_INTERACTIVE));
+        footer_children.push(expanded_footer_piece(
+            if width < 90 { "  " } else { ":top/follow  " },
+            Color::AnsiValue(245),
+        ));
+        footer_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
+        if width >= 90 {
+            footer_children.push(expanded_footer_piece(":back", Color::AnsiValue(245)));
+        }
+        element!(View(
+            flex_direction: FlexDirection::Row,
+            width: 100pct,
+            overflow: Overflow::Hidden,
+        ) {
+            #(footer_children)
+        })
         .into_any()
     };
 
@@ -1880,6 +1961,8 @@ mod tests {
         let following_output = following.render(Some(100)).to_string();
         assert!(following_output.contains("FOLLOWING"));
         assert!(following_output.contains("y:copy all"));
+        assert!(following_output.contains("↑↓ j/k:line"));
+        assert!(following_output.contains("^D/^U:half"));
 
         let mut paused = render_expanded_view(
             &state,

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -64,6 +64,48 @@ enum LogScrollAction {
     Bottom,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogSearchCursor {
+    log_line: usize,
+    char_start: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogSearchOrigin {
+    offset: usize,
+    scroll_mode: ScrollMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogSearchState {
+    query: String,
+    current: Option<LogSearchCursor>,
+    editing: bool,
+    origin: LogSearchOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogSearchMatch {
+    log_line: usize,
+    char_start: usize,
+    char_end: usize,
+}
+
+#[derive(Clone, Copy)]
+struct LogSearchView<'a> {
+    query: &'a str,
+    matches: &'a [LogSearchMatch],
+    current: Option<LogSearchCursor>,
+    editing: bool,
+}
+
+struct ExpandedViewUi<'a> {
+    selection: Option<&'a Selection>,
+    search: Option<LogSearchView<'a>>,
+    scroll_mode: ScrollMode,
+    interrupt_prompt: (bool, bool),
+}
+
 impl Selection {
     /// Create a selection from anchor and cursor, normalizing so start <= end.
     fn from_anchor_cursor(anchor: (usize, usize), cursor: (usize, usize)) -> Self {
@@ -130,6 +172,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut scroll_offset = hooks.use_state(|| 0usize);
     let mut follow_tail = hooks.use_state(|| true);
     let mut scroll_anchor = hooks.use_state(|| None::<ScrollAnchor>);
+    let mut log_search = hooks.use_state(|| None::<LogSearchState>);
 
     // Selection state. Coordinates are (log_line_idx, visual_col) where
     // visual_col is a logical character offset within the log line, regardless
@@ -178,6 +221,25 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         || Arc::new(build_visual_rows(&state.logs, content_width)),
         (Arc::as_ptr(&state.logs) as usize, content_width),
     );
+    let search_query = log_search
+        .read()
+        .as_ref()
+        .map(|search| search.query.clone())
+        .unwrap_or_default();
+    let search_matches: Arc<Vec<LogSearchMatch>> = hooks.use_memo(
+        || {
+            Arc::new(find_log_matches(
+                &state.logs,
+                state.buffer_start_line,
+                &search_query,
+            ))
+        },
+        (
+            Arc::as_ptr(&state.logs) as usize,
+            state.buffer_start_line,
+            search_query.clone(),
+        ),
+    );
     let total_visual_rows = visual_rows.len();
     let current_selection_anchor = selection_anchor.get();
     let current_selection_cursor = selection_cursor.get();
@@ -211,6 +273,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     &visual_rows_for_events,
                     total_visual_rows,
                     viewport_height,
+                    &mut log_search,
                     &mut SelectionState {
                         has_selection,
                         anchor: current_selection_anchor,
@@ -276,18 +339,28 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         .read()
         .map(|ui| (ui.interrupt_prompt_active(), ui.interrupt_prompt_attached()))
         .unwrap_or((false, false));
+    let search_state = log_search.read().clone();
+    let search = search_state.as_ref().map(|search| LogSearchView {
+        query: &search.query,
+        matches: &search_matches,
+        current: search.current,
+        editing: search.editing,
+    });
 
     render_expanded_view(
         &state,
         &visual_rows,
         width,
         height,
-        selection.as_ref(),
-        ScrollMode {
-            follow_tail: follow_tail.get(),
-            anchor: scroll_anchor.get(),
+        ExpandedViewUi {
+            selection: selection.as_ref(),
+            search,
+            scroll_mode: ScrollMode {
+                follow_tail: follow_tail.get(),
+                anchor: scroll_anchor.get(),
+            },
+            interrupt_prompt: (interrupt_prompt_active, interrupt_prompt_attached),
         },
-        (interrupt_prompt_active, interrupt_prompt_attached),
     )
 }
 
@@ -519,6 +592,317 @@ fn apply_scroll_action(
     }
 }
 
+fn folded_chars(value: &str) -> Vec<char> {
+    value.chars().flat_map(char::to_lowercase).collect()
+}
+
+fn case_insensitive_match_ranges(line: &str, query: &str) -> Vec<(usize, usize)> {
+    let needle = folded_chars(query);
+    if needle.is_empty() {
+        return vec![];
+    }
+
+    let haystack: Vec<_> = line
+        .chars()
+        .enumerate()
+        .flat_map(|(source_index, character)| {
+            character
+                .to_lowercase()
+                .map(move |folded| (folded, source_index))
+        })
+        .collect();
+    let mut ranges = Vec::new();
+    let mut index = 0;
+
+    while index + needle.len() <= haystack.len() {
+        if haystack[index..index + needle.len()]
+            .iter()
+            .map(|(character, _)| *character)
+            .eq(needle.iter().copied())
+        {
+            let range = (haystack[index].1, haystack[index + needle.len() - 1].1 + 1);
+            if ranges.last().copied() != Some(range) {
+                ranges.push(range);
+            }
+            index += needle.len();
+        } else {
+            index += 1;
+        }
+    }
+
+    ranges
+}
+
+fn find_log_matches(
+    logs: &VecDeque<String>,
+    buffer_start_line: usize,
+    query: &str,
+) -> Vec<LogSearchMatch> {
+    logs.iter()
+        .enumerate()
+        .flat_map(|(log_idx, line)| {
+            case_insensitive_match_ranges(line, query).into_iter().map(
+                move |(char_start, char_end)| LogSearchMatch {
+                    log_line: buffer_start_line + log_idx,
+                    char_start,
+                    char_end,
+                },
+            )
+        })
+        .collect()
+}
+
+fn search_cursor(search_match: LogSearchMatch) -> LogSearchCursor {
+    LogSearchCursor {
+        log_line: search_match.log_line,
+        char_start: search_match.char_start,
+    }
+}
+
+fn choose_search_match(
+    matches: &[LogSearchMatch],
+    current: Option<LogSearchCursor>,
+    current_scroll_offset: usize,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+) -> Option<LogSearchMatch> {
+    if let Some(current) = current
+        && let Some(search_match) = matches
+            .iter()
+            .find(|search_match| search_cursor(**search_match) == current)
+    {
+        return Some(*search_match);
+    }
+
+    let visible_cursor = visual_rows
+        .get(current_scroll_offset)
+        .map(|row| LogSearchCursor {
+            log_line: buffer_start_line + row.log_idx,
+            char_start: row.char_start,
+        });
+
+    visible_cursor
+        .and_then(|cursor| {
+            matches.iter().find(|search_match| {
+                let candidate = search_cursor(**search_match);
+                (candidate.log_line, candidate.char_start) >= (cursor.log_line, cursor.char_start)
+            })
+        })
+        .copied()
+        .or_else(|| matches.first().copied())
+}
+
+fn adjacent_search_match(
+    matches: &[LogSearchMatch],
+    current: Option<LogSearchCursor>,
+    forward: bool,
+) -> Option<LogSearchMatch> {
+    if matches.is_empty() {
+        return None;
+    }
+
+    let index = current.and_then(|current| {
+        matches
+            .iter()
+            .position(|search_match| search_cursor(*search_match) == current)
+    });
+    let next = match (index, forward) {
+        (Some(index), true) => (index + 1) % matches.len(),
+        (Some(0), false) | (None, false) => matches.len() - 1,
+        (Some(index), false) => index - 1,
+        (None, true) => 0,
+    };
+    matches.get(next).copied()
+}
+
+fn visual_offset_for_search_match(
+    search_match: LogSearchMatch,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+) -> Option<usize> {
+    let log_idx = search_match.log_line.checked_sub(buffer_start_line)?;
+    visual_rows.iter().position(|row| {
+        row.log_idx == log_idx
+            && row.char_start <= search_match.char_start
+            && search_match.char_start < row.char_end.max(row.char_start + 1)
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn focus_search_match(
+    search_match: LogSearchMatch,
+    viewport_height: usize,
+    max_offset: usize,
+    scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+) {
+    if let Some(match_offset) =
+        visual_offset_for_search_match(search_match, buffer_start_line, visual_rows)
+    {
+        let offset = match_offset
+            .saturating_sub(viewport_height / 2)
+            .min(max_offset);
+        pause_at_offset(
+            scroll_offset,
+            follow_tail,
+            scroll_anchor,
+            buffer_start_line,
+            visual_rows,
+            offset,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_log_search_key(
+    key_event: &KeyEvent,
+    log_search: &mut State<Option<LogSearchState>>,
+    logs: &VecDeque<String>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+    current_scroll_offset: usize,
+    viewport_height: usize,
+    max_offset: usize,
+    scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+) -> bool {
+    let control = key_event.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key_event.modifiers.contains(KeyModifiers::ALT);
+    let current_search = log_search.read().clone();
+
+    if let Some(mut search) = current_search.clone().filter(|search| search.editing) {
+        if matches!(key_event.code, KeyCode::Esc)
+            || matches!(key_event.code, KeyCode::Char('c')) && control
+        {
+            scroll_offset.set(search.origin.offset);
+            follow_tail.set(search.origin.scroll_mode.follow_tail);
+            scroll_anchor.set(search.origin.scroll_mode.anchor);
+            log_search.set(None);
+            return true;
+        }
+        match key_event.code {
+            KeyCode::Enter => {
+                if search.query.is_empty() {
+                    scroll_offset.set(search.origin.offset);
+                    follow_tail.set(search.origin.scroll_mode.follow_tail);
+                    scroll_anchor.set(search.origin.scroll_mode.anchor);
+                    log_search.set(None);
+                } else {
+                    search.editing = false;
+                    log_search.set(Some(search));
+                }
+            }
+            KeyCode::Backspace => {
+                search.query.pop();
+                let matches = find_log_matches(logs, buffer_start_line, &search.query);
+                let chosen = choose_search_match(
+                    &matches,
+                    search.current,
+                    current_scroll_offset,
+                    buffer_start_line,
+                    visual_rows,
+                );
+                search.current = chosen.map(search_cursor);
+                if let Some(chosen) = chosen {
+                    focus_search_match(
+                        chosen,
+                        viewport_height,
+                        max_offset,
+                        scroll_offset,
+                        follow_tail,
+                        scroll_anchor,
+                        buffer_start_line,
+                        visual_rows,
+                    );
+                }
+                log_search.set(Some(search));
+            }
+            KeyCode::Char(character) if !control && !alt => {
+                search.query.push(character);
+                let matches = find_log_matches(logs, buffer_start_line, &search.query);
+                let chosen = choose_search_match(
+                    &matches,
+                    search.current,
+                    current_scroll_offset,
+                    buffer_start_line,
+                    visual_rows,
+                );
+                search.current = chosen.map(search_cursor);
+                if let Some(chosen) = chosen {
+                    focus_search_match(
+                        chosen,
+                        viewport_height,
+                        max_offset,
+                        scroll_offset,
+                        follow_tail,
+                        scroll_anchor,
+                        buffer_start_line,
+                        visual_rows,
+                    );
+                }
+                log_search.set(Some(search));
+            }
+            _ => {}
+        }
+        return true;
+    }
+
+    if matches!(key_event.code, KeyCode::Char('/')) && !control && !alt {
+        log_search.set(Some(LogSearchState {
+            query: String::new(),
+            current: None,
+            editing: true,
+            origin: LogSearchOrigin {
+                offset: current_scroll_offset,
+                scroll_mode: ScrollMode {
+                    follow_tail: follow_tail.get(),
+                    anchor: scroll_anchor.get(),
+                },
+            },
+        }));
+        return true;
+    }
+
+    let Some(mut search) = current_search else {
+        return false;
+    };
+
+    match key_event.code {
+        KeyCode::Esc => {
+            log_search.set(None);
+            true
+        }
+        KeyCode::Char('n') | KeyCode::Char('N') if !control && !alt => {
+            let matches = find_log_matches(logs, buffer_start_line, &search.query);
+            let chosen = adjacent_search_match(
+                &matches,
+                search.current,
+                matches!(key_event.code, KeyCode::Char('n')),
+            );
+            search.current = chosen.map(search_cursor);
+            if let Some(chosen) = chosen {
+                focus_search_match(
+                    chosen,
+                    viewport_height,
+                    max_offset,
+                    scroll_offset,
+                    follow_tail,
+                    scroll_anchor,
+                    buffer_start_line,
+                    visual_rows,
+                );
+            }
+            log_search.set(Some(search));
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Mutable selection state passed to event handlers.
 struct SelectionState<'a> {
     has_selection: bool,
@@ -554,6 +938,7 @@ fn handle_key_event(
     visual_rows: &[VisualRow],
     total_visual_rows: usize,
     viewport_height: usize,
+    log_search: &mut State<Option<LogSearchState>>,
     sel: &mut SelectionState<'_>,
 ) {
     if handle_interrupt_prompt_key(&key_event, ui_state, shutdown, command_tx) {
@@ -570,6 +955,22 @@ fn handle_key_event(
         total_visual_rows,
         viewport_height,
     );
+
+    if handle_log_search_key(
+        &key_event,
+        log_search,
+        sel.logs,
+        buffer_start_line,
+        visual_rows,
+        current_scroll_offset,
+        viewport_height,
+        max_offset,
+        scroll_offset,
+        follow_tail,
+        scroll_anchor,
+    ) {
+        return;
+    }
 
     if let Some(action) = keyboard_scroll_action(&key_event, viewport_height) {
         apply_scroll_action(
@@ -825,24 +1226,41 @@ fn text_for_yank(
     }
 }
 
+fn search_result_text(search: LogSearchView<'_>) -> String {
+    if search.query.is_empty() {
+        return "type to search".to_string();
+    }
+    if search.matches.is_empty() {
+        return "no matches".to_string();
+    }
+    let current = search.current.and_then(|current| {
+        search
+            .matches
+            .iter()
+            .position(|search_match| search_cursor(*search_match) == current)
+    });
+    match current {
+        Some(index) => format!("{}/{}", index + 1, search.matches.len()),
+        None => format!("{} matches", search.matches.len()),
+    }
+}
+
 /// Render the expanded view UI
 fn render_expanded_view(
     state: &ExpandedViewState,
     visual_rows: &[VisualRow],
     width: u16,
     height: u16,
-    selection: Option<&Selection>,
-    scroll_mode: ScrollMode,
-    interrupt_prompt: (bool, bool),
+    ui: ExpandedViewUi<'_>,
 ) -> AnyElement<'static> {
-    let (interrupt_prompt_active, interrupt_prompt_attached) = interrupt_prompt;
+    let (interrupt_prompt_active, interrupt_prompt_attached) = ui.interrupt_prompt;
     let viewport_height = calculate_viewport_height(height);
     let total_rows = visual_rows.len();
 
     let clamped_offset = resolved_scroll_offset(
         state.scroll_offset,
-        scroll_mode.follow_tail,
-        scroll_mode.anchor,
+        ui.scroll_mode.follow_tail,
+        ui.scroll_mode.anchor,
         state.buffer_start_line,
         visual_rows,
         total_rows,
@@ -857,7 +1275,8 @@ fn render_expanded_view(
         visible_rows,
         &state.logs,
         state.buffer_start_line,
-        selection,
+        ui.selection,
+        ui.search,
     );
     let padding_elements = build_padding_elements(visible_rows.len(), viewport_height);
 
@@ -865,15 +1284,14 @@ fn render_expanded_view(
     content_elements.extend(padding_elements);
 
     let progress = build_progress_indicator(clamped_offset, viewport_height, total_rows);
-    let follow_status = if scroll_mode.follow_tail {
+    let follow_status = if ui.scroll_mode.follow_tail {
         "FOLLOWING"
     } else {
         "PAUSED"
     };
 
-    // Build footer text - show copy hint when selection is active
-    let footer_text = if interrupt_prompt_active {
-        if interrupt_prompt_attached {
+    let footer = if interrupt_prompt_active {
+        let footer_text = if interrupt_prompt_attached {
             format!(
                 "{} \u{2502} {} \u{2502} Detach or stop the process manager?  Ctrl-C:detach  s:stop manager  Esc:keep watching",
                 follow_status, progress
@@ -888,17 +1306,86 @@ fn render_expanded_view(
                 "{} \u{2502} {} \u{2502} Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  Ctrl-C:quit",
                 follow_status, progress
             )
-        }
-    } else if selection.is_some() {
-        format!(
-            "{} \u{2502} {} \u{2502} y:copy  j/k:line  ^D/^U:half  ^F/^B:page  g:top  G:follow  Ctrl-C:copy  Esc:deselect  q:back",
-            follow_status, progress
-        )
+        };
+        element!(Text(content: footer_text, color: Color::AnsiValue(245))).into_any()
+    } else if let Some(search) = ui.search.filter(|search| search.editing) {
+        let prompt = format!("Search logs: /{}", search.query);
+        let result = search_result_text(search);
+        let prompt_color = if search.matches.is_empty() && !search.query.is_empty() {
+            Color::AnsiValue(160)
+        } else {
+            Color::AnsiValue(220)
+        };
+        element!(View(
+            flex_direction: FlexDirection::Row,
+            justify_content: JustifyContent::SpaceBetween,
+            width: 100pct,
+            overflow: Overflow::Hidden,
+        ) {
+            View(flex_grow: 1.0, flex_shrink: 0.0, min_width: 0, overflow: Overflow::Hidden) {
+                Text(content: prompt, color: prompt_color, weight: Weight::Bold)
+            }
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
+                Text(content: format!("{result}  Enter:select Esc:cancel"), color: Color::AnsiValue(245))
+            }
+        }).into_any()
+    } else if let Some(search) = ui.search {
+        let result = search_result_text(search);
+        let search_color = if search.matches.is_empty() {
+            Color::AnsiValue(160)
+        } else {
+            Color::AnsiValue(220)
+        };
+        let search_text = if width < 90 {
+            format!(
+                "/{query}  {result}  n/N  /:new  Esc:clear",
+                query = search.query
+            )
+        } else {
+            format!(
+                "/{query}  {result}  n/N:match  /:new search  Esc:clear  q:back",
+                query = search.query
+            )
+        };
+        element!(View(
+            flex_direction: FlexDirection::Row,
+            justify_content: JustifyContent::SpaceBetween,
+            width: 100pct,
+            overflow: Overflow::Hidden,
+        ) {
+            View(flex_shrink: 0.0) {
+                Text(
+                    content: format!("{} \u{2502} {}", follow_status, progress),
+                    color: Color::AnsiValue(245)
+                )
+            }
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
+                Text(content: search_text, color: search_color, weight: Weight::Bold)
+            }
+        })
+        .into_any()
     } else {
-        format!(
-            "{} \u{2502} {} \u{2502} y:copy all  j/k:line  ^D/^U:half  ^F/^B:page  g:top  G:follow  q:back",
-            follow_status, progress
-        )
+        let copy_hint = if ui.selection.is_some() {
+            "y:copy  Ctrl-C:copy"
+        } else {
+            "y:copy all"
+        };
+        let footer_text = if width < 90 {
+            format!(
+                "{} \u{2502} {} \u{2502} {}  j/k  ^D/^U  ^F/^B  /  g/G  q",
+                follow_status, progress, copy_hint
+            )
+        } else {
+            format!(
+                "{} \u{2502} {} \u{2502} {}  j/k:line  ^D/^U:half  ^F/^B:page  /:search  g/G:top/follow  q:back",
+                follow_status, progress, copy_hint
+            )
+        };
+        element!(Text(
+            content: footer_text,
+            color: Color::AnsiValue(245)
+        ))
+        .into_any()
     };
 
     element! {
@@ -921,10 +1408,7 @@ fn render_expanded_view(
             }
             // Footer
             View(height: 1, padding_left: 1, padding_right: 1) {
-                Text(
-                    content: footer_text,
-                    color: Color::AnsiValue(245)
-                )
+                #(footer)
             }
         }
     }
@@ -941,6 +1425,7 @@ fn build_line_elements(
     logs: &VecDeque<String>,
     buffer_start_line: usize,
     selection: Option<&Selection>,
+    search: Option<LogSearchView<'_>>,
 ) -> Vec<AnyElement<'static>> {
     let mut elements = Vec::with_capacity(visible_rows.len());
 
@@ -972,6 +1457,25 @@ fn build_line_elements(
             let e = end_col.min(vrow.char_end);
             (e > s).then(|| (s - vrow.char_start, e - vrow.char_start))
         });
+        let search_ranges: Vec<_> = search
+            .into_iter()
+            .flat_map(|search| {
+                search.matches.iter().filter_map(move |search_match| {
+                    if search_match.log_line != absolute_line {
+                        return None;
+                    }
+                    let start = search_match.char_start.max(vrow.char_start);
+                    let end = search_match.char_end.min(vrow.char_end);
+                    (end > start).then(|| {
+                        (
+                            start - vrow.char_start,
+                            end - vrow.char_start,
+                            search.current == Some(search_cursor(*search_match)),
+                        )
+                    })
+                })
+            })
+            .collect();
 
         if let Some((start_col, end_col)) = sel_range {
             let before = char_slice(&display_segment, 0, start_col);
@@ -999,6 +1503,61 @@ fn build_line_elements(
                             content: after,
                             color: Color::AnsiValue(250)
                         )
+                    }
+                }
+                .into_any(),
+            );
+        } else if !search_ranges.is_empty() {
+            let mut cursor = 0;
+            let mut segments = Vec::new();
+            for (start, end, current) in search_ranges {
+                if start > cursor {
+                    segments.push(
+                        element!(Text(
+                            content: char_slice(&display_segment, cursor, start),
+                            color: Color::AnsiValue(250)
+                        ))
+                        .into_any(),
+                    );
+                }
+                let background = if current {
+                    Color::AnsiValue(220)
+                } else {
+                    Color::AnsiValue(58)
+                };
+                let foreground = if current {
+                    Color::AnsiValue(232)
+                } else {
+                    Color::AnsiValue(230)
+                };
+                segments.push(
+                    element!(View(background_color: background) {
+                        Text(
+                            content: char_slice(&display_segment, start, end),
+                            color: foreground
+                        )
+                    })
+                    .into_any(),
+                );
+                cursor = end;
+            }
+            if cursor < display_segment.chars().count() {
+                segments.push(
+                    element!(Text(
+                        content: char_slice(&display_segment, cursor, display_segment.chars().count()),
+                        color: Color::AnsiValue(250)
+                    ))
+                    .into_any(),
+                );
+            }
+            elements.push(
+                element! {
+                    View(height: 1, flex_direction: FlexDirection::Row) {
+                        Text(
+                            content: line_prefix,
+                            color: Color::AnsiValue(250)
+                        )
+                        #(segments)
                     }
                 }
                 .into_any(),
@@ -1101,6 +1660,65 @@ mod tests {
     }
 
     #[test]
+    fn test_log_search_matches_case_insensitively() {
+        assert_eq!(
+            case_insensitive_match_ranges("Error error ERROR", "eRrOr"),
+            vec![(0, 5), (6, 11), (12, 17)]
+        );
+        assert_eq!(
+            case_insensitive_match_ranges("Ärger ärger", "äR"),
+            vec![(0, 2), (6, 8)]
+        );
+
+        let logs = VecDeque::from(["ready".to_string(), "ERROR again".to_string()]);
+        assert_eq!(
+            find_log_matches(&logs, 20, "error"),
+            vec![LogSearchMatch {
+                log_line: 21,
+                char_start: 0,
+                char_end: 5,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_log_search_navigation_wraps() {
+        let matches = [
+            LogSearchMatch {
+                log_line: 4,
+                char_start: 2,
+                char_end: 5,
+            },
+            LogSearchMatch {
+                log_line: 8,
+                char_start: 6,
+                char_end: 9,
+            },
+        ];
+
+        assert_eq!(
+            adjacent_search_match(&matches, Some(search_cursor(matches[0])), true),
+            Some(matches[1])
+        );
+        assert_eq!(
+            adjacent_search_match(&matches, Some(search_cursor(matches[1])), true),
+            Some(matches[0])
+        );
+        assert_eq!(
+            adjacent_search_match(&matches, Some(search_cursor(matches[0])), false),
+            Some(matches[1])
+        );
+        assert_eq!(
+            adjacent_search_match(&matches, None, true),
+            Some(matches[0])
+        );
+        assert_eq!(
+            adjacent_search_match(&matches, None, false),
+            Some(matches[1])
+        );
+    }
+
+    #[test]
     fn test_paused_anchor_survives_log_buffer_rotation() {
         let logs = VecDeque::from([
             "one".to_string(),
@@ -1144,12 +1762,15 @@ mod tests {
             &visual_rows,
             100,
             8,
-            None,
-            ScrollMode {
-                follow_tail: true,
-                anchor: None,
+            ExpandedViewUi {
+                selection: None,
+                search: None,
+                scroll_mode: ScrollMode {
+                    follow_tail: true,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
             },
-            (false, false),
         );
         let following_output = following.render(Some(100)).to_string();
         assert!(following_output.contains("FOLLOWING"));
@@ -1160,16 +1781,103 @@ mod tests {
             &visual_rows,
             100,
             8,
-            None,
-            ScrollMode {
-                follow_tail: false,
-                anchor: None,
+            ExpandedViewUi {
+                selection: None,
+                search: None,
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
             },
-            (false, false),
         );
         let paused_output = paused.render(Some(100)).to_string();
         assert!(paused_output.contains("PAUSED"));
-        assert!(paused_output.contains("G:follow"));
+        assert!(paused_output.contains("g/G:top/follow"));
+    }
+
+    #[test]
+    fn test_render_expanded_view_log_search() {
+        let state = ExpandedViewState {
+            activity_name: "api".to_string(),
+            scroll_offset: 0,
+            logs: Arc::new(VecDeque::from(["Error here".to_string()])),
+            buffer_start_line: 10,
+        };
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+        let matches = find_log_matches(&state.logs, state.buffer_start_line, "error");
+
+        let mut editing = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            ExpandedViewUi {
+                selection: None,
+                search: Some(LogSearchView {
+                    query: "error",
+                    matches: &matches,
+                    current: Some(search_cursor(matches[0])),
+                    editing: true,
+                }),
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
+            },
+        );
+        let editing_output = editing.render(Some(100)).to_string();
+        assert!(editing_output.contains("Search logs: /error"));
+        assert!(editing_output.contains("1/1"));
+
+        let mut selected = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            ExpandedViewUi {
+                selection: None,
+                search: Some(LogSearchView {
+                    query: "error",
+                    matches: &matches,
+                    current: Some(search_cursor(matches[0])),
+                    editing: false,
+                }),
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
+            },
+        );
+        let selected_output = selected.render(Some(100)).to_string();
+        assert!(selected_output.contains("/error"));
+        assert!(selected_output.contains("n/N:match"));
+
+        let mut missing = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            ExpandedViewUi {
+                selection: None,
+                search: Some(LogSearchView {
+                    query: "missing",
+                    matches: &[],
+                    current: None,
+                    editing: true,
+                }),
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
+            },
+        );
+        let missing_output = missing.render(Some(100)).to_string();
+        assert!(missing_output.contains("Search logs: /missing"));
+        assert!(missing_output.contains("no matches"));
     }
 
     #[test]
@@ -1196,12 +1904,15 @@ mod tests {
             &visual_rows,
             100,
             8,
-            None,
-            ScrollMode {
-                follow_tail: true,
-                anchor: None,
+            ExpandedViewUi {
+                selection: None,
+                search: None,
+                scroll_mode: ScrollMode {
+                    follow_tail: true,
+                    anchor: None,
+                },
+                interrupt_prompt: (true, false),
             },
-            (true, false),
         );
         let output = element.render(Some(100)).to_string();
 
@@ -1281,12 +1992,15 @@ mod tests {
             &visual_rows,
             width,
             (visual_rows.len() as u16) + 2,
-            None,
-            ScrollMode {
-                follow_tail: false,
-                anchor: None,
+            ExpandedViewUi {
+                selection: None,
+                search: None,
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
             },
-            (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
 
@@ -1329,12 +2043,15 @@ mod tests {
             &visual_rows,
             width,
             6,
-            Some(&selection),
-            ScrollMode {
-                follow_tail: false,
-                anchor: None,
+            ExpandedViewUi {
+                selection: Some(&selection),
+                search: None,
+                scroll_mode: ScrollMode {
+                    follow_tail: false,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
             },
-            (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
         assert!(output.contains("cdefghij"));

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -9,15 +9,19 @@ use crate::TuiConfig;
 use crate::app::{
     ExitFlag, ProcessCommandSender, handle_interrupt_prompt_key, request_interrupt_prompt,
 };
+use crate::components::COLOR_COMPLETED;
 use crate::model::{ActivityModel, UiState, ViewMode};
 use base64::Engine;
 use crossterm::event::MouseButton;
+use human_repr::HumanCount;
 use iocraft::prelude::*;
 use iocraft::{FullscreenMouseEvent, MouseEventKind};
 use std::collections::VecDeque;
 use std::io::Write as _;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use tokio::sync::Notify;
+use tokio::time::Instant;
 use tokio_shutdown::Shutdown;
 
 /// Width of the line-number field, e.g. "NNNNN".
@@ -27,6 +31,7 @@ const LINE_NUM_SEPARATOR: &str = " \u{2502} ";
 const LINE_NUM_SEPARATOR_WIDTH: usize = 3;
 /// Full prefix width, e.g. "NNNNN │ " = 8 columns.
 const LINE_NUM_PREFIX_WIDTH: usize = LINE_NUM_DIGITS + LINE_NUM_SEPARATOR_WIDTH;
+const COPY_NOTICE_DURATION: Duration = Duration::from_secs(2);
 
 /// Collect `s.chars()[start..end]` into a new `String`.
 fn char_slice(s: &str, start: usize, end: usize) -> String {
@@ -99,9 +104,16 @@ struct LogSearchView<'a> {
     editing: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CopyNotice {
+    lines: usize,
+    bytes: usize,
+}
+
 struct ExpandedViewUi<'a> {
     selection: Option<&'a Selection>,
     search: Option<LogSearchView<'a>>,
+    copy_notice: Option<CopyNotice>,
     scroll_mode: ScrollMode,
     interrupt_prompt: (bool, bool),
 }
@@ -173,6 +185,31 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let mut follow_tail = hooks.use_state(|| true);
     let mut scroll_anchor = hooks.use_state(|| None::<ScrollAnchor>);
     let mut log_search = hooks.use_state(|| None::<LogSearchState>);
+    let mut copy_notice = hooks.use_state(|| None::<CopyNotice>);
+    let mut copy_notice_deadline = hooks.use_ref(|| None::<Instant>);
+    let copy_notice_wake = hooks.use_ref(|| Arc::new(Notify::new()));
+
+    let copy_notice_wake_for_timer = copy_notice_wake.read().clone();
+    hooks.use_future(async move {
+        loop {
+            copy_notice_wake_for_timer.notified().await;
+            loop {
+                let Some(Some(deadline)) = copy_notice_deadline.try_get() else {
+                    break;
+                };
+                tokio::time::sleep_until(deadline).await;
+                let Some(latest_deadline) = copy_notice_deadline.try_get() else {
+                    return;
+                };
+                if latest_deadline.is_some_and(|latest| latest > Instant::now()) {
+                    continue;
+                }
+                copy_notice.set(None);
+                copy_notice_deadline.set(None);
+                break;
+            }
+        }
+    });
 
     // Selection state. Coordinates are (log_line_idx, visual_col) where
     // visual_col is a logical character offset within the log line, regardless
@@ -247,6 +284,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
     let logs_for_copy = state.logs.clone();
     let visual_rows_for_events = visual_rows.clone();
+    let copy_notice_wake_for_events = copy_notice_wake.read().clone();
 
     // Handle keyboard and mouse events - NO MODEL LOCK, only local state updates
     hooks.use_terminal_events({
@@ -274,6 +312,11 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     total_visual_rows,
                     viewport_height,
                     &mut log_search,
+                    &mut CopyFeedbackState {
+                        notice: &mut copy_notice,
+                        deadline: &mut copy_notice_deadline,
+                        wake: &copy_notice_wake_for_events,
+                    },
                     &mut SelectionState {
                         has_selection,
                         anchor: current_selection_anchor,
@@ -355,6 +398,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         ExpandedViewUi {
             selection: selection.as_ref(),
             search,
+            copy_notice: copy_notice.get(),
             scroll_mode: ScrollMode {
                 follow_tail: follow_tail.get(),
                 anchor: scroll_anchor.get(),
@@ -903,6 +947,47 @@ fn handle_log_search_key(
     }
 }
 
+impl CopyNotice {
+    fn from_text(text: &str) -> Option<Self> {
+        (!text.is_empty()).then(|| Self {
+            lines: text.split('\n').count(),
+            bytes: text.len(),
+        })
+    }
+
+    fn message(self) -> String {
+        let unit = if self.lines == 1 { "line" } else { "lines" };
+        format!(
+            "Copied {} {} ({})",
+            self.lines,
+            unit,
+            self.bytes.human_count_bytes()
+        )
+    }
+}
+
+struct CopyFeedbackState<'a> {
+    notice: &'a mut State<Option<CopyNotice>>,
+    deadline: &'a mut Ref<Option<Instant>>,
+    wake: &'a Arc<Notify>,
+}
+
+impl CopyFeedbackState<'_> {
+    fn show(&mut self, text: &str) {
+        if let Some(notice) = CopyNotice::from_text(text) {
+            self.notice.set(Some(notice));
+            self.deadline
+                .set(Some(Instant::now() + COPY_NOTICE_DURATION));
+            self.wake.notify_one();
+        }
+    }
+
+    fn clear(&mut self) {
+        self.notice.set(None);
+        self.deadline.set(None);
+    }
+}
+
 /// Mutable selection state passed to event handlers.
 struct SelectionState<'a> {
     has_selection: bool,
@@ -939,10 +1024,15 @@ fn handle_key_event(
     total_visual_rows: usize,
     viewport_height: usize,
     log_search: &mut State<Option<LogSearchState>>,
+    copy_feedback: &mut CopyFeedbackState<'_>,
     sel: &mut SelectionState<'_>,
 ) {
     if handle_interrupt_prompt_key(&key_event, ui_state, shutdown, command_tx) {
         return;
+    }
+
+    if copy_feedback.notice.get().is_some() {
+        copy_feedback.clear();
     }
 
     let max_offset = total_visual_rows.saturating_sub(viewport_height);
@@ -1020,6 +1110,7 @@ fn handle_key_event(
             let text = text_for_yank(sel.logs, sel.buffer_start_line, selection.as_ref());
             if !text.is_empty() {
                 copy_to_clipboard(&text);
+                copy_feedback.show(&text);
             }
             if sel.has_selection {
                 sel.clear();
@@ -1034,6 +1125,7 @@ fn handle_key_event(
                     let text = extract_selected_text(sel.logs, sel.buffer_start_line, &selection);
                     if !text.is_empty() {
                         copy_to_clipboard(&text);
+                        copy_feedback.show(&text);
                     }
                 }
                 sel.clear();
@@ -1329,6 +1421,18 @@ fn render_expanded_view(
                 Text(content: format!("{result}  Enter:select Esc:cancel"), color: Color::AnsiValue(245))
             }
         }).into_any()
+    } else if let Some(notice) = ui.copy_notice {
+        element!(Text(
+            content: format!(
+                "{} \u{2502} {} \u{2502} {}",
+                follow_status,
+                progress,
+                notice.message()
+            ),
+            color: COLOR_COMPLETED,
+            weight: Weight::Bold
+        ))
+        .into_any()
     } else if let Some(search) = ui.search {
         let result = search_result_text(search);
         let search_color = if search.matches.is_empty() {
@@ -1765,6 +1869,7 @@ mod tests {
             ExpandedViewUi {
                 selection: None,
                 search: None,
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: true,
                     anchor: None,
@@ -1784,6 +1889,7 @@ mod tests {
             ExpandedViewUi {
                 selection: None,
                 search: None,
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,
@@ -1820,6 +1926,7 @@ mod tests {
                     current: Some(search_cursor(matches[0])),
                     editing: true,
                 }),
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,
@@ -1844,6 +1951,7 @@ mod tests {
                     current: Some(search_cursor(matches[0])),
                     editing: false,
                 }),
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,
@@ -1868,6 +1976,7 @@ mod tests {
                     current: None,
                     editing: true,
                 }),
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,
@@ -1890,6 +1999,51 @@ mod tests {
     }
 
     #[test]
+    fn test_copy_notice_counts_and_renders_copied_text() {
+        assert_eq!(CopyNotice::from_text(""), None);
+        assert_eq!(
+            CopyNotice::from_text("first\nsecond"),
+            Some(CopyNotice {
+                lines: 2,
+                bytes: 12,
+            })
+        );
+        assert!(
+            CopyNotice::from_text("one")
+                .unwrap()
+                .message()
+                .contains("1 line")
+        );
+
+        let state = ExpandedViewState {
+            activity_name: "api".to_string(),
+            scroll_offset: 0,
+            logs: Arc::new(VecDeque::from(["first".to_string(), "second".to_string()])),
+            buffer_start_line: 0,
+        };
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+        let mut element = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            ExpandedViewUi {
+                selection: None,
+                search: None,
+                copy_notice: CopyNotice::from_text("first\nsecond"),
+                scroll_mode: ScrollMode {
+                    follow_tail: true,
+                    anchor: None,
+                },
+                interrupt_prompt: (false, false),
+            },
+        );
+        let output = element.render(Some(100)).to_string();
+        assert!(output.contains("Copied 2 lines"));
+        assert!(output.contains("12B"));
+    }
+
+    #[test]
     fn test_render_expanded_view_interrupt_prompt_footer() {
         let state = ExpandedViewState {
             activity_name: "api".to_string(),
@@ -1907,6 +2061,7 @@ mod tests {
             ExpandedViewUi {
                 selection: None,
                 search: None,
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: true,
                     anchor: None,
@@ -1995,6 +2150,7 @@ mod tests {
             ExpandedViewUi {
                 selection: None,
                 search: None,
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,
@@ -2046,6 +2202,7 @@ mod tests {
             ExpandedViewUi {
                 selection: Some(&selection),
                 search: None,
+                copy_notice: None,
                 scroll_mode: ScrollMode {
                     follow_tail: false,
                     anchor: None,

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -44,6 +44,18 @@ struct Selection {
     end: (usize, usize),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ScrollAnchor {
+    log_line: usize,
+    char_start: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ScrollMode {
+    follow_tail: bool,
+    anchor: Option<ScrollAnchor>,
+}
+
 impl Selection {
     /// Create a selection from anchor and cursor, normalizing so start <= end.
     fn from_anchor_cursor(anchor: (usize, usize), cursor: (usize, usize)) -> Self {
@@ -109,6 +121,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     // log line may span multiple visual rows when wrapped.
     let mut scroll_offset = hooks.use_state(|| 0usize);
     let mut follow_tail = hooks.use_state(|| true);
+    let mut scroll_anchor = hooks.use_state(|| None::<ScrollAnchor>);
 
     // Selection state. Coordinates are (log_line_idx, visual_col) where
     // visual_col is a logical character offset within the log line, regardless
@@ -158,13 +171,6 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         (Arc::as_ptr(&state.logs) as usize, content_width),
     );
     let total_visual_rows = visual_rows.len();
-    let current_scroll_offset = resolved_scroll_offset(
-        scroll_offset.get(),
-        follow_tail.get(),
-        total_visual_rows,
-        viewport_height,
-    );
-
     let current_selection_anchor = selection_anchor.get();
     let current_selection_cursor = selection_cursor.get();
     let has_selection = current_selection_anchor.is_some() && current_selection_cursor.is_some();
@@ -192,7 +198,9 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     attached,
                     &mut scroll_offset,
                     &mut follow_tail,
-                    current_scroll_offset,
+                    &mut scroll_anchor,
+                    state.buffer_start_line,
+                    &visual_rows_for_events,
                     total_visual_rows,
                     viewport_height,
                     &mut SelectionState {
@@ -200,6 +208,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         anchor: current_selection_anchor,
                         cursor: current_selection_cursor,
                         logs: &logs_for_copy,
+                        buffer_start_line: state.buffer_start_line,
                         anchor_state: &mut selection_anchor,
                         cursor_state: &mut selection_cursor,
                         is_selecting: &mut is_selecting,
@@ -220,7 +229,8 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                         mouse_event,
                         &mut scroll_offset,
                         &mut follow_tail,
-                        current_scroll_offset,
+                        &mut scroll_anchor,
+                        state.buffer_start_line,
                         total_visual_rows,
                         viewport_height,
                         &visual_rows_for_events,
@@ -265,7 +275,10 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         width,
         height,
         selection.as_ref(),
-        follow_tail.get(),
+        ScrollMode {
+            follow_tail: follow_tail.get(),
+            anchor: scroll_anchor.get(),
+        },
         (interrupt_prompt_active, interrupt_prompt_attached),
     )
 }
@@ -275,6 +288,7 @@ struct ExpandedViewState {
     activity_name: String,
     scroll_offset: usize,
     logs: Arc<VecDeque<String>>,
+    buffer_start_line: usize,
 }
 
 /// A single visual row to render: a slice of one log line, defined by the log
@@ -302,11 +316,15 @@ fn extract_view_state(
         .get_build_logs(activity_id)
         .cloned()
         .unwrap_or_else(|| Arc::new(VecDeque::new()));
+    let buffer_start_line = model
+        .get_log_line_count(activity_id)
+        .saturating_sub(logs.len());
 
     Some(ExpandedViewState {
         activity_name,
         scroll_offset,
         logs,
+        buffer_start_line,
     })
 }
 
@@ -359,15 +377,70 @@ fn calculate_viewport_height(terminal_height: u16) -> usize {
 fn resolved_scroll_offset(
     scroll_offset: usize,
     follow_tail: bool,
+    scroll_anchor: Option<ScrollAnchor>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
     total_visual_rows: usize,
     viewport_height: usize,
 ) -> usize {
     let max_offset = total_visual_rows.saturating_sub(viewport_height);
     if follow_tail {
         max_offset
+    } else if let Some(anchor) = scroll_anchor {
+        if anchor.log_line < buffer_start_line {
+            return 0;
+        }
+        let relative_line = anchor.log_line - buffer_start_line;
+        visual_rows
+            .iter()
+            .position(|row| {
+                row.log_idx > relative_line
+                    || row.log_idx == relative_line && row.char_start >= anchor.char_start
+            })
+            .unwrap_or(max_offset)
+            .min(max_offset)
     } else {
         scroll_offset.min(max_offset)
     }
+}
+
+fn scroll_anchor_for_offset(
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+    offset: usize,
+) -> Option<ScrollAnchor> {
+    visual_rows.get(offset).map(|row| ScrollAnchor {
+        log_line: buffer_start_line + row.log_idx,
+        char_start: row.char_start,
+    })
+}
+
+fn pause_at_offset(
+    scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+    offset: usize,
+) {
+    scroll_offset.set(offset);
+    follow_tail.set(false);
+    scroll_anchor.set(scroll_anchor_for_offset(
+        buffer_start_line,
+        visual_rows,
+        offset,
+    ));
+}
+
+fn follow_at_bottom(
+    scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    max_offset: usize,
+) {
+    scroll_offset.set(max_offset);
+    follow_tail.set(true);
+    scroll_anchor.set(None);
 }
 
 /// Mutable selection state passed to event handlers.
@@ -376,6 +449,7 @@ struct SelectionState<'a> {
     anchor: Option<(usize, usize)>,
     cursor: Option<(usize, usize)>,
     logs: &'a Arc<VecDeque<String>>,
+    buffer_start_line: usize,
     anchor_state: &'a mut State<Option<(usize, usize)>>,
     cursor_state: &'a mut State<Option<(usize, usize)>>,
     is_selecting: &'a mut State<bool>,
@@ -399,7 +473,9 @@ fn handle_key_event(
     attached: bool,
     scroll_offset: &mut State<usize>,
     follow_tail: &mut State<bool>,
-    current_scroll_offset: usize,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
     total_visual_rows: usize,
     viewport_height: usize,
     sel: &mut SelectionState<'_>,
@@ -409,6 +485,15 @@ fn handle_key_event(
     }
 
     let max_offset = total_visual_rows.saturating_sub(viewport_height);
+    let current_scroll_offset = resolved_scroll_offset(
+        scroll_offset.get(),
+        follow_tail.get(),
+        scroll_anchor.get(),
+        buffer_start_line,
+        visual_rows,
+        total_visual_rows,
+        viewport_height,
+    );
 
     match key_event.code {
         // Esc: clear selection first, then exit
@@ -436,47 +521,87 @@ fn handle_key_event(
         // Scroll down one line
         KeyCode::Down | KeyCode::Char('j') => {
             let next = (current_scroll_offset + 1).min(max_offset);
-            scroll_offset.set(next);
-            follow_tail.set(next == max_offset);
+            if next == max_offset {
+                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
+            } else {
+                pause_at_offset(
+                    scroll_offset,
+                    follow_tail,
+                    scroll_anchor,
+                    buffer_start_line,
+                    visual_rows,
+                    next,
+                );
+            }
         }
 
         // Scroll up one line
         KeyCode::Up | KeyCode::Char('k') => {
-            scroll_offset.set(current_scroll_offset.saturating_sub(1));
-            follow_tail.set(false);
+            pause_at_offset(
+                scroll_offset,
+                follow_tail,
+                scroll_anchor,
+                buffer_start_line,
+                visual_rows,
+                current_scroll_offset.saturating_sub(1),
+            );
         }
 
         // Page down
         KeyCode::PageDown | KeyCode::Char(' ') => {
             let next = (current_scroll_offset + viewport_height).min(max_offset);
-            scroll_offset.set(next);
-            follow_tail.set(next == max_offset);
+            if next == max_offset {
+                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
+            } else {
+                pause_at_offset(
+                    scroll_offset,
+                    follow_tail,
+                    scroll_anchor,
+                    buffer_start_line,
+                    visual_rows,
+                    next,
+                );
+            }
         }
 
         // Page up
         KeyCode::PageUp => {
-            scroll_offset.set(current_scroll_offset.saturating_sub(viewport_height));
-            follow_tail.set(false);
+            pause_at_offset(
+                scroll_offset,
+                follow_tail,
+                scroll_anchor,
+                buffer_start_line,
+                visual_rows,
+                current_scroll_offset.saturating_sub(viewport_height),
+            );
         }
 
         // Go to top
         KeyCode::Home | KeyCode::Char('g') => {
-            scroll_offset.set(0);
-            follow_tail.set(false);
+            pause_at_offset(
+                scroll_offset,
+                follow_tail,
+                scroll_anchor,
+                buffer_start_line,
+                visual_rows,
+                0,
+            );
         }
 
         // Go to bottom
         KeyCode::End | KeyCode::Char('G') => {
-            scroll_offset.set(max_offset);
-            follow_tail.set(true);
+            follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
         }
 
-        KeyCode::Char('y') => {
+        KeyCode::Char('y')
+            if !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+        {
             let selection = match (sel.anchor, sel.cursor) {
                 (Some(anchor), Some(cursor)) => Some(Selection::from_anchor_cursor(anchor, cursor)),
                 _ => None,
             };
-            let text = text_for_yank(sel.logs, selection.as_ref());
+            let text = text_for_yank(sel.logs, sel.buffer_start_line, selection.as_ref());
             if !text.is_empty() {
                 copy_to_clipboard(&text);
             }
@@ -490,7 +615,7 @@ fn handle_key_event(
             if sel.has_selection {
                 if let (Some(anchor), Some(cursor)) = (sel.anchor, sel.cursor) {
                     let selection = Selection::from_anchor_cursor(anchor, cursor);
-                    let text = extract_selected_text(sel.logs, &selection);
+                    let text = extract_selected_text(sel.logs, sel.buffer_start_line, &selection);
                     if !text.is_empty() {
                         copy_to_clipboard(&text);
                     }
@@ -511,7 +636,8 @@ fn handle_mouse_event(
     mouse_event: FullscreenMouseEvent,
     scroll_offset: &mut State<usize>,
     follow_tail: &mut State<bool>,
-    current_scroll_offset: usize,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    buffer_start_line: usize,
     total_visual_rows: usize,
     viewport_height: usize,
     visual_rows: &[VisualRow],
@@ -521,6 +647,15 @@ fn handle_mouse_event(
 ) {
     let scroll_lines = 3; // Lines to scroll per wheel tick
     let max_offset = total_visual_rows.saturating_sub(viewport_height);
+    let current_scroll_offset = resolved_scroll_offset(
+        scroll_offset.get(),
+        follow_tail.get(),
+        scroll_anchor.get(),
+        buffer_start_line,
+        visual_rows,
+        total_visual_rows,
+        viewport_height,
+    );
 
     // Map a terminal (row, col) to the logical (log_line_idx, visual_col)
     // selection coordinate. visual_col is a character offset into the *logical*
@@ -530,7 +665,10 @@ fn handle_mouse_event(
         let visual_row_idx = current_scroll_offset + visible_row_idx;
         let vrow = visual_rows.get(visual_row_idx)?;
         let col_in_segment = col.saturating_sub(LINE_NUM_PREFIX_WIDTH);
-        Some((vrow.log_idx, vrow.char_start + col_in_segment))
+        Some((
+            buffer_start_line + vrow.log_idx,
+            vrow.char_start + col_in_segment,
+        ))
     };
 
     match mouse_event.kind {
@@ -550,8 +688,14 @@ fn handle_mouse_event(
             selection_anchor.set(Some(pos));
             selection_cursor.set(Some(pos));
             is_selecting.set(true);
-            scroll_offset.set(current_scroll_offset);
-            follow_tail.set(false);
+            pause_at_offset(
+                scroll_offset,
+                follow_tail,
+                scroll_anchor,
+                buffer_start_line,
+                visual_rows,
+                current_scroll_offset,
+            );
         }
 
         MouseEventKind::Drag(MouseButton::Left) => {
@@ -585,12 +729,28 @@ fn handle_mouse_event(
 
         MouseEventKind::ScrollDown => {
             let next = (current_scroll_offset + scroll_lines).min(max_offset);
-            scroll_offset.set(next);
-            follow_tail.set(next == max_offset);
+            if next == max_offset {
+                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
+            } else {
+                pause_at_offset(
+                    scroll_offset,
+                    follow_tail,
+                    scroll_anchor,
+                    buffer_start_line,
+                    visual_rows,
+                    next,
+                );
+            }
         }
         MouseEventKind::ScrollUp => {
-            scroll_offset.set(current_scroll_offset.saturating_sub(scroll_lines));
-            follow_tail.set(false);
+            pause_at_offset(
+                scroll_offset,
+                follow_tail,
+                scroll_anchor,
+                buffer_start_line,
+                visual_rows,
+                current_scroll_offset.saturating_sub(scroll_lines),
+            );
         }
         _ => {}
     }
@@ -606,15 +766,32 @@ fn copy_to_clipboard(text: &str) {
 }
 
 /// Extract selected text from log lines, stripping ANSI codes.
-fn extract_selected_text(logs: &VecDeque<String>, selection: &Selection) -> String {
+fn extract_selected_text(
+    logs: &VecDeque<String>,
+    buffer_start_line: usize,
+    selection: &Selection,
+) -> String {
     let mut lines = Vec::new();
+    if logs.is_empty() {
+        return String::new();
+    }
+    let Some(buffer_end_line) = buffer_start_line.checked_add(logs.len() - 1) else {
+        return String::new();
+    };
+    let first_line = selection.start.0.max(buffer_start_line);
+    let last_line = selection.end.0.min(buffer_end_line);
+    if first_line > last_line {
+        return String::new();
+    }
 
-    for line_idx in selection.start.0..=selection.end.0 {
-        let Some(line) = logs.get(line_idx) else {
+    for absolute_line in first_line..=last_line {
+        let Some(line) = logs.get(absolute_line - buffer_start_line) else {
             continue;
         };
 
-        if let Some((start_col, end_col)) = selection.line_range(line_idx, line.chars().count()) {
+        if let Some((start_col, end_col)) =
+            selection.line_range(absolute_line, line.chars().count())
+        {
             lines.push(char_slice(line, start_col, end_col));
         }
     }
@@ -622,9 +799,13 @@ fn extract_selected_text(logs: &VecDeque<String>, selection: &Selection) -> Stri
     lines.join("\n")
 }
 
-fn text_for_yank(logs: &VecDeque<String>, selection: Option<&Selection>) -> String {
+fn text_for_yank(
+    logs: &VecDeque<String>,
+    buffer_start_line: usize,
+    selection: Option<&Selection>,
+) -> String {
     match selection {
-        Some(selection) => extract_selected_text(logs, selection),
+        Some(selection) => extract_selected_text(logs, buffer_start_line, selection),
         None => logs.iter().cloned().collect::<Vec<_>>().join("\n"),
     }
 }
@@ -636,7 +817,7 @@ fn render_expanded_view(
     width: u16,
     height: u16,
     selection: Option<&Selection>,
-    follow_tail: bool,
+    scroll_mode: ScrollMode,
     interrupt_prompt: (bool, bool),
 ) -> AnyElement<'static> {
     let (interrupt_prompt_active, interrupt_prompt_attached) = interrupt_prompt;
@@ -645,7 +826,10 @@ fn render_expanded_view(
 
     let clamped_offset = resolved_scroll_offset(
         state.scroll_offset,
-        follow_tail,
+        scroll_mode.follow_tail,
+        scroll_mode.anchor,
+        state.buffer_start_line,
+        visual_rows,
         total_rows,
         viewport_height,
     );
@@ -654,14 +838,23 @@ fn render_expanded_view(
     let end = (start + viewport_height).min(total_rows);
     let visible_rows: &[VisualRow] = &visual_rows[start..end];
 
-    let line_elements = build_line_elements(visible_rows, &state.logs, selection);
+    let line_elements = build_line_elements(
+        visible_rows,
+        &state.logs,
+        state.buffer_start_line,
+        selection,
+    );
     let padding_elements = build_padding_elements(visible_rows.len(), viewport_height);
 
     let mut content_elements = line_elements;
     content_elements.extend(padding_elements);
 
     let progress = build_progress_indicator(clamped_offset, viewport_height, total_rows);
-    let follow_status = if follow_tail { "FOLLOWING" } else { "PAUSED" };
+    let follow_status = if scroll_mode.follow_tail {
+        "FOLLOWING"
+    } else {
+        "PAUSED"
+    };
 
     // Build footer text - show copy hint when selection is active
     let footer_text = if interrupt_prompt_active {
@@ -731,6 +924,7 @@ fn render_expanded_view(
 fn build_line_elements(
     visible_rows: &[VisualRow],
     logs: &VecDeque<String>,
+    buffer_start_line: usize,
     selection: Option<&Selection>,
 ) -> Vec<AnyElement<'static>> {
     let mut elements = Vec::with_capacity(visible_rows.len());
@@ -742,6 +936,7 @@ fn build_line_elements(
 
         let display_segment = char_slice(line, vrow.char_start, vrow.char_end);
 
+        let absolute_line = buffer_start_line + vrow.log_idx;
         let line_number = if vrow.char_start == 0 {
             (vrow.log_idx + 1).to_string()
         } else {
@@ -757,7 +952,7 @@ fn build_line_elements(
         // Intersect the per-log-line selection with the [char_start, char_end)
         // window this row represents, in logical char coordinates.
         let sel_range = selection.and_then(|s| {
-            let (start_col, end_col) = s.line_range(vrow.log_idx, line.chars().count())?;
+            let (start_col, end_col) = s.line_range(absolute_line, line.chars().count())?;
             let s = start_col.max(vrow.char_start);
             let e = end_col.min(vrow.char_end);
             (e > s).then(|| (s - vrow.char_start, e - vrow.char_start))
@@ -847,10 +1042,39 @@ mod tests {
 
     #[test]
     fn test_follow_mode_resolves_to_latest_rows() {
-        assert_eq!(resolved_scroll_offset(0, true, 100, 20), 80);
-        assert_eq!(resolved_scroll_offset(12, false, 100, 20), 12);
-        assert_eq!(resolved_scroll_offset(80, true, 140, 20), 120);
-        assert_eq!(resolved_scroll_offset(120, false, 60, 20), 40);
+        assert_eq!(resolved_scroll_offset(0, true, None, 0, &[], 100, 20), 80);
+        assert_eq!(resolved_scroll_offset(12, false, None, 0, &[], 100, 20), 12);
+        assert_eq!(resolved_scroll_offset(80, true, None, 0, &[], 140, 20), 120);
+        assert_eq!(resolved_scroll_offset(120, false, None, 0, &[], 60, 20), 40);
+    }
+
+    #[test]
+    fn test_paused_anchor_survives_log_buffer_rotation() {
+        let logs = VecDeque::from([
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string(),
+            "four".to_string(),
+            "five".to_string(),
+        ]);
+        let rows = build_visual_rows(&logs, 20);
+        let anchor = Some(ScrollAnchor {
+            log_line: 102,
+            char_start: 0,
+        });
+
+        assert_eq!(
+            resolved_scroll_offset(2, false, anchor, 100, &rows, 5, 1),
+            2
+        );
+        assert_eq!(
+            resolved_scroll_offset(2, false, anchor, 101, &rows, 5, 1),
+            1
+        );
+        assert_eq!(
+            resolved_scroll_offset(2, false, anchor, 103, &rows, 5, 1),
+            0
+        );
     }
 
     #[test]
@@ -859,17 +1083,38 @@ mod tests {
             activity_name: "api".to_string(),
             scroll_offset: 0,
             logs: Arc::new(VecDeque::from(["ready".to_string()])),
+            buffer_start_line: 0,
         };
         let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
 
-        let mut following =
-            render_expanded_view(&state, &visual_rows, 100, 8, None, true, (false, false));
+        let mut following = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            None,
+            ScrollMode {
+                follow_tail: true,
+                anchor: None,
+            },
+            (false, false),
+        );
         let following_output = following.render(Some(100)).to_string();
         assert!(following_output.contains("FOLLOWING"));
         assert!(following_output.contains("y:copy all"));
 
-        let mut paused =
-            render_expanded_view(&state, &visual_rows, 100, 8, None, false, (false, false));
+        let mut paused = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            None,
+            ScrollMode {
+                follow_tail: false,
+                anchor: None,
+            },
+            (false, false),
+        );
         let paused_output = paused.render(Some(100)).to_string();
         assert!(paused_output.contains("PAUSED"));
         assert!(paused_output.contains("G:follow"));
@@ -878,10 +1123,10 @@ mod tests {
     #[test]
     fn test_yank_uses_selection_or_complete_log_buffer() {
         let logs = VecDeque::from(["first".to_string(), "second".to_string()]);
-        assert_eq!(text_for_yank(&logs, None), "first\nsecond");
+        assert_eq!(text_for_yank(&logs, 10, None), "first\nsecond");
 
-        let selection = Selection::from_anchor_cursor((0, 1), (1, 3));
-        assert_eq!(text_for_yank(&logs, Some(&selection)), "irst\nsec");
+        let selection = Selection::from_anchor_cursor((10, 1), (11, 3));
+        assert_eq!(text_for_yank(&logs, 10, Some(&selection)), "irst\nsec");
     }
 
     #[test]
@@ -890,11 +1135,22 @@ mod tests {
             activity_name: "api".to_string(),
             scroll_offset: 0,
             logs: Arc::new(VecDeque::new()),
+            buffer_start_line: 0,
         };
         let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
 
-        let mut element =
-            render_expanded_view(&state, &visual_rows, 100, 8, None, true, (true, false));
+        let mut element = render_expanded_view(
+            &state,
+            &visual_rows,
+            100,
+            8,
+            None,
+            ScrollMode {
+                follow_tail: true,
+                anchor: None,
+            },
+            (true, false),
+        );
         let output = element.render(Some(100)).to_string();
 
         assert!(output.contains("Quit devenv? Nothing has been stopped yet"));
@@ -962,6 +1218,7 @@ mod tests {
             activity_name: "test".to_string(),
             scroll_offset: 0,
             logs: logs.clone(),
+            buffer_start_line: 0,
         };
         let width: u16 = 30;
         let visual_rows = build_visual_rows(&state.logs, content_width_for(width));
@@ -973,7 +1230,10 @@ mod tests {
             width,
             (visual_rows.len() as u16) + 2,
             None,
-            false,
+            ScrollMode {
+                follow_tail: false,
+                anchor: None,
+            },
             (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
@@ -1003,6 +1263,7 @@ mod tests {
             activity_name: "test".to_string(),
             scroll_offset: 0,
             logs: logs_arc.clone(),
+            buffer_start_line: 0,
         };
         let width: u16 = 18; // content_width = 10
         let visual_rows = build_visual_rows(&state.logs, content_width_for(width));
@@ -1017,14 +1278,17 @@ mod tests {
             width,
             6,
             Some(&selection),
-            false,
+            ScrollMode {
+                follow_tail: false,
+                anchor: None,
+            },
             (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
         assert!(output.contains("cdefghij"));
         assert!(output.contains("KLM"));
 
-        let extracted = extract_selected_text(&logs_for_extract, &selection);
+        let extracted = extract_selected_text(&logs_for_extract, 0, &selection);
         assert_eq!(extracted, "cdefghijKLM");
     }
 }

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -56,6 +56,14 @@ struct ScrollMode {
     anchor: Option<ScrollAnchor>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogScrollAction {
+    Forward(usize),
+    Backward(usize),
+    Top,
+    Bottom,
+}
+
 impl Selection {
     /// Create a selection from anchor and cursor, normalizing so start <= end.
     fn from_anchor_cursor(anchor: (usize, usize), cursor: (usize, usize)) -> Self {
@@ -443,6 +451,74 @@ fn follow_at_bottom(
     scroll_anchor.set(None);
 }
 
+fn keyboard_scroll_action(key_event: &KeyEvent, viewport_height: usize) -> Option<LogScrollAction> {
+    let control = key_event.modifiers.contains(KeyModifiers::CONTROL);
+    let half_page = viewport_height.div_ceil(2).max(1);
+
+    match key_event.code {
+        KeyCode::Down | KeyCode::Char('j') => Some(LogScrollAction::Forward(1)),
+        KeyCode::Up | KeyCode::Char('k') => Some(LogScrollAction::Backward(1)),
+        KeyCode::PageDown | KeyCode::Char(' ') => Some(LogScrollAction::Forward(viewport_height)),
+        KeyCode::PageUp => Some(LogScrollAction::Backward(viewport_height)),
+        KeyCode::Char('d') if control => Some(LogScrollAction::Forward(half_page)),
+        KeyCode::Char('u') if control => Some(LogScrollAction::Backward(half_page)),
+        KeyCode::Char('f') if control => Some(LogScrollAction::Forward(viewport_height)),
+        KeyCode::Char('b') if control => Some(LogScrollAction::Backward(viewport_height)),
+        KeyCode::Home | KeyCode::Char('g') => Some(LogScrollAction::Top),
+        KeyCode::End | KeyCode::Char('G') => Some(LogScrollAction::Bottom),
+        _ => None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_scroll_action(
+    action: LogScrollAction,
+    current_scroll_offset: usize,
+    max_offset: usize,
+    scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    scroll_anchor: &mut State<Option<ScrollAnchor>>,
+    buffer_start_line: usize,
+    visual_rows: &[VisualRow],
+) {
+    match action {
+        LogScrollAction::Forward(lines) => {
+            let next = current_scroll_offset.saturating_add(lines).min(max_offset);
+            if next == max_offset {
+                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
+            } else {
+                pause_at_offset(
+                    scroll_offset,
+                    follow_tail,
+                    scroll_anchor,
+                    buffer_start_line,
+                    visual_rows,
+                    next,
+                );
+            }
+        }
+        LogScrollAction::Backward(lines) => pause_at_offset(
+            scroll_offset,
+            follow_tail,
+            scroll_anchor,
+            buffer_start_line,
+            visual_rows,
+            current_scroll_offset.saturating_sub(lines),
+        ),
+        LogScrollAction::Top => pause_at_offset(
+            scroll_offset,
+            follow_tail,
+            scroll_anchor,
+            buffer_start_line,
+            visual_rows,
+            0,
+        ),
+        LogScrollAction::Bottom => {
+            follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset)
+        }
+    }
+}
+
 /// Mutable selection state passed to event handlers.
 struct SelectionState<'a> {
     has_selection: bool,
@@ -495,6 +571,20 @@ fn handle_key_event(
         viewport_height,
     );
 
+    if let Some(action) = keyboard_scroll_action(&key_event, viewport_height) {
+        apply_scroll_action(
+            action,
+            current_scroll_offset,
+            max_offset,
+            scroll_offset,
+            follow_tail,
+            scroll_anchor,
+            buffer_start_line,
+            visual_rows,
+        );
+        return;
+    }
+
     match key_event.code {
         // Esc: clear selection first, then exit
         KeyCode::Esc => {
@@ -516,81 +606,6 @@ fn handle_key_event(
             if let Ok(mut ui) = ui_state.write() {
                 ui.view_mode = ViewMode::Main;
             }
-        }
-
-        // Scroll down one line
-        KeyCode::Down | KeyCode::Char('j') => {
-            let next = (current_scroll_offset + 1).min(max_offset);
-            if next == max_offset {
-                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
-            } else {
-                pause_at_offset(
-                    scroll_offset,
-                    follow_tail,
-                    scroll_anchor,
-                    buffer_start_line,
-                    visual_rows,
-                    next,
-                );
-            }
-        }
-
-        // Scroll up one line
-        KeyCode::Up | KeyCode::Char('k') => {
-            pause_at_offset(
-                scroll_offset,
-                follow_tail,
-                scroll_anchor,
-                buffer_start_line,
-                visual_rows,
-                current_scroll_offset.saturating_sub(1),
-            );
-        }
-
-        // Page down
-        KeyCode::PageDown | KeyCode::Char(' ') => {
-            let next = (current_scroll_offset + viewport_height).min(max_offset);
-            if next == max_offset {
-                follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
-            } else {
-                pause_at_offset(
-                    scroll_offset,
-                    follow_tail,
-                    scroll_anchor,
-                    buffer_start_line,
-                    visual_rows,
-                    next,
-                );
-            }
-        }
-
-        // Page up
-        KeyCode::PageUp => {
-            pause_at_offset(
-                scroll_offset,
-                follow_tail,
-                scroll_anchor,
-                buffer_start_line,
-                visual_rows,
-                current_scroll_offset.saturating_sub(viewport_height),
-            );
-        }
-
-        // Go to top
-        KeyCode::Home | KeyCode::Char('g') => {
-            pause_at_offset(
-                scroll_offset,
-                follow_tail,
-                scroll_anchor,
-                buffer_start_line,
-                visual_rows,
-                0,
-            );
-        }
-
-        // Go to bottom
-        KeyCode::End | KeyCode::Char('G') => {
-            follow_at_bottom(scroll_offset, follow_tail, scroll_anchor, max_offset);
         }
 
         KeyCode::Char('y')
@@ -876,12 +891,12 @@ fn render_expanded_view(
         }
     } else if selection.is_some() {
         format!(
-            "{} \u{2502} {} \u{2502} y:copy  j/k:line  PgUp/PgDn:page  g:top  G:follow  Ctrl-C:copy  Esc:deselect  q:back",
+            "{} \u{2502} {} \u{2502} y:copy  j/k:line  ^D/^U:half  ^F/^B:page  g:top  G:follow  Ctrl-C:copy  Esc:deselect  q:back",
             follow_status, progress
         )
     } else {
         format!(
-            "{} \u{2502} {} \u{2502} y:copy all  j/k:line  PgUp/PgDn:page  g:top  G:follow  q:back",
+            "{} \u{2502} {} \u{2502} y:copy all  j/k:line  ^D/^U:half  ^F/^B:page  g:top  G:follow  q:back",
             follow_status, progress
         )
     };
@@ -1046,6 +1061,43 @@ mod tests {
         assert_eq!(resolved_scroll_offset(12, false, None, 0, &[], 100, 20), 12);
         assert_eq!(resolved_scroll_offset(80, true, None, 0, &[], 140, 20), 120);
         assert_eq!(resolved_scroll_offset(120, false, None, 0, &[], 60, 20), 40);
+    }
+
+    #[test]
+    fn test_keyboard_scroll_shortcuts_use_vim_distances() {
+        let action = |code, control| {
+            let mut event = KeyEvent::new(KeyEventKind::Press, code);
+            if control {
+                event.modifiers = KeyModifiers::CONTROL;
+            }
+            keyboard_scroll_action(&event, 21)
+        };
+
+        assert_eq!(
+            action(KeyCode::Char('d'), true),
+            Some(LogScrollAction::Forward(11))
+        );
+        assert_eq!(
+            action(KeyCode::Char('u'), true),
+            Some(LogScrollAction::Backward(11))
+        );
+        assert_eq!(
+            action(KeyCode::Char('f'), true),
+            Some(LogScrollAction::Forward(21))
+        );
+        assert_eq!(
+            action(KeyCode::Char('b'), true),
+            Some(LogScrollAction::Backward(21))
+        );
+        assert_eq!(
+            action(KeyCode::PageDown, false),
+            Some(LogScrollAction::Forward(21))
+        );
+        assert_eq!(
+            action(KeyCode::PageUp, false),
+            Some(LogScrollAction::Backward(21))
+        );
+        assert_eq!(action(KeyCode::Char('d'), false), None);
     }
 
     #[test]

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -108,6 +108,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     // The offset is measured in visual rows (one per terminal row); a single
     // log line may span multiple visual rows when wrapped.
     let mut scroll_offset = hooks.use_state(|| 0usize);
+    let mut follow_tail = hooks.use_state(|| true);
 
     // Selection state. Coordinates are (log_line_idx, visual_col) where
     // visual_col is a logical character offset within the log line, regardless
@@ -157,6 +158,12 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         (Arc::as_ptr(&state.logs) as usize, content_width),
     );
     let total_visual_rows = visual_rows.len();
+    let current_scroll_offset = resolved_scroll_offset(
+        scroll_offset.get(),
+        follow_tail.get(),
+        total_visual_rows,
+        viewport_height,
+    );
 
     let current_selection_anchor = selection_anchor.get();
     let current_selection_cursor = selection_cursor.get();
@@ -184,6 +191,8 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     command_tx.as_ref(),
                     attached,
                     &mut scroll_offset,
+                    &mut follow_tail,
+                    current_scroll_offset,
                     total_visual_rows,
                     viewport_height,
                     &mut SelectionState {
@@ -199,7 +208,7 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 // Exit keys flip `view_mode` on `ui_state`, which iocraft can't
                 // observe; wake the render loop so leaving the view is prompt
                 // instead of waiting for the idle heartbeat (#2915).
-                notify.notify_waiters();
+                notify.notify_one();
             }
             TerminalEvent::FullscreenMouse(mouse_event) => {
                 let prompt_active = ui_state
@@ -210,6 +219,8 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     handle_mouse_event(
                         mouse_event,
                         &mut scroll_offset,
+                        &mut follow_tail,
+                        current_scroll_offset,
                         total_visual_rows,
                         viewport_height,
                         &visual_rows_for_events,
@@ -254,8 +265,8 @@ pub fn ExpandedLogView(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         width,
         height,
         selection.as_ref(),
-        interrupt_prompt_active,
-        interrupt_prompt_attached,
+        follow_tail.get(),
+        (interrupt_prompt_active, interrupt_prompt_attached),
     )
 }
 
@@ -345,6 +356,20 @@ fn calculate_viewport_height(terminal_height: u16) -> usize {
     (terminal_height as usize).saturating_sub(2) // header + footer
 }
 
+fn resolved_scroll_offset(
+    scroll_offset: usize,
+    follow_tail: bool,
+    total_visual_rows: usize,
+    viewport_height: usize,
+) -> usize {
+    let max_offset = total_visual_rows.saturating_sub(viewport_height);
+    if follow_tail {
+        max_offset
+    } else {
+        scroll_offset.min(max_offset)
+    }
+}
+
 /// Mutable selection state passed to event handlers.
 struct SelectionState<'a> {
     has_selection: bool,
@@ -373,6 +398,8 @@ fn handle_key_event(
     command_tx: Option<&ProcessCommandSender>,
     attached: bool,
     scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    current_scroll_offset: usize,
     total_visual_rows: usize,
     viewport_height: usize,
     sel: &mut SelectionState<'_>,
@@ -408,32 +435,54 @@ fn handle_key_event(
 
         // Scroll down one line
         KeyCode::Down | KeyCode::Char('j') => {
-            scroll_offset.set((scroll_offset.get() + 1).min(max_offset));
+            let next = (current_scroll_offset + 1).min(max_offset);
+            scroll_offset.set(next);
+            follow_tail.set(next == max_offset);
         }
 
         // Scroll up one line
         KeyCode::Up | KeyCode::Char('k') => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(1));
+            scroll_offset.set(current_scroll_offset.saturating_sub(1));
+            follow_tail.set(false);
         }
 
         // Page down
         KeyCode::PageDown | KeyCode::Char(' ') => {
-            scroll_offset.set((scroll_offset.get() + viewport_height).min(max_offset));
+            let next = (current_scroll_offset + viewport_height).min(max_offset);
+            scroll_offset.set(next);
+            follow_tail.set(next == max_offset);
         }
 
         // Page up
         KeyCode::PageUp => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(viewport_height));
+            scroll_offset.set(current_scroll_offset.saturating_sub(viewport_height));
+            follow_tail.set(false);
         }
 
         // Go to top
         KeyCode::Home | KeyCode::Char('g') => {
             scroll_offset.set(0);
+            follow_tail.set(false);
         }
 
         // Go to bottom
         KeyCode::End | KeyCode::Char('G') => {
             scroll_offset.set(max_offset);
+            follow_tail.set(true);
+        }
+
+        KeyCode::Char('y') => {
+            let selection = match (sel.anchor, sel.cursor) {
+                (Some(anchor), Some(cursor)) => Some(Selection::from_anchor_cursor(anchor, cursor)),
+                _ => None,
+            };
+            let text = text_for_yank(sel.logs, selection.as_ref());
+            if !text.is_empty() {
+                copy_to_clipboard(&text);
+            }
+            if sel.has_selection {
+                sel.clear();
+            }
         }
 
         // Ctrl+C: copy selection if active, otherwise open the quit prompt
@@ -461,6 +510,8 @@ fn handle_key_event(
 fn handle_mouse_event(
     mouse_event: FullscreenMouseEvent,
     scroll_offset: &mut State<usize>,
+    follow_tail: &mut State<bool>,
+    current_scroll_offset: usize,
     total_visual_rows: usize,
     viewport_height: usize,
     visual_rows: &[VisualRow],
@@ -476,7 +527,7 @@ fn handle_mouse_event(
     // log line, accounting for the wrap segment that was clicked.
     let map_to_logical = |row: usize, col: usize| -> Option<(usize, usize)> {
         let visible_row_idx = row.checked_sub(1)?;
-        let visual_row_idx = scroll_offset.get() + visible_row_idx;
+        let visual_row_idx = current_scroll_offset + visible_row_idx;
         let vrow = visual_rows.get(visual_row_idx)?;
         let col_in_segment = col.saturating_sub(LINE_NUM_PREFIX_WIDTH);
         Some((vrow.log_idx, vrow.char_start + col_in_segment))
@@ -499,6 +550,8 @@ fn handle_mouse_event(
             selection_anchor.set(Some(pos));
             selection_cursor.set(Some(pos));
             is_selecting.set(true);
+            scroll_offset.set(current_scroll_offset);
+            follow_tail.set(false);
         }
 
         MouseEventKind::Drag(MouseButton::Left) => {
@@ -531,10 +584,13 @@ fn handle_mouse_event(
         }
 
         MouseEventKind::ScrollDown => {
-            scroll_offset.set((scroll_offset.get() + scroll_lines).min(max_offset));
+            let next = (current_scroll_offset + scroll_lines).min(max_offset);
+            scroll_offset.set(next);
+            follow_tail.set(next == max_offset);
         }
         MouseEventKind::ScrollUp => {
-            scroll_offset.set(scroll_offset.get().saturating_sub(scroll_lines));
+            scroll_offset.set(current_scroll_offset.saturating_sub(scroll_lines));
+            follow_tail.set(false);
         }
         _ => {}
     }
@@ -566,6 +622,13 @@ fn extract_selected_text(logs: &VecDeque<String>, selection: &Selection) -> Stri
     lines.join("\n")
 }
 
+fn text_for_yank(logs: &VecDeque<String>, selection: Option<&Selection>) -> String {
+    match selection {
+        Some(selection) => extract_selected_text(logs, selection),
+        None => logs.iter().cloned().collect::<Vec<_>>().join("\n"),
+    }
+}
+
 /// Render the expanded view UI
 fn render_expanded_view(
     state: &ExpandedViewState,
@@ -573,14 +636,19 @@ fn render_expanded_view(
     width: u16,
     height: u16,
     selection: Option<&Selection>,
-    interrupt_prompt_active: bool,
-    interrupt_prompt_attached: bool,
+    follow_tail: bool,
+    interrupt_prompt: (bool, bool),
 ) -> AnyElement<'static> {
+    let (interrupt_prompt_active, interrupt_prompt_attached) = interrupt_prompt;
     let viewport_height = calculate_viewport_height(height);
     let total_rows = visual_rows.len();
 
-    let max_offset = total_rows.saturating_sub(viewport_height);
-    let clamped_offset = state.scroll_offset.min(max_offset);
+    let clamped_offset = resolved_scroll_offset(
+        state.scroll_offset,
+        follow_tail,
+        total_rows,
+        viewport_height,
+    );
 
     let start = clamped_offset.min(total_rows);
     let end = (start + viewport_height).min(total_rows);
@@ -593,34 +661,35 @@ fn render_expanded_view(
     content_elements.extend(padding_elements);
 
     let progress = build_progress_indicator(clamped_offset, viewport_height, total_rows);
+    let follow_status = if follow_tail { "FOLLOWING" } else { "PAUSED" };
 
     // Build footer text - show copy hint when selection is active
     let footer_text = if interrupt_prompt_active {
         if interrupt_prompt_attached {
             format!(
-                "{} \u{2502} Detach or stop the process manager?  Ctrl-C:detach  s:stop manager  Esc:keep watching",
-                progress
+                "{} \u{2502} {} \u{2502} Detach or stop the process manager?  Ctrl-C:detach  s:stop manager  Esc:keep watching",
+                follow_status, progress
             )
         } else if width < 88 {
             format!(
-                "{} \u{2502} Quit devenv?  c:keep running  q/Ctrl-C:quit",
-                progress
+                "{} \u{2502} {} \u{2502} Quit devenv?  c:keep running  q/Ctrl-C:quit",
+                follow_status, progress
             )
         } else {
             format!(
-                "{} \u{2502} Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  Ctrl-C:quit",
-                progress
+                "{} \u{2502} {} \u{2502} Quit devenv? Nothing has been stopped yet  c:keep running  q:quit  Ctrl-C:quit",
+                follow_status, progress
             )
         }
     } else if selection.is_some() {
         format!(
-            "{} \u{2502} j/k:line  PgUp/PgDn:page  g/G:top/bottom  Ctrl-C:copy  Esc:deselect  q:back",
-            progress
+            "{} \u{2502} {} \u{2502} y:copy  j/k:line  PgUp/PgDn:page  g:top  G:follow  Ctrl-C:copy  Esc:deselect  q:back",
+            follow_status, progress
         )
     } else {
         format!(
-            "{} \u{2502} j/k:line  PgUp/PgDn:page  g/G:top/bottom  q:back",
-            progress
+            "{} \u{2502} {} \u{2502} y:copy all  j/k:line  PgUp/PgDn:page  g:top  G:follow  q:back",
+            follow_status, progress
         )
     };
 
@@ -777,6 +846,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_follow_mode_resolves_to_latest_rows() {
+        assert_eq!(resolved_scroll_offset(0, true, 100, 20), 80);
+        assert_eq!(resolved_scroll_offset(12, false, 100, 20), 12);
+        assert_eq!(resolved_scroll_offset(80, true, 140, 20), 120);
+        assert_eq!(resolved_scroll_offset(120, false, 60, 20), 40);
+    }
+
+    #[test]
+    fn test_render_expanded_view_shows_follow_state() {
+        let state = ExpandedViewState {
+            activity_name: "api".to_string(),
+            scroll_offset: 0,
+            logs: Arc::new(VecDeque::from(["ready".to_string()])),
+        };
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+
+        let mut following =
+            render_expanded_view(&state, &visual_rows, 100, 8, None, true, (false, false));
+        let following_output = following.render(Some(100)).to_string();
+        assert!(following_output.contains("FOLLOWING"));
+        assert!(following_output.contains("y:copy all"));
+
+        let mut paused =
+            render_expanded_view(&state, &visual_rows, 100, 8, None, false, (false, false));
+        let paused_output = paused.render(Some(100)).to_string();
+        assert!(paused_output.contains("PAUSED"));
+        assert!(paused_output.contains("G:follow"));
+    }
+
+    #[test]
+    fn test_yank_uses_selection_or_complete_log_buffer() {
+        let logs = VecDeque::from(["first".to_string(), "second".to_string()]);
+        assert_eq!(text_for_yank(&logs, None), "first\nsecond");
+
+        let selection = Selection::from_anchor_cursor((0, 1), (1, 3));
+        assert_eq!(text_for_yank(&logs, Some(&selection)), "irst\nsec");
+    }
+
+    #[test]
     fn test_render_expanded_view_interrupt_prompt_footer() {
         let state = ExpandedViewState {
             activity_name: "api".to_string(),
@@ -785,7 +893,8 @@ mod tests {
         };
         let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
 
-        let mut element = render_expanded_view(&state, &visual_rows, 100, 8, None, true, false);
+        let mut element =
+            render_expanded_view(&state, &visual_rows, 100, 8, None, true, (true, false));
         let output = element.render(Some(100)).to_string();
 
         assert!(output.contains("Quit devenv? Nothing has been stopped yet"));
@@ -865,7 +974,7 @@ mod tests {
             (visual_rows.len() as u16) + 2,
             None,
             false,
-            false,
+            (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
 
@@ -909,7 +1018,7 @@ mod tests {
             6,
             Some(&selection),
             false,
-            false,
+            (false, false),
         );
         let output = element.render(Some(width as usize)).to_string();
         assert!(output.contains("cdefghij"));

--- a/devenv-tui/src/expanded_view.rs
+++ b/devenv-tui/src/expanded_view.rs
@@ -1385,123 +1385,180 @@ fn render_expanded_view(
     } else {
         "PAUSED"
     };
+    let compact_follow_status = if ui.scroll_mode.follow_tail { "F" } else { "P" };
 
     let footer = if interrupt_prompt_active {
-        let mut footer_children = vec![expanded_footer_piece(
-            format!("{} \u{2502} {} \u{2502} ", follow_status, progress),
-            Color::AnsiValue(245),
-        )];
-        if interrupt_prompt_attached {
-            footer_children.push(expanded_footer_piece(
+        let compact = width < 120;
+        let status = if width < 60 {
+            format!("{compact_follow_status} ")
+        } else {
+            format!("{} \u{2502} {} \u{2502} ", follow_status, progress)
+        };
+        let mut action_children = Vec::new();
+        if interrupt_prompt_attached && compact {
+            action_children.push(expanded_footer_piece("Detach? ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("^C", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":detach ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("s", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":stop ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":watch", Color::AnsiValue(245)));
+        } else if interrupt_prompt_attached {
+            action_children.push(expanded_footer_piece(
                 "Detach or stop the process manager?  ",
                 Color::AnsiValue(245),
             ));
-            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":detach  ", Color::AnsiValue(245)));
-            footer_children.push(expanded_footer_piece("s", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(
+            action_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":detach  ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("s", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(
                 ":stop manager  ",
                 Color::AnsiValue(245),
             ));
-            footer_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(
+            action_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(
                 ":keep watching",
                 Color::AnsiValue(245),
             ));
+        } else if compact {
+            action_children.push(expanded_footer_piece("Quit? ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("c", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":run ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":quit ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("^C", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":quit", Color::AnsiValue(245)));
         } else {
-            footer_children.push(expanded_footer_piece(
-                if width < 88 {
-                    "Quit devenv?  "
-                } else {
-                    "Quit devenv? Nothing has been stopped yet  "
-                },
+            action_children.push(expanded_footer_piece(
+                "Quit devenv? Nothing has been stopped yet  ",
                 Color::AnsiValue(245),
             ));
-            footer_children.push(expanded_footer_piece("c", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(
+            action_children.push(expanded_footer_piece("c", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(
                 ":keep running  ",
                 Color::AnsiValue(245),
             ));
-            footer_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":quit  ", Color::AnsiValue(245)));
-            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":quit", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":quit  ", Color::AnsiValue(245)));
+            action_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+            action_children.push(expanded_footer_piece(":quit", Color::AnsiValue(245)));
         }
         element!(View(
             flex_direction: FlexDirection::Row,
             width: 100pct,
             overflow: Overflow::Hidden,
         ) {
-            #(footer_children)
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                Text(content: status, color: Color::AnsiValue(245))
+            }
+            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
+                #(action_children)
+            }
         })
         .into_any()
     } else if let Some(search) = ui.search.filter(|search| search.editing) {
-        let prompt = format!("Search logs: /{}", search.query);
+        let compact = width < 60;
+        let prompt = if compact {
+            format!("/{}", search.query)
+        } else {
+            format!("Search logs: /{}", search.query)
+        };
         let result = search_result_text(search);
         let prompt_color = if search.matches.is_empty() && !search.query.is_empty() {
             Color::AnsiValue(160)
         } else {
             Color::AnsiValue(220)
         };
+        let mut action_children = vec![expanded_footer_piece(
+            format!("{result}  "),
+            Color::AnsiValue(245),
+        )];
+        action_children.push(expanded_footer_piece("Enter", COLOR_INTERACTIVE));
+        if !compact {
+            action_children.push(expanded_footer_piece(":select  ", Color::AnsiValue(245)));
+        } else {
+            action_children.push(expanded_footer_piece("  ", Color::AnsiValue(245)));
+        }
+        action_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
+        if !compact {
+            action_children.push(expanded_footer_piece(":cancel", Color::AnsiValue(245)));
+        }
         element!(View(
             flex_direction: FlexDirection::Row,
             justify_content: JustifyContent::SpaceBetween,
             width: 100pct,
             overflow: Overflow::Hidden,
         ) {
-            View(flex_grow: 1.0, flex_shrink: 0.0, min_width: 0, overflow: Overflow::Hidden) {
+            View(flex_grow: 1.0, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
                 Text(content: prompt, color: prompt_color, weight: Weight::Bold)
             }
-            View(flex_direction: FlexDirection::Row, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
-                Text(content: format!("{result}  "), color: Color::AnsiValue(245))
-                Text(content: "Enter", color: COLOR_INTERACTIVE)
-                Text(content: ":select ", color: Color::AnsiValue(245))
-                Text(content: "Esc", color: COLOR_INTERACTIVE)
-                Text(content: ":cancel", color: Color::AnsiValue(245))
+            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0, margin_left: 1) {
+                #(action_children)
             }
-        }).into_any()
-    } else if let Some(notice) = ui.copy_notice {
-        element!(Text(
-            content: format!(
-                "{} \u{2502} {} \u{2502} {}",
-                follow_status,
-                progress,
-                notice.message()
-            ),
-            color: COLOR_COMPLETED,
-            weight: Weight::Bold
-        ))
+        })
         .into_any()
+    } else if let Some(notice) = ui.copy_notice {
+        if width < 60 {
+            element!(Text(
+                content: notice.message(),
+                color: COLOR_COMPLETED,
+                weight: Weight::Bold
+            ))
+            .into_any()
+        } else {
+            element!(View(
+                flex_direction: FlexDirection::Row,
+                width: 100pct,
+                overflow: Overflow::Hidden,
+            ) {
+                View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                    Text(
+                        content: format!("{} \u{2502} {} \u{2502} ", follow_status, progress),
+                        color: COLOR_COMPLETED,
+                        weight: Weight::Bold
+                    )
+                }
+                View(flex_shrink: 0.0) {
+                    Text(
+                        content: notice.message(),
+                        color: COLOR_COMPLETED,
+                        weight: Weight::Bold
+                    )
+                }
+            })
+            .into_any()
+        }
     } else if let Some(search) = ui.search {
         let result = search_result_text(search);
+        let compact = width < 90;
         let search_color = if search.matches.is_empty() {
             Color::AnsiValue(160)
         } else {
             Color::AnsiValue(220)
         };
-        let mut search_children = vec![
-            expanded_footer_piece(format!("/{}", search.query), search_color),
+        let mut action_children = vec![
             expanded_footer_piece(format!("  {result}  "), Color::AnsiValue(245)),
             expanded_footer_piece("n/N", COLOR_INTERACTIVE),
-            expanded_footer_piece(
-                if width < 90 { "  " } else { ":match  " },
-                Color::AnsiValue(245),
-            ),
-            expanded_footer_piece("/", COLOR_INTERACTIVE),
-            expanded_footer_piece(
-                if width < 90 {
-                    ":new  "
-                } else {
-                    ":new search  "
-                },
-                Color::AnsiValue(245),
-            ),
-            expanded_footer_piece("Esc", COLOR_INTERACTIVE),
-            expanded_footer_piece(":clear", Color::AnsiValue(245)),
         ];
-        if width >= 90 {
-            search_children.push(expanded_footer_piece("  q", COLOR_INTERACTIVE));
-            search_children.push(expanded_footer_piece(":back", Color::AnsiValue(245)));
+        if compact {
+            action_children.push(expanded_footer_piece("  ", Color::AnsiValue(245)));
+        } else {
+            action_children.push(expanded_footer_piece(":match  ", Color::AnsiValue(245)));
+        }
+        action_children.push(expanded_footer_piece("/", COLOR_INTERACTIVE));
+        action_children.push(expanded_footer_piece(
+            if compact { "  " } else { ":new search  " },
+            Color::AnsiValue(245),
+        ));
+        action_children.push(expanded_footer_piece("Esc", COLOR_INTERACTIVE));
+        if compact {
+            action_children.push(expanded_footer_piece("  ", Color::AnsiValue(245)));
+        } else {
+            action_children.push(expanded_footer_piece(":clear  ", Color::AnsiValue(245)));
+        }
+        action_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
+        if !compact {
+            action_children.push(expanded_footer_piece(":back", Color::AnsiValue(245)));
         }
         element!(View(
             flex_direction: FlexDirection::Row,
@@ -1509,66 +1566,77 @@ fn render_expanded_view(
             width: 100pct,
             overflow: Overflow::Hidden,
         ) {
-            View(flex_shrink: 0.0) {
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
                 Text(
-                    content: format!("{} \u{2502} {}", follow_status, progress),
+                    content: if width < 60 {
+                        format!("{compact_follow_status} ")
+                    } else {
+                        format!("{} \u{2502} {}  ", follow_status, progress)
+                    },
                     color: Color::AnsiValue(245)
                 )
             }
-            View(flex_direction: FlexDirection::Row, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
-                #(search_children)
+            View(flex_grow: 1.0, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                Text(content: format!("/{}", search.query), color: search_color)
+            }
+            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
+                #(action_children)
             }
         })
         .into_any()
     } else {
-        let mut footer_children = vec![expanded_footer_piece(
-            format!("{} \u{2502} {} \u{2502} ", follow_status, progress),
-            Color::AnsiValue(245),
-        )];
-        if ui.selection.is_some() {
-            footer_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
-            footer_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
+        let compact = width < 120;
+        let status = if width < 60 {
+            format!("{compact_follow_status} ")
         } else {
-            footer_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
-            footer_children.push(expanded_footer_piece(":copy all  ", Color::AnsiValue(245)));
-        }
-        footer_children.push(expanded_footer_piece("↑↓ j/k", COLOR_INTERACTIVE));
-        footer_children.push(expanded_footer_piece(
-            if width < 90 { "  " } else { ":line  " },
-            Color::AnsiValue(245),
-        ));
-        footer_children.push(expanded_footer_piece("^D/^U", COLOR_INTERACTIVE));
-        footer_children.push(expanded_footer_piece(
-            if width < 90 { "  " } else { ":half  " },
-            Color::AnsiValue(245),
-        ));
-        footer_children.push(expanded_footer_piece("^F/^B", COLOR_INTERACTIVE));
-        footer_children.push(expanded_footer_piece(
-            if width < 90 { "  " } else { ":page  " },
-            Color::AnsiValue(245),
-        ));
-        footer_children.push(expanded_footer_piece("/", COLOR_INTERACTIVE));
-        footer_children.push(expanded_footer_piece(
-            if width < 90 { "  " } else { ":search  " },
-            Color::AnsiValue(245),
-        ));
-        footer_children.push(expanded_footer_piece("g/G", COLOR_INTERACTIVE));
-        footer_children.push(expanded_footer_piece(
-            if width < 90 { "  " } else { ":top/follow  " },
-            Color::AnsiValue(245),
-        ));
-        footer_children.push(expanded_footer_piece("q", COLOR_INTERACTIVE));
-        if width >= 90 {
-            footer_children.push(expanded_footer_piece(":back", Color::AnsiValue(245)));
+            format!("{} \u{2502} {} \u{2502} ", follow_status, progress)
+        };
+        let mut action_children = Vec::new();
+        if compact {
+            action_children.push(expanded_footer_piece(
+                if ui.selection.is_some() {
+                    if width < 60 { "y/^C " } else { "y/Ctrl-C " }
+                } else {
+                    "y "
+                },
+                COLOR_INTERACTIVE,
+            ));
+            for key in ["↑↓ j/k ", "^D/^U ", "^F/^B ", "/ ", "g/G ", "q"] {
+                action_children.push(expanded_footer_piece(key, COLOR_INTERACTIVE));
+            }
+        } else {
+            if ui.selection.is_some() {
+                action_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
+                action_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
+                action_children.push(expanded_footer_piece("Ctrl-C", COLOR_INTERACTIVE));
+                action_children.push(expanded_footer_piece(":copy  ", Color::AnsiValue(245)));
+            } else {
+                action_children.push(expanded_footer_piece("y", COLOR_INTERACTIVE));
+                action_children.push(expanded_footer_piece(":copy all  ", Color::AnsiValue(245)));
+            }
+            for (key, label) in [
+                ("↑↓ j/k", ":line  "),
+                ("^D/^U", ":half  "),
+                ("^F/^B", ":page  "),
+                ("/", ":search  "),
+                ("g/G", ":top/follow  "),
+                ("q", ":back"),
+            ] {
+                action_children.push(expanded_footer_piece(key, COLOR_INTERACTIVE));
+                action_children.push(expanded_footer_piece(label, Color::AnsiValue(245)));
+            }
         }
         element!(View(
             flex_direction: FlexDirection::Row,
             width: 100pct,
             overflow: Overflow::Hidden,
         ) {
-            #(footer_children)
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                Text(content: status, color: Color::AnsiValue(245))
+            }
+            View(flex_direction: FlexDirection::Row, flex_shrink: 0.0) {
+                #(action_children)
+            }
         })
         .into_any()
     };
@@ -1798,6 +1866,26 @@ fn build_progress_indicator(offset: usize, viewport_height: usize, total_lines: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use unicode_width::UnicodeWidthStr;
+
+    fn expanded_ui<'a>(
+        selection: Option<&'a Selection>,
+        search: Option<LogSearchView<'a>>,
+        copy_notice: Option<CopyNotice>,
+        follow_tail: bool,
+        interrupt_prompt: (bool, bool),
+    ) -> ExpandedViewUi<'a> {
+        ExpandedViewUi {
+            selection,
+            search,
+            copy_notice,
+            scroll_mode: ScrollMode {
+                follow_tail,
+                anchor: None,
+            },
+            interrupt_prompt,
+        }
+    }
 
     #[test]
     fn test_follow_mode_resolves_to_latest_rows() {
@@ -1940,12 +2028,12 @@ mod tests {
             logs: Arc::new(VecDeque::from(["ready".to_string()])),
             buffer_start_line: 0,
         };
-        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(120));
 
         let mut following = render_expanded_view(
             &state,
             &visual_rows,
-            100,
+            120,
             8,
             ExpandedViewUi {
                 selection: None,
@@ -1958,7 +2046,7 @@ mod tests {
                 interrupt_prompt: (false, false),
             },
         );
-        let following_output = following.render(Some(100)).to_string();
+        let following_output = following.render(Some(120)).to_string();
         assert!(following_output.contains("FOLLOWING"));
         assert!(following_output.contains("y:copy all"));
         assert!(following_output.contains("↑↓ j/k:line"));
@@ -1967,7 +2055,7 @@ mod tests {
         let mut paused = render_expanded_view(
             &state,
             &visual_rows,
-            100,
+            120,
             8,
             ExpandedViewUi {
                 selection: None,
@@ -1980,9 +2068,147 @@ mod tests {
                 interrupt_prompt: (false, false),
             },
         );
-        let paused_output = paused.render(Some(100)).to_string();
+        let paused_output = paused.render(Some(120)).to_string();
         assert!(paused_output.contains("PAUSED"));
         assert!(paused_output.contains("g/G:top/follow"));
+    }
+
+    #[test]
+    fn expanded_footer_preserves_actions_across_widths() {
+        let state = ExpandedViewState {
+            activity_name: "api".to_string(),
+            scroll_offset: 0,
+            logs: Arc::new((0..1234).map(|line| format!("line {line}")).collect()),
+            buffer_start_line: 0,
+        };
+        let matches = find_log_matches(&state.logs, state.buffer_start_line, "line");
+        let selection = Selection::from_anchor_cursor((0, 0), (0, 1));
+
+        for width in 40u16..=240 {
+            let visual_rows = build_visual_rows(&state.logs, content_width_for(width));
+            let compact_controls = "↑↓ j/k ^D/^U ^F/^B / g/G q";
+            let normal_controls = if width < 120 {
+                compact_controls
+            } else {
+                "↑↓ j/k:line  ^D/^U:half  ^F/^B:page  /:search  g/G:top/follow  q:back"
+            };
+            let selection_copy = if width < 60 {
+                "y/^C"
+            } else if width < 120 {
+                "y/Ctrl-C"
+            } else {
+                "y:copy  Ctrl-C:copy"
+            };
+            let search_edit_actions = if width < 60 {
+                "Enter  Esc"
+            } else {
+                "Enter:select  Esc:cancel"
+            };
+            let search_actions = if width < 90 {
+                "n/N  /  Esc  q"
+            } else {
+                "n/N:match  /:new search  Esc:clear  q:back"
+            };
+            let quit_actions = if width < 120 {
+                "c:run q:quit ^C:quit"
+            } else {
+                "c:keep running  q:quit  Ctrl-C:quit"
+            };
+            let detach_actions = if width < 120 {
+                "^C:detach s:stop Esc:watch"
+            } else {
+                "Ctrl-C:detach  s:stop manager  Esc:keep watching"
+            };
+
+            for (name, ui, expected) in [
+                (
+                    "normal",
+                    expanded_ui(None, None, None, true, (false, false)),
+                    normal_controls,
+                ),
+                (
+                    "selection",
+                    expanded_ui(Some(&selection), None, None, false, (false, false)),
+                    selection_copy,
+                ),
+                (
+                    "search-editing",
+                    expanded_ui(
+                        None,
+                        Some(LogSearchView {
+                            query: "a-very-long-search-query",
+                            matches: &matches,
+                            current: Some(search_cursor(matches[0])),
+                            editing: true,
+                        }),
+                        None,
+                        false,
+                        (false, false),
+                    ),
+                    search_edit_actions,
+                ),
+                (
+                    "search",
+                    expanded_ui(
+                        None,
+                        Some(LogSearchView {
+                            query: "a-very-long-search-query",
+                            matches: &matches,
+                            current: Some(search_cursor(matches[0])),
+                            editing: false,
+                        }),
+                        None,
+                        false,
+                        (false, false),
+                    ),
+                    search_actions,
+                ),
+                (
+                    "copy",
+                    expanded_ui(
+                        None,
+                        None,
+                        CopyNotice::from_text("ready"),
+                        true,
+                        (false, false),
+                    ),
+                    "Copied 1 line (5B)",
+                ),
+                (
+                    "quit",
+                    expanded_ui(None, None, None, true, (true, false)),
+                    quit_actions,
+                ),
+                (
+                    "detach",
+                    expanded_ui(None, None, None, true, (true, true)),
+                    detach_actions,
+                ),
+            ] {
+                let mut element = render_expanded_view(&state, &visual_rows, width, 8, ui);
+                let output = element.render(Some(width as usize)).to_string();
+                let widest = output
+                    .lines()
+                    .map(UnicodeWidthStr::width)
+                    .max()
+                    .unwrap_or(0);
+                assert!(
+                    widest <= width as usize,
+                    "{name} width {widest} exceeds terminal width {width}:\n{output}"
+                );
+                let footer = output.lines().last().unwrap_or_default();
+                assert!(
+                    footer.contains(expected),
+                    "{name} footer lost actions at width {width}:\n{output}"
+                );
+                if name == "selection" {
+                    assert!(
+                        footer.contains(normal_controls),
+                        "selected footer lost navigation at width {width}:\n{output}"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -1993,13 +2219,13 @@ mod tests {
             logs: Arc::new(VecDeque::from(["Error here".to_string()])),
             buffer_start_line: 10,
         };
-        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(120));
         let matches = find_log_matches(&state.logs, state.buffer_start_line, "error");
 
         let mut editing = render_expanded_view(
             &state,
             &visual_rows,
-            100,
+            120,
             8,
             ExpandedViewUi {
                 selection: None,
@@ -2134,12 +2360,12 @@ mod tests {
             logs: Arc::new(VecDeque::new()),
             buffer_start_line: 0,
         };
-        let visual_rows = build_visual_rows(&state.logs, content_width_for(100));
+        let visual_rows = build_visual_rows(&state.logs, content_width_for(120));
 
         let mut element = render_expanded_view(
             &state,
             &visual_rows,
-            100,
+            120,
             8,
             ExpandedViewUi {
                 selection: None,
@@ -2152,7 +2378,7 @@ mod tests {
                 interrupt_prompt: (true, false),
             },
         );
-        let output = element.render(Some(100)).to_string();
+        let output = element.render(Some(120)).to_string();
 
         assert!(output.contains("Quit devenv? Nothing has been stopped yet"));
         assert!(output.contains("c:keep running"));

--- a/devenv-tui/src/lib.rs
+++ b/devenv-tui/src/lib.rs
@@ -79,8 +79,8 @@ impl RedrawSink for State<u64> {
 /// the heartbeat.
 ///
 /// Throttling/coalescing: after any redraw we sleep at least `throttle` before
-/// the next one; notifications during that sleep are coalesced because `version`
-/// keeps climbing and is re-read on the next iteration.
+/// the next one; model notifications are retained by `version`, while input
+/// notifications retain a `Notify` permit for the next iteration.
 ///
 /// The `shutdown` notify bypasses everything: when fired the loop emits one
 /// final redraw and returns immediately, so cooperative-exit flags are observed
@@ -258,7 +258,7 @@ mod tests {
         let before = h.redraws();
 
         // Notify without bumping the version, as the key handlers do.
-        h.notify.notify_waiters();
+        h.notify.notify_one();
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         let after = h.redraws();
@@ -267,6 +267,23 @@ mod tests {
             "an input notify must trigger a redraw (before={before}, after={after})"
         );
 
+        h.stop().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn input_notify_during_throttle_is_not_lost() {
+        let h = Harness::spawn();
+        tokio::task::yield_now().await;
+        let before = h.redraws();
+
+        h.notify.notify_one();
+        tokio::time::sleep(Duration::from_millis(17)).await;
+
+        let after = h.redraws();
+        assert!(
+            after > before,
+            "input during the throttle window must redraw without waiting for the heartbeat"
+        );
         h.stop().await;
     }
 

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -1373,17 +1373,10 @@ impl ActivityModel {
     }
 
     fn is_completed_shell_activity(&self, activity: &Activity) -> bool {
-        let is_shell_activity = match activity.variant {
-            ActivityVariant::Evaluating(_) => true,
-            ActivityVariant::Devenv => {
-                activity.name.to_lowercase().contains("shell")
-                    || self.activities.values().any(|child| {
-                        matches!(child.variant, ActivityVariant::Evaluating(_))
-                            && self.is_direct_child_of(child, activity.id)
-                    })
-            }
-            _ => return false,
-        };
+        let is_shell_activity = matches!(
+            activity.variant,
+            ActivityVariant::Evaluating(_) | ActivityVariant::Devenv
+        ) && activity.name.to_lowercase().contains("shell");
         if !matches!(
             activity.state,
             NixActivityState::Completed { success: true, .. }
@@ -1399,6 +1392,35 @@ impl ActivityModel {
         is_shell_activity
     }
 
+    fn has_diagnostic_descendant(&self, activity_id: u64) -> bool {
+        let mut pending = vec![activity_id];
+        let mut visited = HashSet::from([activity_id]);
+
+        while let Some(parent_id) = pending.pop() {
+            for child in self
+                .activities
+                .values()
+                .filter(|child| self.is_direct_child_of(child, parent_id))
+            {
+                if !visited.insert(child.id) {
+                    continue;
+                }
+                if matches!(
+                    child.variant,
+                    ActivityVariant::Message(MessageActivity {
+                        level: ActivityLevel::Error | ActivityLevel::Warn,
+                        ..
+                    })
+                ) {
+                    return true;
+                }
+                pending.push(child.id);
+            }
+        }
+
+        false
+    }
+
     pub fn collapsible_descendant_count(
         &self,
         activity_id: u64,
@@ -1406,6 +1428,7 @@ impl ActivityModel {
     ) -> Option<usize> {
         let activity = self.activities.get(&activity_id)?;
         if !self.is_completed_shell_activity(activity)
+            || self.has_diagnostic_descendant(activity_id)
             || activity
                 .parent_id
                 .and_then(|parent_id| self.activities.get(&parent_id))

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -160,6 +160,7 @@ pub struct UiState {
     pub viewport: ViewportConfig,
     pub selected_activity: Option<u64>,
     pub inline_logs_activity: Option<u64>,
+    pub process_previews_hidden: bool,
     pub expanded_activities: HashSet<u64>,
     pub process_search: Option<ProcessSearch>,
     pub hide_stopped_processes: bool,
@@ -193,6 +194,7 @@ impl UiState {
             },
             selected_activity: None,
             inline_logs_activity: None,
+            process_previews_hidden: false,
             expanded_activities: HashSet::new(),
             process_search: None,
             hide_stopped_processes: false,
@@ -282,6 +284,16 @@ impl UiState {
             Some(id) if self.inline_logs_activity != Some(id) => Some(id),
             _ => None,
         };
+    }
+
+    pub fn focus_inline_logs(&mut self, activity_id: u64) {
+        self.inline_logs_activity = Some(activity_id);
+        self.process_previews_hidden = true;
+    }
+
+    pub fn hide_process_previews(&mut self) {
+        self.inline_logs_activity = None;
+        self.process_previews_hidden = true;
     }
 
     pub fn toggle_activity_expansion(&mut self, activity_id: u64) {
@@ -1164,9 +1176,18 @@ impl ActivityModel {
     }
 
     pub fn get_selectable_activity_ids(&self, ui_state: &UiState) -> Vec<u64> {
+        let display = self.get_display_activities(ui_state);
+        self.get_selectable_activity_ids_from_display(&display, ui_state)
+    }
+
+    pub fn get_selectable_activity_ids_from_display(
+        &self,
+        display: &[DisplayActivity],
+        ui_state: &UiState,
+    ) -> Vec<u64> {
         let mut seen = HashSet::new();
-        self.get_display_activities(ui_state)
-            .into_iter()
+        display
+            .iter()
             .filter(|da| {
                 // Processes are always selectable (so disabled ones can be started)
                 matches!(da.activity.variant, ActivityVariant::Process(_))
@@ -1184,9 +1205,18 @@ impl ActivityModel {
     }
 
     pub fn get_matching_process_activity_ids(&self, ui_state: &UiState, query: &str) -> Vec<u64> {
+        let display = self.get_display_activities(ui_state);
+        self.get_matching_process_activity_ids_from_display(&display, query)
+    }
+
+    pub fn get_matching_process_activity_ids_from_display(
+        &self,
+        display: &[DisplayActivity],
+        query: &str,
+    ) -> Vec<u64> {
         let query = query.to_lowercase();
-        self.get_display_activities(ui_state)
-            .into_iter()
+        display
+            .iter()
             .filter(|da| matches!(da.activity.variant, ActivityVariant::Process(_)))
             .filter(|da| da.activity.name.to_lowercase().contains(&query))
             .map(|da| da.activity.id)
@@ -1338,12 +1368,6 @@ impl ActivityModel {
     }
 
     fn is_completed_shell_activity(&self, activity: &Activity) -> bool {
-        if self.activities.values().any(|child| {
-            matches!(child.variant, ActivityVariant::Process(_))
-                && self.is_direct_child_of(child, activity.id)
-        }) {
-            return false;
-        }
         let is_shell_activity = match activity.variant {
             ActivityVariant::Evaluating(_) => true,
             ActivityVariant::Devenv => {
@@ -1353,24 +1377,44 @@ impl ActivityModel {
                             && self.is_direct_child_of(child, activity.id)
                     })
             }
-            _ => false,
+            _ => return false,
         };
+        if !matches!(
+            activity.state,
+            NixActivityState::Completed { success: true, .. }
+        ) {
+            return false;
+        }
+        if self.activities.values().any(|child| {
+            matches!(child.variant, ActivityVariant::Process(_))
+                && self.is_direct_child_of(child, activity.id)
+        }) {
+            return false;
+        }
         is_shell_activity
-            && matches!(
-                activity.state,
-                NixActivityState::Completed { success: true, .. }
-            )
+    }
+
+    pub fn collapsible_descendant_count(
+        &self,
+        activity_id: u64,
+        ui_state: &UiState,
+    ) -> Option<usize> {
+        let activity = self.activities.get(&activity_id)?;
+        if !self.is_completed_shell_activity(activity)
+            || activity
+                .parent_id
+                .and_then(|parent_id| self.activities.get(&parent_id))
+                .is_some_and(|parent| self.is_completed_shell_activity(parent))
+        {
+            return None;
+        }
+        let descendant_count = self.visible_descendant_count(activity_id, ui_state);
+        (descendant_count > 0).then_some(descendant_count)
     }
 
     pub fn is_activity_collapsible(&self, activity_id: u64, ui_state: &UiState) -> bool {
-        self.activities.get(&activity_id).is_some_and(|activity| {
-            self.is_completed_shell_activity(activity)
-                && !activity
-                    .parent_id
-                    .and_then(|parent_id| self.activities.get(&parent_id))
-                    .is_some_and(|parent| self.is_completed_shell_activity(parent))
-                && self.visible_descendant_count(activity_id, ui_state) > 0
-        })
+        self.collapsible_descendant_count(activity_id, ui_state)
+            .is_some()
     }
 
     pub fn is_activity_collapsed(&self, activity_id: u64, ui_state: &UiState) -> bool {

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -252,6 +252,10 @@ impl UiState {
     /// When `forward` is true, selects the next activity (or first if none selected).
     /// When `forward` is false, selects the previous activity (or last if none selected).
     pub fn select_activity(&mut self, selectable: &[u64], forward: bool) {
+        self.select_activity_by(selectable, 1, forward);
+    }
+
+    pub fn select_activity_by(&mut self, selectable: &[u64], steps: usize, forward: bool) {
         if selectable.is_empty() {
             return;
         }
@@ -266,11 +270,12 @@ impl UiState {
             Some(current_id) => {
                 if let Some(current_pos) = selectable.iter().position(|&id| id == current_id) {
                     if forward {
-                        if current_pos + 1 < selectable.len() {
-                            self.selected_activity = Some(selectable[current_pos + 1]);
-                        }
-                    } else if current_pos > 0 {
-                        self.selected_activity = Some(selectable[current_pos - 1]);
+                        self.selected_activity = selectable
+                            .get(current_pos.saturating_add(steps).min(selectable.len() - 1))
+                            .copied();
+                    } else {
+                        self.selected_activity =
+                            selectable.get(current_pos.saturating_sub(steps)).copied();
                     }
                 } else {
                     self.selected_activity = selectable.first().copied();

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -159,6 +159,8 @@ pub struct Activity {
 pub struct UiState {
     pub viewport: ViewportConfig,
     pub selected_activity: Option<u64>,
+    pub inline_logs_activity: Option<u64>,
+    pub process_search: Option<ProcessSearch>,
     pub hide_stopped_processes: bool,
     pub scroll: ScrollState,
     pub view_options: ViewOptions,
@@ -189,6 +191,8 @@ impl UiState {
                 activities_visible: 5,
             },
             selected_activity: None,
+            inline_logs_activity: None,
+            process_search: None,
             hide_stopped_processes: false,
             scroll: ScrollState {
                 log_offset: 0,
@@ -270,6 +274,33 @@ impl UiState {
             }
         }
     }
+
+    pub fn toggle_inline_logs(&mut self) {
+        self.inline_logs_activity = match self.selected_activity {
+            Some(id) if self.inline_logs_activity != Some(id) => Some(id),
+            _ => None,
+        };
+    }
+
+    pub fn start_process_search(&mut self) {
+        if self.process_search.is_none() {
+            self.process_search = Some(ProcessSearch {
+                query: String::new(),
+                original_selection: self.selected_activity,
+            });
+            self.inline_logs_activity = None;
+        }
+    }
+
+    pub fn finish_process_search(&mut self) {
+        self.process_search = None;
+    }
+
+    pub fn cancel_process_search(&mut self) {
+        if let Some(search) = self.process_search.take() {
+            self.selected_activity = search.original_selection;
+        }
+    }
 }
 
 impl Default for UiState {
@@ -301,6 +332,12 @@ pub struct ScrollState {
 #[derive(Debug)]
 pub struct ViewOptions {
     pub show_details: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessSearch {
+    pub query: String,
+    pub original_selection: Option<u64>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -1134,6 +1171,16 @@ impl ActivityModel {
                 let id = da.activity.id;
                 seen.insert(id).then_some(id)
             })
+            .collect()
+    }
+
+    pub fn get_matching_process_activity_ids(&self, ui_state: &UiState, query: &str) -> Vec<u64> {
+        let query = query.to_lowercase();
+        self.get_display_activities(ui_state)
+            .into_iter()
+            .filter(|da| matches!(da.activity.variant, ActivityVariant::Process(_)))
+            .filter(|da| da.activity.name.to_lowercase().contains(&query))
+            .map(|da| da.activity.id)
             .collect()
     }
 

--- a/devenv-tui/src/model.rs
+++ b/devenv-tui/src/model.rs
@@ -160,6 +160,7 @@ pub struct UiState {
     pub viewport: ViewportConfig,
     pub selected_activity: Option<u64>,
     pub inline_logs_activity: Option<u64>,
+    pub expanded_activities: HashSet<u64>,
     pub process_search: Option<ProcessSearch>,
     pub hide_stopped_processes: bool,
     pub scroll: ScrollState,
@@ -192,6 +193,7 @@ impl UiState {
             },
             selected_activity: None,
             inline_logs_activity: None,
+            expanded_activities: HashSet::new(),
             process_search: None,
             hide_stopped_processes: false,
             scroll: ScrollState {
@@ -280,6 +282,12 @@ impl UiState {
             Some(id) if self.inline_logs_activity != Some(id) => Some(id),
             _ => None,
         };
+    }
+
+    pub fn toggle_activity_expansion(&mut self, activity_id: u64) {
+        if !self.expanded_activities.insert(activity_id) {
+            self.expanded_activities.remove(&activity_id);
+        }
     }
 
     pub fn start_process_search(&mut self) {
@@ -1162,6 +1170,7 @@ impl ActivityModel {
             .filter(|da| {
                 // Processes are always selectable (so disabled ones can be started)
                 matches!(da.activity.variant, ActivityVariant::Process(_))
+                    || self.is_activity_collapsible(da.activity.id, ui_state)
                     || self
                         .build_logs
                         .get(&da.activity.id)
@@ -1258,6 +1267,10 @@ impl ActivityModel {
                 });
             }
 
+            if activity_visible && self.is_activity_collapsed(activity_id, ui_state) {
+                return;
+            }
+
             // Recursively process children.
             // Even if this activity is filtered, still traverse to children
             // so we can find visible descendants (e.g., Info messages under Debug parents).
@@ -1322,6 +1335,77 @@ impl ActivityModel {
                 self.is_direct_child_of(a, parent_id) && self.is_hidden_process(a, ui_state)
             })
             .count()
+    }
+
+    fn is_completed_shell_activity(&self, activity: &Activity) -> bool {
+        if self.activities.values().any(|child| {
+            matches!(child.variant, ActivityVariant::Process(_))
+                && self.is_direct_child_of(child, activity.id)
+        }) {
+            return false;
+        }
+        let is_shell_activity = match activity.variant {
+            ActivityVariant::Evaluating(_) => true,
+            ActivityVariant::Devenv => {
+                activity.name.to_lowercase().contains("shell")
+                    || self.activities.values().any(|child| {
+                        matches!(child.variant, ActivityVariant::Evaluating(_))
+                            && self.is_direct_child_of(child, activity.id)
+                    })
+            }
+            _ => false,
+        };
+        is_shell_activity
+            && matches!(
+                activity.state,
+                NixActivityState::Completed { success: true, .. }
+            )
+    }
+
+    pub fn is_activity_collapsible(&self, activity_id: u64, ui_state: &UiState) -> bool {
+        self.activities.get(&activity_id).is_some_and(|activity| {
+            self.is_completed_shell_activity(activity)
+                && !activity
+                    .parent_id
+                    .and_then(|parent_id| self.activities.get(&parent_id))
+                    .is_some_and(|parent| self.is_completed_shell_activity(parent))
+                && self.visible_descendant_count(activity_id, ui_state) > 0
+        })
+    }
+
+    pub fn is_activity_collapsed(&self, activity_id: u64, ui_state: &UiState) -> bool {
+        self.is_activity_collapsible(activity_id, ui_state)
+            && !ui_state.expanded_activities.contains(&activity_id)
+    }
+
+    pub fn visible_descendant_count(&self, activity_id: u64, ui_state: &UiState) -> usize {
+        fn visit(
+            model: &ActivityModel,
+            activity_id: u64,
+            ui_state: &UiState,
+            visited: &mut HashSet<u64>,
+        ) -> usize {
+            model
+                .activities
+                .values()
+                .filter(|child| {
+                    !matches!(child.variant, ActivityVariant::UserOperation)
+                        && !model.is_hidden_process(child, ui_state)
+                        && model.is_direct_child_of(child, activity_id)
+                })
+                .map(|child| {
+                    if visited.insert(child.id) {
+                        usize::from(child.level <= model.config.filter_level)
+                            + visit(model, child.id, ui_state, visited)
+                    } else {
+                        0
+                    }
+                })
+                .sum()
+        }
+
+        let mut visited = HashSet::from([activity_id]);
+        visit(self, activity_id, ui_state, &mut visited)
     }
 
     pub fn calculate_summary(&self) -> ActivitySummary {

--- a/devenv-tui/src/model_events.rs
+++ b/devenv-tui/src/model_events.rs
@@ -27,13 +27,19 @@ impl UiEvent {
                     Down | Char('j') => {
                         let selectable = activity_model.get_selectable_activity_ids(ui_state);
                         ui_state.select_activity(&selectable, true);
+                        ui_state.inline_logs_activity = None;
                     }
                     Up | Char('k') => {
                         let selectable = activity_model.get_selectable_activity_ids(ui_state);
                         ui_state.select_activity(&selectable, false);
+                        ui_state.inline_logs_activity = None;
                     }
                     Esc => {
-                        ui_state.selected_activity = None;
+                        if ui_state.inline_logs_activity.is_some() {
+                            ui_state.inline_logs_activity = None;
+                        } else {
+                            ui_state.selected_activity = None;
+                        }
                     }
                     // Note: 'e' for expand is handled directly in TuiApp to trigger view switch
                     _ => {}
@@ -44,5 +50,25 @@ impl UiEvent {
                 ui_state.set_terminal_size(size.width, size.height);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_closes_inline_logs_before_clearing_selection() {
+        let model = ActivityModel::new();
+        let mut ui_state = UiState::new();
+        ui_state.selected_activity = Some(1);
+        ui_state.inline_logs_activity = Some(1);
+
+        UiEvent::KeyInput(KeyCode::Esc).apply(&model, &mut ui_state);
+        assert_eq!(ui_state.selected_activity, Some(1));
+        assert_eq!(ui_state.inline_logs_activity, None);
+
+        UiEvent::KeyInput(KeyCode::Esc).apply(&model, &mut ui_state);
+        assert_eq!(ui_state.selected_activity, None);
     }
 }

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -11,8 +11,7 @@ use iocraft::Context;
 use iocraft::components::ContextProvider;
 use iocraft::hooks::UseComponentRect;
 use iocraft::prelude::*;
-use std::collections::HashMap;
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -152,6 +151,12 @@ pub fn view(
         .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
     let selected_activity = selected_id.and_then(|id| model.get_activity(id));
     let activities_to_show: Vec<_> = active_activities.iter().collect();
+    let process_search_match_ids = ui_state.process_search.as_ref().map(|search| {
+        model
+            .get_matching_process_activity_ids_from_display(&active_activities, &search.query)
+            .into_iter()
+            .collect::<HashSet<_>>()
+    });
 
     // Create owned activity elements, including hidden children indicators
     let mut activity_elements: Vec<AnyElement<'static>> = Vec::new();
@@ -159,6 +164,7 @@ pub fn view(
     for (display_activity, tree_position) in activities_to_show.iter().zip(tree_positions) {
         let activity = &display_activity.activity;
         let is_selected = selected_id.is_some_and(|id| activity.id == id && activity.id != 0);
+        let is_dimmed = activity_is_dimmed(activity, process_search_match_ids.as_ref());
         let show_inline_logs =
             activity_shows_inline_logs(model, ui_state, activity.id, process_previews_fit);
         let disclosure = model
@@ -228,6 +234,7 @@ pub fn view(
                     tree_position,
                     disclosure,
                     is_selected,
+                    is_dimmed,
                     show_inline_logs,
                     logs: activity_logs,
                     log_line_count: model.get_log_line_count(activity.id),
@@ -247,14 +254,6 @@ pub fn view(
     // Determine if navigation is possible
     let selectable_ids =
         model.get_selectable_activity_ids_from_display(&active_activities, ui_state);
-    let process_search_ids = model.get_matching_process_activity_ids_from_display(
-        &active_activities,
-        ui_state
-            .process_search
-            .as_ref()
-            .map(|search| search.query.as_str())
-            .unwrap_or_default(),
-    );
     let (can_go_up, can_go_down) = if let Some(current_id) = selected_id {
         if let Some(pos) = selectable_ids.iter().position(|&id| id == current_id) {
             (pos > 0, pos + 1 < selectable_ids.len())
@@ -284,7 +283,7 @@ pub fn view(
                 .process_search
                 .as_ref()
                 .map(|search| search.query.clone()),
-            process_search_matches: process_search_ids.len(),
+            process_search_matches: process_search_match_ids.as_ref().map_or(0, HashSet::len),
             process_search_available: active_activities
                 .iter()
                 .any(|display| matches!(display.activity.variant, ActivityVariant::Process(_))),
@@ -387,6 +386,7 @@ struct ActivityRenderContext {
     tree_position: TreePosition,
     disclosure: Option<ActivityDisclosure>,
     is_selected: bool,
+    is_dimmed: bool,
     show_inline_logs: bool,
     logs: Option<Arc<VecDeque<String>>>,
     /// Total log line count (not affected by buffer rotation)
@@ -401,6 +401,15 @@ struct ActivityRenderContext {
     shutting_down: bool,
     /// Number of direct children hidden by the `hide_stopped_processes` filter.
     hidden_children_count: usize,
+}
+
+fn activity_is_dimmed(
+    activity: &Activity,
+    process_search_match_ids: Option<&HashSet<u64>>,
+) -> bool {
+    process_search_match_ids.is_some_and(|matches| {
+        matches!(activity.variant, ActivityVariant::Process(_)) && !matches.contains(&activity.id)
+    })
 }
 
 fn disclosed_name(activity: &Activity, disclosure: Option<&ActivityDisclosure>) -> String {
@@ -517,6 +526,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         tree_position,
         disclosure,
         is_selected,
+        is_dimmed,
         show_inline_logs,
         logs,
         log_line_count,
@@ -938,6 +948,11 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // state; transient states pulse instead of animating a spinner.
             let (dot_glyph, dot_color, dot_pulse) =
                 process_status_dot(&process_data.status, *completed, *shutting_down);
+            let dot_color = if *is_dimmed {
+                COLOR_HIERARCHY
+            } else {
+                dot_color
+            };
             let prefix =
                 build_process_prefix(*depth, tree_position, dot_glyph, dot_color, dot_pulse);
 
@@ -958,6 +973,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             )
             .with_suffix(status_text)
             .with_selection(*is_selected)
+            .with_dimmed(*is_dimmed)
             .render(terminal_width, *depth, prefix);
 
             let process_failed = *completed == Some(false) || process_data.status.is_failed();
@@ -1289,6 +1305,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         } else {
             format!("{result} • ↑↓ next • Enter select • Esc cancel")
         };
+        let prompt_color = process_search_prompt_color(process_search_matches);
         return element!(View(
             flex_direction: FlexDirection::Row,
             justify_content: JustifyContent::SpaceBetween,
@@ -1296,7 +1313,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             overflow: Overflow::Hidden,
         ) {
             View(flex_grow: 1.0, flex_shrink: 0.0, min_width: 0, overflow: Overflow::Hidden) {
-                Text(content: prompt, color: COLOR_INTERACTIVE, weight: Weight::Bold)
+                Text(content: prompt, color: prompt_color, weight: Weight::Bold)
             }
             View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
                 Text(content: hints)
@@ -1754,6 +1771,14 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     }).into_any()
 }
 
+fn process_search_prompt_color(matches: usize) -> Color {
+    if matches == 0 {
+        COLOR_FAILED
+    } else {
+        COLOR_INTERACTIVE
+    }
+}
+
 /// Format a duration in a human-readable way
 pub fn format_duration(duration: Duration) -> String {
     if cfg!(feature = "deterministic-tui") {
@@ -1932,6 +1957,46 @@ mod tests {
             .to_string();
         assert!(output.contains("1 match"));
         assert!(output.contains("Esc cancel"));
+    }
+
+    #[test]
+    fn test_process_search_prompt_turns_red_without_matches() {
+        assert_eq!(process_search_prompt_color(0), COLOR_FAILED);
+        assert_eq!(process_search_prompt_color(1), COLOR_INTERACTIVE);
+    }
+
+    #[test]
+    fn test_process_search_dims_only_non_matching_processes() {
+        let mut model = ActivityModel::default();
+        let ui_state = UiState::new();
+
+        for (id, name) in [(1, "email-worker"), (2, "event-router")] {
+            model.apply_activity_event(ActivityEvent::Process(Process::Start {
+                id,
+                name: name.to_string(),
+                parent: None,
+                command: None,
+                ports: vec![],
+                ready_probe: None,
+                level: ActivityLevel::Info,
+                timestamp: Timestamp::now(),
+            }));
+        }
+
+        let matches: HashSet<_> = model
+            .get_matching_process_activity_ids(&ui_state, "ema")
+            .into_iter()
+            .collect();
+
+        assert!(!activity_is_dimmed(
+            model.get_activity(1).unwrap(),
+            Some(&matches)
+        ));
+        assert!(activity_is_dimmed(
+            model.get_activity(2).unwrap(),
+            Some(&matches)
+        ));
+        assert!(!activity_is_dimmed(model.get_activity(2).unwrap(), None));
     }
 
     #[test]

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -1295,10 +1295,10 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             width: 100pct,
             overflow: Overflow::Hidden,
         ) {
-            View(flex_grow: 1.0, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+            View(flex_grow: 1.0, flex_shrink: 0.0, min_width: 0, overflow: Overflow::Hidden) {
                 Text(content: prompt, color: COLOR_INTERACTIVE, weight: Weight::Bold)
             }
-            View(flex_shrink: 0.0, margin_left: 2) {
+            View(flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden, margin_left: 2) {
                 Text(content: hints)
             }
         })
@@ -1908,6 +1908,30 @@ mod tests {
         assert!(!output.contains("hide stopped"));
         assert!(!output.contains("show stopped"));
         assert!(!output.contains("Ctrl-H"));
+    }
+
+    #[test]
+    fn test_process_search_keeps_query_visible_across_terminal_widths() {
+        let mut ctx = summary_ctx(false, false, 0);
+        ctx.process_search = Some("worker".to_string());
+        ctx.process_search_matches = 1;
+
+        for width in [32, 48, 72, 120] {
+            let output = build_summary_view_impl(&ctx, width)
+                .render(Some(width as usize))
+                .to_string();
+
+            assert!(
+                output.contains("Search processes: /worker"),
+                "search query was truncated at {width} columns: {output:?}"
+            );
+        }
+
+        let output = build_summary_view_impl(&ctx, 120)
+            .render(Some(120))
+            .to_string();
+        assert!(output.contains("1 match"));
+        assert!(output.contains("Esc cancel"));
     }
 
     #[test]

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -52,11 +52,10 @@ pub fn view(
         .selected_activity
         .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
     let selected_activity = selected_id.and_then(|id| model.get_activity(id));
-    let selected_logs = selected_activity
-        .as_ref()
-        .and_then(|a| model.get_build_logs(a.id));
+    let inline_logs_id = ui_state
+        .inline_logs_activity
+        .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
 
-    // Show all activities (including the selected activity with inline logs)
     let activities_to_show: Vec<_> = active_activities.iter().collect();
 
     // Create owned activity elements, including hidden children indicators
@@ -65,11 +64,11 @@ pub fn view(
     for display_activity in activities_to_show.iter() {
         let activity = &display_activity.activity;
         let is_selected = selected_id.is_some_and(|id| activity.id == id && activity.id != 0);
+        let show_inline_logs = inline_logs_id.is_some_and(|id| activity.id == id);
 
         // Pass logs for activities that should display them:
         // - Tasks with show_output=true or failed: show logs inline
         // - Messages with details: always show details inline
-        // - Selected activities: show logs when selected
         let task_failed = matches!(
             (&activity.variant, &activity.state),
             (
@@ -99,10 +98,8 @@ pub fn view(
                 ActivityVariant::Message(msg_data) => msg_data.details.is_some(),
                 _ => false,
             };
-        let activity_logs = if show_activity_logs {
+        let activity_logs = if show_activity_logs || show_inline_logs {
             model.get_build_logs(activity.id).cloned()
-        } else if is_selected {
-            selected_logs.cloned()
         } else {
             None
         };
@@ -127,6 +124,7 @@ pub fn view(
                     activity: activity.clone(),
                     depth: display_activity.depth,
                     is_selected,
+                    show_inline_logs,
                     logs: activity_logs,
                     log_line_count: model.get_log_line_count(activity.id),
                     completed,
@@ -144,6 +142,14 @@ pub fn view(
 
     // Determine if navigation is possible
     let selectable_ids = model.get_selectable_activity_ids(ui_state);
+    let process_search_ids = model.get_matching_process_activity_ids(
+        ui_state,
+        ui_state
+            .process_search
+            .as_ref()
+            .map(|search| search.query.as_str())
+            .unwrap_or_default(),
+    );
     let (can_go_up, can_go_down) = if let Some(current_id) = selected_id {
         if let Some(pos) = selectable_ids.iter().position(|&id| id == current_id) {
             (pos > 0, pos + 1 < selectable_ids.len())
@@ -161,12 +167,20 @@ pub fn view(
         ContextProvider(value: Context::owned(SummaryViewContext {
             summary: summary.clone(),
             selected: selected_activity.cloned(),
-            showing_logs: selected_logs.is_some(),
+            showing_logs: inline_logs_id.is_some(),
             can_go_up,
             can_go_down,
             interrupt_prompt_active: ui_state.interrupt_prompt_active(),
             interrupt_prompt_attached: ui_state.interrupt_prompt_attached(),
             hide_stopped_processes: ui_state.hide_stopped_processes,
+            process_search: ui_state
+                .process_search
+                .as_ref()
+                .map(|search| search.query.clone()),
+            process_search_matches: process_search_ids.len(),
+            process_search_available: !model
+                .get_matching_process_activity_ids(ui_state, "")
+                .is_empty(),
         })) {
             SummaryView
         }
@@ -247,6 +261,7 @@ struct ActivityRenderContext {
     activity: Activity,
     depth: usize,
     is_selected: bool,
+    show_inline_logs: bool,
     logs: Option<Arc<VecDeque<String>>>,
     /// Total log line count (not affected by buffer rotation)
     log_line_count: usize,
@@ -321,6 +336,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         activity,
         depth,
         is_selected,
+        show_inline_logs,
         logs,
         log_line_count,
         completed,
@@ -359,8 +375,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 build_data.phase.clone()
             };
 
-            // For selected build activities, use custom multi-line rendering
-            if *is_selected {
+            if *show_inline_logs {
                 let prefix = build_activity_prefix(*depth, *completed, true);
 
                 let main_line = ActivityTextComponent::new(
@@ -446,7 +461,9 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
 
             // Show logs inline for tasks with show_output=true or failed tasks
             let task_failed = *completed == Some(false);
-            if (task_data.show_output || task_failed) && logs.is_some() {
+            if (task_data.show_output || task_failed || *show_inline_logs)
+                && (logs.is_some() || *show_inline_logs)
+            {
                 let empty_message = if completed.is_some() {
                     "  → no output"
                 } else {
@@ -457,7 +474,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     .with_empty_message(empty_message);
                 if task_failed {
                     component = component.with_max_lines(LOG_VIEWPORT_FAILED);
-                } else if task_data.show_output && !is_selected {
+                } else if task_data.show_output && !show_inline_logs {
                     component = component.with_max_lines(LOG_VIEWPORT_SHOW_OUTPUT);
                 }
                 return component.render_with_main_line(main_line);
@@ -590,9 +607,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             .with_selection(*is_selected)
             .render(terminal_width, *depth, prefix);
 
-            // Show logs when selected or when failed (so error details are visible)
             let failed = *completed == Some(false);
-            if (failed || *is_selected) && logs.is_some() {
+            if *show_inline_logs || failed && logs.is_some() {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
                     .with_terminal_width(terminal_width)
                     .with_empty_message("  → no files evaluated yet (press Ctrl-E to expand)");
@@ -666,9 +682,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             .with_selection(*is_selected)
             .render(terminal_width, *depth, prefix);
 
-            // Show logs when selected or when failed
             let failed = *completed == Some(false);
-            if (failed || *is_selected) && logs.is_some() {
+            if *show_inline_logs || failed && logs.is_some() {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
                     .with_terminal_width(terminal_width)
                     .with_empty_message("  → no output yet");
@@ -753,18 +768,16 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             .with_selection(*is_selected)
             .render(terminal_width, *depth, prefix);
 
-            // Show logs: always show LOG_VIEWPORT_SHOW_OUTPUT lines,
-            // expand when selected, show more when failed
             let process_failed = *completed == Some(false) || process_data.status.is_failed();
-            if logs.is_some() {
+            if *show_inline_logs
+                || (process_failed && *render_context == RenderContext::Final && logs.is_some())
+            {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
                     .with_terminal_width(terminal_width)
                     .with_depth(*depth)
-                    .with_empty_message("→ no output yet (press 'e' to expand)");
+                    .with_empty_message("→ no output yet");
                 if process_failed && *render_context == RenderContext::Final {
                     component = component.with_max_lines(LOG_VIEWPORT_FAILED);
-                } else if !is_selected {
-                    component = component.with_max_lines(LOG_VIEWPORT_SHOW_OUTPUT);
                 }
 
                 let mut elements = vec![main_line];
@@ -954,6 +967,9 @@ struct SummaryViewContext {
     interrupt_prompt_active: bool,
     interrupt_prompt_attached: bool,
     hide_stopped_processes: bool,
+    process_search: Option<String>,
+    process_search_matches: usize,
+    process_search_available: bool,
 }
 
 /// Summary view component that adapts to terminal width
@@ -975,6 +991,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         interrupt_prompt_active,
         interrupt_prompt_attached,
         hide_stopped_processes,
+        process_search,
+        process_search_matches,
+        process_search_available,
     } = ctx;
     let selected = selected.as_ref();
     let showing_logs = *showing_logs;
@@ -983,6 +1002,8 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     let interrupt_prompt_active = *interrupt_prompt_active;
     let interrupt_prompt_attached = *interrupt_prompt_attached;
     let hide_stopped_processes = *hide_stopped_processes;
+    let process_search_matches = *process_search_matches;
+    let process_search_available = *process_search_available;
 
     if interrupt_prompt_active {
         if interrupt_prompt_attached {
@@ -1045,6 +1066,38 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
                 Text(content: if compact { ":quit " } else { " quit • " })
                 Text(content: "Ctrl-C", color: COLOR_INTERACTIVE)
                 Text(content: ":quit")
+            }
+        })
+        .into_any();
+    }
+
+    if let Some(query) = process_search {
+        let prompt = if query.is_empty() {
+            "Search processes: /".to_string()
+        } else {
+            format!("Search processes: /{query}")
+        };
+        let result = match process_search_matches {
+            0 => "no matches".to_string(),
+            1 => "1 match".to_string(),
+            count => format!("{count} matches"),
+        };
+        let hints = if terminal_width < 72 {
+            format!("{result}  Enter:select Esc:cancel")
+        } else {
+            format!("{result} • ↑↓ next • Enter select • Esc cancel")
+        };
+        return element!(View(
+            flex_direction: FlexDirection::Row,
+            justify_content: JustifyContent::SpaceBetween,
+            width: 100pct,
+            overflow: Overflow::Hidden,
+        ) {
+            View(flex_grow: 1.0, flex_shrink: 1.0, min_width: 0, overflow: Overflow::Hidden) {
+                Text(content: prompt, color: COLOR_INTERACTIVE, weight: Weight::Bold)
+            }
+            View(flex_shrink: 0.0, margin_left: 2) {
+                Text(content: hints)
             }
         })
         .into_any();
@@ -1299,13 +1352,21 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         } else {
             help_children.push(element!(Text(content: " • ")).into_any());
         }
+        help_children.push(element!(Text(content: "Enter", color: COLOR_INTERACTIVE)).into_any());
+        if use_symbols {
+            help_children.push(element!(Text(content: " ▾ • ")).into_any());
+        } else if use_short_text {
+            help_children.push(element!(Text(content: " preview ")).into_any());
+        } else {
+            help_children.push(element!(Text(content: " preview logs • ")).into_any());
+        }
         help_children.push(element!(Text(content: if use_short_text { "^E" } else { "Ctrl-E" }, color: COLOR_INTERACTIVE)).into_any());
         if use_symbols {
             help_children.push(element!(Text(content: " ▼ • ")).into_any());
         } else if use_short_text {
-            help_children.push(element!(Text(content: " expand ")).into_any());
+            help_children.push(element!(Text(content: " logs ")).into_any());
         } else {
-            help_children.push(element!(Text(content: " expand logs • ")).into_any());
+            help_children.push(element!(Text(content: " full logs • ")).into_any());
         }
         if is_process {
             if is_stoppable {
@@ -1340,6 +1401,16 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
                 help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped • " } else { " hide stopped • " })).into_any());
             }
         }
+        if process_search_available {
+            help_children.push(element!(Text(content: "/", color: COLOR_INTERACTIVE)).into_any());
+            if use_symbols {
+                help_children.push(element!(Text(content: " ")).into_any());
+            } else if use_short_text {
+                help_children.push(element!(Text(content: " search ")).into_any());
+            } else {
+                help_children.push(element!(Text(content: " search processes • ")).into_any());
+            }
+        }
         help_children.push(element!(Text(content: "Esc", color: COLOR_INTERACTIVE)).into_any());
         if showing_logs {
             if use_symbols {
@@ -1357,7 +1428,11 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         // Show navigate hint only when no selection (Ctrl-E requires selection)
         help_children.push(element!(Text(content: "↑", color: up_arrow_color)).into_any());
         help_children.push(element!(Text(content: "↓", color: down_arrow_color)).into_any());
-        let trail = if show_hide_toggle { " • " } else { "" };
+        let trail = if show_hide_toggle || process_search_available {
+            " • "
+        } else {
+            ""
+        };
         if !use_symbols {
             if use_short_text {
                 help_children.push(element!(Text(content: format!(" nav{trail}"))).into_any());
@@ -1371,6 +1446,15 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             help_children.push(element!(Text(content: if use_short_text { "^H" } else { "Ctrl-H" }, color: COLOR_INTERACTIVE)).into_any());
             if !use_symbols {
                 help_children.push(element!(Text(content: if hide_stopped_processes { " show stopped" } else { " hide stopped" })).into_any());
+            }
+        }
+        if process_search_available {
+            if show_hide_toggle {
+                help_children.push(element!(Text(content: " • ")).into_any());
+            }
+            help_children.push(element!(Text(content: "/", color: COLOR_INTERACTIVE)).into_any());
+            if !use_symbols {
+                help_children.push(element!(Text(content: " search")).into_any());
             }
         }
     }
@@ -1455,6 +1539,9 @@ mod tests {
             interrupt_prompt_active,
             interrupt_prompt_attached: false,
             hide_stopped_processes,
+            process_search: None,
+            process_search_matches: 0,
+            process_search_available: false,
         }
     }
 

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -82,6 +82,10 @@ pub(crate) fn process_previews_fit(
     activities: &[DisplayActivity],
     terminal_size: TerminalSize,
 ) -> bool {
+    let activity_rows: usize = activities
+        .iter()
+        .map(|display| non_process_activity_height(model, display, terminal_size))
+        .sum();
     let preview_rows: usize = activities
         .iter()
         .filter(|display| matches!(display.activity.variant, ActivityVariant::Process(_)))
@@ -99,7 +103,73 @@ pub(crate) fn process_previews_fit(
         .sum();
     let available_rows = terminal_size.height.saturating_sub(SUMMARY_BAR_HEIGHT) as usize;
 
-    preview_rows > 0 && activities.len() + preview_rows <= available_rows
+    preview_rows > 0 && activity_rows + preview_rows <= available_rows
+}
+
+/// Height of an activity before automatic process log previews are added.
+///
+/// Process rows are always one line at this stage. For other activities, this
+/// mirrors the multi-line layouts in `ActivityItem` so the preview preflight
+/// does not enable previews that would immediately require scrolling.
+fn non_process_activity_height(
+    model: &ActivityModel,
+    display: &DisplayActivity,
+    terminal_size: TerminalSize,
+) -> usize {
+    let activity = &display.activity;
+    let expanded_content_height = |max_lines| {
+        model
+            .get_build_logs(activity.id)
+            .map(|logs| {
+                1 + ExpandedContentComponent::new(Some(logs.as_ref()))
+                    .with_terminal_width(terminal_size.width)
+                    .with_max_lines(max_lines)
+                    .visual_height()
+            })
+            .unwrap_or(1)
+    };
+
+    match &activity.variant {
+        ActivityVariant::Process(_) => 1,
+        ActivityVariant::Task(task_data) => {
+            let failed = matches!(
+                &activity.state,
+                NixActivityState::Completed { success: false, .. }
+            );
+            if failed {
+                expanded_content_height(LOG_VIEWPORT_FAILED)
+            } else if task_data.show_output {
+                expanded_content_height(LOG_VIEWPORT_SHOW_OUTPUT)
+            } else {
+                1
+            }
+        }
+        ActivityVariant::Download(download_data) => {
+            if download_data.size_current.is_some() && download_data.size_total.is_some()
+                || activity
+                    .progress
+                    .as_ref()
+                    .is_some_and(|progress| progress.total.unwrap_or(0) > 0)
+            {
+                2
+            } else {
+                1
+            }
+        }
+        ActivityVariant::Evaluating(_) | ActivityVariant::Devenv
+            if matches!(
+                &activity.state,
+                NixActivityState::Completed { success: false, .. }
+            ) =>
+        {
+            expanded_content_height(LOG_VIEWPORT_FAILED)
+        }
+        ActivityVariant::Message(message_data) if message_data.details.is_some() => model
+            .get_build_logs(activity.id)
+            .map(|logs| 1 + logs.len().min(LOG_VIEWPORT_FAILED))
+            .unwrap_or(1),
+        _ => 1,
+    }
 }
 
 pub(crate) fn activity_shows_inline_logs(
@@ -1849,7 +1919,10 @@ pub fn format_duration(duration: Duration) -> String {
 mod tests {
     use super::*;
     use crate::model::ActivityModel;
-    use devenv_activity::{ActivityEvent, ActivityLevel, Operation, Process, Timestamp};
+    use devenv_activity::{
+        ActivityEvent, ActivityLevel, Operation, Process, Timestamp,
+        test_helpers::{process_log, process_start, task_hierarchy_single, task_log, task_start},
+    };
 
     #[test]
     fn tree_positions_connect_nested_siblings() {
@@ -1926,6 +1999,33 @@ mod tests {
             ),
             "      "
         );
+    }
+
+    #[test]
+    fn process_previews_do_not_fit_beside_multiline_task_output() {
+        let mut model = ActivityModel::new();
+        model.apply_activity_event(task_hierarchy_single(1, "build", None, true, false));
+        model.apply_activity_event(task_start(1));
+        model.apply_activity_event(task_log(1, "line one", false));
+        model.apply_activity_event(task_log(1, "line two", false));
+        model.apply_activity_event(task_log(1, "line three", false));
+        model.apply_activity_event(process_start(2, "server"));
+        model.apply_activity_event(process_log(2, "listening", false));
+
+        let ui_state = UiState::new();
+        let display = model.get_display_activities(&ui_state);
+
+        // The task occupies four rows (its main row plus three output rows),
+        // and the process with its preview occupies two more. The five-row
+        // viewport therefore cannot show automatic previews without scrolling.
+        assert!(!process_previews_fit(
+            &model,
+            &display,
+            TerminalSize {
+                width: 80,
+                height: 7,
+            },
+        ));
     }
 
     fn summary_ctx(

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -77,6 +77,31 @@ fn tree_positions_for_depths(depths: &[usize]) -> Vec<TreePosition> {
     positions
 }
 
+pub(crate) fn process_previews_fit(
+    model: &ActivityModel,
+    activities: &[DisplayActivity],
+    terminal_size: TerminalSize,
+) -> bool {
+    let preview_rows: usize = activities
+        .iter()
+        .filter(|display| matches!(display.activity.variant, ActivityVariant::Process(_)))
+        .filter_map(|display| {
+            model
+                .get_build_logs(display.activity.id)
+                .filter(|logs| !logs.is_empty())
+                .map(|logs| {
+                    ExpandedContentComponent::new(Some(logs.as_ref()))
+                        .with_terminal_width(terminal_size.width)
+                        .with_border_indent(display.depth * 2)
+                        .visual_height()
+                })
+        })
+        .sum();
+    let available_rows = terminal_size.height.saturating_sub(SUMMARY_BAR_HEIGHT) as usize;
+
+    preview_rows > 0 && activities.len() + preview_rows <= available_rows
+}
+
 /// Main view function that creates the UI
 pub fn view(
     model: &ActivityModel,
@@ -101,6 +126,8 @@ pub fn view(
     let inline_logs_id = ui_state
         .inline_logs_activity
         .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
+    let process_previews_fit = process_previews_fit(model, &active_activities, terminal_size);
+    let auto_expand_process_logs = inline_logs_id.is_none() && process_previews_fit;
 
     let activities_to_show: Vec<_> = active_activities.iter().collect();
 
@@ -110,7 +137,18 @@ pub fn view(
     for (display_activity, tree_position) in activities_to_show.iter().zip(tree_positions) {
         let activity = &display_activity.activity;
         let is_selected = selected_id.is_some_and(|id| activity.id == id && activity.id != 0);
-        let show_inline_logs = inline_logs_id.is_some_and(|id| activity.id == id);
+        let show_inline_logs = inline_logs_id.is_some_and(|id| activity.id == id)
+            || auto_expand_process_logs
+                && matches!(activity.variant, ActivityVariant::Process(_))
+                && model
+                    .get_build_logs(activity.id)
+                    .is_some_and(|logs| !logs.is_empty());
+        let disclosure = model
+            .is_activity_collapsible(activity.id, ui_state)
+            .then(|| ActivityDisclosure {
+                collapsed: model.is_activity_collapsed(activity.id, ui_state),
+                descendant_count: model.visible_descendant_count(activity.id, ui_state),
+            });
 
         // Pass logs for activities that should display them:
         // - Tasks with show_output=true or failed: show logs inline
@@ -170,6 +208,7 @@ pub fn view(
                     activity: activity.clone(),
                     depth: display_activity.depth,
                     tree_position,
+                    disclosure,
                     is_selected,
                     show_inline_logs,
                     logs: activity_logs,
@@ -228,6 +267,17 @@ pub fn view(
             process_search_available: !model
                 .get_matching_process_activity_ids(ui_state, "")
                 .is_empty(),
+            selected_disclosure: selected_id.and_then(|id| {
+                model
+                    .is_activity_collapsible(id, ui_state)
+                    .then(|| model.is_activity_collapsed(id, ui_state))
+            }),
+            selected_has_logs: selected_id.is_some_and(|id| {
+                model
+                    .get_build_logs(id)
+                    .is_some_and(|logs| !logs.is_empty())
+            }),
+            process_previews_fit,
         })) {
             SummaryView
         }
@@ -304,10 +354,17 @@ pub fn view(
 
 /// Context for activity rendering
 #[derive(Clone)]
+struct ActivityDisclosure {
+    collapsed: bool,
+    descendant_count: usize,
+}
+
+#[derive(Clone)]
 struct ActivityRenderContext {
     activity: Activity,
     depth: usize,
     tree_position: TreePosition,
+    disclosure: Option<ActivityDisclosure>,
     is_selected: bool,
     show_inline_logs: bool,
     logs: Option<Arc<VecDeque<String>>>,
@@ -323,6 +380,32 @@ struct ActivityRenderContext {
     shutting_down: bool,
     /// Number of direct children hidden by the `hide_stopped_processes` filter.
     hidden_children_count: usize,
+}
+
+fn disclosed_name(activity: &Activity, disclosure: Option<&ActivityDisclosure>) -> String {
+    match disclosure {
+        Some(disclosure) if disclosure.collapsed => format!("▸ {}", activity.name),
+        Some(_) => format!("▾ {}", activity.name),
+        None => activity.name.clone(),
+    }
+}
+
+fn disclosed_suffix(
+    suffix: Option<String>,
+    disclosure: Option<&ActivityDisclosure>,
+) -> Option<String> {
+    let Some(disclosure) = disclosure.filter(|disclosure| disclosure.collapsed) else {
+        return suffix;
+    };
+    let summary = if disclosure.descendant_count == 1 {
+        "1 step".to_string()
+    } else {
+        format!("{} steps", disclosure.descendant_count)
+    };
+    Some(match suffix {
+        Some(suffix) => format!("{summary} • {suffix}"),
+        None => summary,
+    })
 }
 
 /// Helper to build activity prefix with hierarchy and status indicator.
@@ -377,6 +460,21 @@ fn build_process_prefix(
     prefix
 }
 
+fn process_preview_prefix(depth: usize, tree_position: &TreePosition) -> String {
+    let mut prefix = "  ".to_string();
+    for continues in &tree_position.ancestor_continuations {
+        prefix.push_str(if *continues { "│ " } else { "  " });
+    }
+    if depth > 0 {
+        prefix.push_str(if tree_position.is_last_sibling {
+            "  "
+        } else {
+            "│ "
+        });
+    }
+    prefix
+}
+
 /// Render a single activity (owned version)
 #[component]
 fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
@@ -396,6 +494,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
         activity,
         depth,
         tree_position,
+        disclosure,
         is_selected,
         show_inline_logs,
         logs,
@@ -663,11 +762,12 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             } else {
                 activity.detail.clone()
             };
+            let suffix = disclosed_suffix(suffix, disclosure.as_ref());
 
             let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             let main_line = ActivityTextComponent::name_only(
-                activity.name.clone(),
+                disclosed_name(activity, disclosure.as_ref()),
                 elapsed_str,
                 activity.variant.clone(),
             )
@@ -740,9 +840,10 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             } else {
                 base_suffix
             };
+            let suffix = disclosed_suffix(suffix, disclosure.as_ref());
 
             let main_line = ActivityTextComponent::name_only(
-                activity.name.clone(),
+                disclosed_name(activity, disclosure.as_ref()),
                 elapsed_str,
                 activity.variant.clone(),
             )
@@ -844,7 +945,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             {
                 let mut component = ExpandedContentComponent::new(logs.as_deref())
                     .with_terminal_width(terminal_width)
-                    .with_depth(*depth)
+                    .with_border_indent(*depth * 2)
+                    .with_line_prefix(process_preview_prefix(*depth, tree_position))
                     .with_empty_message("→ no output yet");
                 if process_failed && *render_context == RenderContext::Final {
                     component = component.with_max_lines(LOG_VIEWPORT_FAILED);
@@ -1040,6 +1142,9 @@ struct SummaryViewContext {
     process_search: Option<String>,
     process_search_matches: usize,
     process_search_available: bool,
+    selected_disclosure: Option<bool>,
+    selected_has_logs: bool,
+    process_previews_fit: bool,
 }
 
 /// Summary view component that adapts to terminal width
@@ -1064,6 +1169,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         process_search,
         process_search_matches,
         process_search_available,
+        selected_disclosure,
+        selected_has_logs,
+        process_previews_fit,
     } = ctx;
     let selected = selected.as_ref();
     let showing_logs = *showing_logs;
@@ -1074,6 +1182,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     let hide_stopped_processes = *hide_stopped_processes;
     let process_search_matches = *process_search_matches;
     let process_search_available = *process_search_available;
+    let selected_disclosure = *selected_disclosure;
+    let selected_has_logs = *selected_has_logs;
+    let process_previews_fit = *process_previews_fit;
 
     if interrupt_prompt_active {
         if interrupt_prompt_attached {
@@ -1422,21 +1533,71 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         } else {
             help_children.push(element!(Text(content: " • ")).into_any());
         }
-        help_children.push(element!(Text(content: "Enter", color: COLOR_INTERACTIVE)).into_any());
-        if use_symbols {
-            help_children.push(element!(Text(content: " ▾ • ")).into_any());
-        } else if use_short_text {
-            help_children.push(element!(Text(content: " preview ")).into_any());
-        } else {
-            help_children.push(element!(Text(content: " preview logs • ")).into_any());
+        let directional_open = selected_disclosure == Some(true) || is_process && !showing_logs;
+        let directional_close = selected_disclosure == Some(false) || is_process && showing_logs;
+        help_children.push(
+            element!(Text(
+                content: if directional_open && !use_short_text {
+                    "Enter/l/→"
+                } else if directional_close && !use_short_text {
+                    "Enter/h/←"
+                } else {
+                    "Enter"
+                },
+                color: COLOR_INTERACTIVE
+            ))
+            .into_any(),
+        );
+        match selected_disclosure {
+            Some(true) if use_symbols => {
+                help_children.push(element!(Text(content: " ▾ • ")).into_any());
+            }
+            Some(false) if use_symbols => {
+                help_children.push(element!(Text(content: " ▴ • ")).into_any());
+            }
+            Some(true) => {
+                help_children.push(element!(Text(content: " expand ")).into_any());
+            }
+            Some(false) => {
+                help_children.push(element!(Text(content: " collapse ")).into_any());
+            }
+            None if is_process && !showing_logs && process_previews_fit && use_symbols => {
+                help_children.push(element!(Text(content: " ◎ • ")).into_any());
+            }
+            None if is_process && showing_logs && process_previews_fit && use_symbols => {
+                help_children.push(element!(Text(content: " ▦ • ")).into_any());
+            }
+            None if is_process && showing_logs && use_symbols => {
+                help_children.push(element!(Text(content: " ▴ • ")).into_any());
+            }
+            None if use_symbols => {
+                help_children.push(element!(Text(content: " ▾ • ")).into_any());
+            }
+            None if is_process && !showing_logs && process_previews_fit => {
+                help_children.push(element!(Text(content: " focus ")).into_any());
+            }
+            None if is_process && showing_logs && process_previews_fit => {
+                help_children.push(element!(Text(content: " show all ")).into_any());
+            }
+            None if is_process && showing_logs => {
+                help_children.push(element!(Text(content: " hide preview ")).into_any());
+            }
+            None if use_short_text => {
+                help_children.push(element!(Text(content: " preview ")).into_any());
+            }
+            None => {
+                help_children.push(element!(Text(content: " preview logs • ")).into_any());
+            }
         }
-        help_children.push(element!(Text(content: if use_short_text { "^E" } else { "Ctrl-E" }, color: COLOR_INTERACTIVE)).into_any());
-        if use_symbols {
-            help_children.push(element!(Text(content: " ▼ • ")).into_any());
-        } else if use_short_text {
-            help_children.push(element!(Text(content: " logs ")).into_any());
-        } else {
-            help_children.push(element!(Text(content: " full logs • ")).into_any());
+        if selected_has_logs || is_process {
+            help_children.push(element!(Text(content: if use_short_text { "^E" } else { "Ctrl-E" }, color: COLOR_INTERACTIVE)).into_any());
+            if use_symbols {
+                help_children.push(element!(Text(content: " ▼ • ")).into_any());
+            } else if use_short_text {
+                help_children.push(element!(Text(content: " logs ")).into_any());
+            } else {
+                help_children.push(element!(Text(content: " full logs • ")).into_any());
+            }
         }
         if is_process {
             if is_stoppable {
@@ -1625,6 +1786,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn process_preview_prefix_matches_tree_position() {
+        assert_eq!(
+            process_preview_prefix(
+                1,
+                &TreePosition {
+                    ancestor_continuations: vec![],
+                    is_last_sibling: false,
+                },
+            ),
+            "  │ "
+        );
+        assert_eq!(
+            process_preview_prefix(
+                1,
+                &TreePosition {
+                    ancestor_continuations: vec![],
+                    is_last_sibling: true,
+                },
+            ),
+            "    "
+        );
+        assert_eq!(
+            process_preview_prefix(
+                2,
+                &TreePosition {
+                    ancestor_continuations: vec![true],
+                    is_last_sibling: false,
+                },
+            ),
+            "  │ │ "
+        );
+        assert_eq!(
+            process_preview_prefix(
+                2,
+                &TreePosition {
+                    ancestor_continuations: vec![false],
+                    is_last_sibling: true,
+                },
+            ),
+            "      "
+        );
+    }
+
     fn summary_ctx(
         hide_stopped_processes: bool,
         interrupt_prompt_active: bool,
@@ -1645,6 +1850,9 @@ mod tests {
             process_search: None,
             process_search_matches: 0,
             process_search_available: false,
+            selected_disclosure: None,
+            selected_has_logs: false,
+            process_previews_fit: false,
         }
     }
 

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -1339,7 +1339,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     );
 
     // Determine display mode based on terminal width
-    let use_symbols = terminal_width < 60; // Use unicode symbols for very narrow terminals
+    let use_symbols = terminal_width < 100;
 
     // Builds - only show if there are any builds (active, completed, or failed)
     if summary.active_builds > 0 || summary.completed_builds > 0 || summary.failed_builds > 0 {
@@ -1562,6 +1562,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         help_children.push(element!(Text(content: " j", color: down_arrow_color)).into_any());
         help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
         help_children.push(element!(Text(content: "k", color: up_arrow_color)).into_any());
+        help_children.push(element!(Text(content: if use_short_text { " ^D" } else { " Ctrl-D" }, color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        help_children.push(element!(Text(content: if use_short_text { "^U" } else { "Ctrl-U" }, color: up_arrow_color)).into_any());
         if !use_symbols {
             if use_short_text {
                 // Compact, single-space separators on narrow terminals (< 100
@@ -1697,6 +1700,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         help_children.push(element!(Text(content: " j", color: down_arrow_color)).into_any());
         help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
         help_children.push(element!(Text(content: "k", color: up_arrow_color)).into_any());
+        help_children.push(element!(Text(content: if use_short_text { " ^D" } else { " Ctrl-D" }, color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        help_children.push(element!(Text(content: if use_short_text { "^U" } else { "Ctrl-U" }, color: up_arrow_color)).into_any());
         let trail = if show_hide_toggle || process_search_available {
             " • "
         } else {
@@ -1954,6 +1960,11 @@ mod tests {
                 output.contains("↑↓ j/k"),
                 "missing navigation keys at {width}: {output:?}"
             );
+            if width < 160 {
+                assert!(output.contains("^D/^U"));
+            } else {
+                assert!(output.contains("Ctrl-D/Ctrl-U"));
+            }
         }
 
         let mut model = ActivityModel::default();
@@ -1973,7 +1984,7 @@ mod tests {
         let output = build_summary_view_impl(&ctx, 120)
             .render(Some(120))
             .to_string();
-        assert!(output.contains("↑↓ j/k nav"));
+        assert!(output.contains("↑↓ j/k ^D/^U nav"));
     }
 
     #[test]

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -297,6 +297,8 @@ pub fn view(
                     .get_build_logs(id)
                     .is_some_and(|logs| !logs.is_empty())
             }),
+            selected_preview_focused: selected_id
+                .is_some_and(|id| ui_state.inline_logs_activity == Some(id)),
             process_previews_fit,
         })) {
             SummaryView
@@ -1181,6 +1183,7 @@ struct SummaryViewContext {
     process_search_available: bool,
     selected_disclosure: Option<bool>,
     selected_has_logs: bool,
+    selected_preview_focused: bool,
     process_previews_fit: bool,
 }
 
@@ -1208,6 +1211,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         process_search_available,
         selected_disclosure,
         selected_has_logs,
+        selected_preview_focused,
         process_previews_fit,
     } = ctx;
     let selected = selected.as_ref();
@@ -1221,6 +1225,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     let process_search_available = *process_search_available;
     let selected_disclosure = *selected_disclosure;
     let selected_has_logs = *selected_has_logs;
+    let selected_preview_focused = *selected_preview_focused;
     let process_previews_fit = *process_previews_fit;
 
     if interrupt_prompt_active {
@@ -1339,7 +1344,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     );
 
     // Determine display mode based on terminal width
-    let use_symbols = terminal_width < 100;
+    let use_symbols = terminal_width < if has_selection { 120 } else { 100 };
 
     // Builds - only show if there are any builds (active, completed, or failed)
     if summary.active_builds > 0 || summary.completed_builds > 0 || summary.failed_builds > 0 {
@@ -1541,7 +1546,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
     // The verbose process vocabulary can exceed even a 120-column terminal
     // once summary counts and the hide-stopped action are present. Keep the
     // compact tier through 159 columns; very narrow terminals use keys only.
-    let use_short_text = terminal_width < 160;
+    let use_short_text = terminal_width < if has_selection { 200 } else { 160 };
     let show_hide_toggle = summary.stopped_processes > 0 || hide_stopped_processes;
 
     let up_arrow_color = if can_go_up {
@@ -1616,6 +1621,13 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             }
             None if is_process && !showing_logs && process_previews_fit => {
                 help_children.push(element!(Text(content: " focus ")).into_any());
+            }
+            None if is_process
+                && showing_logs
+                && process_previews_fit
+                && !selected_preview_focused =>
+            {
+                help_children.push(element!(Text(content: " hide previews ")).into_any());
             }
             None if is_process && showing_logs => {
                 help_children.push(element!(Text(content: " hide preview ")).into_any());
@@ -1734,20 +1746,54 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         }
     }
 
-    if has_selection {
-        if terminal_width < 60 {
-            return element!(View(
-                flex_direction: FlexDirection::Row,
-                width: terminal_width.saturating_sub(2) as u32,
-                overflow: Overflow::Hidden
-            ) {
-                #(help_children)
-            })
-            .into_any();
+    if has_selection && terminal_width < 60 {
+        let mut compact_help_children = vec![
+            element!(Text(content: "↑", color: up_arrow_color)).into_any(),
+            element!(Text(content: "↓", color: down_arrow_color)).into_any(),
+            element!(Text(content: " j", color: down_arrow_color)).into_any(),
+            element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any(),
+            element!(Text(content: "k", color: up_arrow_color)).into_any(),
+            element!(Text(content: " ^D", color: down_arrow_color)).into_any(),
+            element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any(),
+            element!(Text(content: "^U", color: up_arrow_color)).into_any(),
+            element!(Text(content: " Enter", color: COLOR_INTERACTIVE)).into_any(),
+        ];
+        if selected_has_logs || is_process {
+            compact_help_children
+                .push(element!(Text(content: " ^E", color: COLOR_INTERACTIVE)).into_any());
         }
+        if is_stoppable {
+            compact_help_children
+                .push(element!(Text(content: " ^X", color: COLOR_INTERACTIVE)).into_any());
+        }
+        if is_restartable {
+            compact_help_children
+                .push(element!(Text(content: " ^R", color: COLOR_INTERACTIVE)).into_any());
+        }
+        if show_hide_toggle {
+            compact_help_children
+                .push(element!(Text(content: " ^H", color: COLOR_INTERACTIVE)).into_any());
+        }
+        if process_search_available {
+            compact_help_children
+                .push(element!(Text(content: " /", color: COLOR_INTERACTIVE)).into_any());
+        }
+        compact_help_children
+            .push(element!(Text(content: " Esc", color: COLOR_INTERACTIVE)).into_any());
         return element!(View(
             flex_direction: FlexDirection::Row,
-            width: 100pct,
+            width: terminal_width.saturating_sub(2) as u32,
+            overflow: Overflow::Hidden
+        ) {
+            #(compact_help_children)
+        })
+        .into_any();
+    }
+
+    if has_selection && terminal_width < 72 {
+        return element!(View(
+            flex_direction: FlexDirection::Row,
+            width: terminal_width.saturating_sub(2) as u32,
             overflow: Overflow::Hidden
         ) {
             #(help_children)
@@ -1904,6 +1950,7 @@ mod tests {
             process_search_available: false,
             selected_disclosure: None,
             selected_has_logs: false,
+            selected_preview_focused: false,
             process_previews_fit: false,
         }
     }
@@ -1980,11 +2027,46 @@ mod tests {
         }));
         ctx.selected = model.get_activity(1).cloned();
         ctx.can_go_up = true;
+        ctx.summary.running_processes = 1;
+        ctx.summary.total_processes = 1;
 
         let output = build_summary_view_impl(&ctx, 120)
             .render(Some(120))
             .to_string();
         assert!(output.contains("↑↓ j/k ^D/^U nav"));
+        assert!(output.contains("1 process"));
+    }
+
+    #[test]
+    fn test_summary_process_preview_action_matches_scope() {
+        let mut model = ActivityModel::default();
+        model.apply_activity_event(ActivityEvent::Process(Process::Start {
+            id: 1,
+            name: "api".to_string(),
+            parent: None,
+            command: None,
+            ports: vec![],
+            ready_probe: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+
+        let mut ctx = summary_ctx(false, false, 0);
+        ctx.selected = model.get_activity(1).cloned();
+        ctx.showing_logs = true;
+        ctx.process_previews_fit = true;
+
+        let automatic = build_summary_view_impl(&ctx, 120)
+            .render(Some(120))
+            .to_string();
+        assert!(automatic.contains("hide previews"));
+
+        ctx.selected_preview_focused = true;
+        let focused = build_summary_view_impl(&ctx, 120)
+            .render(Some(120))
+            .to_string();
+        assert!(focused.contains("hide preview"));
+        assert!(!focused.contains("hide previews"));
     }
 
     #[test]
@@ -2308,7 +2390,7 @@ mod tests {
     fn process_view_renders_every_status_label_and_gave_up_affordance() {
         let mut model = ActivityModel::default();
         let mut ui_state = UiState::new();
-        ui_state.set_terminal_size(160, 30);
+        ui_state.set_terminal_size(200, 30);
 
         model.apply_activity_event(ActivityEvent::Operation(Operation::Start {
             id: 100,
@@ -2366,7 +2448,7 @@ mod tests {
             false,
         )
         .into();
-        let rendered = element.render(Some(160)).to_string();
+        let rendered = element.render(Some(200)).to_string();
 
         for label in [
             "auto start off",

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -1714,7 +1714,7 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             } else {
                 help_children.push(element!(Text(content: format!(" navigate{trail}"))).into_any());
             }
-        } else if show_hide_toggle {
+        } else if show_hide_toggle || process_search_available {
             help_children.push(element!(Text(content: " • ")).into_any());
         }
         if show_hide_toggle {

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -1559,6 +1559,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         // Show full navigation when something is selected
         help_children.push(element!(Text(content: "↑", color: up_arrow_color)).into_any());
         help_children.push(element!(Text(content: "↓", color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: " j", color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        help_children.push(element!(Text(content: "k", color: up_arrow_color)).into_any());
         if !use_symbols {
             if use_short_text {
                 // Compact, single-space separators on narrow terminals (< 100
@@ -1691,6 +1694,9 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
         // Show navigate hint only when no selection (Ctrl-E requires selection)
         help_children.push(element!(Text(content: "↑", color: up_arrow_color)).into_any());
         help_children.push(element!(Text(content: "↓", color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: " j", color: down_arrow_color)).into_any());
+        help_children.push(element!(Text(content: "/", color: COLOR_HIERARCHY)).into_any());
+        help_children.push(element!(Text(content: "k", color: up_arrow_color)).into_any());
         let trail = if show_hide_toggle || process_search_available {
             " • "
         } else {
@@ -1933,6 +1939,41 @@ mod tests {
         assert!(!output.contains("hide stopped"));
         assert!(!output.contains("show stopped"));
         assert!(!output.contains("Ctrl-H"));
+    }
+
+    #[test]
+    fn test_summary_navigation_shows_arrow_and_vim_keys() {
+        let mut ctx = summary_ctx(false, false, 0);
+        ctx.can_go_down = true;
+
+        for width in [48, 100, 180] {
+            let output = build_summary_view_impl(&ctx, width)
+                .render(Some(width as usize))
+                .to_string();
+            assert!(
+                output.contains("↑↓ j/k"),
+                "missing navigation keys at {width}: {output:?}"
+            );
+        }
+
+        let mut model = ActivityModel::default();
+        model.apply_activity_event(ActivityEvent::Process(Process::Start {
+            id: 1,
+            name: "api".to_string(),
+            parent: None,
+            command: None,
+            ports: vec![],
+            ready_probe: None,
+            level: ActivityLevel::Info,
+            timestamp: Timestamp::now(),
+        }));
+        ctx.selected = model.get_activity(1).cloned();
+        ctx.can_go_up = true;
+
+        let output = build_summary_view_impl(&ctx, 120)
+            .render(Some(120))
+            .to_string();
+        assert!(output.contains("↑↓ j/k nav"));
     }
 
     #[test]

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -30,6 +30,7 @@ pub type ActivityHeights = Ref<HashMap<u64, i32>>;
 pub struct ScrollState {
     pub handle: Option<Ref<ScrollViewHandle>>,
     pub display_activities: Vec<DisplayActivity>,
+    pub process_previews_fit: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -102,6 +103,29 @@ pub(crate) fn process_previews_fit(
     preview_rows > 0 && activities.len() + preview_rows <= available_rows
 }
 
+pub(crate) fn activity_shows_inline_logs(
+    model: &ActivityModel,
+    ui_state: &UiState,
+    activity_id: u64,
+    process_previews_fit: bool,
+) -> bool {
+    if ui_state.inline_logs_activity == Some(activity_id) {
+        return true;
+    }
+    if ui_state.inline_logs_activity.is_some()
+        || ui_state.process_previews_hidden
+        || !process_previews_fit
+    {
+        return false;
+    }
+    model.get_activity(activity_id).is_some_and(|activity| {
+        matches!(activity.variant, ActivityVariant::Process(_))
+            && model
+                .get_build_logs(activity_id)
+                .is_some_and(|logs| !logs.is_empty())
+    })
+}
+
 /// Main view function that creates the UI
 pub fn view(
     model: &ActivityModel,
@@ -110,9 +134,13 @@ pub fn view(
     scroll: Option<ScrollState>,
     shutting_down: bool,
 ) -> impl Into<AnyElement<'static>> {
-    let (scroll_handle, active_activities) = match scroll {
-        Some(s) => (s.handle, s.display_activities),
-        None => (None, model.get_display_activities(ui_state)),
+    let (scroll_handle, active_activities, process_previews_fit) = match scroll {
+        Some(s) => (s.handle, s.display_activities, s.process_previews_fit),
+        None => {
+            let activities = model.get_display_activities(ui_state);
+            let previews_fit = process_previews_fit(model, &activities, ui_state.terminal_size);
+            (None, activities, previews_fit)
+        }
     };
 
     let summary = model.calculate_summary();
@@ -123,12 +151,6 @@ pub fn view(
         .selected_activity
         .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
     let selected_activity = selected_id.and_then(|id| model.get_activity(id));
-    let inline_logs_id = ui_state
-        .inline_logs_activity
-        .filter(|id| active_activities.iter().any(|da| da.activity.id == *id));
-    let process_previews_fit = process_previews_fit(model, &active_activities, terminal_size);
-    let auto_expand_process_logs = inline_logs_id.is_none() && process_previews_fit;
-
     let activities_to_show: Vec<_> = active_activities.iter().collect();
 
     // Create owned activity elements, including hidden children indicators
@@ -137,17 +159,13 @@ pub fn view(
     for (display_activity, tree_position) in activities_to_show.iter().zip(tree_positions) {
         let activity = &display_activity.activity;
         let is_selected = selected_id.is_some_and(|id| activity.id == id && activity.id != 0);
-        let show_inline_logs = inline_logs_id.is_some_and(|id| activity.id == id)
-            || auto_expand_process_logs
-                && matches!(activity.variant, ActivityVariant::Process(_))
-                && model
-                    .get_build_logs(activity.id)
-                    .is_some_and(|logs| !logs.is_empty());
+        let show_inline_logs =
+            activity_shows_inline_logs(model, ui_state, activity.id, process_previews_fit);
         let disclosure = model
-            .is_activity_collapsible(activity.id, ui_state)
-            .then(|| ActivityDisclosure {
-                collapsed: model.is_activity_collapsed(activity.id, ui_state),
-                descendant_count: model.visible_descendant_count(activity.id, ui_state),
+            .collapsible_descendant_count(activity.id, ui_state)
+            .map(|descendant_count| ActivityDisclosure {
+                collapsed: !ui_state.expanded_activities.contains(&activity.id),
+                descendant_count,
             });
 
         // Pass logs for activities that should display them:
@@ -227,9 +245,10 @@ pub fn view(
     }
 
     // Determine if navigation is possible
-    let selectable_ids = model.get_selectable_activity_ids(ui_state);
-    let process_search_ids = model.get_matching_process_activity_ids(
-        ui_state,
+    let selectable_ids =
+        model.get_selectable_activity_ids_from_display(&active_activities, ui_state);
+    let process_search_ids = model.get_matching_process_activity_ids_from_display(
+        &active_activities,
         ui_state
             .process_search
             .as_ref()
@@ -253,7 +272,9 @@ pub fn view(
         ContextProvider(value: Context::owned(SummaryViewContext {
             summary: summary.clone(),
             selected: selected_activity.cloned(),
-            showing_logs: inline_logs_id.is_some(),
+            showing_logs: selected_id.is_some_and(|id| {
+                activity_shows_inline_logs(model, ui_state, id, process_previews_fit)
+            }),
             can_go_up,
             can_go_down,
             interrupt_prompt_active: ui_state.interrupt_prompt_active(),
@@ -264,13 +285,13 @@ pub fn view(
                 .as_ref()
                 .map(|search| search.query.clone()),
             process_search_matches: process_search_ids.len(),
-            process_search_available: !model
-                .get_matching_process_activity_ids(ui_state, "")
-                .is_empty(),
+            process_search_available: active_activities
+                .iter()
+                .any(|display| matches!(display.activity.variant, ActivityVariant::Process(_))),
             selected_disclosure: selected_id.and_then(|id| {
                 model
-                    .is_activity_collapsible(id, ui_state)
-                    .then(|| model.is_activity_collapsed(id, ui_state))
+                    .collapsible_descendant_count(id, ui_state)
+                    .map(|_| !ui_state.expanded_activities.contains(&id))
             }),
             selected_has_logs: selected_id.is_some_and(|id| {
                 model
@@ -1564,9 +1585,6 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             None if is_process && !showing_logs && process_previews_fit && use_symbols => {
                 help_children.push(element!(Text(content: " ◎ • ")).into_any());
             }
-            None if is_process && showing_logs && process_previews_fit && use_symbols => {
-                help_children.push(element!(Text(content: " ▦ • ")).into_any());
-            }
             None if is_process && showing_logs && use_symbols => {
                 help_children.push(element!(Text(content: " ▴ • ")).into_any());
             }
@@ -1575,9 +1593,6 @@ fn build_summary_view_impl(ctx: &SummaryViewContext, terminal_width: u16) -> Any
             }
             None if is_process && !showing_logs && process_previews_fit => {
                 help_children.push(element!(Text(content: " focus ")).into_any());
-            }
-            None if is_process && showing_logs && process_previews_fit => {
-                help_children.push(element!(Text(content: " show all ")).into_any());
             }
             None if is_process && showing_logs => {
                 help_children.push(element!(Text(content: " hide preview ")).into_any());
@@ -1942,6 +1957,7 @@ mod tests {
             Some(ScrollState {
                 handle: None,
                 display_activities,
+                process_previews_fit: false,
             }),
             false,
         )
@@ -1996,6 +2012,7 @@ mod tests {
                 Some(ScrollState {
                     handle: None,
                     display_activities,
+                    process_previews_fit: false,
                 }),
                 false,
             )
@@ -2061,6 +2078,7 @@ mod tests {
             Some(ScrollState {
                 handle: None,
                 display_activities,
+                process_previews_fit: false,
             }),
             false,
         )
@@ -2126,6 +2144,7 @@ mod tests {
             Some(ScrollState {
                 handle: None,
                 display_activities,
+                process_previews_fit: false,
             }),
             false,
         )
@@ -2201,6 +2220,7 @@ mod tests {
             Some(ScrollState {
                 handle: None,
                 display_activities,
+                process_previews_fit: false,
             }),
             false,
         )

--- a/devenv-tui/src/view.rs
+++ b/devenv-tui/src/view.rs
@@ -32,6 +32,51 @@ pub struct ScrollState {
     pub display_activities: Vec<DisplayActivity>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct TreePosition {
+    ancestor_continuations: Vec<bool>,
+    is_last_sibling: bool,
+}
+
+fn tree_positions(activities: &[DisplayActivity]) -> Vec<TreePosition> {
+    let depths: Vec<_> = activities.iter().map(|activity| activity.depth).collect();
+    tree_positions_for_depths(&depths)
+}
+
+fn tree_positions_for_depths(depths: &[usize]) -> Vec<TreePosition> {
+    let mut positions = vec![TreePosition::default(); depths.len()];
+    let mut last_at_depth: Vec<Option<usize>> = Vec::new();
+
+    for (index, depth) in depths.iter().copied().enumerate() {
+        last_at_depth.truncate(depth + 1);
+        if last_at_depth.len() <= depth {
+            last_at_depth.resize(depth + 1, None);
+        }
+        if let Some(previous) = last_at_depth[depth].replace(index) {
+            positions[previous].is_last_sibling = false;
+        }
+        positions[index].is_last_sibling = true;
+    }
+
+    let last_siblings: Vec<_> = positions
+        .iter()
+        .map(|position| position.is_last_sibling)
+        .collect();
+    let mut ancestors: Vec<usize> = Vec::new();
+
+    for (index, depth) in depths.iter().copied().enumerate() {
+        ancestors.truncate(depth);
+        positions[index].ancestor_continuations = ancestors
+            .iter()
+            .skip(1)
+            .map(|ancestor| !last_siblings[*ancestor])
+            .collect();
+        ancestors.push(index);
+    }
+
+    positions
+}
+
 /// Main view function that creates the UI
 pub fn view(
     model: &ActivityModel,
@@ -47,6 +92,7 @@ pub fn view(
 
     let summary = model.calculate_summary();
     let terminal_size = ui_state.terminal_size;
+    let tree_positions = tree_positions(&active_activities);
 
     let selected_id = ui_state
         .selected_activity
@@ -61,7 +107,7 @@ pub fn view(
     // Create owned activity elements, including hidden children indicators
     let mut activity_elements: Vec<AnyElement<'static>> = Vec::new();
 
-    for display_activity in activities_to_show.iter() {
+    for (display_activity, tree_position) in activities_to_show.iter().zip(tree_positions) {
         let activity = &display_activity.activity;
         let is_selected = selected_id.is_some_and(|id| activity.id == id && activity.id != 0);
         let show_inline_logs = inline_logs_id.is_some_and(|id| activity.id == id);
@@ -123,6 +169,7 @@ pub fn view(
                 ContextProvider(value: Context::owned(ActivityRenderContext {
                     activity: activity.clone(),
                     depth: display_activity.depth,
+                    tree_position,
                     is_selected,
                     show_inline_logs,
                     logs: activity_logs,
@@ -260,6 +307,7 @@ pub fn view(
 struct ActivityRenderContext {
     activity: Activity,
     depth: usize,
+    tree_position: TreePosition,
     is_selected: bool,
     show_inline_logs: bool,
     logs: Option<Arc<VecDeque<String>>>,
@@ -282,10 +330,16 @@ struct ActivityRenderContext {
 /// - Nested (depth > 0): [HierarchyPrefix][StatusIndicator]
 fn build_activity_prefix(
     depth: usize,
+    tree_position: &TreePosition,
     completed: Option<bool>,
     show_spinner: bool,
 ) -> Vec<AnyElement<'static>> {
-    let mut prefix = HierarchyPrefixComponent::new(depth).render();
+    let mut prefix = HierarchyPrefixComponent::new(
+        depth,
+        &tree_position.ancestor_continuations,
+        tree_position.is_last_sibling,
+    )
+    .render();
 
     prefix.push(
         element!(View(margin_right: 1) {
@@ -301,11 +355,17 @@ fn build_activity_prefix(
 /// encodes the lifecycle state (see `process_status_dot`) instead of a spinner.
 fn build_process_prefix(
     depth: usize,
+    tree_position: &TreePosition,
     glyph: &'static str,
     color: Color,
     pulse: bool,
 ) -> Vec<AnyElement<'static>> {
-    let mut prefix = HierarchyPrefixComponent::new(depth).render();
+    let mut prefix = HierarchyPrefixComponent::new(
+        depth,
+        &tree_position.ancestor_continuations,
+        tree_position.is_last_sibling,
+    )
+    .render();
 
     prefix.push(
         element!(View(margin_right: 1) {
@@ -335,6 +395,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
     let ActivityRenderContext {
         activity,
         depth,
+        tree_position,
         is_selected,
         show_inline_logs,
         logs,
@@ -376,7 +437,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             };
 
             if *show_inline_logs {
-                let prefix = build_activity_prefix(*depth, *completed, true);
+                let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
                 let main_line = ActivityTextComponent::new(
                     "building".to_string(),
@@ -396,7 +457,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             }
 
             // Non-selected build activities use normal rendering
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::new(
                 "building".to_string(),
@@ -447,7 +508,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     base_status
                 };
 
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             let main_line = ActivityTextComponent::name_only(
                 activity.name.clone(),
@@ -488,6 +549,10 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 (download_data.size_current, download_data.size_total)
             {
                 return DownloadActivityComponent::new(activity, *depth, *is_selected)
+                    .with_hierarchy(
+                        &tree_position.ancestor_continuations,
+                        tree_position.is_last_sibling,
+                    )
                     .with_completed(*completed)
                     .with_cached(*cached)
                     .render(terminal_width);
@@ -495,6 +560,10 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 // Use generic progress if available
                 if progress.total.unwrap_or(0) > 0 {
                     return DownloadActivityComponent::new(activity, *depth, *is_selected)
+                        .with_hierarchy(
+                            &tree_position.ancestor_continuations,
+                            tree_position.is_last_sibling,
+                        )
                         .with_completed(*completed)
                         .with_cached(*cached)
                         .render(terminal_width);
@@ -507,7 +576,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                             progress.current.unwrap_or(0).human_count_bytes()
                         )
                     });
-                    let prefix = build_activity_prefix(*depth, *completed, true);
+                    let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
                     return ActivityTextComponent::new(
                         "downloading".to_string(),
@@ -526,7 +595,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                     .substituter
                     .as_ref()
                     .map(|s| format!("from {}", s));
-                let prefix = build_activity_prefix(*depth, *completed, true);
+                let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
                 return ActivityTextComponent::new(
                     "downloading".to_string(),
@@ -541,7 +610,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             }
         }
         ActivityVariant::Copy => {
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::new(
                 "copying".to_string(),
@@ -559,7 +628,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 .substituter
                 .as_ref()
                 .map(|s| format!("from {}", s));
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::new(
                 "querying".to_string(),
@@ -573,7 +642,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             .render(terminal_width, *depth, prefix);
         }
         ActivityVariant::FetchTree => {
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::new(
                 "fetching".to_string(),
@@ -595,7 +664,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
                 activity.detail.clone()
             };
 
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             let main_line = ActivityTextComponent::name_only(
                 activity.name.clone(),
@@ -621,7 +690,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             return main_line;
         }
         ActivityVariant::UserOperation => {
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::name_only(
                 activity.name.clone(),
@@ -633,7 +702,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             .render(terminal_width, *depth, prefix);
         }
         ActivityVariant::Devenv => {
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             // Show line count as suffix when active or failed with logs
             let base_suffix = if *completed == Some(true) {
@@ -747,7 +816,8 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             // state; transient states pulse instead of animating a spinner.
             let (dot_glyph, dot_color, dot_pulse) =
                 process_status_dot(&process_data.status, *completed, *shutting_down);
-            let prefix = build_process_prefix(*depth, dot_glyph, dot_color, dot_pulse);
+            let prefix =
+                build_process_prefix(*depth, tree_position, dot_glyph, dot_color, dot_pulse);
 
             // Hide elapsed time for not-started/stopped processes
             let process_elapsed = if matches!(process_data.status, ProcessStatus::NotStarted)
@@ -941,7 +1011,7 @@ fn ActivityItem(mut hooks: Hooks) -> impl Into<AnyElement<'static>> {
             }
         }
         ActivityVariant::Unknown => {
-            let prefix = build_activity_prefix(*depth, *completed, true);
+            let prefix = build_activity_prefix(*depth, tree_position, *completed, true);
 
             return ActivityTextComponent::new(
                 "unknown".to_string(),
@@ -1521,6 +1591,39 @@ mod tests {
     use super::*;
     use crate::model::ActivityModel;
     use devenv_activity::{ActivityEvent, ActivityLevel, Operation, Process, Timestamp};
+
+    #[test]
+    fn tree_positions_connect_nested_siblings() {
+        assert_eq!(
+            tree_positions_for_depths(&[0, 1, 2, 2, 1, 2]),
+            vec![
+                TreePosition {
+                    ancestor_continuations: vec![],
+                    is_last_sibling: true,
+                },
+                TreePosition {
+                    ancestor_continuations: vec![],
+                    is_last_sibling: false,
+                },
+                TreePosition {
+                    ancestor_continuations: vec![true],
+                    is_last_sibling: false,
+                },
+                TreePosition {
+                    ancestor_continuations: vec![true],
+                    is_last_sibling: true,
+                },
+                TreePosition {
+                    ancestor_continuations: vec![],
+                    is_last_sibling: true,
+                },
+                TreePosition {
+                    ancestor_continuations: vec![false],
+                    is_last_sibling: true,
+                },
+            ]
+        );
+    }
 
     fn summary_ctx(
         hide_stopped_processes: bool,

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -56,9 +56,8 @@ expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r
-expect:^E
-send:h
-expect:focus
+resize:80x8
+expect:restart
 send:l
 expect:processed deterministic job 1
 expect:hide preview

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -56,6 +56,7 @@ expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r
+expect:^E
 send:h
 expect:focus
 send:l
@@ -96,6 +97,7 @@ send:n
 expect:2/3
 send:y
 expect:bGlzdGVuaW5nIG9uIGh0dHA6Ly8xMjcuMC4wLjE6ODA4MA==
+expect:Copied 1 line
 send:G
 expect:FOLLOWING
 send:g

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -52,6 +52,7 @@ expect:processed deterministic job 1
 expect:disabled
 expect:stopped
 resize:48x6
+expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -35,9 +35,8 @@ cleanup() {
 trap cleanup EXIT
 
 fixture="$repo_root/devenv-tui/replays/processes.jsonl"
-command="\"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\" \"$fixture\""
+command="exec \"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\" \"$fixture\""
 
-# The selected process and its actions must survive the narrow-to-wide resize.
 # Avoid standalone Esc in this byte-level harness: the emulated terminal reports
 # no keyboard-protocol enhancement, so legacy decoding keeps Esc ambiguous until
 # another input byte arrives.
@@ -51,13 +50,12 @@ expect:worker
 expect:processed deterministic job 1
 expect:disabled
 expect:stopped
-resize:48x6
-expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r
-resize:120x12
-expect:restart
+expect:hide preview
+send:h
+expect:focus
 send:l
 expect:processed deterministic job 1
 expect:hide preview
@@ -105,8 +103,11 @@ send:G
 expect:FOLLOWING
 send:q
 expect:Running processes
-resize:48x12
-resize:120x40
+expect:focus
+send:/api
+expect:Search processes: /api
+send:\r
+expect:focus
 send:\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12
 expect:restarting
 expect:ready

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -80,6 +80,14 @@ send:\x1b[D
 expect:focus
 send:\x05
 expect:FOLLOWING
+send:\x15
+expect:PAUSED
+send:\x04
+expect:FOLLOWING
+send:\x02
+expect:PAUSED
+send:\x06
+expect:FOLLOWING
 send:y
 expect:bGlzdGVuaW5nIG9uIGh0dHA6Ly8xMjcuMC4wLjE6ODA4MA==
 send:g

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -56,7 +56,6 @@ expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r
-expect:hide preview
 send:h
 expect:focus
 send:l
@@ -88,8 +87,17 @@ send:\x02
 expect:PAUSED
 send:\x06
 expect:FOLLOWING
+send:/t
+expect:Search logs: /t
+expect:1/3
+send:\r
+expect:/t  1/3
+send:n
+expect:2/3
 send:y
 expect:bGlzdGVuaW5nIG9uIGh0dHA6Ly8xMjcuMC4wLjE6ODA4MA==
+send:G
+expect:FOLLOWING
 send:g
 expect:PAUSED
 send:G

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -56,7 +56,7 @@ expect:^H
 send:/worker
 expect:Search processes: /worker
 send:\r
-resize:80x8
+resize:120x12
 expect:restart
 send:l
 expect:processed deterministic job 1
@@ -91,7 +91,7 @@ send:/t
 expect:Search logs: /t
 expect:1/3
 send:\r
-expect:/t  1/3
+expect:n/N
 send:n
 expect:2/3
 send:y

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -15,6 +15,7 @@ work_dir=$(mktemp -d)
 transcript="$work_dir/transcript"
 event_log="$work_dir/events.jsonl"
 export TUI_REPLAY_EVENT_LOG=$event_log
+export TUI_REPLAY_TRANSCRIPT=$transcript
 
 cleanup() {
   status=$?
@@ -48,12 +49,18 @@ expect:api
 expect:worker
 expect:disabled
 expect:stopped
-send:j
-expect:restart
+run:! grep -Fq 'processed deterministic job 1' "$TUI_REPLAY_TRANSCRIPT"
+send:/worker
+expect:Search processes: /worker
+send:\r
+send:\r
+expect:processed deterministic job 1
+send:\r
+send:/api
+expect:Search processes: /api
+send:\r
 resize:48x12
-expect:api
 resize:120x40
-expect:restart
 send:\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12
 expect:restarting
 expect:ready

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -46,6 +46,7 @@ command="\"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\"
 # process while that row is still being inserted can clear or move the selection.
 "$pty_driver" pty --step-timeout 10 "$transcript" "$command" >/dev/null <<'EOF'
 expect:api
+expect:├
 expect:worker
 expect:disabled
 expect:stopped

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -55,9 +55,12 @@ resize:48x6
 send:/worker
 expect:Search processes: /worker
 send:\r
+expect:hide preview
+send:h
 expect:focus
 send:l
-expect:show all
+expect:processed deterministic job 1
+expect:hide preview
 send:h
 expect:focus
 send:/api
@@ -65,7 +68,8 @@ expect:Search processes: /api
 send:\r
 expect:focus
 send:\x1b[C
-expect:show all
+expect:listening on http://127.0.0.1:8080
+expect:hide preview
 send:\x1b[D
 expect:focus
 send:\x05

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -48,18 +48,36 @@ command="\"$tui_replay\" --hold --attached --reactive --event-log \"$event_log\"
 expect:api
 expect:├
 expect:worker
+expect:processed deterministic job 1
 expect:disabled
 expect:stopped
-run:! grep -Fq 'processed deterministic job 1' "$TUI_REPLAY_TRANSCRIPT"
+resize:48x6
 send:/worker
 expect:Search processes: /worker
 send:\r
-send:\r
-expect:processed deterministic job 1
-send:\r
+expect:focus
+send:l
+expect:show all
+send:h
+expect:focus
 send:/api
 expect:Search processes: /api
 send:\r
+expect:focus
+send:\x1b[C
+expect:show all
+send:\x1b[D
+expect:focus
+send:\x05
+expect:FOLLOWING
+send:y
+expect:bGlzdGVuaW5nIG9uIGh0dHA6Ly8xMjcuMC4wLjE6ODA4MA==
+send:g
+expect:PAUSED
+send:G
+expect:FOLLOWING
+send:q
+expect:Running processes
 resize:48x12
 resize:120x40
 send:\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12\x12
@@ -69,14 +87,14 @@ run:test "$(tail -n 1 "$TUI_REPLAY_EVENT_LOG")" = '{"kind":"status","process":"a
 send:\x18
 expect:stopping
 run:while ! tail -n 1 "$TUI_REPLAY_EVENT_LOG" | grep -Fq '"process":"api","status":"stopped"'; do sleep 0.02; done
-expect:restart
+expect:^R
 send:\x12
 expect:restarting
 expect:ready
 send:\x03
 expect:Detach
 send:c
-expect:restart
+expect:^R
 send:\x03
 expect:Detach
 send:s

--- a/devenv-tui/tests/replay-pty.sh
+++ b/devenv-tui/tests/replay-pty.sh
@@ -64,6 +64,11 @@ expect:processed deterministic job 1
 expect:hide preview
 send:h
 expect:focus
+send:/missing
+expect:Search processes: /missing
+expect:no matches
+send:\r
+expect:nav
 send:/api
 expect:Search processes: /api
 send:\r

--- a/devenv-tui/tests/snapshots/tui_tests__activity_with_details.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__activity_with_details.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Building shell → nix eval --json .#devenv.config [TIME]
 
-                                                   ↑↓ nav
+                                             ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__cachix_push_alongside_build.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__cachix_push_alongside_build.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Building  hello-2.12 buildPhase         [TIME]
 ⠋ Pushing to my-cache 3/7 → python-3.11.5 [TIME]
 
- 0 of 1 builds                            ↑↓ nav
+ 0/1 builds                         ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__cachix_push_progress.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__cachix_push_progress.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Pushing to my-cache 3/10 → hello-2.12 [TIME]
 
-                                        ↑↓ nav
+                                  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__cachix_push_started.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__cachix_push_started.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Pushing to my-cache [TIME]
 
-                      ↑↓ nav
+                ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__cachix_push_success.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__cachix_push_success.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ✓ Pushing to my-cache [TIME]
 
-                      ↑↓ nav
+                ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__cachix_push_with_failures.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__cachix_push_with_failures.snap
@@ -6,4 +6,4 @@ expression: output
   │ openssl-3.0.0: HTTP 403: Access Denied
   │ glibc-2.37: HTTP 500: Internal Server Error
 
-                                         ↑↓ nav
+                                   ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
@@ -2,6 +2,6 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: collapsed
 ---
-✓ ▸ Building shell 2 steps   [TIME] 
+✓ ▸ Building shell 2 steps              [TIME] 
 
- ↑↓ j/k ^D/^U • Enter ▾ • Esc clear
+ 1/1 builds ↑↓ j/k ^D/^U • Enter ▾ • Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
@@ -2,6 +2,6 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: collapsed
 ---
-✓ ▸ Building shell 2 steps [TIME] 
+✓ ▸ Building shell 2 steps   [TIME] 
 
- ↑↓ nav Enter expand Esc clear
+ ↑↓ j/k ^D/^U • Enter ▾ • Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_collapsed.snap
@@ -1,0 +1,7 @@
+---
+source: devenv-tui/tests/tui_tests.rs
+expression: collapsed
+---
+✓ ▸ Building shell 2 steps [TIME] 
+
+ ↑↓ nav Enter expand Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
@@ -1,0 +1,9 @@
+---
+source: devenv-tui/tests/tui_tests.rs
+expression: expanded
+---
+✓ ▾ Building shell           [TIME] 
+  └ ✓ Evaluating Nix         [TIME]
+    └ ✓ Building  hello-2.12 [TIME]
+
+ ↑↓ nav Enter collapse Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
@@ -6,4 +6,4 @@ expression: expanded
   └ ✓ Evaluating Nix         [TIME]
     └ ✓ Building  hello-2.12 [TIME]
 
- ↑↓ nav Enter collapse Esc clear
+ ↑↓ j/k ^D/^U • Enter ▴ • Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__completed_shell_tree_expanded.snap
@@ -2,8 +2,8 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: expanded
 ---
-✓ ▾ Building shell           [TIME] 
-  └ ✓ Evaluating Nix         [TIME]
-    └ ✓ Building  hello-2.12 [TIME]
+✓ ▾ Building shell                      [TIME] 
+  └ ✓ Evaluating Nix                    [TIME]
+    └ ✓ Building  hello-2.12            [TIME]
 
- ↑↓ j/k ^D/^U • Enter ▴ • Esc clear
+ 1/1 builds ↑↓ j/k ^D/^U • Enter ▴ • Esc clear

--- a/devenv-tui/tests/snapshots/tui_tests__deep_nesting.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__deep_nesting.snap
@@ -9,4 +9,4 @@ expression: output
       └ ⠋ Downloading  readline-8.2 from cache.nixos.org           [TIME]
         └ ⠋ Downloading  ncurses-6.4 from cache.nixos.org          [TIME]
 
- 0 of 1 builds  │  0 of 3 downloads                                ↑↓ nav
+ 0/1 builds │ 0/3 downloads                                  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__devenv_failed_shows_logs.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__devenv_failed_shows_logs.snap
@@ -7,4 +7,4 @@ expression: output
   │ error: command 'foo' not found
   │ hint: did you mean 'bar'?
 
-                            ↑↓ nav
+                      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__download_with_progress.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__download_with_progress.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Downloading Downloading nixpkgs                                  [TIME]
     ──────────────────────────────────────────────────5kB / 10kB at 50kB/s
 
- 0 of 1 downloads                                                  ↑↓ nav
+ 0/1 downloads                                               ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__download_with_substituter.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__download_with_substituter.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Downloading Downloading package from cache.nixos.org             [TIME]
     ───────────────────────────────────────────────────1kB / 2kB at 10kB/s
 
- 0 of 1 downloads                                                  ↑↓ nav
+ 0/1 downloads                                               ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__empty_model.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__empty_model.snap
@@ -3,4 +3,4 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 
-   ↑↓ nav
+  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__error_message_with_details.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__error_message_with_details.snap
@@ -10,4 +10,4 @@ expression: output
            error: undefined variable 'pkgs'
   ✗ error: undefined variable 'pkgs'
 
-                                     ↑↓ nav
+                               ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__error_message_with_parent.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__error_message_with_parent.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Building shell              [TIME]
   ✗ error: undefined variable 'pkgs'
 
-                              ↑↓ nav
+                        ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__error_message_without_details.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__error_message_without_details.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Building shell [TIME]
   ✗ error: simple error
 
-                 ↑↓ nav
+           ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__error_with_active_builds.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__error_with_active_builds.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Building  hello-2.12 buildPhase [TIME]
 
- 0 of 1 builds                    ↑↓ nav
+ 0/1 builds                 ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__evaluate_failed_shows_error_details.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__evaluate_failed_shows_error_details.snap
@@ -17,4 +17,4 @@ expression: output
   • evaluating file 3
   • evaluating file 4
 
-                                                                         ↑↓ nav
+                                                                   ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__evaluating_activity.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__evaluating_activity.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Building shell [TIME]
 
-                 ↑↓ nav
+           ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__fetch_tree_activity.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__fetch_tree_activity.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Fetching  Fetching github:NixOS/nixpkgs [TIME]
 
-                                          ↑↓ nav
+                                    ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__indeterminate_progress.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__indeterminate_progress.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Downloading  large-file.tar.gz from example.com [42MB] [TIME]
 
- 0 of 1 downloads                                        ↑↓ nav
+ 0/1 downloads                                     ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__many_concurrent_activities.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__many_concurrent_activities.snap
@@ -13,4 +13,4 @@ expression: output
 ⠋ task-6                                                           [TIME]
 ⠋ Building shell                                                   [TIME]
 
- 0 of 2 builds  │  0 of 2 downloads  │  0 of 2 tasks               ↑↓ nav
+ 0/2 builds │ 0/2 downloads │ 0/2 tasks                      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__mixed_completed_and_active.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__mixed_completed_and_active.snap
@@ -8,4 +8,4 @@ expression: output
 ⠋ Downloading runtime-dep from cache.nixos.org                     [TIME]
     ───────────────────────────────────────────────────3MB / 5MB at 30MB/s
 
- 1 of 3 builds  │  0 of 1 downloads                                ↑↓ nav
+ 1/3 builds │ 0/1 downloads                                  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__multiple_activities.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__multiple_activities.snap
@@ -7,4 +7,4 @@ expression: output
     ─────────────────────────────────────────────────2.5kB / 5kB at 25kB/s
 ⠋ Running setup                                                    [TIME]
 
- 0 of 1 builds  │  0 of 1 downloads  │  0 of 1 tasks               ↑↓ nav
+ 0/1 builds │ 0/1 downloads │ 0/1 tasks                      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__multiple_error_messages.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__multiple_error_messages.snap
@@ -3,4 +3,4 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 
-   ↑↓ nav
+  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__multiple_parallel_builds.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__multiple_parallel_builds.snap
@@ -7,4 +7,4 @@ expression: output
 ⠋ Building  python-3.11.5 installPhase   [TIME]
 ⠋ Building  gcc-12.3.0 unpackPhase       [TIME]
 
- 0 of 4 builds                           ↑↓ nav
+ 0/4 builds                        ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
@@ -8,4 +8,4 @@ expression: output
   │ └ ⠋ Downloading  glibc-2.35 from cache.nixos.org  [TIME]
   └ ⠋ Downloading  openssl-3.0.0 from cache.nixos.org [TIME]
 
- 0 of 1 builds  │  0 of 2 downloads                   ↑↓ nav
+ 0/1 builds │ 0/2 downloads                     ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__nested_evaluation_with_children.snap
@@ -3,9 +3,9 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 ⠋ Building shell                                      [TIME]
-  └ ⠋ Fetching  github:NixOS/nixpkgs                  [TIME]
-  └ ⠋ Building  hello-2.12 buildPhase                 [TIME]
-    └ ⠋ Downloading  glibc-2.35 from cache.nixos.org  [TIME]
+  ├ ⠋ Fetching  github:NixOS/nixpkgs                  [TIME]
+  ├ ⠋ Building  hello-2.12 buildPhase                 [TIME]
+  │ └ ⠋ Downloading  glibc-2.35 from cache.nixos.org  [TIME]
   └ ⠋ Downloading  openssl-3.0.0 from cache.nixos.org [TIME]
 
  0 of 1 builds  │  0 of 2 downloads                   ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__parallel_downloads_and_builds.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__parallel_downloads_and_builds.snap
@@ -11,4 +11,4 @@ expression: output
 ⠋ Downloading python-3.11.5 from cache.nixos.org                   [TIME]
     ──────────────────────────────────────────────────1MB / 50MB at 10MB/s
 
- 0 of 2 builds  │  0 of 3 downloads                                ↑↓ nav
+ 0/2 builds │ 0/3 downloads                                  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
@@ -1,12 +1,11 @@
 ---
 source: devenv-tui/tests/tui_tests.rs
-assertion_line: 2103
 expression: output
 ---
 ⠋ Running processes       [TIME]
-  └ ⠋ Evaluating Nix      [TIME]
-  └ ◐ api-server starting [TIME]
-  └ ◐ mysql starting      [TIME]
+  ├ ⠋ Evaluating Nix      [TIME]
+  ├ ◐ api-server starting [TIME]
+  ├ ◐ mysql starting      [TIME]
   └ ◐ zookeeper starting  [TIME]
 
  3 processes   ↑↓ nav • / search

--- a/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
@@ -9,4 +9,4 @@ expression: output
   └ ◐ mysql starting      [TIME]
   └ ◐ zookeeper starting  [TIME]
 
- 3 processes              ↑↓ nav
+ 3 processes   ↑↓ nav • / search

--- a/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__processes_alphabetical_order.snap
@@ -8,4 +8,4 @@ expression: output
   ├ ◐ mysql starting      [TIME]
   └ ◐ zookeeper starting  [TIME]
 
- 3 processes   ↑↓ nav • / search
+ 3 processes    ↑↓ j/k ^D/^U • /

--- a/devenv-tui/tests/snapshots/tui_tests__query_activity.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__query_activity.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Querying  7xyndmr0mgfissin0h5ggzb0b2i5drbz-cargo-vendor-dir from some… [TIME]
 
- 0 of 1 queries                                                          ↑↓ nav
+ 0/1 queries                                                       ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__single_build_activity.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__single_build_activity.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ Building  Building hello-world buildPhase [TIME]
 
- 0 of 1 builds                              ↑↓ nav
+ 0/1 builds                           ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__standalone_error_message.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__standalone_error_message.snap
@@ -3,4 +3,4 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 
-   ↑↓ nav
+  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_additional_parents.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_additional_parents.snap
@@ -7,4 +7,4 @@ expression: output
 ⠋ test:integration [TIME]
   └ ⠋ build        [TIME]
 
- 0 of 3 tasks      ↑↓ nav
+ 0/3 tasks   ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_deep_nesting.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_deep_nesting.snap
@@ -7,4 +7,4 @@ expression: output
     └ ⠋ test:level2   [TIME]
       └ ⠋ test:level3 [TIME]
 
- 0 of 4 tasks         ↑↓ nav
+ 0/4 tasks      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_dependency_failed_never_started.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_dependency_failed_never_started.snap
@@ -5,4 +5,4 @@ expression: output
 ✗ test:dependent failed [TIME]
   └ ✗ test:dep failed   [TIME]
 
- 0 of 2 tasks           ↑↓ nav
+ 0/2 tasks        ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_diamond_dependency.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_diamond_dependency.snap
@@ -3,8 +3,8 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 ⠋ test:root         [TIME]
-  └ ⠋ test:branch-a [TIME]
-    └ ⠋ test:shared [TIME]
+  ├ ⠋ test:branch-a [TIME]
+  │ └ ⠋ test:shared [TIME]
   └ ⠋ test:branch-b [TIME]
     └ ⠋ test:shared [TIME]
 

--- a/devenv-tui/tests/snapshots/tui_tests__task_diamond_dependency.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_diamond_dependency.snap
@@ -8,4 +8,4 @@ expression: output
   └ ⠋ test:branch-b [TIME]
     └ ⠋ test:shared [TIME]
 
- 0 of 4 tasks       ↑↓ nav
+ 0/4 tasks    ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_failed.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_failed.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ✗ Tests failed failed [TIME]
 
- 0 of 1 tasks         ↑↓ nav
+ 0/1 tasks      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_failed_shows_logs.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_failed_shows_logs.snap
@@ -7,4 +7,4 @@ expression: output
   │ FAILED: assertion error in test_foo
   │ Expected: 42, Got: 0
 
- 0 of 1 tasks                                     ↑↓ nav
+ 0/1 tasks                                  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_multiple_under_same_parent.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_multiple_under_same_parent.snap
@@ -3,8 +3,8 @@ source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
 ⠋ test:parent      [TIME]
-  └ ⠋ test:child-a [TIME]
-  └ ⠋ test:child-b [TIME]
+  ├ ⠋ test:child-a [TIME]
+  ├ ⠋ test:child-b [TIME]
   └ ⠋ test:child-c [TIME]
 
  0 of 4 tasks      ↑↓ nav

--- a/devenv-tui/tests/snapshots/tui_tests__task_multiple_under_same_parent.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_multiple_under_same_parent.snap
@@ -7,4 +7,4 @@ expression: output
   ├ ⠋ test:child-b [TIME]
   └ ⠋ test:child-c [TIME]
 
- 0 of 4 tasks      ↑↓ nav
+ 0/4 tasks   ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_queued_state.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_queued_state.snap
@@ -2,8 +2,8 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-⠋ test:first    [TIME]
+⠋ test:first     [TIME]
 ⠋ test:second pending
 ⠋ test:third pending
 
- 0 of 3 tasks   ↑↓ nav
+ 0/3 tasks ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_running.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_running.snap
@@ -2,6 +2,6 @@
 source: devenv-tui/tests/tui_tests.rs
 expression: output
 ---
-⠋ Running tests [TIME]
+⠋ Running tests  [TIME]
 
- 0 of 1 tasks   ↑↓ nav
+ 0/1 tasks ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_show_output_false.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_show_output_false.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ⠋ test:without-output 2 lines → HIDDEN_OUTPUT_LINE_2 [TIME]
 
- 0 of 1 tasks                                        ↑↓ nav
+ 0/1 tasks                                     ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_show_output_true.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_show_output_true.snap
@@ -6,4 +6,4 @@ expression: output
   │ VISIBLE_OUTPUT_LINE_1
   │ VISIBLE_OUTPUT_LINE_2
 
- 0 of 1 tasks                                      ↑↓ nav
+ 0/1 tasks                                   ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_skipped_never_started.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_skipped_never_started.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ✓ test:skipped-task skipped [TIME]
 
- 1 of 1 tasks               ↑↓ nav
+ 1/1 tasks            ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__task_success.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__task_success.snap
@@ -4,4 +4,4 @@ expression: output
 ---
 ✓ Build completed [TIME]
 
- 1 of 1 tasks     ↑↓ nav
+ 1/1 tasks  ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/snapshots/tui_tests__warning_message_with_parent.snap
+++ b/devenv-tui/tests/snapshots/tui_tests__warning_message_with_parent.snap
@@ -5,4 +5,4 @@ expression: output
 ⠋ Building shell                            [TIME]
   • warning: deprecated option 'services.foo' used
 
-                                            ↑↓ nav
+                                      ↑↓ j/k ^D/^U

--- a/devenv-tui/tests/tui_proptest.rs
+++ b/devenv-tui/tests/tui_proptest.rs
@@ -363,12 +363,10 @@ fn max_line_width(out: &str) -> usize {
     out.lines().map(UnicodeWidthStr::width).max().unwrap_or(0)
 }
 
-/// Regression for the bottom navigation/help bar overflow on standard-width
-/// terminals. The richest short-text state (a process selected, with the
-/// hide-stopped toggle showing) must fit a normal ~80-column terminal.
-///
+/// A selected process keeps complete controls at every usable width and keeps
+/// its status summary whenever both can fit without fragmentation.
 #[test]
-fn navbar_fits_standard_widths() {
+fn selected_navbar_preserves_status_and_fits_usable_widths() {
     let mut m = ActivityModel::new();
     m.apply_activity_event(process_start(1, "web"));
     m.apply_activity_event(process_status(1, ProcessStatus::Running));
@@ -376,7 +374,7 @@ fn navbar_fits_standard_widths() {
     m.apply_activity_event(process_start(2, "db"));
     m.apply_activity_event(process_complete(2, ActivityOutcome::Success));
 
-    for w in 76u16..=99 {
+    for w in 40u16..=240 {
         let mut ui = UiState::new();
         ui.set_terminal_size(w, 24);
         ui.selected_activity = Some(1);
@@ -386,6 +384,42 @@ fn navbar_fits_standard_widths() {
             widest <= w as usize,
             "nav bar width {widest} exceeds terminal width {w}:\n{out}"
         );
+        if w < 60 {
+            assert!(
+                out.contains("↑↓ j/k ^D/^U Enter ^E ^X ^R ^H / Esc"),
+                "ultra-compact controls are incomplete at width {w}:\n{out}"
+            );
+        } else if w < 120 {
+            assert!(
+                out.contains("↑↓ j/k ^D/^U • Enter ▾ • ^E ▼ • ^X ^R ^H / Esc clear"),
+                "symbol controls are incomplete at width {w}:\n{out}"
+            );
+        } else if w < 200 {
+            assert!(
+                out.contains(
+                    "↑↓ j/k ^D/^U nav Enter preview ^E logs ^X stop ^R restart ^H hide / search Esc clear"
+                ),
+                "compact controls are incomplete at width {w}:\n{out}"
+            );
+        } else {
+            assert!(
+                out.contains(
+                    "↑↓ j/k Ctrl-D/Ctrl-U navigate • Enter/l/→ preview logs • Ctrl-E full logs • Ctrl-X stop process • Ctrl-R (re)start process • Ctrl-H hide stopped • / search processes • Esc clear"
+                ),
+                "wide controls are incomplete at width {w}:\n{out}"
+            );
+        }
+        if w >= 72 {
+            let status = if w < 120 {
+                "1/2 processes"
+            } else {
+                "1 of 2 processes"
+            };
+            assert!(
+                out.contains(status),
+                "selected footer lost process status at width {w}:\n{out}"
+            );
+        }
     }
 }
 

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -1171,10 +1171,8 @@ fn test_task_diamond_dependency() {
     insta::assert_snapshot!(output);
 }
 
-/// Test that when activities overflow a small terminal, the bottom content
-/// (running processes with logs) remains visible and the summary line is last.
 #[test]
-fn test_overflow_clips_top_keeps_bottom() {
+fn test_overflow_keeps_collapsed_process_visible() {
     let model = ActivityModel::new();
     let mut ui_state = UiState::new();
     // Use a very small terminal height to force overflow
@@ -1208,12 +1206,12 @@ fn test_overflow_clips_top_keeps_bottom() {
         last_non_empty
     );
 
-    // The process log should be visible
     assert!(
-        output.contains("Listening on port 3000"),
-        "Process log line should be visible in overflow output.\nFull output:\n{}",
+        output.contains("web-server"),
+        "Process should be visible in overflow output.\nFull output:\n{}",
         output
     );
+    assert!(!output.contains("Listening on port 3000"));
 
     // The very last line should be the summary (no trailing empty lines)
     let last_line = lines.last().unwrap();
@@ -1529,6 +1527,49 @@ fn test_processes_alphabetical_order() {
     );
 
     insta::assert_snapshot!(output);
+}
+
+#[test]
+fn test_process_logs_are_collapsed_until_explicitly_opened() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(process_start(1, "chatty-service"));
+    model.apply_activity_event(process_log(1, "seeding database", false));
+
+    ui_state.selected_activity = Some(1);
+    let selected = render_to_string(&model, &ui_state);
+    assert!(!selected.contains("seeding database"));
+
+    ui_state.toggle_inline_logs();
+    let opened = render_to_string(&model, &ui_state);
+    assert!(opened.contains("seeding database"));
+
+    ui_state.toggle_inline_logs();
+    let closed = render_to_string(&model, &ui_state);
+    assert!(!closed.contains("seeding database"));
+}
+
+#[test]
+fn test_process_search_matches_names_case_insensitively() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(process_start(1, "scope-api"));
+    model.apply_activity_event(process_start(2, "scope-consumer"));
+    model.apply_activity_event(build_start(3, "scope-api-build"));
+
+    assert_eq!(
+        model.get_matching_process_activity_ids(&ui_state, "API"),
+        vec![1]
+    );
+    assert_eq!(
+        model.get_matching_process_activity_ids(&ui_state, "scope"),
+        vec![1, 2]
+    );
+    assert!(
+        model
+            .get_matching_process_activity_ids(&ui_state, "missing")
+            .is_empty()
+    );
 }
 
 /// Test cachix push alongside other activities (build + push concurrent).

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -1202,7 +1202,7 @@ fn test_overflow_keeps_collapsed_process_visible() {
     let lines: Vec<&str> = output.lines().collect();
     let last_non_empty = lines.iter().rev().find(|l| !l.trim().is_empty()).unwrap();
     assert!(
-        last_non_empty.contains("nav"),
+        last_non_empty.contains("↑↓ j/k"),
         "Last line should be the summary status line, got: {:?}",
         last_non_empty
     );
@@ -1546,7 +1546,7 @@ fn test_process_logs_follow_terminal_height_and_manual_focus() {
     ui_state.selected_activity = Some(1);
     let roomy = render_to_string(&model, &ui_state);
     assert!(roomy.contains("seeding database"));
-    assert!(roomy.contains("hide preview"));
+    assert!(roomy.contains("Enter ▴"));
     let process_line = roomy
         .lines()
         .find(|line| line.contains("chatty-service"))
@@ -1562,12 +1562,12 @@ fn test_process_logs_follow_terminal_height_and_manual_focus() {
     ui_state.set_terminal_size(TEST_WIDTH, 3);
     let crowded = render_to_string(&model, &ui_state);
     assert!(!crowded.contains("seeding database"));
-    assert!(crowded.contains("preview"));
+    assert!(crowded.contains("Enter ▾"));
 
     ui_state.focus_inline_logs(1);
     let focused = render_to_string(&model, &ui_state);
     assert!(focused.contains("seeding database"));
-    assert!(focused.contains("hide preview"));
+    assert!(focused.contains("Enter ▴"));
     let focused_log_line = focused
         .lines()
         .find(|line| line.contains("seeding database"))

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -8,6 +8,7 @@ use devenv_activity::test_helpers::*;
 use devenv_activity::{ActivityLevel, ActivityOutcome, FetchKind, TaskInfo};
 use devenv_tui::{ActivityModel, RenderContext, UiState, view::view};
 use iocraft::prelude::*;
+use unicode_width::UnicodeWidthStr;
 
 const TEST_WIDTH: u16 = 80;
 const TEST_HEIGHT: u16 = 24;
@@ -1545,23 +1546,43 @@ fn test_process_logs_follow_terminal_height_and_manual_focus() {
     ui_state.selected_activity = Some(1);
     let roomy = render_to_string(&model, &ui_state);
     assert!(roomy.contains("seeding database"));
-    assert!(roomy.contains("Enter focus"));
+    assert!(roomy.contains("hide preview"));
+    let process_line = roomy
+        .lines()
+        .find(|line| line.contains("chatty-service"))
+        .unwrap();
+    let log_line = roomy
+        .lines()
+        .find(|line| line.contains("seeding database"))
+        .unwrap();
+    let process_column = process_line[..process_line.find("chatty-service").unwrap()].width();
+    let log_column = log_line[..log_line.find("seeding database").unwrap()].width();
+    assert_eq!(log_column, process_column, "{roomy}");
 
     ui_state.set_terminal_size(TEST_WIDTH, 3);
     let crowded = render_to_string(&model, &ui_state);
     assert!(!crowded.contains("seeding database"));
-    assert!(crowded.contains("Enter preview"));
+    assert!(crowded.contains("preview"));
 
-    ui_state.toggle_inline_logs();
+    ui_state.focus_inline_logs(1);
     let focused = render_to_string(&model, &ui_state);
     assert!(focused.contains("seeding database"));
-    assert!(focused.contains("    seeding database"), "{focused}");
-    assert!(!focused.contains("│ seeding database"), "{focused}");
-    assert!(focused.contains("Enter hide preview"));
+    assert!(focused.contains("hide preview"));
+    let focused_log_line = focused
+        .lines()
+        .find(|line| line.contains("seeding database"))
+        .unwrap();
+    let focused_log_column =
+        focused_log_line[..focused_log_line.find("seeding database").unwrap()].width();
+    assert_eq!(focused_log_column, process_column, "{focused}");
 
-    ui_state.toggle_inline_logs();
-    let automatic = render_to_string(&model, &ui_state);
-    assert!(!automatic.contains("seeding database"));
+    ui_state.hide_process_previews();
+    let hidden = render_to_string(&model, &ui_state);
+    assert!(!hidden.contains("seeding database"));
+
+    ui_state.focus_inline_logs(1);
+    let reopened = render_to_string(&model, &ui_state);
+    assert!(reopened.contains("seeding database"));
 }
 
 #[test]
@@ -1588,7 +1609,7 @@ fn test_process_preview_preserves_required_tree_continuation() {
     ui_state.toggle_inline_logs();
     let rendered = render_to_string(&model, &ui_state);
 
-    assert!(rendered.contains("  │ seeding database"), "{rendered}");
+    assert!(rendered.contains("  │   seeding database"), "{rendered}");
     assert!(rendered.contains("  └"), "{rendered}");
 }
 

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -1660,17 +1660,69 @@ fn test_failed_shell_tree_stays_expanded() {
 }
 
 #[test]
+fn test_successful_shell_tree_with_warning_stays_expanded() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(1, "Building shell"));
+    model.apply_activity_event(evaluate_start_with(
+        2,
+        "Evaluating Nix",
+        ActivityLevel::Info,
+        Some(1),
+    ));
+    model.apply_activity_event(message_with(
+        3,
+        ActivityLevel::Warn,
+        "Deprecated option `old.option`",
+        Some(2),
+    ));
+    model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+
+    let rendered = render_to_string(&model, &ui_state);
+    assert!(!rendered.contains("▸ Building shell"));
+    assert!(rendered.contains("Evaluating Nix"));
+    assert!(rendered.contains("Deprecated option `old.option`"));
+}
+
+#[test]
 fn test_completed_non_shell_operation_stays_expanded() {
     let (mut model, ui_state) = new_test_model();
 
     model.apply_activity_event(operation_start(1, "Pushing to cache"));
-    model.apply_activity_event(build_start_with(2, "cached-build", Some(1)));
-    model.apply_activity_event(build_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(evaluate_start_with(
+        2,
+        "Evaluating package search",
+        ActivityLevel::Info,
+        Some(1),
+    ));
+    model.apply_activity_event(build_start_with(3, "cached-build", Some(2)));
+    model.apply_activity_event(build_complete(3, ActivityOutcome::Success));
+    model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
     model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
 
     let rendered = render_to_string(&model, &ui_state);
     assert!(!rendered.contains("▸ Pushing to cache"));
+    assert!(rendered.contains("Evaluating package search"));
     assert!(rendered.contains("cached-build"));
+}
+
+#[test]
+fn test_completed_non_shell_evaluation_stays_expanded() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(evaluate_start(
+        1,
+        "Validating lock file",
+        ActivityLevel::Info,
+    ));
+    model.apply_activity_event(build_start_with(2, "validation-input", Some(1)));
+    model.apply_activity_event(build_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(evaluate_complete(1, ActivityOutcome::Success));
+
+    let rendered = render_to_string(&model, &ui_state);
+    assert!(!rendered.contains("▸ Validating lock file"));
+    assert!(rendered.contains("validation-input"));
 }
 
 #[test]

--- a/devenv-tui/tests/tui_tests.rs
+++ b/devenv-tui/tests/tui_tests.rs
@@ -1181,7 +1181,7 @@ fn test_overflow_keeps_collapsed_process_visible() {
     let mut model = model;
 
     // Create several completed activities (these should get clipped at the top)
-    for i in 1..=5 {
+    for i in 1..=8 {
         model.apply_activity_event(build_start(i, format!("completed-build-{}", i)));
         model.apply_activity_event(build_complete(i, ActivityOutcome::Success));
     }
@@ -1530,23 +1530,146 @@ fn test_processes_alphabetical_order() {
 }
 
 #[test]
-fn test_process_logs_are_collapsed_until_explicitly_opened() {
+fn test_process_logs_follow_terminal_height_and_manual_focus() {
     let (mut model, mut ui_state) = new_test_model();
 
-    model.apply_activity_event(process_start(1, "chatty-service"));
+    model.apply_activity_event(operation_start(10, "Running processes"));
+    model.apply_activity_event(process_start_with(
+        1,
+        "chatty-service",
+        Some(10),
+        ActivityLevel::Info,
+    ));
     model.apply_activity_event(process_log(1, "seeding database", false));
 
     ui_state.selected_activity = Some(1);
-    let selected = render_to_string(&model, &ui_state);
-    assert!(!selected.contains("seeding database"));
+    let roomy = render_to_string(&model, &ui_state);
+    assert!(roomy.contains("seeding database"));
+    assert!(roomy.contains("Enter focus"));
+
+    ui_state.set_terminal_size(TEST_WIDTH, 3);
+    let crowded = render_to_string(&model, &ui_state);
+    assert!(!crowded.contains("seeding database"));
+    assert!(crowded.contains("Enter preview"));
 
     ui_state.toggle_inline_logs();
-    let opened = render_to_string(&model, &ui_state);
-    assert!(opened.contains("seeding database"));
+    let focused = render_to_string(&model, &ui_state);
+    assert!(focused.contains("seeding database"));
+    assert!(focused.contains("    seeding database"), "{focused}");
+    assert!(!focused.contains("│ seeding database"), "{focused}");
+    assert!(focused.contains("Enter hide preview"));
 
     ui_state.toggle_inline_logs();
-    let closed = render_to_string(&model, &ui_state);
-    assert!(!closed.contains("seeding database"));
+    let automatic = render_to_string(&model, &ui_state);
+    assert!(!automatic.contains("seeding database"));
+}
+
+#[test]
+fn test_process_preview_preserves_required_tree_continuation() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(10, "Running processes"));
+    model.apply_activity_event(process_start_with(
+        1,
+        "chatty-service",
+        Some(10),
+        ActivityLevel::Info,
+    ));
+    model.apply_activity_event(process_log(1, "seeding database", false));
+    model.apply_activity_event(process_start_with(
+        2,
+        "next-service",
+        Some(10),
+        ActivityLevel::Info,
+    ));
+
+    ui_state.set_terminal_size(TEST_WIDTH, 4);
+    ui_state.selected_activity = Some(1);
+    ui_state.toggle_inline_logs();
+    let rendered = render_to_string(&model, &ui_state);
+
+    assert!(rendered.contains("  │ seeding database"), "{rendered}");
+    assert!(rendered.contains("  └"), "{rendered}");
+}
+
+#[test]
+fn test_completed_shell_tree_collapses_into_expandable_summary() {
+    let (mut model, mut ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(1, "Building shell"));
+    model.apply_activity_event(evaluate_start_with(
+        2,
+        "Evaluating Nix",
+        ActivityLevel::Info,
+        Some(1),
+    ));
+    model.apply_activity_event(build_start_with(3, "hello-2.12", Some(2)));
+    model.apply_activity_event(build_complete(3, ActivityOutcome::Success));
+    model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+
+    ui_state.selected_activity = Some(1);
+    let collapsed = render_to_string(&model, &ui_state);
+    assert!(collapsed.contains("▸ Building shell"));
+    assert!(collapsed.contains("2 steps"));
+    assert!(!collapsed.contains("Evaluating Nix"));
+    assert!(!collapsed.contains("hello-2.12"));
+    insta::assert_snapshot!("completed_shell_tree_collapsed", collapsed);
+
+    ui_state.toggle_activity_expansion(1);
+    let expanded = render_to_string(&model, &ui_state);
+    assert!(expanded.contains("▾ Building shell"));
+    assert!(expanded.contains("Evaluating Nix"));
+    assert!(expanded.contains("hello-2.12"));
+    insta::assert_snapshot!("completed_shell_tree_expanded", expanded);
+}
+
+#[test]
+fn test_failed_shell_tree_stays_expanded() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(1, "Building shell"));
+    model.apply_activity_event(build_start_with(2, "broken-build", Some(1)));
+    model.apply_activity_event(build_complete(2, ActivityOutcome::Failed));
+    model.apply_activity_event(operation_complete(1, ActivityOutcome::Failed));
+
+    let rendered = render_to_string(&model, &ui_state);
+    assert!(!rendered.contains("▸ Building shell"));
+    assert!(rendered.contains("broken-build"));
+}
+
+#[test]
+fn test_completed_non_shell_operation_stays_expanded() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(1, "Pushing to cache"));
+    model.apply_activity_event(build_start_with(2, "cached-build", Some(1)));
+    model.apply_activity_event(build_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+
+    let rendered = render_to_string(&model, &ui_state);
+    assert!(!rendered.contains("▸ Pushing to cache"));
+    assert!(rendered.contains("cached-build"));
+}
+
+#[test]
+fn test_running_process_group_never_collapses() {
+    let (mut model, ui_state) = new_test_model();
+
+    model.apply_activity_event(operation_start(1, "Running processes"));
+    model.apply_activity_event(evaluate_start_with(
+        2,
+        "Evaluating Nix",
+        ActivityLevel::Info,
+        Some(1),
+    ));
+    model.apply_activity_event(evaluate_complete(2, ActivityOutcome::Success));
+    model.apply_activity_event(process_start_with(3, "api", Some(1), ActivityLevel::Info));
+    model.apply_activity_event(operation_complete(1, ActivityOutcome::Success));
+
+    let rendered = render_to_string(&model, &ui_state);
+    assert!(!rendered.contains("▸ Running processes"));
+    assert!(rendered.contains("api"));
 }
 
 #[test]


### PR DESCRIPTION
# Changes

  - stop opening chatty process logs just by moving the selection
  - show process log previews automatically only when the complete tree fits in the terminal
  - keep previews collapsed when space is limited, while allowing explicit preview at any terminal size
  - keep explicit preview choices stable while navigating instead of returning to automatic disclosure
  - keep the Running processes group expanded so active processes are always visible
  - collapse completed successful shell evaluation trees into a compact step summary
  - keep failed evaluations and non-shell activity trees expanded
  - add / process search with case-insensitive matching, live match counts, ↑/↓ navigation, Enter confirmation, and Esc cancellation
  - use Enter to toggle previews, l/→ to open, and h/← to close
  - make Esc hide the current preview before clearing the selection
  - connect tree branches correctly across nested activities, sibling processes, and inline previews
  - render process logs without fake child branches while preserving required sibling continuation lines
  - restore muted gray log output and align it with the process name
  - wrap long inline log lines without breaking the tree or terminal width
  - keep the selected row visible when previews open, close, or change height
  - make repeated navigation input and redraws respond immediately under busy log output
  - avoid repeated activity-tree calculations during rendering
  - add follow and paused states to the existing Ctrl-E fullscreen log view
  - pause following when scrolling and resume with G, End, or by reaching the bottom
  - keep paused fullscreen logs anchored while the bounded log buffer rotates
  - add y to copy the current selection, or all retained logs when nothing is selected
  - update adaptive footer hints for preview, search, fullscreen, follow, and copy controls

  ## tree rendering

  Before:
```
  ├ Running tasks
    └ cleanup
  └ Running processes
    └ api
      │ starting server
    └ worker
```
  After:
```
  ├ Running tasks
  │ └ cleanup
  └ Running processes
    ├ ● api
    │   starting server
    └ ● worker
```