### PR TITLE
shell: preserve application Ctrl-Alt input in alternate screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed reload-shell shortcuts intercepting Ctrl-Alt input from full-screen terminal applications such as Neovim ([#3107](https://github.com/cachix/devenv/issues/3107)).
 - Fixed `showOutput = true` / `--show-output` being ignored when AI-agent auto-quiet (or `--quiet`) is active. Explicit task output now streams even at Quiet, without treating stdout as an error ([#3038](https://github.com/cachix/devenv/issues/3038)).
 - Fixed `devenv tasks run` skipping a process that a task depends on via `@completed` when that process has `start.enable = false`. The process now runs to completion as the dependency requires; `devenv up` still does not auto-start it ([#3005](https://github.com/cachix/devenv/issues/3005)).
 - Fixed `devenv tasks run --no-tui` staying silent until the run finished when AI-agent auto-quiet was active (`CLAUDECODE`, and similar). Quiet mode now prints task running/succeeded/failed lines incrementally, without streaming full task output ([#3115](https://github.com/cachix/devenv/issues/3115)).

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -2703,6 +2703,21 @@ mod tests {
     }
 
     #[test]
+    fn local_keybind_is_forwarded_when_application_owns_alternate_screen() {
+        let keybindings = ShellKeybindings::default();
+        // Legacy terminals encode Ctrl-Alt-D as ESC followed by Ctrl-D. Keep
+        // that shortcut at the prompt, but forward it to full-screen apps.
+        assert_eq!(
+            classify_stdin(&keybindings, &[0x1b, 0x04], true),
+            StdinDisposition::TogglePause
+        );
+        assert_eq!(
+            classify_stdin(&keybindings, &[0x1b, 0x04], false),
+            StdinDisposition::ForwardToPty
+        );
+    }
+
+    #[test]
     fn batched_stdin_error_toggle_defers_presentation_to_the_pty_frame() {
         assert!(present_stdin_error_immediately(
             StdinPresentation::Immediate,

--- a/devenv-shell/tests/session_tests.rs
+++ b/devenv-shell/tests/session_tests.rs
@@ -376,6 +376,52 @@ async fn test_custom_shell_keybinding_replaces_default() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ctrl_alt_input_forwarded_in_alternate_screen() {
+    let (io, mut stdin_ours, mut stdout_ours) = test_io();
+    let (cmd_tx, cmd_rx) = mpsc::channel(10);
+    let (event_tx, _event_rx) = mpsc::channel(10);
+
+    let session = test_session();
+    let handle = tokio::spawn(async move { session.run(cmd_rx, event_tx, io).await });
+
+    cmd_tx
+        .send(spawn_cmd(
+            "stty raw -echo; printf '\\033[?1049hREADY'; \
+             bytes=$(dd bs=2 count=1 2>/dev/null | od -An -tx1); \
+             stty sane; printf '\\033[?1049lRECEIVED:%s\\n' \"$bytes\"",
+        ))
+        .await
+        .unwrap();
+
+    let ready = read_until(&mut stdout_ours, b"READY", Duration::from_secs(5));
+    assert!(
+        ready
+            .windows(b"READY".len())
+            .any(|window| window == b"READY"),
+        "alternate-screen application did not become ready: {:?}",
+        String::from_utf8_lossy(&ready)
+    );
+
+    // Legacy terminals encode Ctrl-Alt-D as ESC followed by Ctrl-D. Full-screen
+    // applications such as Neovim own this input while the alternate screen is active.
+    stdin_ours.write_all(&[0x1b, 0x04]).unwrap();
+    stdin_ours.flush().unwrap();
+
+    let received = read_until(&mut stdout_ours, b"RECEIVED: 1b 04", Duration::from_secs(5));
+    assert!(
+        received
+            .windows(b"RECEIVED: 1b 04".len())
+            .any(|window| window == b"RECEIVED: 1b 04"),
+        "alternate-screen application did not receive Ctrl-Alt-D: {:?}",
+        String::from_utf8_lossy(&received)
+    );
+
+    drop(stdin_ours);
+    drop(cmd_tx);
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_custom_shell_keybinding_is_forwarded_in_alternate_screen() {
     let (io, mut stdin_ours, mut stdout_ours) = test_io();
     let (cmd_tx, cmd_rx) = mpsc::channel(10);

--- a/tests/reload-alternate-screen-input/.test.sh
+++ b/tests/reload-alternate-screen-input/.test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+
+devenv-run-tests pty shell.typescript "devenv shell" >/dev/null <<'EOF'
+expect:DEVENV_SHELL_READY
+send:./alternate-screen-reader.sh\n
+expect:READY
+send:\033\004
+expect:RECEIVED: 1b 04
+send:exit\n
+EOF
+
+grep -aFq "RECEIVED: 1b 04" shell.typescript

--- a/tests/reload-alternate-screen-input/alternate-screen-reader.sh
+++ b/tests/reload-alternate-screen-input/alternate-screen-reader.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
+stty raw -echo
+printf '\033[?1049hREADY'
+bytes=$(dd bs=2 count=1 2>/dev/null | od -An -tx1)
+stty sane
+printf '\033[?1049lRECEIVED:%s\n' "$bytes"

--- a/tests/reload-alternate-screen-input/devenv.nix
+++ b/tests/reload-alternate-screen-input/devenv.nix
@@ -1,0 +1,6 @@
+{ ... }:
+{
+  enterShell = ''
+    echo DEVENV_SHELL_READY
+  '';
+}


### PR DESCRIPTION
Fixes #3107

## Summary

- Keep reload-shell Ctrl-Alt shortcuts active at the shell prompt.
- Forward the same byte sequences to full-screen applications while they own the terminal's alternate screen, so editors such as Neovim receive their input.
- Add unit, session PTY, and real `devenv shell` regression coverage for forwarding `ESC Ctrl-D` unchanged.

## Root cause

The reload shell classified legacy Ctrl-Alt byte sequences before writing stdin to the child PTY. That classification remained active after a full-screen application entered the alternate screen, so application keybindings that produced the same bytes were consumed as devenv shortcuts.

## Validation

- [x] Repository pre-commit hooks (`nixfmt`, `rustfmt`)
- [x] `shellcheck tests/reload-alternate-screen-input/alternate-screen-reader.sh tests/reload-alternate-screen-input/.test.sh`
- [x] `nix build --accept-flake-config .#devenv --no-link --print-out-paths`
- [x] Targeted session PTY regression
- [x] Nix-built `devenv-run-tests run tests --only reload-alternate-screen-input` (real reload shell, exact `1b 04` bytes)
- [x] Remaining `devenv-shell` suite with two unrelated timing assertions skipped (188 library tests and 18 PTY tests passed)

The unfiltered suite also ran. The new regression passed; two existing status-line timing assertions remain sensitive to zero/one-millisecond elapsed values (`test_build_lifecycle_status_line` and `status_line_cache_invalidates_for_state_width_and_spinner_changes`).
