### PR TITLE
fix(files): order treefmt after devenv:files, copy atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.3.1 (unreleased)
 
+### Bug Fixes
+
+- Fixed `devenv shell` intermittently failing with a treefmt error such as `failed to stat <file>: no such file or directory` when `treefmt.enable = true` and the project has files managed by devenv. The tree-wide formatter now runs after devenv has written those files, and a file with `copyMode = "copy"` is replaced atomically, so tools that walk the project never see it missing.
+
 ## 2.3.0 (2026-09-07)
 
 ### Bug Fixes

--- a/docs/src/content/docs/creating-files.md
+++ b/docs/src/content/docs/creating-files.md
@@ -156,7 +156,7 @@ The `copyMode` attribute accepts:
 
 - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
 - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. This is useful for seeding configuration files from templates that the user can then edit to fit their project.
-- `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. This is useful when a tool must write to the file in place but devenv should remain the source of truth.
+- `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. The file is replaced atomically, by renaming a temporary file in the same directory over it, so tools that walk the project never see it missing. This is useful when a tool must write to the file in place but devenv should remain the source of truth.
 
 :::tip[New in version 2.2]
 :::

--- a/src/modules/files.nix
+++ b/src/modules/files.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, config, ... }:
 
 let
-  inherit (builtins) dirOf mapAttrs;
+  inherit (builtins) baseNameOf dirOf mapAttrs;
   inherit (lib) types optionalAttrs optionalString mkOption attrNames filter length mapAttrsToList concatStringsSep head assertMsg;
   inherit (types) attrsOf submodule;
 
@@ -101,7 +101,7 @@ let
 
         - `symlink` (default): symlink to the read-only file in the Nix store. Edits are not possible; devenv keeps the link pointed at the current contents.
         - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. Useful for seeding configuration from templates the user then edits.
-        - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. Useful when a tool must write to the file in place but devenv should remain the source of truth.
+        - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. The file is replaced atomically, so tools that walk the project never see it missing. Useful when a tool must write to the file in place but devenv should remain the source of truth.
       '';
     };
   };
@@ -127,6 +127,49 @@ let
     fi
   '';
 
+  # Materialize the store contents at `filename` as a writable copy.
+  #
+  # A regular file is staged next to its destination and renamed over it, so the destination
+  # is never missing: tools that walk the project concurrently (a tree-wide formatter, an
+  # editor's file watcher) would otherwise stat a path that has momentarily disappeared.
+  writeCopyScript = filename: fileOption: ''
+    mkdir -p "${dirOf filename}"
+    if [ -d ${fileOption.file} ]; then
+      # A directory cannot be swapped in atomically: `mv` onto an existing directory moves
+      # the copy *inside* it and `mv -T` is GNU-only, so replace it in place.
+      rm -rf "${filename}"
+      cp -RL ${fileOption.file} "${filename}"
+      chmod -R u+w "${filename}"
+    else
+      # `mktemp -d` with a template (the portable form, BSD/macOS included) gives an
+      # unpredictable 0700 directory next to the destination, hence on the same filesystem.
+      # Letting `cp` create the file inside it keeps the store mode, executable bit included.
+      _devenv_staging=$(mktemp -d "${dirOf filename}/.${baseNameOf filename}.XXXXXX")
+      # A directory at the destination would swallow the rename: `mv` moves the staged file
+      # *inside* it. `mv` resolves a symlink to a directory as well, so unlink the link
+      # itself - `rm` on a symlink never touches its target. Only a destination that is
+      # already a symlink to a directory goes briefly missing here, never a managed file.
+      if [ -d "${filename}" ]; then
+        if [ -L "${filename}" ]; then
+          rm -f "${filename}"
+        else
+          rm -rf "${filename}"
+        fi
+      fi
+      # `mv -f` renames: it replaces an existing regular file atomically, and replaces any
+      # remaining symlink itself instead of following it. Both hold for GNU and BSD `mv`.
+      if ! {
+        cp -L ${fileOption.file} "$_devenv_staging/file" &&
+          chmod u+w "$_devenv_staging/file" &&
+          mv -f "$_devenv_staging/file" "${filename}"
+      }; then
+        rm -rf "$_devenv_staging"
+        exit 1
+      fi
+      rmdir "$_devenv_staging"
+    fi
+  '';
+
   # Copy the file into place as a writable file the user can edit.
   # "seed" only creates the file when missing; "copy" overwrites it every time.
   createCopyScript = filename: fileOption: ''
@@ -134,20 +177,21 @@ let
     if [ -L "${filename}" ] && [[ "$(readlink "${filename}")" == /nix/store/* ]]; then
       rm "${filename}"
     fi
-    ${optionalString (fileOption.copyMode == "copy") ''
+    ${if fileOption.copyMode == "copy" then ''
       if [ -e "${filename}" ] || [ -L "${filename}" ]; then
         echo "Overwriting ${filename}"
-        rm -rf "${filename}"
+      else
+        echo "Creating ${filename}"
+      fi
+      ${writeCopyScript filename fileOption}
+    '' else ''
+      if [ -e "${filename}" ]; then
+        echo "Keeping existing ${filename}"
+      else
+        echo "Creating ${filename}"
+        ${writeCopyScript filename fileOption}
       fi
     ''}
-    if [ -e "${filename}" ]; then
-      echo "Keeping existing ${filename}"
-    else
-      echo "Creating ${filename}"
-      mkdir -p "${dirOf filename}"
-      cp -RL ${fileOption.file} "${filename}"
-      chmod -R u+w "${filename}"
-    fi
     echo "${filename}" >> "$DEVENV_FILES_CREATED"
   '';
 

--- a/src/modules/integrations/treefmt.nix
+++ b/src/modules/integrations/treefmt.nix
@@ -71,6 +71,12 @@ in
     treefmt.config.projectRootFile = lib.mkDefault "";
 
     tasks."devenv:treefmt:run" = {
+      # Files materialized by `devenv:files` have to exist before the tree-wide sweep walks
+      # them: without an edge between the two the scheduler runs them concurrently and
+      # treefmt fails to stat a managed file that is being replaced. `devenv:files` is
+      # always declared (files.nix only makes its *contents* conditional on `files`), so the
+      # name always resolves - an unresolved name in `after` aborts the run.
+      after = [ "devenv:files" ];
       before = [ "devenv:enterShell" ];
       exec = "${treefmtWrapper}/bin/treefmt";
     };

--- a/tests/files-treefmt-order/.gitignore
+++ b/tests/files-treefmt-order/.gitignore
@@ -1,0 +1,5 @@
+decoy.yaml
+decoydir
+dirlinked.yaml
+linked.yaml
+managed.yaml

--- a/tests/files-treefmt-order/.patch.sh
+++ b/tests/files-treefmt-order/.patch.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Set up the destinations enterTest (in devenv.nix) asserts on. The first run creates every
+# file; the state left here is what the run inside `devenv test` has to replace.
+devenv shell true
+
+# A user edit: the copy is renamed over an existing regular file.
+echo "user edit" > managed.yaml
+
+# A symlink: the copy replaces the link itself instead of writing through it.
+echo "untouched" > decoy.yaml
+rm linked.yaml
+ln -s decoy.yaml linked.yaml
+
+# A symlink to a directory: `mv` resolves such a link and would drop the copy inside the
+# directory, so the link has to be unlinked before the rename.
+mkdir -p decoydir
+rm dirlinked.yaml
+ln -s decoydir dirlinked.yaml

--- a/tests/files-treefmt-order/devenv.nix
+++ b/tests/files-treefmt-order/devenv.nix
@@ -1,0 +1,99 @@
+{ pkgs, ... }:
+{
+  packages = [ pkgs.jq ];
+
+  treefmt = {
+    enable = true;
+
+    config.programs = {
+      nixfmt.enable = true;
+    };
+  };
+
+  # Copy-mode files are rewritten by `devenv:files` on every shell entry, so the tree-wide
+  # treefmt sweep has to wait for them: without an ordering edge the two run concurrently
+  # and treefmt fails to stat a file that is being replaced.
+  files."managed.yaml" = {
+    text = "managed: content\n";
+    copyMode = "copy";
+  };
+  files."linked.yaml" = {
+    text = "linked: content\n";
+    copyMode = "copy";
+  };
+  files."dirlinked.yaml" = {
+    text = "dirlinked: content\n";
+    copyMode = "copy";
+  };
+
+  enterTest = ''
+    # The formatter walks the whole tree, so it must run after the files are in place.
+    # $DEVENV_TASK_FILE is the task graph devenv runs.
+    jq -e '
+      map(select(.name == "devenv:treefmt:run")) as $treefmt
+      | ($treefmt | length) == 1
+        and ($treefmt[0].after | index("devenv:files")) != null
+    ' "$DEVENV_TASK_FILE" > /dev/null || {
+      echo "devenv:treefmt:run is not ordered after devenv:files"
+      exit 1
+    }
+
+    # .patch.sh left a user edit here: the copy is renamed over the existing file.
+    test ! -L "$DEVENV_ROOT/managed.yaml" || {
+      echo "managed.yaml should not be a symlink"
+      exit 1
+    }
+    test -w "$DEVENV_ROOT/managed.yaml" || {
+      echo "managed.yaml should be writable"
+      exit 1
+    }
+    grep -qx "managed: content" "$DEVENV_ROOT/managed.yaml" || {
+      echo "managed.yaml not overwritten"
+      exit 1
+    }
+
+    # .patch.sh left a symlink here: the copy replaces the link itself, so the file it
+    # pointed at stays untouched.
+    test ! -L "$DEVENV_ROOT/linked.yaml" || {
+      echo "linked.yaml should have replaced the symlink"
+      exit 1
+    }
+    grep -qx "linked: content" "$DEVENV_ROOT/linked.yaml" || {
+      echo "linked.yaml not overwritten"
+      exit 1
+    }
+    grep -qx "untouched" "$DEVENV_ROOT/decoy.yaml" || {
+      echo "the symlink was followed instead of replaced"
+      exit 1
+    }
+
+    # .patch.sh left a symlink to a directory here: `mv` resolves such a link, so the link
+    # has to be unlinked first or the copy lands inside the directory.
+    test ! -L "$DEVENV_ROOT/dirlinked.yaml" || {
+      echo "dirlinked.yaml should have replaced the symlink"
+      exit 1
+    }
+    test -f "$DEVENV_ROOT/dirlinked.yaml" || {
+      echo "dirlinked.yaml should be a regular file"
+      exit 1
+    }
+    grep -qx "dirlinked: content" "$DEVENV_ROOT/dirlinked.yaml" || {
+      echo "dirlinked.yaml not overwritten"
+      exit 1
+    }
+    test -z "$(ls -A "$DEVENV_ROOT/decoydir")" || {
+      echo "the copy was moved into the directory the symlink pointed at"
+      exit 1
+    }
+
+    # Each copy is staged in a temporary directory next to its destination and renamed over
+    # it. Nothing may be left behind.
+    for staging in "$DEVENV_ROOT"/.managed.yaml.* "$DEVENV_ROOT"/.linked.yaml.* \
+      "$DEVENV_ROOT"/.dirlinked.yaml.*; do
+      if [ -e "$staging" ]; then
+        echo "staging path left behind: $staging"
+        exit 1
+      fi
+    done
+  '';
+}

--- a/tests/files-treefmt-order/devenv.yaml
+++ b/tests/files-treefmt-order/devenv.yaml
@@ -1,0 +1,6 @@
+inputs:
+  treefmt-nix:
+    url: github:numtide/treefmt-nix
+    inputs:
+      nixpkgs:
+        follows: nixpkgs


### PR DESCRIPTION
## Problem

Interactive `devenv shell` intermittently fails when `treefmt.enable = true` and the project has
files managed by `files.<name>` with `copyMode = "copy"`:

```text
devenv:treefmt:run failed → Error: failed to finalise formatting: failed to wait for formatters:
failed to stat <project>/<file>: no such file or directory
```

`<file>` is a git-tracked, copy-mode file matched by a treefmt formatter (real case:
`.qr-exclude.yaml` under yamlfmt).

## Cause

- `tasks."devenv:treefmt:run"` (`src/modules/integrations/treefmt.nix`) and
  `tasks."devenv:files"` (`src/modules/files.nix`) both declared only
  `before = [ "devenv:enterShell" ]`, with no edge between them.
- `devenv-tasks` (`devenv-tasks/src/tasks.rs`) only adds a dependency edge for names listed in
  `after`/`before`; two edge-less tasks are spawned concurrently.
- `copyMode = "copy"` materialized a file as `rm -rf` followed by `cp -RL`, so the destination was
  briefly absent while the tree-wide treefmt sweep concurrently walked the project and tried to
  stat it.

## Fix

```text
CHANGELOG.md                            |  4 ++
docs/src/content/docs/creating-files.md |  2 +-
src/modules/files.nix                   | 68 ++++++++++++++++++++++-----
src/modules/integrations/treefmt.nix    |  6 +++
tests/files-treefmt-order/.gitignore    |  5 +++
tests/files-treefmt-order/.patch.sh     | 20 ++++++++++
tests/files-treefmt-order/devenv.nix    | 99 +++++++++++++++++++++++++++++++++++++++
tests/files-treefmt-order/devenv.yaml   |  6 +++
8 files changed, 197 insertions(+), 13 deletions(-)
```

- `src/modules/integrations/treefmt.nix`: add `after = [ "devenv:files" ]` to
  `tasks."devenv:treefmt:run"`. `devenv:files` is always declared (`files.nix` only wraps its
  *contents* in `optionalAttrs`), and an unresolved name in `after` is a hard error
  (`TasksNotFound`), so this is safe regardless of whether `files.*` is used.
- `src/modules/files.nix`: extract a `writeCopyScript` for copy-mode materialization; reword the
  `copyMode` option's own description to mention atomic replacement (regenerates
  `docs/src/data/options.json` via CI, not hand-edited here). A regular file is staged via
  `mktemp -d` beside the destination and `mv -f`'d into place: an existing file is replaced
  atomically, and a destination symlink is replaced rather than followed, including one
  pointing at a directory, which `mv` would otherwise resolve and drop the copy inside (that
  case's destination is briefly absent, never a plain file or an existing managed copy). Source
  directories keep the previous remove-then-copy path (`mv` onto an existing directory moves
  into it; `mv -T` is GNU-only).
- `docs/src/content/docs/creating-files.md`: note the atomic replacement for `copyMode = "copy"`.
- `CHANGELOG.md`: entry under `## 2.3.1 (unreleased)` / `### Bug Fixes`.
- `tests/files-treefmt-order/`: new `devenv-run-tests` case. `devenv.nix` declares three
  `copyMode = "copy"` files and asserts, via `$DEVENV_TASK_FILE`, that `devenv:treefmt:run` has
  exactly one `after` edge to `devenv:files`. `.patch.sh` pre-seeds three destinations: a plain
  file with a user edit (overwrite), a symlink elsewhere (replaced, not followed), and a symlink
  to a decoy directory (replaced; directory stays empty). The test checks no
  `.<name>.XXXXXX` staging directory is left behind for any of them.

## Behaviour changes / compat notes

- Log output: overwriting an existing `copyMode = "copy"` file now logs only `Overwriting <file>`,
  not also `Creating <file>` right after (old code removed the file first, then hit that branch).
- `copyMode = "seed"` over a *dangling* symlink now replaces the link instead of aborting: the old
  `cp -RL` wrote through the symlink and failed with "not writing through dangling symlink".
  `seed` shares `writeCopyScript` with `copy`, so it inherits the fix rather than regressing.
- Not verified on macOS/BSD: `mv -f` replacing a symlink, `mktemp -d TEMPLATE` beside the
  destination. Documented as portable, only exercised on Linux here.

### Notes

- No `trap` around the staging directory: a shell killed between `mktemp -d` and `rmdir` leaves a
  hidden `.<name>.XXXXXX/` dir behind. That matches the current signal-handling bar elsewhere in
  `devenv:files`, not a new gap.
- The new edge re-serializes `devenv:treefmt:run` behind `devenv:files`: a small, unavoidable loss
  of parallelism at shell entry.
- `devenv:gitnr:install` also writes into the project root with no edge to treefmt: same class of
  hazard, out of scope here.

## Testing

- `devenv-run-tests run tests --only files --only files-cleanup --only files-copy
  --only files-treefmt-order --only treefmt` → 5 passed (re-run after the symlink-to-directory
  fix and third test destination were added).
- Negative controls: reverting the `after` edge, and separately removing the symlink-to-directory
  unlink guard, both make `tests/files-treefmt-order` fail as expected.
- Separate 12-scenario old-vs-new harness: source mode (0444/0555) × destination state (missing,
  regular file, symlink-to-file, symlink-to-directory, dangling symlink, real directory): 0
  differences in resulting type, mode, or content.
- Stress: 300 replacements under a concurrent `test -e` poller: 0 "missing" observations with the
  new staged-rename sequence vs. 129 784 with the old `rm -rf` + `cp -RL` sequence.
- `$DEVENV_TASK_FILE` (read by the test via `jq`) is a real variable exported by
  `src/modules/tasks.nix` and read by `devenv-tasks/src/main.rs`, but undocumented elsewhere.
- `prek` (nixfmt, nixpkgs-fmt) passes on the changed files.

## Related

- Fixes: #3172
- #2387 ("treefmt: make treefmt run at enter shell") gave the treefmt task its
  `before = ["devenv:enterShell"]`, making it a scheduling sibling of `devenv:files`. This PR adds
  the missing edge between the two siblings.
- #2948 ("feat(files): add copy mode for editable files") introduced the non-atomic
  `rm -rf` + `cp -RL` sequence this PR replaces.
- `tasks."devenv:git-hooks:install"` already declares `after = [ "devenv:files" ]` for the same
  class of reason.
- #2465 (cross-process task locking) is an adjacent but distinct problem (a lock between separate
  `devenv` invocations, not an ordering edge between two tasks in the same run), and is not touched
  or duplicated here.