### PR TITLE
fix: typo in "compared to flakes" table

### DIFF
--- a/docs/src/content/docs/guides/using-with-flakes.md
+++ b/docs/src/content/docs/guides/using-with-flakes.md
@@ -45,7 +45,7 @@ Consider using the Flake integration when:
 | Protection from garbage-collection | ✓ | ✗ |
 | Faster evaluation (lazy trees) | ✓ | ✗ |
 | Evaluation caching | ✓ | ✗ |
-| Pure evaluation | ✓ | ✗ (`impure` by default) |
+| Pure evaluation | ✗ (`impure` by default) | ✓ |
 | Cross-project references | ✓ | ✓ |
 | secretspec.dev | ✓ | ✗ |
 | Running processes when testing | ✓ | ✗ |


### PR DESCRIPTION
The guide with a "devenv vs. nix flake" comparison table mixes up which one operates in a pure evaluation mode.