### PR TITLE
Honor showOutput under Quiet / AI-agent auto-quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed `showOutput = true` / `--show-output` being ignored when AI-agent auto-quiet (or `--quiet`) is active. Explicit task output now streams even at Quiet, without treating stdout as an error ([#3038](https://github.com/cachix/devenv/issues/3038)).
 - Fixed `devenv tasks run` skipping a process that a task depends on via `@completed` when that process has `start.enable = false`. The process now runs to completion as the dependency requires; `devenv up` still does not auto-start it ([#3005](https://github.com/cachix/devenv/issues/3005)).
 - Fixed `devenv tasks run --no-tui` staying silent until the run finished when AI-agent auto-quiet was active (`CLAUDECODE`, and similar). Quiet mode now prints task running/succeeded/failed lines incrementally, without streaming full task output ([#3115](https://github.com/cachix/devenv/issues/3115)).
 - Fixed `devenv --from` also loading the current directory's `devenv.local.nix`. Options set there for the local project, such as tuning a process the external project doesn't define, no longer leak into the external environment and break evaluation.

--- a/devenv/src/console.rs
+++ b/devenv/src/console.rs
@@ -1,9 +1,11 @@
 //! Console output for activity events when the TUI is disabled.
 //!
 //! Most lines go through `ConsoleOutput::write`, which applies the verbosity
-//! filter before writing to stderr. Task start/complete lines are the
-//! exception: Quiet still prints them so `--no-tui` and redirected runs have
-//! mid-run liveness without streaming task logs (see #3115).
+//! filter before writing to stderr. Quiet has two exceptions: task
+//! start/complete lines still print so `--no-tui` and redirected runs have
+//! mid-run liveness without streaming task logs (see #3115); task logs with
+//! `show_output` bypass the gate so `--quiet` / AI-agent auto-quiet still
+//! stream explicit task output without reclassifying stdout as Error (see #3038).
 //!
 //! All output goes to stderr. stdout is owned by the caller's command
 //! result (e.g. `devenv eval` JSON), so writing diagnostics there breaks
@@ -70,13 +72,17 @@ struct Entry {
     suppressed_logs: BoundedLog,
     /// Print start/end even when Quiet would hide `level`. Used for task
     /// lifecycle so AI-agent auto-quiet `--no-tui` logs aren't empty until
-    /// exit. Child logs stay gated by `log_level`.
+    /// exit. Child logs stay gated by `log_level` unless `force_output`.
     show_lifecycle: bool,
+    /// Explicit `show_output` / `--show-output`: stream this task's logs even
+    /// when Quiet would hide `log_level`. Does not reclassify stdout as Error.
+    force_output: bool,
 }
 
 struct PendingTask {
     name: String,
     log_level: ActivityLevel,
+    force_output: bool,
 }
 
 pub struct ConsoleOutput {
@@ -235,6 +241,7 @@ impl ConsoleOutput {
                         PendingTask {
                             name: format!("Running {}", t.name),
                             log_level: if t.show_output { Info } else { Debug },
+                            force_output: t.show_output,
                         },
                     );
                 }
@@ -243,8 +250,9 @@ impl ConsoleOutput {
                 if let Some(p) = self.pending_tasks.remove(&id) {
                     // Quiet hides Info, but task running/succeeded/failed is
                     // the liveness signal for `--no-tui` and redirected logs
-                    // (including AI-agent auto-quiet). Logs stay at log_level.
-                    self.begin_with(id, p.name, Info, p.log_level, true);
+                    // (including AI-agent auto-quiet). Logs stay at log_level
+                    // unless `show_output` sets force_output.
+                    self.begin_with(id, p.name, Info, p.log_level, true, p.force_output);
                 }
             }
             ActivityEvent::Task(Task::Complete { id, outcome, .. }) => self.end(id, outcome),
@@ -300,7 +308,7 @@ impl ConsoleOutput {
     }
 
     fn begin(&mut self, id: u64, name: String, level: ActivityLevel, log_level: ActivityLevel) {
-        self.begin_with(id, name, level, log_level, false);
+        self.begin_with(id, name, level, log_level, false, false);
     }
 
     fn begin_with(
@@ -310,6 +318,7 @@ impl ConsoleOutput {
         level: ActivityLevel,
         log_level: ActivityLevel,
         show_lifecycle: bool,
+        force_output: bool,
     ) {
         let entry = Entry {
             name,
@@ -318,6 +327,7 @@ impl ConsoleOutput {
             log_level,
             suppressed_logs: BoundedLog::new(MAX_SUPPRESSED_LINES),
             show_lifecycle,
+            force_output,
         };
         self.write_visible(
             show_lifecycle || self.show_at(level),
@@ -362,19 +372,23 @@ impl ConsoleOutput {
     }
 
     fn log(&mut self, id: u64, line: &str, is_error: bool) {
+        let (log_level, force_output) = self
+            .entries
+            .get(&id)
+            .map(|e| (e.log_level, e.force_output))
+            .unwrap_or((ActivityLevel::Info, false));
         let level = if is_error {
             ActivityLevel::Error
         } else {
-            self.entries
-                .get(&id)
-                .map(|e| e.log_level)
-                .unwrap_or(ActivityLevel::Info)
+            log_level
         };
-        let visible = self.show_at(level);
+        // `show_output` is an explicit per-task opt-in: bypass Quiet without
+        // promoting stdout to Error (which would paint it as a failure).
+        let visible = force_output || self.show_at(level);
         // Indent so chunks nest visually under their activity's start line.
         for chunk in line.split('\n') {
             if visible {
-                self.write(level, format_args!("  {chunk}"));
+                self.write_visible(true, format_args!("  {chunk}"));
             } else if let Some(entry) = self.entries.get_mut(&id) {
                 entry.suppressed_logs.push(chunk.to_string());
             }
@@ -776,6 +790,65 @@ mod tests {
         assert!(
             start < replay && replay < fail,
             "expected start, then replayed stdout, then failure, got:\n{out}"
+        );
+    }
+
+    /// `show_output: true` is an explicit per-task opt-in: Quiet (including
+    /// AI-agent auto-quiet) must still stream those logs. See #3038.
+    #[test]
+    fn quiet_show_output_streams_task_stdout() {
+        let mut h = Harness::new(VerbosityLevel::Quiet);
+        h.dispatch(hierarchy(1, "demo:visible", true));
+        h.dispatch(task_start(1));
+        h.dispatch(task_log(1, "VISIBLE_OUTPUT_MARKER", false));
+        h.dispatch(task_complete(1, ActivityOutcome::Success));
+
+        let out = h.stderr.contents();
+        assert!(
+            out.contains("  VISIBLE_OUTPUT_MARKER"),
+            "show_output must stream stdout at Quiet, got:\n{out}"
+        );
+        assert_eq!(
+            out.matches("VISIBLE_OUTPUT_MARKER").count(),
+            1,
+            "must not double-print on success, got:\n{out}"
+        );
+        assert!(
+            !out.contains("✖ VISIBLE_OUTPUT_MARKER"),
+            "stdout must not be reclassified as Error, got:\n{out}"
+        );
+    }
+
+    /// Without show_output, Quiet still suppresses successful task stdout.
+    #[test]
+    fn quiet_without_show_output_suppresses_task_stdout() {
+        let mut h = Harness::new(VerbosityLevel::Quiet);
+        h.dispatch(hierarchy(1, "demo:hidden", false));
+        h.dispatch(task_start(1));
+        h.dispatch(task_log(1, "HIDDEN_OUTPUT_MARKER", false));
+        h.dispatch(task_complete(1, ActivityOutcome::Success));
+
+        let out = h.stderr.contents();
+        assert!(
+            !out.contains("HIDDEN_OUTPUT_MARKER"),
+            "Quiet without show_output must suppress stdout, got:\n{out}"
+        );
+    }
+
+    /// Quiet + show_output streams live; failure must not replay a second copy.
+    #[test]
+    fn quiet_show_output_no_duplicate_on_fail() {
+        let mut h = Harness::new(VerbosityLevel::Quiet);
+        h.dispatch(hierarchy(1, "demo:visible", true));
+        h.dispatch(task_start(1));
+        h.dispatch(task_log(1, "step 1", false));
+        h.dispatch(task_complete(1, ActivityOutcome::Failed));
+
+        let stderr = h.stderr.contents();
+        assert_eq!(
+            stderr.matches("step 1").count(),
+            1,
+            "show_output line should appear exactly once at Quiet, got:\n{stderr}"
         );
     }
 

--- a/tests/tasks/.test.sh
+++ b/tests/tasks/.test.sh
@@ -116,6 +116,48 @@ if ! echo "$OUTPUT" | grep -q "HIDDEN_OUTPUT_MARKER"; then
 fi
 echo "✓ --show-output flag displays output"
 
+# Test: showOutput still streams under --quiet (AI-agent auto-quiet uses Quiet)
+OUTPUT=$(devenv --quiet --no-tui tasks run test:with-output 2>&1)
+if ! echo "$OUTPUT" | grep -q "VISIBLE_OUTPUT_MARKER"; then
+  echo "FAIL: test:with-output should show output under --quiet but didn't"
+  echo "Got output: $OUTPUT"
+  exit 1
+fi
+echo "✓ showOutput=true displays output under --quiet"
+
+# Test: without showOutput, --quiet still hides successful task stdout
+OUTPUT=$(devenv --quiet --no-tui tasks run test:without-output 2>&1)
+if echo "$OUTPUT" | grep -q "HIDDEN_OUTPUT_MARKER"; then
+  echo "FAIL: test:without-output should hide output under --quiet but didn't"
+  echo "Got output: $OUTPUT"
+  exit 1
+fi
+echo "✓ showOutput=false hides output under --quiet"
+
+# Test: --show-output still wins under --quiet
+OUTPUT=$(devenv --quiet --no-tui tasks run test:without-output --show-output 2>&1)
+if ! echo "$OUTPUT" | grep -q "HIDDEN_OUTPUT_MARKER"; then
+  echo "FAIL: --show-output should show output under --quiet but didn't"
+  echo "Got output: $OUTPUT"
+  exit 1
+fi
+echo "✓ --show-output flag displays output under --quiet"
+
+# Test: CLAUDECODE auto-quiet still honors showOutput (#3038)
+OUTPUT=$(env -u DEVENV_NO_AI_AGENT CLAUDECODE=1 devenv --no-tui tasks run test:with-output 2>&1)
+if ! echo "$OUTPUT" | grep -q "VISIBLE_OUTPUT_MARKER"; then
+  echo "FAIL: test:with-output should show output under CLAUDECODE=1 but didn't"
+  echo "Got output: $OUTPUT"
+  exit 1
+fi
+OUTPUT=$(env -u DEVENV_NO_AI_AGENT CLAUDECODE=1 devenv --no-tui tasks run test:without-output 2>&1)
+if echo "$OUTPUT" | grep -q "HIDDEN_OUTPUT_MARKER"; then
+  echo "FAIL: test:without-output should hide output under CLAUDECODE=1 but didn't"
+  echo "Got output: $OUTPUT"
+  exit 1
+fi
+echo "✓ showOutput honors CLAUDECODE auto-quiet"
+
 # Test: Nix-defined task input is passed via DEVENV_TASK_INPUT
 devenv tasks run test:input
 INPUT=$(cat input-result.json)


### PR DESCRIPTION
Fixes #3038

## Summary

- `showOutput = true` and `--show-output` now stream task stdout even when AI-agent auto-quiet (or `--quiet`) sets `VerbosityLevel::Quiet`.
- Quiet without `show_output` still suppresses successful task stdout.
- Stdout is not reclassified as `Error`; the console renderer treats `show_output` as an explicit per-task force flag.

## Root cause

AI-agent detection (`CLAUDECODE` and similar) selects `VerbosityLevel::Quiet`. `show_output` only promoted task logs from `Debug` to `Info`, and Quiet admits only `Error`, so an explicit `showOutput = true` was still filtered. Task stderr already used `Error`, which is why the original report looked like “stdout missing, stderr shown”.

This is the remaining #3038 item after maintainers narrowed it: CI without agent env is unaffected; failing-task replay on `main` was already fixed by ab87ccb3.

## Relationship to #3115 / #3145

#3115 is the Quiet `--no-tui` **lifecycle** gap (no running/succeeded lines until exit). #3145 has merged; this branch is rebased onto that `main`. Both live in `devenv/src/console.rs` and now compose: #3145’s `show_lifecycle` for start/end, this PR’s `force_output` for `show_output` logs. Quiet without `show_output` still suppresses task stdout.

## What changed

- `ConsoleOutput` stores `force_output` from `TaskInfo.show_output` alongside `show_lifecycle`.
- Task log lines with `force_output` bypass the verbosity gate via `write_visible`, still rendered as ordinary indented logs (not Error).
- Unit tests in `devenv/src/console.rs`:
  - `quiet_show_output_streams_task_stdout`
  - `quiet_without_show_output_suppresses_task_stdout`
  - `quiet_show_output_no_duplicate_on_fail`
- Integration coverage in `tests/tasks/.test.sh` for `--quiet` and `CLAUDECODE=1`.

## Validation

- [x] Confirmed no existing open PR already fixes #3038 (searched cachix/devenv for 3038 / showOutput + quiet)
- [x] Rebased onto current `cachix/devenv` main (`b537c844`)
- [x] `git diff --check`
- [ ] `cargo test -p devenv --lib quiet_show_output` — blocked here: this environment has no `nix-flake-c.pc` / Nix. CI on this PR should run the new unit tests and `tests/tasks`.

Workarounds `--verbose` and `DEVENV_NO_AI_AGENT=1` remain valid; they are no longer required for explicit `showOutput`.