### PR TITLE
feat(nix): build devenv-static outputs in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,15 @@ jobs:
           devenv_path=$(nix build -L --show-trace --print-out-paths --system ${{ inputs.system }} .#devenv)
           echo "path=$devenv_path" >> $GITHUB_OUTPUT
 
+      # Build and cache the relocatable static binaries
+      - name: Build devenv-static-${{ inputs.system }}
+        run: |
+          nix build -L --show-trace --print-out-paths --system ${{ inputs.system }} .#devenv-static
+
+      - name: Build devenv-static-unwrapped-${{ inputs.system }}
+        run: |
+          nix build -L --show-trace --print-out-paths --system ${{ inputs.system }} .#devenv-static-unwrapped
+
   extended-tests:
     needs: [build]
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,16 @@
                   let
                     staticComponents = prev.nixComponents2.overrideScope (
                       _finalScope: prevScope: {
-                        nix-store = prevScope.nix-store.override { withAWS = false; };
+                        nix-store = prevScope.nix-store.override (
+                          {
+                            withAWS = false;
+                          }
+                          # nixpkgs gates this on isStatic alone, but the
+                          # sandbox shell is Linux-only and needs busybox.
+                          // prev.lib.optionalAttrs prev.stdenv.hostPlatform.isDarwin {
+                            embeddedSandboxShell = false;
+                          }
+                        );
                       }
                     );
                   in
@@ -210,11 +219,17 @@
           # config, so libc++ (and thus SIMD) builds cleanly. The simd C++ is
           # compiled SIMDUTF_NO_LIBCXX/-fno-exceptions/-fno-rtti, so the static
           # archive we link references no libc++ symbols at runtime.
-          libghosttyVtStatic = pkgsStatic.libghostty-vt.overrideAttrs (old: {
-            zigBuildFlags = old.zigBuildFlags ++ [
-              "-Dtarget=${pkgsStatic.stdenv.hostPlatform.parsed.cpu.name}-linux-musl"
-            ];
-          });
+          # darwin has no musl-style static libc, so the native build is
+          # already ABI-identical; only musl needs an explicit zig target.
+          libghosttyVtStatic =
+            if pkgsStatic.stdenv.hostPlatform.isDarwin then
+              pkgs.libghostty-vt
+            else
+              pkgsStatic.libghostty-vt.overrideAttrs (old: {
+                zigBuildFlags = old.zigBuildFlags ++ [
+                  "-Dtarget=${pkgsStatic.stdenv.hostPlatform.parsed.cpu.name}-linux-musl"
+                ];
+              });
           workspaceStatic = pkgsStatic.callPackage ./nix/workspace.nix {
             inherit gitRev;
             rustc = rustToolchainStatic;

--- a/nix/crate-config.nix
+++ b/nix/crate-config.nix
@@ -15,6 +15,7 @@
   libunistring,
   llhttp,
   mimalloc,
+  libiconvReal,
   gitRev ? "",
   isRelease ? false,
   stripReleaseBinaries ? false,
@@ -121,11 +122,20 @@ let
     // staticPkgConfig;
 
   # Common overrides for crates needing openssl
-  opensslOverride = attrs: {
-    buildInputs = (attrs.buildInputs or [ ]) ++ [ openssl ];
-    nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
-    OPENSSL_NO_VENDOR = "1";
-  };
+  opensslOverride =
+    attrs:
+    {
+      buildInputs = (attrs.buildInputs or [ ]) ++ [ openssl ];
+      nativeBuildInputs = (attrs.nativeBuildInputs or [ ]) ++ [ pkg-config ];
+      OPENSSL_NO_VENDOR = "1";
+    }
+    # Unset, openssl-sys falls back to probing Homebrew on darwin (the nix
+    # sandbox is off there) and links its dylibs into the static binary.
+    // lib.optionalAttrs (stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isDarwin) {
+      OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+      OPENSSL_INCLUDE_DIR = "${lib.getDev openssl}/include";
+      OPENSSL_STATIC = "1";
+    };
 
   # Override for crates needing dbus (Linux only)
   dbusOverride = attrs: {
@@ -153,6 +163,13 @@ let
     "link-arg=-lmimalloc"
   ];
 
+  # [tier2] The Nix libs need GNU libiconv's renamed _libiconv* symbols, absent
+  # from Apple's. Absolute path: buildRustCrate's -L would win over -liconv.
+  staticIconvLinkOpts = lib.optionals (stdenv.hostPlatform.isStatic && stdenv.hostPlatform.isDarwin) [
+    "-C"
+    "link-arg=${lib.getLib libiconvReal}/lib/libiconv.a"
+  ];
+
   # Shared override for crates linking against nix, openssl, dbus, and bindgen.
   devenvBase =
     attrs:
@@ -178,6 +195,7 @@ let
         ]
         ++ lib.optional stripReleaseBinaries "-C strip=symbols"
         ++ staticAllocLinkOpts
+        ++ staticIconvLinkOpts
         ++ staticBoostLinkOpts;
     }
     // staticPkgConfig;

--- a/nix/workspace.nix
+++ b/nix/workspace.nix
@@ -44,15 +44,27 @@ let
     stripReleaseBinaries = cargoProfile == "release";
   };
 
+  # musl-specific: darwin keeps a dynamic libSystem and ld64 rejects these
+  # flags outright.
+  isMusl = !stdenv.hostPlatform.isDarwin;
+
   # rust+musl defaults to static-PIE, which segfaults on exec (the musl-gcc
   # wrappers don't support static-PIE — rust-lang/rust#95926). Fix: non-PIE
   # codegen via -Crelocation-model=static plus -Clink-arg=-no-pie to force a
   # non-PIE link, so the final musl host binary actually runs. These apply to
   # the host (musl) crate compiles only.
-  staticRustcOpts = [
+
+  # nix's libblake3 and the Rust `blake3` crate both define
+  # blake3_compress_in_place_portable; collides on aarch64 only.
+  staticRustcOpts = lib.optionals isMusl [
     "-Crelocation-model=static"
     "-Clink-arg=-no-pie"
+    "-Clink-arg=-Wl,--allow-multiple-definition"
   ];
+
+  # buildRustCrate hashes rustcTarget, not the stdenv, into an rlib's filename.
+  # darwin shares one across host and build, so the two sets collide in deps.
+  hostAbiTag = lib.optionals stdenv.hostPlatform.isDarwin [ "devenv-static-host" ];
 
   # Build scripts (build.rs) are the real Tier 2 blocker. crate2nix compiles a
   # crate's build.rs *inside the musl host derivation*, but with NO `--target`
@@ -75,7 +87,7 @@ let
   #      exec. Passing `-Wl,-dynamic-linker,<glibc ld.so>` ourselves bypasses
   #      that guard and restores the interpreter, so build.rs runs.
   buildCc = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
-  buildRsRustcOpts = [
+  buildRsRustcOpts = lib.optionals isMusl [
     "-C"
     "linker=${buildCc}"
     "-C"
@@ -86,6 +98,7 @@ let
     crate:
     crate
     // {
+      features = (crate.features or [ ]) ++ hostAbiTag;
       extraRustcOpts = (crate.extraRustcOpts or [ ]) ++ staticRustcOpts;
       extraRustcOptsForBuildRs = (crate.extraRustcOptsForBuildRs or [ ]) ++ buildRsRustcOpts;
     };


### PR DESCRIPTION
The static build only worked on `x86_64-linux`. Caught this bug with [this run](https://github.com/paulbertin/devenv-prebuild/actions/runs/34263405564) on a downstream repo.

Several flags and overrides were applied unconditionally, so `.#devenv-static` and `.#devenv-static-unwrapped` failed to build on `aarch64-linux` and `aarch64-darwin`. This gates them per platform and puts both static outputs in CI.

Verified all arch builds succeed locally.