### PR TITLE
fix(tui): only auto-quiet for autonomous coding agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed `devenv processes down` returning before Overmind had finished stopping. Overmind left its control socket behind, and the next `devenv up` refused to start. devenv now waits for the manager to exit before it cleans up.
 - Fixed a foreground `devenv up` with an external process manager being invisible to other devenv commands. `devenv processes down` in another terminal now stops it, and a second `devenv up` attaches instead of starting a rival manager.
 - Fixed `devenv processes down` doing nothing after you log out and back in. systemd removes `/run/user/$UID` when your last session ends, which used to lose a detached process manager: it kept running, nothing could stop it, and the next `devenv up` started a second one beside it. devenv now keeps a copy of the manager state in `.devenv`.
+- Fixed devenv suppressing the TUI and forcing quiet output for every shell started from Warp. AI-agent auto-detection now matches only autonomous agents, not "hybrid" environments.
 
 ## 2.2.2 (2026-08-13)
 

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -86,6 +86,11 @@ fn same_process_command(
 /// We use the `detect-coding-agent` crate to recognize well-known AI agents
 /// (Claude Code, Cursor, Aider, ...) from their environment variables.
 ///
+/// Only `AgentKind::Agent` counts. The crate's own `is_agent()` also matches
+/// `AgentKind::Hybrid`, which marks environments that *can* run an agent rather
+/// than ones that currently are, so it strips the TUI from humans at an
+/// interactive prompt.
+///
 /// Set `DEVENV_NO_AI_AGENT=1` to opt out of detection (forces normal output/TUI
 /// even when running under a detected agent). The result is cached for the
 /// process lifetime.
@@ -95,8 +100,13 @@ pub fn is_ai_agent() -> bool {
         if std::env::var_os("DEVENV_NO_AI_AGENT").is_some() {
             return false;
         }
-        detect_coding_agent::is_agent()
+        is_unattended_agent(detect_coding_agent::detect().map(|agent| agent.kind))
     })
+}
+
+/// Whether a detected coding environment runs without a human in the loop.
+fn is_unattended_agent(kind: Option<detect_coding_agent::AgentKind>) -> bool {
+    matches!(kind, Some(detect_coding_agent::AgentKind::Agent))
 }
 
 pub static DIRENVRC: Lazy<String> = Lazy::new(|| {
@@ -3978,6 +3988,33 @@ fn native_manager_seedable(pid_status: Option<&processes::PidStatus>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn only_autonomous_agents_are_unattended() {
+        use detect_coding_agent::AgentKind;
+
+        assert!(is_unattended_agent(Some(AgentKind::Agent)));
+        assert!(!is_unattended_agent(Some(AgentKind::Interactive)));
+        assert!(!is_unattended_agent(Some(AgentKind::Hybrid)));
+        assert!(!is_unattended_agent(None));
+    }
+
+    #[test]
+    fn a_warp_terminal_prompt_is_not_an_agent() {
+        let env = |vars: &[(&str, &str)]| {
+            vars.iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect()
+        };
+
+        // Hybrid terminal environment like Warp sets TERM_PROGRAM for every shell it starts, agent or human.
+        let warp = detect_coding_agent::detect_with_env(env(&[("TERM_PROGRAM", "WarpTerminal")]));
+        assert!(!is_unattended_agent(warp.map(|agent| agent.kind)));
+
+        // Agents with a dedicated marker still switch devenv to unattended output.
+        let claude_code = detect_coding_agent::detect_with_env(env(&[("CLAUDECODE", "1")]));
+        assert!(is_unattended_agent(claude_code.map(|agent| agent.kind)));
+    }
 
     #[test]
     fn identical_attached_process_commands_compare_by_kind_and_target() {


### PR DESCRIPTION
Starting with 2.2.0, devenv switches to quiet mode by default in Warp, so users no longer see TUI progress.

This happens because [`detect_coding_agent::is_agent()`](https://docs.rs/detect-coding-agent/latest/detect_coding_agent/fn.is_agent.html) matches `Agent` and `Hybrid` providers. Warp is [the only `Hybrid` provider](https://docs.rs/detect-coding-agent/latest/src/detect_coding_agent/providers.rs.html#316-322), and the crate detects it from the `TERM_PROGRAM=WarpTerminal` variable that is set in every tab, regardless if it's running in terminal or agent mode.

This proposal changes the condition to match only `AgentKind::Agent`. Other multi-mode apps (e.g. [Cursor](https://docs.rs/detect-coding-agent/latest/src/detect_coding_agent/providers.rs.html#262-273)) split into `Agent` and `Interactive` pairs, each with a different marker. A same split upstream would be cleaner, but Warp exposes no second marker to differentiate the two modes.

The trade-off is that quiet mode will no longer be auto-enabled in Warp agent mode, which I assumed is better than suppressing the TUI completely. Current behavior does not change for any other tool.

`DEVENV_NO_AI_AGENT=1` works as a workaround, so this isn't blocking, but it might not be trivial for newcomers (and it prevents from getting auto-quiet mode e.g. when running Claude Code in Warp terminal), so I thought it was worth a fix.

Thanks!