### PR TITLE
fix(cachix): deduplicate cachix.pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.3.1 (unreleased)
 
+### Bug Fixes
+
+- Fixed `cachix.pull` containing duplicate caches. The module adds `devenv` (and `cachix.push`) to the list, so a cache also listed in `devenv.nix` was registered twice and Nix warned `Substituter '...' is already present in the substituters list` on every command. The option now deduplicates its value.
+
 ## 2.3.0 (2026-09-07)
 
 ### Bug Fixes

--- a/src/modules/cachix.nix
+++ b/src/modules/cachix.nix
@@ -19,6 +19,7 @@ in
       description = "Which Cachix caches to pull from.";
       default = [ ];
       defaultText = lib.literalExpression ''[ "devenv" ]'';
+      apply = lib.unique;
     };
 
     push = lib.mkOption {

--- a/tests/cachix-pull-unique/.test.sh
+++ b/tests/cachix-pull-unique/.test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -xe
+
+output=$(devenv eval cachix.pull)
+echo "$output" | jq -e '.["cachix.pull"] | length == 2'
+echo "$output" | jq -e '.["cachix.pull"] | sort == ["devenv", "nixpkgs-python"]'

--- a/tests/cachix-pull-unique/devenv.nix
+++ b/tests/cachix-pull-unique/devenv.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  # "devenv" is also added by the cachix module itself, and "nixpkgs-python"
+  # is listed twice on purpose: cachix.pull must come out without duplicates.
+  cachix.pull = [
+    "devenv"
+    "nixpkgs-python"
+    "nixpkgs-python"
+  ];
+}


### PR DESCRIPTION
## Summary

Python and cachix modules already add nixpkgs-python and devenv to the substituters list, so listing them again in devenv.nix creates duplicates that trip the "already present" check. This is annoying because it duplicates warning messages.

`config.cachix.pull` (and `devenv eval cachix.pull`) should carry each cache once, no matter what.

I think this fix makes sense, mainly because the docs only say "some languages and integrations may automatically add caches" so the user can't really know beforehand what's going to be duplicated. Also, this is treated as a "set" in the code.

## Repro

```nix
{ cachix.pull = [ "devenv" "nixpkgs-python" ]; }
```

## Test plan

- [x] New `tests/cachix-pull-unique` asserts the evaluated list has two entries and equals `["devenv","nixpkgs-python"]` after sorting; verified locally with `--override-input devenv path:.?dir=src/modules`.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)