### PR TITLE
fix(shell): guard against a 0x0 terminal size crashing the interactive session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed the interactive `devenv shell` session crashing with "terminal error: invalid value" when the terminal briefly reports a `0x0` size, most commonly seen on WSL2 right after `devenv`'s shell hook auto-activates on `cd`.
 - Fixed environment capture accumulating unbounded `.devenv/shell-*.sh` files. Capture-specific activation scripts are now temporary, and non-interactive commands are passed as arguments instead of being embedded in persistent activation scripts ([#3149](https://github.com/cachix/devenv/issues/3149)).
 - Restored dotenv compatibility with older devenv CLIs whose project inputs resolve newer modules. These CLIs now fall back to the legacy Nix parser instead of failing because the `loadDotenv` primop is unavailable.
 - Fixed `devenv shell` hanging on exit or repeatedly reloading when a configured dotenv file was missing, especially in large repositories.

--- a/devenv-shell/src/pty.rs
+++ b/devenv-shell/src/pty.rs
@@ -148,8 +148,28 @@ impl Pty {
 }
 
 /// Get the current terminal size.
+///
+/// `crossterm::terminal::size()` reads the size via `TIOCGWINSZ` on the
+/// controlling terminal. Under WSL2, that ioctl can succeed with a `0x0`
+/// winsize for a brief window right as a new process attaches to the pty
+/// (e.g. `devenv`'s zsh/bash hook auto-spawning `devenv shell` on `cd`) —
+/// the Windows-side pty host hasn't reported real dimensions yet, but
+/// crossterm has no way to tell that apart from a legitimately empty
+/// terminal, so it returns `Ok((0, 0))` rather than an `Err` we could
+/// already fall back on below.
+///
+/// A `0` in either dimension is never usable: it reaches
+/// `libghostty_vt::Terminal::new(cols, rows)` when the interactive shell
+/// session starts its VT emulator, and that rejects zero dimensions
+/// outright with `Error::InvalidValue` ("terminal error: invalid value"),
+/// aborting the whole session. Treat a zero-sized `Ok` result the same as
+/// a failed query and fall back to the default.
 pub fn get_terminal_size() -> PtySize {
-    let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    const DEFAULT_SIZE: (u16, u16) = (80, 24);
+    let (cols, rows) = match crossterm::terminal::size() {
+        Ok((cols, rows)) if cols != 0 && rows != 0 => (cols, rows),
+        _ => DEFAULT_SIZE,
+    };
     PtySize {
         rows,
         cols,

--- a/devenv-shell/src/session.rs
+++ b/devenv-shell/src/session.rs
@@ -1724,8 +1724,17 @@ impl ShellSession {
         // writer) instead of crossterm::terminal::size() which always uses the
         // process's controlling terminal. That would make this work correctly even
         // with injected I/O and remove the need for the config.size guard.
+        //
+        // Like `get_terminal_size()`, this can come back `Ok` with a `0x0` size
+        // (observed transiently under WSL2, and consistently in some
+        // non-terminal-backed ptys). Ignore that instead of clobbering the
+        // already-valid size `ShellSession::new` computed, since a `0` in
+        // either dimension later crashes `libghostty_vt::Terminal::new` with
+        // "invalid value".
         if self.config.size.is_none()
             && let Ok((cols, rows)) = terminal::size()
+            && cols != 0
+            && rows != 0
         {
             self.size = PtySize {
                 rows,


### PR DESCRIPTION
Fixes #3160

## Summary

`devenv-shell/src/pty.rs`'s `get_terminal_size()` and `ShellSession::run()`'s own re-query of `crossterm::terminal::size()` (`devenv-shell/src/session.rs`) both only fell back to defaults when the crossterm call returned an `Err`. Under WSL2, that ioctl (`TIOCGWINSZ`) can succeed with a `0x0` winsize for a brief window right as a new process attaches to the pty (e.g. `devenv`'s zsh/bash hook auto-spawning `devenv shell` on `cd`), since crossterm has no way to distinguish that from a legitimately empty terminal.

That `0` then reached `libghostty_vt::Terminal::new(cols, rows)` when the interactive shell session starts its VT emulator, which rejects zero dimensions outright, aborting the whole session with `Shell session error / terminal error: invalid value`.

Bisected against a real system (`cachix/devenv` pinned at various revs in a downstream flake) to confirm the regression window: `df5c75a8` (working) to `30058c52` (broken). Neither the interactive `ShellSession`/PTY-takeover feature nor the size-query call sites themselves changed anywhere in that range — both predate it, unmodified. The one thing that *did* change in that window is `c9b40aa0`, which bumped the vendored `libghostty-vt` native library across many upstream revisions. The `0x0`-size gap in devenv's own code was already there before this window and harmless; it started crashing once that dependency bump made the native library reject a zero-sized terminal outright instead of tolerating it.

## Fix

Two call sites needed the same guard:
- `get_terminal_size()`, used when constructing the session: now treats a zero-sized `Ok` result the same as a failed query and falls back to the `80x24` default.
- `ShellSession::run()`'s own re-query right before the VT is created: this one bypassed `get_terminal_size()` entirely and could clobber an already-valid size with zeros. It now ignores a zero-sized result and keeps the existing size instead.

## Test plan

- [x] `cargo build -p devenv-shell` / `cargo build -p devenv`
- [x] `cargo nextest run -p devenv-shell` (188 tests, all passing)
- [x] Reproduced the crash directly against a persistently `0x0` pty (not just the transient WSL race) and confirmed the interactive session no longer aborts with both fixes applied together

🤖 Generated with [Claude Code](https://claude.com/claude-code)

