### PR TITLE
feat(claude): add claude.code.skills

### DIFF
--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -25,6 +25,7 @@ This tells Claude to use devenv for running commands, ensuring all tools and dep
 - **Automatic code formatting**: Runs `pre-commit` hooks on files after Claude edits them
 - **Custom hooks**: Define pre/post actions for Claude's tool usage
 - **Project commands**: Create custom slash commands for common tasks
+- **Skills**: Package project knowledge Claude loads on demand
 - **Seamless integration**: Works with your existing git-hooks configuration
 
 ## Basic Setup
@@ -308,6 +309,92 @@ Any agent can also be requested explicitly, by asking Claude to use it or by des
 4. **Ask for proactive use carefully**: Only say "use proactively" in the description of agents that should run automatically
 
 For more details on agents, see the [official Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/sub-agents).
+
+## Skills
+
+Skills are folders of instructions Claude loads on demand. Only a skill's `description` stays in context; the body is read when Claude decides the skill applies.
+That makes them the right place for knowledge that is important when it is relevant and noise the rest of the time (e.g., migration workflows, API conventions, deployment runbooks).
+
+Skills are written to `.claude/skills/<name>/SKILL.md`.
+
+```nix
+{
+  claude.code.skills = {
+    database-migrations = {
+      description = "How to write and run migrations in this project. Use when adding, editing or rolling back a migration.";
+      content = ''
+        Migrations live in `migrations/` and are applied with `diesel migration run`.
+
+        - One logical change per migration; never edit an applied migration.
+        - Always write the matching `down.sql`.
+        - Run `devenv tasks run db:reset` before opening a pull request.
+      '';
+    };
+  };
+}
+```
+
+### Properties
+
+- **description**: What the skill covers and when to use it. This is the only part Claude sees before loading the skill, so it decides whether the skill ever triggers.
+  Keep it one line and name the situations that should pull it in.
+- **content**: The body of `SKILL.md`.
+- **allowedTools**: Restrict the tools available while the skill is active. Empty (the default) means no restriction.
+- **resources**: Extra files placed next to `SKILL.md`, keyed by path relative to the skill directory.
+  A bare path is the common case; use `{ source = ./x; executable = true; }`
+  when the file needs to be run directly rather than passed to an interpreter.
+- **copyMode**: How the files are materialised, as in [`files.<name>.copyMode`](../reference/options.md#filesnamecopymode). Defaults to `symlink`.
+
+Skill names must be lowercase letters, digits and single hyphens, at most 64 characters.
+Devenv asserts this, because Claude Code silently ignores skill directories it cannot match to a valid name.
+
+### Bundled resources
+
+Long reference material belongs in its own file rather than in `content`, so Claude pulls it in only when it needs the detail:
+
+```nix
+{
+  claude.code.skills.api-conventions = {
+    description = "REST conventions for this codebase. Use when adding or changing an HTTP endpoint.";
+    allowedTools = [ "Read" "Grep" ];
+    resources = {
+      "references/error-codes.md" = ./docs/error-codes.md;
+      "scripts/lint-endpoints.sh" = {
+        source = ./scripts/lint-endpoints.sh;
+        executable = true;
+      };
+    };
+    content = ''
+      Endpoints are versioned under `/v1`.
+      Read references/error-codes.md before inventing a new error code.
+    '';
+  };
+}
+```
+
+### Editing a skill in place
+
+By default the generated files are symlinks into the Nix store and cannot be edited.
+Set `copyMode = "seed"` to have devenv write the skill once and leave it writable, so you can iterate on the prose and move it back into `devenv.nix` when it settles:
+
+```nix
+{
+  claude.code.skills.api-conventions = {
+    copyMode = "seed";
+    # ...
+  };
+}
+```
+
+### Skills, commands or agents?
+
+- A **skill** is knowledge Claude loads by itself when the task matches.
+- A **command** is something you invoke explicitly with `/name`.
+- An **agent** is a separate context window with its own tools and prompt.
+
+Reach for a skill when you would otherwise repeat the same explanation to Claude across sessions.
+
+For more details, see the [official Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code/skills).
 
 ## MCP Servers
 

--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -342,7 +342,7 @@ Skills are written to `.claude/skills/<name>/SKILL.md`.
 - **allowedTools**: Tools Claude can use without asking permission during the turn that invokes the skill; the grant clears when you send your next message.
   This pre-approves tools rather than restricting them; use **disallowedTools** to take tools away.
 - **whenToUse**: Extra context for when Claude should invoke the skill, such as trigger phrases or example requests.
-  Appended to **description** in the skill listing.
+  Appended to **description** in the skill listing and counts toward the 1536-character cap; devenv warns when a skill goes over.
 - **disallowedTools**: Tools removed from Claude's available pool while the skill is active, cleared when you send your next message.
   Use it for a skill that should never call a given tool, such as an autonomous loop that must not stop to ask a question.
 - **disableModelInvocation**: Prevent Claude from automatically loading the skill. Use for workflows you want to trigger manually with `/<name>`.

--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -339,7 +339,9 @@ Skills are written to `.claude/skills/<name>/SKILL.md`.
 - **description**: What the skill covers and when to use it. This is the only part Claude sees before loading the skill, so it decides whether the skill ever triggers.
   Keep it one line and name the situations that should pull it in.
 - **content**: The body of `SKILL.md`.
-- **allowedTools**: Restrict the tools available while the skill is active. Empty (the default) means no restriction.
+- **allowedTools**: Tools Claude can use without asking permission during the turn that invokes the skill.
+  The grant clears when you send your next message.
+  This pre-approves tools rather than restricting them; use **disallowedTools** to take tools away.
 - **resources**: Extra files placed next to `SKILL.md`, keyed by path relative to the skill directory.
   A bare path is the common case; use `{ source = ./x; executable = true; }`
   when the file needs to be run directly rather than passed to an interpreter.

--- a/docs/src/integrations/claude-code.md
+++ b/docs/src/integrations/claude-code.md
@@ -339,16 +339,31 @@ Skills are written to `.claude/skills/<name>/SKILL.md`.
 - **description**: What the skill covers and when to use it. This is the only part Claude sees before loading the skill, so it decides whether the skill ever triggers.
   Keep it one line and name the situations that should pull it in.
 - **content**: The body of `SKILL.md`.
-- **allowedTools**: Tools Claude can use without asking permission during the turn that invokes the skill.
-  The grant clears when you send your next message.
+- **allowedTools**: Tools Claude can use without asking permission during the turn that invokes the skill; the grant clears when you send your next message.
   This pre-approves tools rather than restricting them; use **disallowedTools** to take tools away.
+- **whenToUse**: Extra context for when Claude should invoke the skill, such as trigger phrases or example requests.
+  Appended to **description** in the skill listing.
+- **disallowedTools**: Tools removed from Claude's available pool while the skill is active, cleared when you send your next message.
+  Use it for a skill that should never call a given tool, such as an autonomous loop that must not stop to ask a question.
+- **disableModelInvocation**: Prevent Claude from automatically loading the skill. Use for workflows you want to trigger manually with `/<name>`.
+- **userInvocable**: Whether you can invoke the skill yourself with `/<name>`. Set to `false` when only Claude should invoke it, for background knowledge rather than a command.
+- **argumentHint**: Hint shown during autocomplete to indicate the expected arguments, e.g. `[issue-number]`.
+- **arguments**: Named positional arguments, substituted into **content** as `$name` in the order given.
+- **model**: Model to use while the skill is active, for the rest of the turn. Accepts an alias, a full model ID, or `inherit`.
+  With `context = "fork"` it sets the forked subagent's model instead.
+- **effort**: Effort level while the skill is active: `low`, `medium`, `high`, `xhigh` or `max`.
+- **context**: Set to `"fork"` to run the skill in a forked subagent context.
+- **agent**: Which subagent type to use when `context = "fork"` is set, such as one of [`claude.code.agents`](#agents).
+- **background**: Only applies with `context = "fork"`. Set to `false` to wait for the forked subagent's result in the turn that invoked the skill.
 - **resources**: Extra files placed next to `SKILL.md`, keyed by path relative to the skill directory.
   A bare path is the common case; use `{ source = ./x; executable = true; }`
   when the file needs to be run directly rather than passed to an interpreter.
+  Resources take the same content options as [`files`](../reference/options.md#files), so they can also be written inline instead of pointing at a path.
 - **copyMode**: How the files are materialised, as in [`files.<name>.copyMode`](../reference/options.md#filesnamecopymode). Defaults to `symlink`.
 
 Skill names must be lowercase letters, digits and single hyphens, at most 64 characters.
 Devenv asserts this, because Claude Code silently ignores skill directories it cannot match to a valid name.
+`synced` is rejected too: Claude Code reserves that directory for the skills it downloads from your claude.ai account.
 
 ### Bundled resources
 

--- a/src/modules/files.nix
+++ b/src/modules/files.nix
@@ -25,7 +25,9 @@ let
   currentManagedFiles = attrNames config.files;
 
 
-  fileType = types.submodule ({ name, config, ... }: {
+  copyModeType = types.enum [ "symlink" "seed" "copy" ];
+
+  fileSpecModule = { name, config, ... }: {
     options = {
       format = mkOption {
         type = types.anything;
@@ -54,17 +56,6 @@ let
         description = "Make the file executable";
       };
 
-      copyMode = mkOption {
-        type = types.enum [ "symlink" "seed" "copy" ];
-        default = "symlink";
-        description = ''
-          How to materialize the file in the project root:
-
-          - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
-          - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. Useful for seeding configuration from templates the user then edits.
-          - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. Useful when a tool must write to the file in place but devenv should remain the source of truth.
-        '';
-      };
     } // (mapAttrs
       (name: format: mkOption {
         type = types.nullOr format.type;
@@ -97,7 +88,24 @@ let
           else
             generated;
       };
-  });
+  };
+
+  fileType = types.submodule {
+    imports = [ fileSpecModule ];
+
+    options.copyMode = mkOption {
+      type = copyModeType;
+      default = "symlink";
+      description = ''
+        How to materialize the file in the project root:
+
+        - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
+        - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. Useful for seeding configuration from templates the user then edits.
+        - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. Useful when a tool must write to the file in place but devenv should remain the source of truth.
+      '';
+    };
+  };
+
   # Track successfully created files for partial state saving
   createSymlinkScript = filename: fileOption: ''
     if [ -L "${filename}" ]; then
@@ -212,6 +220,9 @@ in
   };
 
   config = {
+    lib.fileSpecType = types.submodule fileSpecModule;
+    lib.fileCopyModeType = copyModeType;
+
     tasks."devenv:files:cleanup" = {
       description = "Cleanup orphaned files";
       exec = cleanupScript;

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -40,6 +40,29 @@ let
     };
   };
 
+  # A file bundled next to a skill's SKILL.md. A bare path is the common case;
+  # the attribute set form exists because a bundled script cannot be made
+  # executable after the fact: the symlink target is read-only in the store, and
+  # a copied file is rewritten on every shell entry.
+  skillResourceType = lib.types.coercedTo lib.types.path (source: { inherit source; }) (
+    lib.types.submodule {
+      options = {
+        source = lib.mkOption {
+          type = lib.types.path;
+          description = "File to place next to SKILL.md.";
+        };
+        executable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Make the file executable, for a resource that is run directly
+            rather than passed to an interpreter.
+          '';
+        };
+      };
+    }
+  );
+
   # Reserved keys that are not tool names (for backward compat detection)
   reservedPermissionKeys = [ "defaultMode" "disableBypassPermissionsMode" "additionalDirectories" "rules" ];
 
@@ -455,6 +478,108 @@ in
       '';
     };
 
+    skills = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule ({ name, ... }: {
+          options = {
+            description = lib.mkOption {
+              type = lib.types.str;
+              description = ''
+                What the skill covers and when Claude should load it.
+                Descriptions are the only part of a skill kept in context at all
+                times, so this is what decides whether the skill ever triggers.
+              '';
+            };
+            content = lib.mkOption {
+              type = lib.types.lines;
+              description = "The body of SKILL.md, loaded when the skill triggers.";
+            };
+            allowedTools = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Restrict the tools available while this skill is active. Empty means no restriction.";
+            };
+            resources = lib.mkOption {
+              type = lib.types.attrsOf skillResourceType;
+              default = { };
+              example = lib.literalExpression ''
+                {
+                  "references/api.md" = ./api.md;
+                  "scripts/check.sh" = { source = ./check.sh; executable = true; };
+                }
+              '';
+              description = ''
+                Files placed alongside SKILL.md, keyed by path relative to the
+                skill directory. Claude reads these on demand, so bulky reference
+                material belongs here rather than in `content`.
+              '';
+            };
+            copyMode = lib.mkOption {
+              type = lib.types.enum [ "symlink" "seed" "copy" ];
+              default = "symlink";
+              description = ''
+                How to materialise the skill's files, as in `files.<name>.copyMode`.
+                Use `seed` to hand-edit a skill after devenv writes it once.
+              '';
+            };
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.unspecified;
+              default = [ ];
+              internal = true;
+              visible = false;
+              description = "Assertions raised by this skill's submodule, collected into the top-level assertions.";
+            };
+          };
+
+          config.assertions = [
+            {
+              assertion = builtins.match "[a-z0-9]+(-[a-z0-9]+)*" name != null && builtins.stringLength name <= 64;
+              message = ''
+                claude.code.skills.${name}: skill names must be lowercase letters, digits and
+                single hyphens, at most 64 characters. Claude Code skips directories it cannot
+                match to a valid skill name.
+              '';
+            }
+          ];
+        })
+      );
+      default = { };
+      description = ''
+        Custom Claude Code skills to create in the project.
+        A skill is a folder of instructions Claude loads on demand when its
+        description matches the task, keeping specialised knowledge out of the
+        always-on context.
+
+        For more details, see: https://docs.anthropic.com/en/docs/claude-code/skills
+      '';
+      example = lib.literalExpression ''
+        {
+          database-migrations = {
+            description = "How to write and run migrations in this project. Use when adding, editing or rolling back a migration.";
+            content = '''
+              Migrations live in `migrations/` and are applied with `diesel migration run`.
+
+              - One logical change per migration; never edit an applied migration.
+              - Always write the matching `down.sql`.
+              - Run `devenv tasks run db:reset` before opening a pull request.
+            ''';
+          };
+
+          api-conventions = {
+            description = "REST conventions for this codebase. Use when adding or changing an HTTP endpoint.";
+            allowedTools = [ "Read" "Grep" ];
+            resources = {
+              "references/error-codes.md" = ./docs/error-codes.md;
+            };
+            content = '''
+              Endpoints are versioned under `/v1`.
+              Read references/error-codes.md before inventing a new error code.
+            ''';
+          };
+        }
+      '';
+    };
+
     apiKeyHelper = lib.mkOption {
       type = lib.types.nullOr lib.types.str;
       default = null;
@@ -717,7 +842,8 @@ in
     }
 
     {
-      assertions = lib.flatten (lib.mapAttrsToList (_: agent: agent.assertions) cfg.agents);
+      assertions = lib.flatten (lib.mapAttrsToList (_: agent: agent.assertions) cfg.agents)
+        ++ lib.flatten (lib.mapAttrsToList (_: skill: skill.assertions) cfg.skills);
     }
 
     (lib.mkIf cfg.enable {
@@ -759,6 +885,47 @@ in
             };
           })
           cfg.agents)
+
+        # Skill files
+        (lib.mapAttrs'
+          (name: skill: {
+            name = ".claude/skills/${name}/SKILL.md";
+            value = {
+              inherit (skill) copyMode;
+              text =
+                let
+                  # Built as a list so an unset field leaves no blank line behind.
+                  frontmatter = [
+                    "name: ${name}"
+                    # toJSON gives a quoted YAML scalar, so a description
+                    # containing a colon or a quote stays valid frontmatter.
+                    "description: ${builtins.toJSON skill.description}"
+                  ]
+                  ++ lib.optional (skill.allowedTools != [ ])
+                    # Quoted for the same reason as the description: a tool
+                    # pattern may contain a colon.
+                    "allowed-tools: ${builtins.toJSON (lib.concatStringsSep ", " skill.allowedTools)}";
+                in
+                ''
+                  ---
+                  ${lib.concatStringsSep "\n" frontmatter}
+                  ---
+
+                  ${skill.content}
+                '';
+            };
+          })
+          cfg.skills)
+
+        # Files bundled alongside a skill (references, scripts, assets)
+        (lib.listToAttrs (lib.concatLists (lib.mapAttrsToList
+          (name: skill: lib.mapAttrsToList
+            (path: resource: lib.nameValuePair ".claude/skills/${name}/${path}" {
+              inherit (resource) source executable;
+              inherit (skill) copyMode;
+            })
+            skill.resources)
+          cfg.skills)))
       ];
 
       # Add a message about the integration
@@ -784,6 +951,11 @@ in
             ${lib.optionalString (subAgents != { })
               "- Sub-agents: ${
                 lib.concatStringsSep ", " (lib.attrNames subAgents)
+              }"
+            }
+            ${lib.optionalString (cfg.skills != { })
+              "- Skills: ${
+                lib.concatStringsSep ", " (lib.attrNames cfg.skills)
               }"
             }
             ${lib.optionalString (cfg.mcpServers != { })

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -497,7 +497,14 @@ in
             allowedTools = lib.mkOption {
               type = lib.types.listOf lib.types.str;
               default = [ ];
-              description = "Restrict the tools available while this skill is active. Empty means no restriction.";
+              description = ''
+                Tools Claude can use without asking permission during the turn that invokes
+                this skill. The grant clears when you send your next message.
+
+                This pre-approves tools rather than restricting them; use `disallowedTools`
+                to take tools away.
+              '';
+              example = [ "Read" "Grep" "Bash(git status:*)" ];
             };
             resources = lib.mkOption {
               type = lib.types.attrsOf skillResourceType;

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -540,6 +540,14 @@ in
                 match to a valid skill name.
               '';
             }
+            {
+              assertion = name != "synced";
+              message = ''
+                claude.code.skills.synced: `synced` is a reserved directory name. Claude Code
+                uses .claude/skills/synced/ for the skills it downloads from your claude.ai
+                account, and skips a skill you author at that name. Pick a different name.
+              '';
+            }
           ];
         })
       );

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -490,6 +490,15 @@ in
                 times, so this is what decides whether the skill ever triggers.
               '';
             };
+            whenToUse = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Additional context for when Claude should invoke the skill, such as trigger
+                phrases or example requests. Appended to `description` in the skill listing.
+              '';
+              example = "Use when the user mentions migrations, schema changes or rollbacks.";
+            };
             content = lib.mkOption {
               type = lib.types.lines;
               description = "The body of SKILL.md, loaded when the skill triggers.";
@@ -505,6 +514,92 @@ in
                 to take tools away.
               '';
               example = [ "Read" "Grep" "Bash(git status:*)" ];
+            };
+            disallowedTools = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = ''
+                Tools removed from Claude's available pool while this skill is active; the
+                restriction clears when you send your next message. Use it for a skill that
+                should never call a given tool, such as an autonomous loop that must not stop
+                to ask a question.
+              '';
+              example = [ "AskUserQuestion" ];
+            };
+            disableModelInvocation = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Prevent Claude from automatically loading this skill. Use for workflows you
+                want to trigger manually with `/${name}`.
+              '';
+            };
+            userInvocable = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = ''
+                Whether you can invoke the skill yourself with `/${name}`. Set to false when
+                only Claude should invoke it, for background knowledge rather than a command.
+              '';
+            };
+            argumentHint = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "Hint shown during autocomplete to indicate the expected arguments.";
+              example = "[issue-number]";
+            };
+            arguments = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = ''
+                Named positional arguments, substituted into `content` as `$name`. Names map
+                to argument positions in order.
+              '';
+              example = [ "issue" "branch" ];
+            };
+            model = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Model to use while this skill is active, for the rest of the current turn.
+                Accepts an alias (`sonnet`, `opus`, `haiku`, `fable`), a full model ID
+                (e.g. `claude-opus-5`), or `inherit`. With `context = "fork"` it sets the
+                forked subagent's model instead.
+              '';
+              example = "opus";
+            };
+            effort = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "low" "medium" "high" "xhigh" "max" ]);
+              default = null;
+              description = ''
+                Override the effort level while this skill is active.
+                Which levels are available depends on the model.
+              '';
+            };
+            context = lib.mkOption {
+              type = lib.types.nullOr (lib.types.enum [ "fork" ]);
+              default = null;
+              description = ''
+                Set to `fork` to run the skill in a forked subagent context.
+              '';
+            };
+            agent = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Which subagent type to use when `context = "fork"` is set, such as one of
+                `claude.code.agents`.
+              '';
+              example = "code-reviewer";
+            };
+            background = lib.mkOption {
+              type = lib.types.nullOr lib.types.bool;
+              default = null;
+              description = ''
+                Only applies with `context = "fork"`. Set to false to wait for the forked
+                subagent's result in the turn that invoked the skill, instead of letting it
+                run in the background.
+              '';
             };
             resources = lib.mkOption {
               type = lib.types.attrsOf skillResourceType;
@@ -909,17 +1004,32 @@ in
               inherit (skill) copyMode;
               text =
                 let
+                  # toJSON keeps colons and quotes valid; a list renders as a JSON
+                  # array, sidestepping the comma/space separator rules these fields
+                  # disagree on.
+                  scalar = key: value: "${key}: ${builtins.toJSON value}";
+                  optionalScalar = key: value: lib.optional (value != null) (scalar key value);
+                  optionalList = key: value: lib.optional (value != [ ]) (scalar key value);
+                  optionalFlag = key: value: default: lib.optional (value != default) "${key}: ${lib.boolToString value}";
+
                   # Built as a list so an unset field leaves no blank line behind.
                   frontmatter = [
                     "name: ${name}"
-                    # toJSON gives a quoted YAML scalar, so a description
-                    # containing a colon or a quote stays valid frontmatter.
-                    "description: ${builtins.toJSON skill.description}"
+                    (scalar "description" skill.description)
                   ]
-                  ++ lib.optional (skill.allowedTools != [ ])
-                    # Quoted for the same reason as the description: a tool
-                    # pattern may contain a colon.
-                    "allowed-tools: ${builtins.toJSON (lib.concatStringsSep ", " skill.allowedTools)}";
+                  ++ optionalScalar "when_to_use" skill.whenToUse
+                  ++ optionalList "allowed-tools" skill.allowedTools
+                  ++ optionalList "disallowed-tools" skill.disallowedTools
+                  ++ optionalFlag "disable-model-invocation" skill.disableModelInvocation false
+                  ++ optionalFlag "user-invocable" skill.userInvocable true
+                  ++ optionalScalar "argument-hint" skill.argumentHint
+                  ++ optionalList "arguments" skill.arguments
+                  ++ optionalScalar "model" skill.model
+                  ++ optionalScalar "effort" skill.effort
+                  ++ optionalScalar "context" skill.context
+                  ++ optionalScalar "agent" skill.agent
+                  ++ lib.optional (skill.background != null)
+                    "background: ${lib.boolToString skill.background}";
                 in
                 ''
                   ---

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -40,28 +40,14 @@ let
     };
   };
 
-  # A file bundled next to a skill's SKILL.md. A bare path is the common case;
-  # the attribute set form exists because a bundled script cannot be made
-  # executable after the fact: the symlink target is read-only in the store, and
-  # a copied file is rewritten on every shell entry.
-  skillResourceType = lib.types.coercedTo lib.types.path (source: { inherit source; }) (
-    lib.types.submodule {
-      options = {
-        source = lib.mkOption {
-          type = lib.types.path;
-          description = "File to place next to SKILL.md.";
-        };
-        executable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = ''
-            Make the file executable, for a resource that is run directly
-            rather than passed to an interpreter.
-          '';
-        };
-      };
-    }
-  );
+  # A file bundled next to a skill's SKILL.md. A bare path is the common case, so
+  # it coerces; the attribute set form takes the same contents and `executable`
+  # options as `files.<name>`, reused through `config.lib.fileSpecType`.
+  skillResourceType = lib.types.coercedTo lib.types.path (source: { inherit source; })
+    config.lib.fileSpecType;
+
+  # Bound out here because the skills submodule shadows `config` with its own.
+  fileCopyModeType = config.lib.fileCopyModeType;
 
   # Reserved keys that are not tool names (for backward compat detection)
   reservedPermissionKeys = [ "defaultMode" "disableBypassPermissionsMode" "additionalDirectories" "rules" ];
@@ -617,7 +603,7 @@ in
               '';
             };
             copyMode = lib.mkOption {
-              type = lib.types.enum [ "symlink" "seed" "copy" ];
+              type = fileCopyModeType;
               default = "symlink";
               description = ''
                 How to materialise the skill's files, as in `files.<name>.copyMode`.
@@ -1046,7 +1032,7 @@ in
         (lib.listToAttrs (lib.concatLists (lib.mapAttrsToList
           (name: skill: lib.mapAttrsToList
             (path: resource: lib.nameValuePair ".claude/skills/${name}/${path}" {
-              inherit (resource) source executable;
+              source = resource.file;
               inherit (skill) copyMode;
             })
             skill.resources)

--- a/src/modules/integrations/claude.nix
+++ b/src/modules/integrations/claude.nix
@@ -40,6 +40,10 @@ let
     };
   };
 
+  # Claude Code's default cap on the combined `description` + `when_to_use` text
+  # it keeps in the always-on skill listing, per skill.
+  skillListingMaxDescChars = 1536;
+
   # A file bundled next to a skill's SKILL.md. A bare path is the common case, so
   # it coerces; the attribute set form takes the same contents and `executable`
   # options as `files.<name>`, reused through `config.lib.fileSpecType`.
@@ -466,7 +470,7 @@ in
 
     skills = lib.mkOption {
       type = lib.types.attrsOf (
-        lib.types.submodule ({ name, ... }: {
+        lib.types.submodule ({ name, config, ... }: {
           options = {
             description = lib.mkOption {
               type = lib.types.str;
@@ -481,7 +485,8 @@ in
               default = null;
               description = ''
                 Additional context for when Claude should invoke the skill, such as trigger
-                phrases or example requests. Appended to `description` in the skill listing.
+                phrases or example requests. Appended to `description` in the skill listing
+                and counts toward the ${toString skillListingMaxDescChars}-character cap.
               '';
               example = "Use when the user mentions migrations, schema changes or rollbacks.";
             };
@@ -617,7 +622,31 @@ in
               visible = false;
               description = "Assertions raised by this skill's submodule, collected into the top-level assertions.";
             };
+            warnings = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              internal = true;
+              visible = false;
+              description = "Warnings raised by this skill's submodule, collected into the top-level warnings.";
+            };
           };
+
+          config.warnings =
+            let
+              hasWhenToUse = config.whenToUse != null;
+              listingLength =
+                builtins.stringLength config.description
+                + (if hasWhenToUse then builtins.stringLength config.whenToUse else 0);
+              subject =
+                if hasWhenToUse
+                then "`description` and `whenToUse` add up to"
+                else "`description` is";
+            in
+            lib.optional (listingLength > skillListingMaxDescChars) ''
+              claude.code.skills.${name}: ${subject} ${toString listingLength} characters, over the
+              ${toString skillListingMaxDescChars} Claude Code keeps in the skill listing. The rest is truncated, so
+              put the key use case first or move the detail into `content`.
+            '';
 
           config.assertions = [
             {
@@ -940,6 +969,7 @@ in
     {
       assertions = lib.flatten (lib.mapAttrsToList (_: agent: agent.assertions) cfg.agents)
         ++ lib.flatten (lib.mapAttrsToList (_: skill: skill.assertions) cfg.skills);
+      warnings = lib.flatten (lib.mapAttrsToList (_: skill: skill.warnings) cfg.skills);
     }
 
     (lib.mkIf cfg.enable {

--- a/tests/claude-skills/.gitignore
+++ b/tests/claude-skills/.gitignore
@@ -1,0 +1,2 @@
+.claude
+.mcp.json

--- a/tests/claude-skills/.test.sh
+++ b/tests/claude-skills/.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Skills are written to .claude/skills/<name>/SKILL.md, with any `resources`
+# placed alongside them.
+
+skill=.claude/skills/package-scoping/SKILL.md
+
+test -f "$skill" || { echo "missing $skill"; exit 1; }
+test -f .claude/skills/minimal/SKILL.md || { echo "missing minimal skill"; exit 1; }
+
+grep -qF -- 'name: package-scoping' "$skill" \
+  || { echo "expected name in frontmatter:"; cat "$skill"; exit 1; }
+
+grep -qF -- 'description: "Decide system vs user: use when a \"package\" lands in the wrong layer."' "$skill" \
+  || { echo "expected description in frontmatter:"; cat "$skill"; exit 1; }
+
+grep -qF -- 'allowed-tools: "Read, Grep, Bash(git status: *)"' "$skill" \
+  || { echo "expected allowed-tools in frontmatter:"; cat "$skill"; exit 1; }
+
+grep -qF -- '# Package scoping' "$skill" \
+  || { echo "expected skill body:"; cat "$skill"; exit 1; }
+
+# No tool restriction means no allowed-tools key, and no blank line left where
+# it would have gone.
+if grep -q 'allowed-tools' .claude/skills/minimal/SKILL.md; then
+  echo "minimal skill should not declare allowed-tools:"
+  cat .claude/skills/minimal/SKILL.md
+  exit 1
+fi
+
+frontmatter=$(awk 'NR == 1 && $0 == "---" { inside = 1; next } inside && $0 == "---" { exit } inside' .claude/skills/minimal/SKILL.md)
+if [ -n "$(echo "$frontmatter" | grep '^$' || true)" ]; then
+  echo "frontmatter should not contain blank lines:"
+  cat .claude/skills/minimal/SKILL.md
+  exit 1
+fi
+
+# Bundled resources land next to SKILL.md.
+grep -qF -- '/etc/profiles/per-user' .claude/skills/package-scoping/references/table.md \
+  || { echo "missing bundled resource"; exit 1; }
+
+# A resource marked executable is runnable.
+test -x .claude/skills/package-scoping/scripts/check.sh \
+  || { echo "bundled script is not executable:"; ls -l .claude/skills/package-scoping/scripts/check.sh; exit 1; }
+
+[ "$(.claude/skills/package-scoping/scripts/check.sh)" = "SCRIPT-RESOURCE-RAN" ] \
+  || { echo "bundled script did not run"; exit 1; }
+
+# The plain-path shorthand stays non-executable.
+if [ -x .claude/skills/package-scoping/references/table.md ]; then
+  echo "plain-path resource should not be executable"
+  exit 1
+fi
+
+# Skills are reported by `devenv info`.
+devenv info | grep -qF -- "- Skills: minimal, package-scoping" \
+  || { echo "expected skills in devenv info output:"; devenv info; exit 1; }

--- a/tests/claude-skills/.test.sh
+++ b/tests/claude-skills/.test.sh
@@ -15,7 +15,9 @@ grep -qF -- 'name: package-scoping' "$skill" \
 grep -qF -- 'description: "Decide system vs user: use when a \"package\" lands in the wrong layer."' "$skill" \
   || { echo "expected description in frontmatter:"; cat "$skill"; exit 1; }
 
-grep -qF -- 'allowed-tools: "Read, Grep, Bash(git status: *)"' "$skill" \
+# Rendered as a YAML flow sequence, so a pattern containing a comma or a colon
+# stays a single entry.
+grep -qF -- 'allowed-tools: ["Read","Grep","Bash(git status: *)"]' "$skill" \
   || { echo "expected allowed-tools in frontmatter:"; cat "$skill"; exit 1; }
 
 grep -qF -- '# Package scoping' "$skill" \
@@ -53,6 +55,30 @@ if [ -x .claude/skills/package-scoping/references/table.md ]; then
   exit 1
 fi
 
+# Every frontmatter field the module renders lands in SKILL.md, and a tool
+# pattern containing a comma survives as one list entry.
+everything=.claude/skills/everything/SKILL.md
+
+while IFS= read -r expected; do
+  grep -qF -- "$expected" "$everything" \
+    || { echo "expected in $everything: $expected"; cat "$everything"; exit 1; }
+done <<'EOF'
+name: everything
+description: "A skill exercising every frontmatter field."
+when_to_use: "Use when checking that the frontmatter renders in full."
+allowed-tools: ["Read","Bash(git log --format=a,b:*)"]
+disallowed-tools: ["AskUserQuestion"]
+disable-model-invocation: true
+user-invocable: false
+argument-hint: "[issue-number]"
+arguments: ["issue","branch"]
+model: "opus"
+effort: "high"
+context: "fork"
+agent: "code-reviewer"
+background: false
+EOF
+
 # Skills are reported by `devenv info`.
-devenv info | grep -qF -- "- Skills: minimal, package-scoping" \
+devenv info | grep -qF -- "- Skills: everything, minimal, package-scoping" \
   || { echo "expected skills in devenv info output:"; devenv info; exit 1; }

--- a/tests/claude-skills/check.sh
+++ b/tests/claude-skills/check.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "SCRIPT-RESOURCE-RAN"

--- a/tests/claude-skills/devenv.nix
+++ b/tests/claude-skills/devenv.nix
@@ -1,0 +1,32 @@
+{ ... }: {
+  claude.code = {
+    enable = true;
+
+    skills = {
+      # Left on the default copyMode on purpose: SKILL.md and its resources are
+      # symlinked into the store, which is the shape most projects will get.
+      package-scoping = {
+        # A colon and a quote, to prove the description survives as a YAML scalar.
+        description = ''Decide system vs user: use when a "package" lands in the wrong layer.'';
+        allowedTools = [ "Read" "Grep" "Bash(git status: *)" ];
+        resources = {
+          "references/table.md" = ./table.md;
+          "scripts/check.sh" = {
+            source = ./check.sh;
+            executable = true;
+          };
+        };
+        content = ''
+          # Package scoping
+
+          Ask who needs the binary, not where you would prefer it.
+        '';
+      };
+
+      minimal = {
+        description = "A skill with no tool restriction and no bundled resources.";
+        content = "Body.";
+      };
+    };
+  };
+}

--- a/tests/claude-skills/devenv.nix
+++ b/tests/claude-skills/devenv.nix
@@ -27,6 +27,25 @@
         description = "A skill with no tool restriction and no bundled resources.";
         content = "Body.";
       };
+
+      # Every field the module knows how to render, to prove each one lands in
+      # the frontmatter and that a value containing a comma survives the list.
+      everything = {
+        description = "A skill exercising every frontmatter field.";
+        whenToUse = "Use when checking that the frontmatter renders in full.";
+        allowedTools = [ "Read" "Bash(git log --format=a,b:*)" ];
+        disallowedTools = [ "AskUserQuestion" ];
+        disableModelInvocation = true;
+        userInvocable = false;
+        argumentHint = "[issue-number]";
+        arguments = [ "issue" "branch" ];
+        model = "opus";
+        effort = "high";
+        context = "fork";
+        agent = "code-reviewer";
+        background = false;
+        content = "Body of everything.";
+      };
     };
   };
 }

--- a/tests/claude-skills/table.md
+++ b/tests/claude-skills/table.md
@@ -1,0 +1,4 @@
+| layer  | path                     |
+| ------ | ------------------------ |
+| system | /run/current-system/sw   |
+| user   | /etc/profiles/per-user   |


### PR DESCRIPTION
Small addition to the Claude Code integration: skills, alongside the existing commands and agents.

My motivation is that most `.claude/` is generated in our projects, but skills were the one part we still manage outside devenv.

They're generated to `.claude/skills/<name>/SKILL.md` through the same `files` mechanism `claude.code.commands` and `claude.code.agents` already use. `resources` places extra files next to `SKILL.md` and mirrors `files`, including `executable`. `copyMode` is passed through too, so `seed` lets you iterate on a skill in place before moving the prose back into `devenv.nix`.

Smaller note: I emit the description with `builtins.toJSON` so it stays valid YAML. `claude.code.agents` does `description: ${agent.description}` unquoted, so `description: Reviews code: checks quality` is invalid, and a ` #` in a description silently truncates it. Happy to fold this one-line fix along here.

Thanks!