### PR TITLE
fix(cli): load YAML from remote --from sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.3.1 (unreleased)
 
+### Bug Fixes
+
+- Fixed fetched `--from` sources loading only `devenv.nix`. They now also load the source's complete YAML configuration and imports.
+
 ## 2.3.0 (2026-09-07)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **[Instant environments](https://devenv.sh/blog/2024/10/03/devenv-13-instant-developer-environments-with-nix-caching/)** with incremental Nix evaluation caching (sub 100ms when nothing changed)
 - **[LSP for devenv.nix](https://devenv.sh/lsp/)** with autocomplete, hover docs, and go to definition via bundled nixd
 - **[Ad hoc environments](https://devenv.sh/ad-hoc-developer-environments/)** from the CLI without any config files (`--option languages.rust.enable:bool true`)
-- **[Out of tree devenvs](https://devenv.sh/ad-hoc-developer-environments/)** to use configs from other repos (`--from github:myorg/configs`)
+- **[Out of tree devenvs](https://devenv.sh/guides/out-of-tree-devenvs/)** to use configs from other repos (`--from github:myorg/configs`)
 
 ### Languages, packages, and services
 

--- a/devenv-core/src/config.rs
+++ b/devenv-core/src/config.rs
@@ -489,16 +489,22 @@ impl Config {
     }
 
     /// Like [`Config::load`], but additionally merges the configuration of an
-    /// out-of-tree source directory (a `path:` `--from` source).
+    /// out-of-tree source directory.
     ///
     /// The source's `devenv.yaml` import graph merges at the lowest precedence
     /// (the project's own configuration wins), and the source's inputs and
     /// imports are rewritten to absolute `path:` form so they resolve from the
-    /// live source directory regardless of the project root. The source's
-    /// module (`devenv.nix`) is appended to `imports` as an absolute `path:`
-    /// import, so it must exist even when the source has no `devenv.yaml`.
+    /// source directory regardless of the project root. The source's module
+    /// (`devenv.nix`) is appended to `imports` as an absolute `path:` import,
+    /// so it must exist even when the source has no `devenv.yaml`.
     pub fn load_with_source(source_dir: Option<&Path>) -> Result<Self> {
-        Self::load_from_with_source("./", source_dir)
+        Self::load_from_with_source_root("./", source_dir, None)
+    }
+
+    /// Like [`Config::load_with_source`], with an explicit repository root for
+    /// imports from a fetched source whose store tree has no `.git` metadata.
+    pub fn load_with_source_root(source_dir: &Path, source_repository_root: &Path) -> Result<Self> {
+        Self::load_from_with_source_root("./", Some(source_dir), Some(source_repository_root))
     }
 
     /// Loads configuration from a directory path, including all imported configurations.
@@ -529,6 +535,17 @@ impl Config {
     /// [`Config::load_from`] with an optional out-of-tree source directory;
     /// see [`Config::load_with_source`] for the source merge semantics.
     pub fn load_from_with_source<P>(path: P, source_dir: Option<&Path>) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        Self::load_from_with_source_root(path, source_dir, None)
+    }
+
+    fn load_from_with_source_root<P>(
+        path: P,
+        source_dir: Option<&Path>,
+        source_repository_root: Option<&Path>,
+    ) -> Result<Self>
     where
         P: AsRef<Path>,
     {
@@ -578,12 +595,16 @@ impl Config {
         let mut source_yamls = Vec::new();
         let mut source_dir_only_imports = Vec::new();
         let mut source_module_imports = Vec::new();
-        // Canonical root of the out-of-tree source (`None` if it doesn't
-        // resolve). Reused to import the source module and to classify which
-        // inputs were defined by source-side configs.
-        let source_root_canon = source_dir.and_then(|d| d.canonicalize().ok());
+        let source_dir_canon = source_dir.and_then(|dir| dir.canonicalize().ok());
+        let detected_source_repository_root = source_dir
+            .filter(|_| source_repository_root.is_none())
+            .and_then(Self::detect_git_root);
+        let source_repository_root =
+            source_repository_root.or(detected_source_repository_root.as_deref());
+        let source_containment_root = source_repository_root
+            .or(source_dir)
+            .and_then(|root| root.canonicalize().ok());
         if let Some(source_dir) = source_dir {
-            let source_git_root = Self::detect_git_root(source_dir);
             let source_yaml = source_dir.join(YAML_CONFIG);
             if source_yaml.exists() {
                 let canonical =
@@ -619,7 +640,7 @@ impl Config {
                 Self::collect_import_files(
                     &source_result.config.imports,
                     source_dir,
-                    source_git_root.as_deref(),
+                    source_repository_root,
                     &mut source_yamls,
                     &mut source_dir_only_imports,
                     &mut visited,
@@ -641,11 +662,8 @@ impl Config {
                 // imports pass through below).
                 for import in &source_result.config.imports {
                     if Self::is_file_import(import) {
-                        let resolved = Self::resolve_import_path(
-                            import,
-                            source_dir,
-                            source_git_root.as_deref(),
-                        )?;
+                        let resolved =
+                            Self::resolve_import_path(import, source_dir, source_repository_root)?;
                         let resolved = resolved.canonicalize().unwrap_or(resolved);
                         source_module_imports.push(format!("path:{}", resolved.display()));
                     }
@@ -654,7 +672,7 @@ impl Config {
 
             // The source module itself (devenv.nix plus devenv.local.nix at
             // eval time), imported live even when the source has no yaml.
-            let canonical = source_root_canon
+            let canonical = source_dir_canon
                 .clone()
                 .unwrap_or_else(|| source_dir.to_path_buf());
             source_module_imports.push(format!("path:{}", canonical.display()));
@@ -808,7 +826,7 @@ impl Config {
                 // the live source tree; emit them absolute so they stay valid
                 // from the project root (relative escapes also break under
                 // lazy-trees).
-                let from_source_side = source_root_canon.as_ref().is_some_and(|root| {
+                let from_source_side = source_containment_root.as_ref().is_some_and(|root| {
                     input_dir
                         .canonicalize()
                         .is_ok_and(|dir| dir.starts_with(root))
@@ -2028,6 +2046,50 @@ inputs:
             "missing common import: {:?}",
             config.imports
         );
+    }
+
+    #[test]
+    fn explicit_source_root_allows_imports_without_git_metadata() {
+        let repository = tempfile::tempdir().expect("Failed to create repository");
+        let common = repository.path().join("profiles").join("common");
+        let dependency = common.join("dependency");
+        let rooted = repository.path().join("rooted");
+        let profile = repository.path().join("profiles").join("rails");
+        fs::create_dir_all(&dependency).expect("Failed to create common dependency");
+        fs::create_dir(&rooted).expect("Failed to create rooted module");
+        fs::create_dir_all(&profile).expect("Failed to create profile");
+        fs::write(
+            common.join("devenv.yaml"),
+            "inputs:\n  shared-input:\n    url: path:./dependency\n",
+        )
+        .expect("Failed to write common config");
+        fs::write(rooted.join("devenv.nix"), "{ }\n").expect("Failed to write rooted module");
+        fs::write(
+            profile.join("devenv.yaml"),
+            "imports:\n  - ../common\n  - /rooted\n",
+        )
+        .expect("Failed to write profile config");
+
+        let project = tempfile::tempdir().expect("Failed to create project");
+        let config = Config::load_from_with_source_root(
+            project.path(),
+            Some(&profile),
+            Some(repository.path()),
+        )
+        .expect("Failed to load config");
+
+        let expected_url = format!("path:{}", dependency.canonicalize().unwrap().display());
+        assert_eq!(
+            config
+                .inputs
+                .get("shared-input")
+                .and_then(|input| input.url.as_deref()),
+            Some(expected_url.as_str())
+        );
+        for imported in [&common, &rooted] {
+            let import = format!("path:{}", imported.canonicalize().unwrap().display());
+            assert!(config.imports.contains(&import), "missing import {import}");
+        }
     }
 
     #[test]

--- a/devenv-nix-backend/src/backend.rs
+++ b/devenv-nix-backend/src/backend.rs
@@ -16,7 +16,7 @@
 //! let (flake_settings, fetchers_settings) = build_settings()?;
 //! let logger_setup = logger::setup_nix_logger()?;
 //! let fingerprint = lock::with_lock_scope(&logger_setup.bridge, || {
-//!     let eval_state = lock::build_eval_state(&store, &root, &flake_settings)?;
+//!     let eval_state = lock::build_eval_state(&store, &root, &flake_settings, false)?;
 //!     lock::validate_and_load(&eval_state, &store, &fetchers_settings,
 //!         &flake_settings, &root, &lock_file, &inputs)
 //! })?;
@@ -1478,7 +1478,7 @@ fn build_eval_state(
         .to_str()
         .ok_or_else(|| miette!("Nixpkgs config path contains invalid UTF-8"))?;
 
-    let mut builder = EvalStateBuilder::new(store.clone())
+    let builder = EvalStateBuilder::new(store.clone())
         .to_miette()
         .wrap_err("Failed to create eval state builder")?
         .base_directory(root_str)
@@ -1491,16 +1491,7 @@ fn build_eval_state(
         .to_miette()
         .wrap_err("Failed to configure flakes")?;
 
-    // `devenv update` sets this so branch and tag inputs are re-resolved
-    // instead of served from cache within tarball-ttl. The eval state's own
-    // fetchers::Settings is what governs locking, so the override must land
-    // here rather than on the global config or the locker's settings argument.
-    if refresh_fetchers {
-        builder = builder
-            .fetch_setting("tarball-ttl", "0")
-            .to_miette()
-            .wrap_err("Failed to set tarball-ttl")?;
-    }
+    let builder = crate::lock::apply_fetcher_refresh(builder, refresh_fetchers)?;
 
     let mut eval_state = builder
         .build()

--- a/devenv-nix-backend/src/lib.rs
+++ b/devenv-nix-backend/src/lib.rs
@@ -27,6 +27,7 @@ mod gc_store;
 mod file_limit;
 
 pub mod lock;
+pub mod source;
 
 pub mod primops;
 pub use primops::{
@@ -66,6 +67,62 @@ pub mod umask_guard;
 // Helpers for shaping Nix errors into miette diagnostics
 mod error;
 
+fn create_flake_input_base(
+    fetch_settings: &FetchersSettings,
+    flake_settings: &FlakeSettings,
+    parse_flags: &FlakeReferenceParseFlags,
+    input: &Input,
+) -> Result<Option<FlakeInput>> {
+    let (flake_ref, is_flake) = if let Some(url) = &input.url {
+        let (flake_ref, _fragment) =
+            FlakeReference::parse_with_fragment(fetch_settings, flake_settings, parse_flags, url)?;
+        (flake_ref, input.flake)
+    } else if let Some(follows_target) = &input.follows {
+        let (placeholder_ref, _) = FlakeReference::parse_with_fragment(
+            fetch_settings,
+            flake_settings,
+            parse_flags,
+            follows_target,
+        )?;
+        (placeholder_ref, true)
+    } else {
+        return Ok(None);
+    };
+
+    let mut flake_input = FlakeInput::new(&flake_ref, is_flake)?;
+    if let Some(follows_path) = &input.follows {
+        flake_input.set_follows(follows_path)?;
+    }
+    Ok(Some(flake_input))
+}
+
+fn create_flake_input(
+    fetch_settings: &FetchersSettings,
+    flake_settings: &FlakeSettings,
+    parse_flags: &FlakeReferenceParseFlags,
+    input: &Input,
+) -> Result<Option<FlakeInput>> {
+    let Some(mut flake_input) =
+        create_flake_input_base(fetch_settings, flake_settings, parse_flags, input)?
+    else {
+        return Ok(None);
+    };
+
+    if !input.inputs.is_empty() {
+        let mut overrides = FlakeInputs::new()?;
+        for (nested_name, nested_input) in &input.inputs {
+            if let Some(nested_flake_input) =
+                create_flake_input_base(fetch_settings, flake_settings, parse_flags, nested_input)?
+            {
+                overrides.add(nested_name, nested_flake_input)?;
+            }
+        }
+        flake_input.set_overrides(overrides)?;
+    }
+
+    Ok(Some(flake_input))
+}
+
 /// Convert devenv inputs to FlakeInputs
 ///
 /// # Arguments
@@ -83,78 +140,12 @@ pub fn create_flake_inputs(
     // Preserve relative paths so they can be resolved during locking via source_path context
     parse_flags.set_preserve_relative_paths(true)?;
 
-    // Convert each devenv input to a FlakeInput
-    for (name, input) in inputs.iter() {
-        let mut flake_input = if let Some(url) = &input.url {
-            let (flake_ref, _fragment) = FlakeReference::parse_with_fragment(
-                fetch_settings,
-                flake_settings,
-                &parse_flags,
-                url,
-            )?;
-            FlakeInput::new(&flake_ref, input.flake)?
-        } else if let Some(follows_target) = &input.follows {
-            // Top-level input has only follows - use follows target as placeholder reference
-            // (the reference gets cleared internally by set_follows)
-            let (placeholder_ref, _) = FlakeReference::parse_with_fragment(
-                fetch_settings,
-                flake_settings,
-                &parse_flags,
-                follows_target,
-            )?;
-            FlakeInput::new(&placeholder_ref, true)?
-        } else {
-            continue;
-        };
-
-        // Set follows relationship before adding to collection
-        // (C API does not support modifying inputs after they're added)
-        if let Some(follows_path) = &input.follows {
-            flake_input.set_follows(follows_path)?;
+    for (name, input) in inputs {
+        if let Some(flake_input) =
+            create_flake_input(fetch_settings, flake_settings, &parse_flags, input)?
+        {
+            flake_inputs.add(name, flake_input)?;
         }
-
-        // Handle nested input overrides (e.g., git-hooks.inputs.nixpkgs.follows = "nixpkgs")
-        if !input.inputs.is_empty() {
-            let mut overrides = FlakeInputs::new()?;
-
-            for (nested_name, nested_input) in input.inputs.iter() {
-                let mut nested_flake_input = if let Some(nested_url) = &nested_input.url {
-                    // Nested input has a URL - parse it
-                    let (nested_ref, _) = FlakeReference::parse_with_fragment(
-                        fetch_settings,
-                        flake_settings,
-                        &parse_flags,
-                        nested_url,
-                    )?;
-                    FlakeInput::new(&nested_ref, nested_input.flake)?
-                } else if let Some(follows_target) = &nested_input.follows {
-                    // Nested input has only follows - use follows target as placeholder reference
-                    // (the reference gets cleared internally by set_follows)
-                    let (placeholder_ref, _) = FlakeReference::parse_with_fragment(
-                        fetch_settings,
-                        flake_settings,
-                        &parse_flags,
-                        follows_target,
-                    )?;
-                    FlakeInput::new(&placeholder_ref, true)?
-                } else {
-                    // Nested input has neither URL nor follows - skip it
-                    continue;
-                };
-
-                // Set follows if specified
-                if let Some(follows_path) = &nested_input.follows {
-                    nested_flake_input.set_follows(follows_path)?;
-                }
-
-                overrides.add(nested_name, nested_flake_input)?;
-            }
-
-            // Set the overrides on the parent input
-            flake_input.set_overrides(overrides)?;
-        }
-
-        flake_inputs.add(name, flake_input)?;
     }
 
     // Add nixpkgs as a default input if not already specified
@@ -184,6 +175,51 @@ pub fn create_flake_inputs(
     }
 
     Ok(flake_inputs)
+}
+
+/// Lock one source input in memory without adding default inputs or writing a lock file.
+pub fn lock_source_input(
+    eval_state: &EvalState,
+    fetch_settings: &FetchersSettings,
+    flake_settings: &FlakeSettings,
+    root: &Path,
+    lock_file_path: &Path,
+    source_input: &Input,
+    refresh: bool,
+) -> Result<LockFile> {
+    let mut parse_flags = FlakeReferenceParseFlags::new(flake_settings)?;
+    parse_flags.set_preserve_relative_paths(true)?;
+
+    let source_input =
+        create_flake_input(fetch_settings, flake_settings, &parse_flags, source_input)?
+            .context("Source input requires a URL or follows target")?;
+    let mut flake_inputs = FlakeInputs::new()?;
+    flake_inputs.add("from", source_input)?;
+
+    let old_lock =
+        load_lock_file(fetch_settings, lock_file_path).context("Failed to load lock file")?;
+    let source_path = root.join("devenv.nix");
+    let source_path_str = source_path
+        .to_str()
+        .context("Source path contains invalid UTF-8")?;
+
+    let mut locker = InputsLocker::new(flake_settings)
+        .with_inputs(flake_inputs)
+        .source_path(source_path_str)
+        .mode(LockMode::Virtual)
+        .use_registries(true);
+
+    if let Some(lock) = &old_lock {
+        locker = locker.old_lock_file(lock);
+    }
+    if refresh {
+        locker = locker.update_input("from");
+    }
+
+    let _guard = crate::umask_guard::UmaskGuard::restrictive();
+    locker
+        .lock(fetch_settings, eval_state)
+        .context("Failed to lock source input")
 }
 
 /// Load an existing lock file if it exists

--- a/devenv-nix-backend/src/lock.rs
+++ b/devenv-nix-backend/src/lock.rs
@@ -25,11 +25,12 @@ pub fn build_eval_state(
     store: &Store,
     root: &Path,
     flake_settings: &FlakeSettings,
+    refresh_fetchers: bool,
 ) -> Result<EvalState> {
     let root_str = root
         .to_str()
         .ok_or_else(|| miette::miette!("Root path contains invalid UTF-8"))?;
-    EvalStateBuilder::new(store.clone())
+    let builder = EvalStateBuilder::new(store.clone())
         .to_miette()
         .wrap_err("Failed to create eval state builder")?
         .base_directory(root_str)
@@ -37,10 +38,25 @@ pub fn build_eval_state(
         .wrap_err("Failed to set base directory")?
         .flakes(flake_settings)
         .to_miette()
-        .wrap_err("Failed to configure flakes")?
+        .wrap_err("Failed to configure flakes")?;
+    apply_fetcher_refresh(builder, refresh_fetchers)?
         .build()
         .to_miette()
         .wrap_err("Failed to build eval state")
+}
+
+/// Apply `--refresh` semantics to an eval state's fetcher cache.
+pub(crate) fn apply_fetcher_refresh(
+    mut builder: EvalStateBuilder,
+    refresh_fetchers: bool,
+) -> Result<EvalStateBuilder> {
+    if refresh_fetchers {
+        builder = builder
+            .fetch_setting("tarball-ttl", "0")
+            .to_miette()
+            .wrap_err("Failed to set tarball-ttl")?;
+    }
+    Ok(builder)
 }
 
 /// Run `f` inside a "Validating lock" activity + `begin_eval` scope.
@@ -113,4 +129,127 @@ pub fn update(
         overrides,
     )
     .to_miette()
+}
+
+#[cfg(all(test, feature = "test-nix-store"))]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use devenv_core::{NixSettings, StoreSettings};
+
+    use super::*;
+
+    fn write_octal(field: &mut [u8], value: u64) {
+        let value = format!("{value:o}");
+        field.fill(b'0');
+        let start = field.len() - value.len() - 1;
+        field[start..start + value.len()].copy_from_slice(value.as_bytes());
+        field[field.len() - 1] = 0;
+    }
+
+    fn tarball() -> Vec<u8> {
+        let contents = b"cached";
+        let mut header = [0_u8; 512];
+        header[..12].copy_from_slice(b"source/value");
+        write_octal(&mut header[100..108], 0o644);
+        write_octal(&mut header[108..116], 0);
+        write_octal(&mut header[116..124], 0);
+        write_octal(&mut header[124..136], contents.len() as u64);
+        write_octal(&mut header[136..148], 0);
+        header[148..156].fill(b' ');
+        header[156] = b'0';
+        header[257..263].copy_from_slice(b"ustar\0");
+        header[263..265].copy_from_slice(b"00");
+        let checksum: u64 = header.iter().map(|byte| u64::from(*byte)).sum();
+        header[148..156].copy_from_slice(format!("{checksum:06o}\0 ").as_bytes());
+
+        let mut archive = Vec::from(header);
+        archive.extend_from_slice(contents);
+        archive.resize(1024, 0);
+        archive.resize(2048, 0);
+        archive
+    }
+
+    fn fetch_tarball(eval_state: &mut EvalState, root: &Path, url: &str) {
+        let url = ser_nix::to_string(&url).unwrap();
+        let expression = format!("toString (builtins.fetchTarball {url})");
+        let value = eval_state
+            .eval_from_string(&expression, root.to_str().unwrap())
+            .unwrap();
+        eval_state.realise_string(&value, false).unwrap();
+    }
+
+    #[test]
+    fn fetcher_refresh_does_not_leak_between_evaluators() {
+        let listener = match TcpListener::bind("127.0.0.1:0") {
+            Ok(listener) => listener,
+            Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+                eprintln!("skipping: binding a TCP socket is not permitted: {error}");
+                return;
+            }
+            Err(error) => panic!("failed to bind a TCP listener: {error}"),
+        };
+        let address = listener.local_addr().unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = Arc::clone(&requests);
+        let stopped = Arc::new(AtomicBool::new(false));
+        let server_stopped = Arc::clone(&stopped);
+        let archive = tarball();
+        let server = std::thread::spawn(move || {
+            while !server_stopped.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        if server_stopped.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let mut request = [0_u8; 4096];
+                        stream
+                            .set_read_timeout(Some(Duration::from_secs(2)))
+                            .unwrap();
+                        let _ = stream.read(&mut request);
+                        server_requests.fetch_add(1, Ordering::Relaxed);
+                        let _ = write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Type: application/x-tar\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                            archive.len()
+                        );
+                        let _ = stream.write_all(&archive);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("HTTP server failed: {error}"),
+                }
+            }
+        });
+
+        let root = tempfile::tempdir().unwrap();
+        let nix_settings = NixSettings::default();
+        let store_settings = StoreSettings::default();
+        let _gc_registration = crate::backend::init_nix(&nix_settings, &store_settings).unwrap();
+        let store = crate::backend::open_store(&store_settings).unwrap();
+        let (flake_settings, _) = crate::backend::build_settings().unwrap();
+        let url = format!("http://{address}/{}/source.tar", uuid::Uuid::new_v4());
+
+        let mut refreshing = build_eval_state(&store, root.path(), &flake_settings, true).unwrap();
+        fetch_tarball(&mut refreshing, root.path(), &url);
+        drop(refreshing);
+        let first_requests = requests.load(Ordering::Relaxed);
+
+        let mut cached = build_eval_state(&store, root.path(), &flake_settings, false).unwrap();
+        fetch_tarball(&mut cached, root.path(), &url);
+        let cached_requests = requests.load(Ordering::Relaxed);
+
+        stopped.store(true, Ordering::Relaxed);
+        TcpStream::connect(address).unwrap();
+        server.join().unwrap();
+
+        assert!(first_requests > 0);
+        assert_eq!(cached_requests, first_requests);
+    }
 }

--- a/devenv-nix-backend/src/source.rs
+++ b/devenv-nix-backend/src/source.rs
@@ -9,12 +9,28 @@ use serde_json::Value;
 use crate::anyhow_ext::AnyhowToMiette;
 use crate::{backend, lock};
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct MaterializedSource {
+    repository_root: PathBuf,
+    directory: Option<PathBuf>,
+}
+
+impl MaterializedSource {
+    pub fn repository_root(&self) -> &Path {
+        &self.repository_root
+    }
+
+    pub fn directory(&self) -> &Path {
+        self.directory.as_deref().unwrap_or(&self.repository_root)
+    }
+}
+
 pub fn materialize_source(
     nix_settings: &NixSettings,
     root: &Path,
     lock_file_path: &Path,
     source_input: &Input,
-) -> Result<PathBuf> {
+) -> Result<MaterializedSource> {
     let store_settings = StoreSettings::default();
     let _gc_registration = backend::init_nix(nix_settings, &store_settings)
         .wrap_err("Failed to initialize Nix for source resolution")?;
@@ -22,8 +38,9 @@ pub fn materialize_source(
         .wrap_err("Failed to open the Nix store for source resolution")?;
     let (flake_settings, fetchers_settings) =
         backend::build_settings().wrap_err("Failed to build Nix source settings")?;
-    let mut eval_state = lock::build_eval_state(&store, root, &flake_settings)
-        .wrap_err("Failed to build the Nix source evaluator")?;
+    let mut eval_state =
+        lock::build_eval_state(&store, root, &flake_settings, nix_settings.refresh_fetchers)
+            .wrap_err("Failed to build the Nix source evaluator")?;
 
     let source_lock = crate::lock_source_input(
         &eval_state,
@@ -109,7 +126,7 @@ fn locked_source_attributes(lock_json: &str) -> Result<(Value, Option<String>)> 
     Ok((Value::Object(locked), dir))
 }
 
-fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<PathBuf> {
+fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<MaterializedSource> {
     let fetched_root = fs::canonicalize(fetched_root)
         .into_diagnostic()
         .wrap_err_with(|| {
@@ -119,7 +136,10 @@ fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<Pat
             )
         })?;
     let Some(dir) = dir else {
-        return Ok(fetched_root);
+        return Ok(MaterializedSource {
+            repository_root: fetched_root,
+            directory: None,
+        });
     };
 
     let mut relative_dir = PathBuf::new();
@@ -151,7 +171,11 @@ fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<Pat
             selected.display()
         );
     }
-    Ok(selected)
+    let directory = (selected != fetched_root).then_some(selected);
+    Ok(MaterializedSource {
+        repository_root: fetched_root,
+        directory,
+    })
 }
 
 #[cfg(test)]
@@ -163,8 +187,10 @@ mod tests {
         let source = tempfile::tempdir().unwrap();
 
         let selected = select_source_directory(source.path(), None).unwrap();
+        let root = fs::canonicalize(source.path()).unwrap();
 
-        assert_eq!(selected, fs::canonicalize(source.path()).unwrap());
+        assert_eq!(selected.repository_root(), root);
+        assert_eq!(selected.directory(), root);
     }
 
     #[test]
@@ -175,7 +201,11 @@ mod tests {
 
         let selected = select_source_directory(source.path(), Some("profiles/rails")).unwrap();
 
-        assert_eq!(selected, fs::canonicalize(child).unwrap());
+        assert_eq!(
+            selected.repository_root(),
+            fs::canonicalize(source.path()).unwrap()
+        );
+        assert_eq!(selected.directory(), fs::canonicalize(child).unwrap());
     }
 
     #[test]

--- a/devenv-nix-backend/src/source.rs
+++ b/devenv-nix-backend/src/source.rs
@@ -1,0 +1,198 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use devenv_core::config::Input;
+use devenv_core::{NixSettings, StoreSettings};
+use miette::{IntoDiagnostic, Result, WrapErr, bail, miette};
+use serde_json::Value;
+
+use crate::anyhow_ext::AnyhowToMiette;
+use crate::{backend, lock};
+
+pub fn materialize_source(
+    nix_settings: &NixSettings,
+    root: &Path,
+    lock_file_path: &Path,
+    source_input: &Input,
+) -> Result<PathBuf> {
+    let store_settings = StoreSettings::default();
+    let _gc_registration = backend::init_nix(nix_settings, &store_settings)
+        .wrap_err("Failed to initialize Nix for source resolution")?;
+    let store = backend::open_store(&store_settings)
+        .wrap_err("Failed to open the Nix store for source resolution")?;
+    let (flake_settings, fetchers_settings) =
+        backend::build_settings().wrap_err("Failed to build Nix source settings")?;
+    let mut eval_state = lock::build_eval_state(&store, root, &flake_settings)
+        .wrap_err("Failed to build the Nix source evaluator")?;
+
+    let source_lock = crate::lock_source_input(
+        &eval_state,
+        &fetchers_settings,
+        &flake_settings,
+        root,
+        lock_file_path,
+        source_input,
+        nix_settings.refresh_fetchers,
+    )
+    .to_miette()
+    .wrap_err("Failed to lock the source input")?;
+    let lock_json = source_lock
+        .to_string()
+        .to_miette()
+        .wrap_err("Failed to serialize the source lock")?;
+    let (locked_attributes, dir) = locked_source_attributes(&lock_json)?;
+
+    let locked_json = serde_json::to_string(&locked_attributes)
+        .into_diagnostic()
+        .wrap_err("Locked source attributes are invalid")?;
+    let locked_nix_string = ser_nix::to_string(&locked_json)
+        .into_diagnostic()
+        .wrap_err("Failed to serialize locked source attributes for Nix")?;
+    let expression =
+        format!("toString (builtins.fetchTree (builtins.fromJSON {locked_nix_string})).outPath");
+    let base = root
+        .to_str()
+        .ok_or_else(|| miette!("Source root path contains invalid UTF-8"))?;
+    let fetched_value = eval_state
+        .eval_from_string(&expression, base)
+        .to_miette()
+        .wrap_err("Nix could not fetch the locked source")?;
+    let fetched_root = eval_state
+        .realise_string(&fetched_value, false)
+        .to_miette()
+        .wrap_err("Nix could not fetch the locked source")?;
+
+    select_source_directory(Path::new(&fetched_root.s), dir.as_deref())
+}
+
+fn locked_source_attributes(lock_json: &str) -> Result<(Value, Option<String>)> {
+    let lock: Value = serde_json::from_str(lock_json)
+        .into_diagnostic()
+        .wrap_err("Locked source attributes are invalid: the lock is not valid JSON")?;
+    let nodes = lock
+        .get("nodes")
+        .and_then(Value::as_object)
+        .ok_or_else(|| miette!("Source lock node is absent: the lock has no nodes"))?;
+    let root_name = lock
+        .get("root")
+        .and_then(Value::as_str)
+        .ok_or_else(|| miette!("Source lock node is absent: the lock has no root node"))?;
+    let root_node = nodes
+        .get(root_name)
+        .ok_or_else(|| miette!("Source lock node is absent: root node '{root_name}' is missing"))?;
+    let source_node_name = root_node
+        .get("inputs")
+        .and_then(|inputs| inputs.get("from"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| miette!("Source lock node is absent: input 'from' is missing"))?;
+    let source_node = nodes.get(source_node_name).ok_or_else(|| {
+        miette!("Source lock node is absent: node '{source_node_name}' is missing")
+    })?;
+    let mut locked = source_node
+        .get("locked")
+        .and_then(Value::as_object)
+        .cloned()
+        .ok_or_else(|| {
+            miette!(
+                "Locked source attributes are invalid: node '{source_node_name}' has no locked attribute set"
+            )
+        })?;
+    let dir = match locked.remove("dir") {
+        Some(Value::String(dir)) => Some(dir),
+        Some(_) => {
+            bail!(
+                "Locked source attributes are invalid: node '{source_node_name}' has a non-string dir"
+            )
+        }
+        None => None,
+    };
+    Ok((Value::Object(locked), dir))
+}
+
+fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<PathBuf> {
+    let fetched_root = fs::canonicalize(fetched_root)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "The fetched source root does not exist: {}",
+                fetched_root.display()
+            )
+        })?;
+    let Some(dir) = dir else {
+        return Ok(fetched_root);
+    };
+
+    let mut relative_dir = PathBuf::new();
+    for component in Path::new(dir).components() {
+        match component {
+            Component::Normal(component) => relative_dir.push(component),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("The requested dir '{dir}' escapes the source root")
+            }
+        }
+    }
+
+    let selected = fetched_root.join(relative_dir);
+    let selected = fs::canonicalize(&selected)
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "The selected source directory does not exist: {}",
+                selected.display()
+            )
+        })?;
+    if selected != fetched_root && !selected.starts_with(&fetched_root) {
+        bail!("The requested dir '{dir}' escapes the source root");
+    }
+    Ok(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_source_root_without_dir() {
+        let source = tempfile::tempdir().unwrap();
+
+        let selected = select_source_directory(source.path(), None).unwrap();
+
+        assert_eq!(selected, fs::canonicalize(source.path()).unwrap());
+    }
+
+    #[test]
+    fn selects_source_child_from_dir() {
+        let source = tempfile::tempdir().unwrap();
+        let child = source.path().join("profiles").join("rails");
+        fs::create_dir_all(&child).unwrap();
+
+        let selected = select_source_directory(source.path(), Some("profiles/rails")).unwrap();
+
+        assert_eq!(selected, fs::canonicalize(child).unwrap());
+    }
+
+    #[test]
+    fn rejects_parent_directory_in_dir() {
+        let source = tempfile::tempdir().unwrap();
+
+        let error = select_source_directory(source.path(), Some("../outside")).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "The requested dir '../outside' escapes the source root"
+        );
+    }
+
+    #[test]
+    fn reports_missing_source_lock_input() {
+        let lock_json = r#"{"nodes":{"root":{"inputs":{}}},"root":"root"}"#;
+
+        let error = locked_source_attributes(lock_json).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Source lock node is absent: input 'from' is missing"
+        );
+    }
+}

--- a/devenv-nix-backend/src/source.rs
+++ b/devenv-nix-backend/src/source.rs
@@ -145,6 +145,12 @@ fn select_source_directory(fetched_root: &Path, dir: Option<&str>) -> Result<Pat
     if selected != fetched_root && !selected.starts_with(&fetched_root) {
         bail!("The requested dir '{dir}' escapes the source root");
     }
+    if !selected.is_dir() {
+        bail!(
+            "The selected source path is not a directory: {}",
+            selected.display()
+        );
+    }
     Ok(selected)
 }
 
@@ -170,6 +176,23 @@ mod tests {
         let selected = select_source_directory(source.path(), Some("profiles/rails")).unwrap();
 
         assert_eq!(selected, fs::canonicalize(child).unwrap());
+    }
+
+    #[test]
+    fn rejects_file_from_dir() {
+        let source = tempfile::tempdir().unwrap();
+        let file = source.path().join("devenv.yaml");
+        fs::write(&file, "inputs: {}").unwrap();
+
+        let error = select_source_directory(source.path(), Some("devenv.yaml")).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "The selected source path is not a directory: {}",
+                fs::canonicalize(file).unwrap().display()
+            )
+        );
     }
 
     #[test]

--- a/devenv/src/devenv/mod.rs
+++ b/devenv/src/devenv/mod.rs
@@ -706,6 +706,7 @@ impl Devenv {
                             &store,
                             &paths.root,
                             &flake_settings,
+                            nix_settings.refresh_fetchers,
                         )?;
                         devenv_nix_backend::lock::validate_and_load(
                             &eval_state,

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -420,6 +420,13 @@ fn enter_discovered_project_root() -> Result<()> {
     enter_root(&root)
 }
 
+fn should_refresh_source(command: &Commands) -> bool {
+    match command {
+        Commands::Update { name } => name.as_deref().is_none_or(|name| name == "from"),
+        _ => false,
+    }
+}
+
 /// Prepare a config-backed CLI command for execution.
 fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCommand> {
     // --- Project discovery and working directory ---
@@ -522,6 +529,7 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
     let nix_debugger = cli.nix_args.nix_debugger;
     let nix_options = devenv_core::NixOptions::from(cli.nix_args);
     let refresh_fetchers = matches!(&command, Commands::Update { .. });
+    let refresh_source = should_refresh_source(&command);
 
     // Keep `path:` sources live. Relative refs resolve against the invocation
     // directory, and Config::load_with_source reads their complete YAML graph.
@@ -552,17 +560,20 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         let target_config = Config::load()?;
         let mut preliminary_nix_settings =
             NixSettings::resolve(nix_options.clone(), &target_config);
-        preliminary_nix_settings.refresh_fetchers = refresh_fetchers;
+        preliminary_nix_settings.refresh_fetchers = refresh_source;
         let target_root = env::current_dir()
             .into_diagnostic()
             .wrap_err("Failed to resolve the target directory")?;
-        let source_path = devenv_nix_backend::source::materialize_source(
+        let materialized_source = devenv_nix_backend::source::materialize_source(
             &preliminary_nix_settings,
             &target_root,
             &target_root.join("devenv.lock"),
             source_input,
         )?;
-        Config::load_with_source(Some(&source_path))?
+        Config::load_with_source_root(
+            materialized_source.directory(),
+            materialized_source.repository_root(),
+        )?
     } else {
         Config::load_with_source(from_path.as_deref())?
     };
@@ -1810,6 +1821,18 @@ mod tests {
     use std::sync::Mutex;
 
     static PROCESS_STATE_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn source_refresh_matches_update_scope() {
+        assert!(should_refresh_source(&Commands::Update { name: None }));
+        assert!(should_refresh_source(&Commands::Update {
+            name: Some("from".to_string()),
+        }));
+        assert!(!should_refresh_source(&Commands::Update {
+            name: Some("nixpkgs".to_string()),
+        }));
+        assert!(!should_refresh_source(&Commands::Info {}));
+    }
 
     #[test]
     fn only_interactive_tui_and_shell_commands_load_user_configuration() {

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -567,12 +567,6 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         Config::load_with_source(from_path.as_deref())?
     };
 
-    // Retain the original reference in the final lock. The materialized store
-    // path is only a configuration loading detail.
-    if let Some(source_input) = remote_source_input {
-        config.inputs.insert("from".to_string(), source_input);
-    }
-
     let input_overrides = InputOverrides::from(cli.input_overrides);
     for chunk in input_overrides.override_inputs.chunks_exact(2) {
         let [name, url] = chunk else {
@@ -581,6 +575,11 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
         config
             .override_input_url(name, url)
             .wrap_err_with(|| format!("Failed to override input {name} with URL {url}"))?;
+    }
+    // Retain the original reference in the final lock. The materialized store
+    // path is only a configuration loading detail.
+    if let Some(source_input) = remote_source_input {
+        config.inputs.insert("from".to_string(), source_input);
     }
     config.check_version(crate_version!())?;
 

--- a/devenv/src/main.rs
+++ b/devenv/src/main.rs
@@ -519,10 +519,12 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
 
     // --- Project configuration ---
 
-    // A `path:` source resolves to a live directory whose devenv.yaml graph is
-    // merged into the config by Config::load_with_source, which also appends
-    // the source's module as an absolute `path:` import. Relative refs resolve
-    // against the invocation cwd (persisted bindings are always absolute).
+    let nix_debugger = cli.nix_args.nix_debugger;
+    let nix_options = devenv_core::NixOptions::from(cli.nix_args);
+    let refresh_fetchers = matches!(&command, Commands::Update { .. });
+
+    // Keep `path:` sources live. Relative refs resolve against the invocation
+    // directory, and Config::load_with_source reads their complete YAML graph.
     let from_path = from_source
         .as_deref()
         .and_then(|from| from.strip_prefix("path:"))
@@ -534,8 +536,42 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
             fs::canonicalize(&full_path).unwrap_or(full_path)
         });
 
-    let mut config = Config::load_with_source(from_path.as_deref())?;
-    config.check_version(crate_version!())?;
+    let remote_source_input = if from_path.is_none() {
+        from_source.as_ref().map(|from| devenv_core::config::Input {
+            url: Some(from.clone()),
+            flake: false,
+            follows: None,
+            inputs: BTreeMap::new(),
+            overlays: Vec::new(),
+        })
+    } else {
+        None
+    };
+
+    let mut config = if let Some(source_input) = remote_source_input.as_ref() {
+        let target_config = Config::load()?;
+        let mut preliminary_nix_settings =
+            NixSettings::resolve(nix_options.clone(), &target_config);
+        preliminary_nix_settings.refresh_fetchers = refresh_fetchers;
+        let target_root = env::current_dir()
+            .into_diagnostic()
+            .wrap_err("Failed to resolve the target directory")?;
+        let source_path = devenv_nix_backend::source::materialize_source(
+            &preliminary_nix_settings,
+            &target_root,
+            &target_root.join("devenv.lock"),
+            source_input,
+        )?;
+        Config::load_with_source(Some(&source_path))?
+    } else {
+        Config::load_with_source(from_path.as_deref())?
+    };
+
+    // Retain the original reference in the final lock. The materialized store
+    // path is only a configuration loading detail.
+    if let Some(source_input) = remote_source_input {
+        config.inputs.insert("from".to_string(), source_input);
+    }
 
     let input_overrides = InputOverrides::from(cli.input_overrides);
     for chunk in input_overrides.override_inputs.chunks_exact(2) {
@@ -546,34 +582,12 @@ fn prepare_command(mut cli: Cli, shell_hint: Option<&str>) -> Result<PreparedCom
             .override_input_url(name, url)
             .wrap_err_with(|| format!("Failed to override input {name} with URL {url}"))?;
     }
-
-    // A non-path source (flake ref, via --from or a persisted binding) is
-    // fetched as the `from` input and its devenv.nix imported from the store.
-    // Its devenv.yaml is not merged (that needs a fetch before config load);
-    // `path:` sources get the full merge via Config::load_with_source above.
-    if from_path.is_none()
-        && let Some(from) = &from_source
-    {
-        let from_input = devenv_core::config::Input {
-            url: Some(from.clone()),
-            flake: false,
-            follows: None,
-            inputs: BTreeMap::new(),
-            overlays: Vec::new(),
-        };
-        config.inputs.insert("from".to_string(), from_input);
-        config.imports.push("from".to_string());
-    }
+    config.check_version(crate_version!())?;
 
     // --- Resolved settings ---
 
-    // Read before the conversion consumes `cli.nix_args`.
-    let nix_debugger = cli.nix_args.nix_debugger;
-    let mut nix_settings =
-        NixSettings::resolve(devenv_core::NixOptions::from(cli.nix_args), &config);
-    if matches!(command, Commands::Update { .. }) {
-        nix_settings.refresh_fetchers = true;
-    }
+    let mut nix_settings = NixSettings::resolve(nix_options, &config);
+    nix_settings.refresh_fetchers = refresh_fetchers;
     let mut shell_settings = ShellSettings::resolve_with_shell_hint(
         devenv_core::ShellOptions::from(cli.shell_args),
         &config,

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -222,6 +222,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { label: 'Ad-hoc Environments', slug: 'ad-hoc-developer-environments' },
+            { label: 'Out-of-tree devenvs', slug: 'guides/out-of-tree-devenvs' },
             { label: 'Examples', slug: 'examples' },
             { label: 'Cloud', slug: 'cloud' },
             { label: 'Migrating to 2.0', slug: 'guides/migrating-to-20' },

--- a/docs/src/content/docs/ad-hoc-developer-environments.md
+++ b/docs/src/content/docs/ad-hoc-developer-environments.md
@@ -71,18 +71,6 @@ $ devenv -O packages:pkgs! "ncdu git" shell
 
 This replaces all packages rather than appending to whatever `devenv.nix` already defines.
 
-## Out-of-tree Sources
-
-Use `allow` to bind the current directory to a local or fetched source:
-
-```console
-devenv --from path:../shared-devenv allow
-devenv --from github:myorg/devenv-configs?dir=rust-web allow
-```
-
-Local and fetched sources load the complete `devenv.yaml` import graph and all Nix modules.
-The target directory configuration has higher precedence than the source configuration.
-
 ## Combining with `devenv.nix`
 
 When used with an existing `devenv.nix` file, `--option` values will override the configuration in the file.

--- a/docs/src/content/docs/ad-hoc-developer-environments.md
+++ b/docs/src/content/docs/ad-hoc-developer-environments.md
@@ -71,6 +71,18 @@ $ devenv -O packages:pkgs! "ncdu git" shell
 
 This replaces all packages rather than appending to whatever `devenv.nix` already defines.
 
+## Out-of-tree Sources
+
+Use `allow` to bind the current directory to a local or fetched source:
+
+```console
+devenv --from path:../shared-devenv allow
+devenv --from github:myorg/devenv-configs?dir=rust-web allow
+```
+
+Local and fetched sources load the complete `devenv.yaml` import graph and all Nix modules.
+The target directory configuration has higher precedence than the source configuration.
+
 ## Combining with `devenv.nix`
 
 When used with an existing `devenv.nix` file, `--option` values will override the configuration in the file.

--- a/docs/src/content/docs/blog/2026/03/05/devenv-20-a-fresh-interface-to-nix.md
+++ b/docs/src/content/docs/blog/2026/03/05/devenv-20-a-fresh-interface-to-nix.md
@@ -133,7 +133,7 @@ This builds on the existing [monorepo](/guides/monorepo/) support and extends it
 
 ### Out of tree devenvs
 
-Not every project has a `devenv.nix` checked in, and sometimes you want one configuration to serve multiple repositories. This was the [fourth most upvoted issue](https://github.com/cachix/devenv/issues/67). devenv 2.0 adds [`--from`](/ad-hoc-developer-environments/):
+Not every project has a `devenv.nix` checked in, and sometimes you want one configuration to serve multiple repositories. This was the [fourth most upvoted issue](https://github.com/cachix/devenv/issues/67). devenv 2.0 adds [`--from`](/guides/out-of-tree-devenvs/):
 
 ```sh
 $ devenv shell --from github:myorg/devenv-configs?dir=rust-web

--- a/docs/src/content/docs/blog/2026/07/28/devenv-22-attach-to-running-processes-and-persistent-out-of-tree-environments.md
+++ b/docs/src/content/docs/blog/2026/07/28/devenv-22-attach-to-running-processes-and-persistent-out-of-tree-environments.md
@@ -43,7 +43,7 @@ Closes [devenv#971](https://github.com/cachix/devenv/issues/971), open since Feb
 
 ## Configure an environment once, use it anywhere
 
-[`--from`](/ad-hoc-developer-environments/) lets you use a devenv without checking `devenv.nix` into the project. In 2.1 you had to repeat the flag for every command. In 2.2, `devenv allow` can bind the current directory to that source:
+[`--from`](/guides/out-of-tree-devenvs/) lets you use a devenv without checking `devenv.nix` into the project. In 2.1 you had to repeat the flag for every command. In 2.2, `devenv allow` can bind the current directory to that source:
 
 ```sh
 $ cd my-project

--- a/docs/src/content/docs/guides/out-of-tree-devenvs.md
+++ b/docs/src/content/docs/guides/out-of-tree-devenvs.md
@@ -1,0 +1,105 @@
+---
+title: "Out-of-tree devenvs"
+description: "Use a devenv configuration from another local or remote repository."
+---
+
+<small class="added-in">Added in <code>2.0</code></small>
+
+An out-of-tree devenv lets a project use a configuration that exists outside that project.
+This method lets many repositories share one configuration without copies.
+Your project does not need a local `devenv.nix`.
+
+## Select a source
+
+The `--from` option accepts a local path or a [supported input URI](/inputs/#supported-uri-formats):
+
+```console
+$ devenv --from path:../shared-devenv shell
+$ devenv --from 'github:myorg/devenv-configs?dir=rust-web' shell
+```
+
+The `path:` prefix is required for file system paths.
+devenv resolves a relative path from the directory where you run the command.
+The `dir` query selects a devenv within the fetched repository.
+
+Use `--from` with commands such as `shell`, `test`, `up`, and `build`.
+
+:::caution
+The source can define scripts, processes, and shell hooks.
+Use only a source that you trust.
+:::
+
+## Bind a directory to the source
+
+Use `allow` to save the source for the current directory:
+
+```console
+$ cd my-project
+$ devenv --from 'github:myorg/devenv-configs?dir=rust-web' allow
+$ devenv shell
+```
+
+The binding applies to the current directory and its subdirectories.
+Later commands use the saved source without `--from`.
+An installed [shell hook](/auto-activation/) also starts the environment when you enter the bound directory.
+
+:::tip[Persistent bindings in version 2.2]
+Before version 2.2, each command required the `--from` option.
+:::
+
+## Load the source configuration
+
+An out-of-tree source can contain these files and references:
+
+- `devenv.nix` and `devenv.local.nix`
+- `devenv.yaml` and `devenv.local.yaml`
+- YAML imports and inputs
+- Nix modules from the YAML import graph
+
+:::tip[Complete fetched sources in version 2.3.1]
+Fetched sources now load the complete YAML configuration.
+Earlier versions loaded only `devenv.nix` from a fetched source.
+:::
+
+A local `path:` source stays live.
+devenv reads its changes without another fetch or `allow` command.
+
+A fetched source uses the revision in the target directory's `devenv.lock`.
+Run `devenv update` to fetch a new revision.
+Commit the lock file to give all users the same source revision.
+
+## Add target-specific YAML
+
+The target directory can contain `devenv.yaml` and `devenv.local.yaml` for project-specific settings.
+devenv loads the source YAML first, so the target YAML has higher precedence.
+
+An explicit `--from` option does not load the target's `devenv.nix` or `devenv.local.nix`.
+Without an explicit option, a local `devenv.nix` has priority over a saved binding.
+
+## Save profiles
+
+Pass profiles to `allow` to save them with the binding:
+
+```console
+$ devenv --from github:myorg/devenv-configs \
+    --profile backend \
+    --profile observability \
+    allow
+```
+
+devenv applies these profiles to later commands.
+An explicit `--profile` option has priority over the saved profiles.
+
+## Change or remove the binding
+
+Run `allow` with a different source to replace the current binding:
+
+```console
+$ devenv --from path:../new-shared-devenv allow
+```
+
+Run `revoke` to remove the binding and its trust entry:
+
+```console
+$ devenv revoke
+```

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -86,6 +86,15 @@ if ! out=$(devenv --from "$fetched_source" shell -- sh -c 'printf %s "$FETCHED_F
   fetched_source_failures=$((fetched_source_failures + 1))
 fi
 
+if out=$(devenv --from "$fetched_source" \
+  --override-input from "$fetched_source" info 2>&1); then
+  echo "fetched source accepted a from input override" >&2
+  fetched_source_failures=$((fetched_source_failures + 1))
+elif [[ "$out" != *"Input from does not exist so it can't be overridden."* ]]; then
+  echo "fetched source returned an unexpected from input override error: $out" >&2
+  fetched_source_failures=$((fetched_source_failures + 1))
+fi
+
 fetched_target="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-target.XXXXXX")"
 pushd "$fetched_target" >/dev/null
 devenv --from "$fetched_source" allow

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -55,6 +55,52 @@ for path in "path:$from_test_dir" "path:./from-test"; do
   ! echo "$out" | grep -q "python3" || fail "--from=$path leaked local python3"
 done
 
+step "--from loads YAML imports from a fetched source"
+fetched_source_repo="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-source.XXXXXX")"
+mkdir -p "$fetched_source_repo/configs/source/modules/marker"
+cat > "$fetched_source_repo/configs/source/devenv.nix" <<'EOF'
+{ ... }: { }
+EOF
+cat > "$fetched_source_repo/configs/source/devenv.yaml" <<'EOF'
+imports:
+  - ./modules/marker
+EOF
+cat > "$fetched_source_repo/configs/source/modules/marker/devenv.nix" <<'EOF'
+{ ... }:
+{
+  env.FETCHED_FROM_YAML_IMPORT = "loaded-from-yaml-import";
+}
+EOF
+git -C "$fetched_source_repo" init -q
+git -C "$fetched_source_repo" config user.email "tests@devenv.sh"
+git -C "$fetched_source_repo" config user.name "devenv tests"
+git -C "$fetched_source_repo" config commit.gpgsign false
+git -C "$fetched_source_repo" add .
+git -C "$fetched_source_repo" commit -q -m "Add fetched source fixture"
+fetched_source="git+file://$fetched_source_repo?dir=configs/source"
+
+fetched_source_failures=0
+if ! out=$(devenv --from "$fetched_source" shell -- sh -c 'printf %s "$FETCHED_FROM_YAML_IMPORT"') \
+  || [[ "$out" != *"loaded-from-yaml-import"* ]]; then
+  echo "direct fetched source did not load its YAML import" >&2
+  fetched_source_failures=$((fetched_source_failures + 1))
+fi
+
+fetched_target="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-target.XXXXXX")"
+pushd "$fetched_target" >/dev/null
+devenv --from "$fetched_source" allow
+if ! out=$(devenv shell -- sh -c 'printf %s "$FETCHED_FROM_YAML_IMPORT"') \
+  || [[ "$out" != *"loaded-from-yaml-import"* ]]; then
+  echo "persisted fetched source did not load its YAML import" >&2
+  fetched_source_failures=$((fetched_source_failures + 1))
+fi
+devenv revoke
+popd >/dev/null
+rm -rf "$fetched_target" "$fetched_source_repo"
+
+(( fetched_source_failures == 0 )) \
+  || fail "$fetched_source_failures fetched --from checks failed"
+
 step "--from ignores the local devenv.local.nix"
 mkdir -p test-local-override && pushd test-local-override >/dev/null
 cat > devenv.nix <<'EOF'

--- a/tests/cli/.test.sh
+++ b/tests/cli/.test.sh
@@ -57,6 +57,7 @@ done
 
 step "--from loads YAML imports from a fetched source"
 fetched_source_repo="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-source.XXXXXX")"
+fetched_source_remote="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-remote.XXXXXX")"
 mkdir -p "$fetched_source_repo/configs/source/modules/marker"
 cat > "$fetched_source_repo/configs/source/devenv.nix" <<'EOF'
 { ... }: { }
@@ -77,7 +78,10 @@ git -C "$fetched_source_repo" config user.name "devenv tests"
 git -C "$fetched_source_repo" config commit.gpgsign false
 git -C "$fetched_source_repo" add .
 git -C "$fetched_source_repo" commit -q -m "Add fetched source fixture"
-fetched_source="git+file://$fetched_source_repo?dir=configs/source"
+git -C "$fetched_source_remote" init -q --bare
+git -C "$fetched_source_repo" remote add origin "$fetched_source_remote"
+git -C "$fetched_source_repo" push -q -u origin HEAD
+fetched_source="git+file://$fetched_source_remote?dir=configs/source"
 
 fetched_source_failures=0
 if ! out=$(devenv --from "$fetched_source" shell -- sh -c 'printf %s "$FETCHED_FROM_YAML_IMPORT"') \
@@ -97,15 +101,32 @@ fi
 
 fetched_target="$(mktemp -d "${TMPDIR:-/tmp}/devenv-from-target.XXXXXX")"
 pushd "$fetched_target" >/dev/null
+mkdir fixture
+cat > devenv.yaml <<'EOF'
+inputs:
+  fixture:
+    url: path:./fixture
+    flake: false
+EOF
 devenv --from "$fetched_source" allow
 if ! out=$(devenv shell -- sh -c 'printf %s "$FETCHED_FROM_YAML_IMPORT"') \
   || [[ "$out" != *"loaded-from-yaml-import"* ]]; then
   echo "persisted fetched source did not load its YAML import" >&2
   fetched_source_failures=$((fetched_source_failures + 1))
 fi
+cat >> "$fetched_source_repo/configs/source/devenv.yaml" <<'EOF'
+require_version: ">=999.0"
+EOF
+git -C "$fetched_source_repo" add configs/source/devenv.yaml
+git -C "$fetched_source_repo" commit -q -m "Change fetched source fixture"
+git -C "$fetched_source_repo" push -q
+if ! devenv update fixture; then
+  echo "updating another input refreshed the fetched source" >&2
+  fetched_source_failures=$((fetched_source_failures + 1))
+fi
 devenv revoke
 popd >/dev/null
-rm -rf "$fetched_target" "$fetched_source_repo"
+rm -rf "$fetched_target" "$fetched_source_repo" "$fetched_source_remote"
 
 (( fetched_source_failures == 0 )) \
   || fail "$fetched_source_failures fetched --from checks failed"


### PR DESCRIPTION
## Summary

- Materialize non-path `--from` sources before the final configuration load.
- Load remote `devenv.yaml`, `devenv.local.yaml`, YAML imports, YAML inputs, and Nix modules.
- Keep `path:` sources live, and keep target configuration at higher precedence.
- Use a virtual source-only lock, and retain the original source in the final lock.
- Add resolver unit tests and a network-free `git+file://` integration test.
- Add a dedicated out-of-tree devenvs guide and update related links.

## Use case

I keep the shared Rails configuration in [`rafaelfranca/devenv`](https://github.com/rafaelfranca/devenv/tree/main/rails/rails).

Each Rails checkout runs this command once:

```console
devenv --from 'github:rafaelfranca/devenv?dir=rails/rails' allow
```

Normal `devenv` commands then use the saved binding.
This change removes the local clone and temporary YAML copy from my current helper.

## Related work

[#2940](https://github.com/cachix/devenv/pull/2940) added persistent out-of-tree `--from` bindings.

Commit [`0497317e`](https://github.com/cachix/devenv/commit/0497317e622da8d1152285c69f42e3e2da489c8c) added source YAML support for live `path:` references.

Commit [`0999a140`](https://github.com/cachix/devenv/commit/0999a1409be16ec3333e6d7bd1f1458dc3b35319) improved out-of-tree source resolution and trust checks.

[#3055](https://github.com/cachix/devenv/pull/3055) adds remote YAML composition through input-style imports such as `shared-config/profiles/backend`.

PR #3055 still limits non-path `--from` sources to `devenv.nix`.
This pull request covers that separate entry point.

Both changes need virtual locking and source materialization.
The common resolver parts should be shared if both changes merge.

## Verification

- `cargo test -p devenv-nix-backend`: 56 passed.
- `cargo test -p devenv-core source_`: 4 passed.
- The focused source resolver tests: 4 passed.
- Direct and persisted `git+file://` source checks passed.
- The live `path:` update check passed.
- The public GitHub source and persisted binding checks passed.
- `cargo fmt --check`, `cargo clippy`, and the final debug build passed.
- `astro check`: no errors, warnings, or hints.
- `astro build`: 205 pages built, including `/guides/out-of-tree-devenvs/`.
- The documentation URL validator resolved all 201 legacy URLs.
- Browser checks confirmed the guide layout and HTTP 200 responses for its internal links.

## Known test failure

`proxy::tests::waits_for_previous_proxy_to_release_control_socket` failed twice with `EWOULDBLOCK`.
This pull request does not change proxy code.
