### PR TITLE
docs: explain trusted-users for cachix.pull on multi-user Nix

### DIFF
--- a/docs/src/content/docs/binary-caching.md
+++ b/docs/src/content/docs/binary-caching.md
@@ -81,6 +81,59 @@ It mirrors the official NixOS cache and is designed to provide caching for the [
 Some languages and integrations may automatically add caches when enabled.
 :::
 
+## Multi-user Nix and trusted users
+
+devenv registers the caches in `cachix.pull` with Nix as substituters, together with their public signing keys.
+On a multi-user install (the default on macOS, and `--daemon` installs on Linux) the Nix daemon performs
+the builds, and it only accepts substituters and keys requested by users listed in
+[`trusted-users`](https://nix.dev/manual/nix/latest/command-ref/conf-file#conf-trusted-users), or
+substituters already present in `trusted-substituters`. For anyone else the daemon drops the request and
+builds every path that is missing from `cache.nixos.org` locally, without an error in the shell.
+
+Check whether the daemon trusts you:
+
+```sh
+$ nix store info
+...
+Trusted: 1
+```
+
+If it reports `Trusted: 0`, either make yourself a trusted user or configure the caches in the daemon's own
+configuration.
+
+### Adding yourself to `trusted-users`
+
+Pass it when installing Nix:
+
+```sh
+# nix-installer
+$ curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install --extra-conf "trusted-users = root $USER"
+```
+
+Or on an existing install, append it to the daemon's configuration and restart the daemon.
+On macOS with nix-installer that file is `/etc/nix/nix.custom.conf`; on Linux it is `/etc/nix/nix.conf`:
+
+```sh
+$ echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+$ sudo systemctl restart nix-daemon      # Linux
+$ sudo launchctl kickstart -k system/org.nixos.nix-daemon   # macOS
+```
+
+On NixOS or nix-darwin, set `nix.settings.trusted-users = [ "root" "yourname" ];` instead.
+
+A trusted user can add arbitrary paths to the Nix store, so grant it only to the person who uses the machine.
+
+### Configuring the caches in the daemon
+
+Alternatively, add the caches and their public keys to the daemon's configuration so they apply to every
+user without trusting anyone. The key is shown on the cache's page at `https://app.cachix.org/cache/<name>`:
+
+```
+extra-substituters = https://devenv.cachix.org
+extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+```
+
+Single-user installs (`--no-daemon`) have no daemon and are not affected.
 
 ## Pushing
 


### PR DESCRIPTION
## What happened

Our team's Macs run multi-user Nix from nix-installer, which does not add the developer to `trusted-users`. After a devenv update, `devenv shell` spent about 15 minutes compiling devenv's own `rust_devenv-*` crates and the rustc toolchain, although every one of those store paths is on devenv.cachix.org. 

`nix store info` reported `Trusted: 0` implying the daemon drops substituters and keys requested by users it does not trust.

My understanding is devenv 1.x printed a remediation for exactly this case ("You're not a trusted user of the Nix store. You have the following options..."), so users learnt about `trusted-users` from the tool. 2.x does not detect it, so newcomers may run into trouble like me.

## Who else hits this

Anyone on a multi-user install who has not been made a trusted user: every macOS install with either installer's defaults, and `--daemon` installs on Linux. The symptom is always the same silent one: paths that a cache serves get built locally.

## Change

Adds a "Multi-user Nix and trusted users" section after "Pull":

- how to check (`nix store info` → `Trusted: 1`)
- becoming a trusted user at install time (`--extra-conf`) or afterwards (`nix.conf` / `nix.custom.conf` plus daemon restart, and the NixOS/nix-darwin option), with the security note that a trusted user can add arbitrary store paths
- the daemon-side alternative of `extra-substituters` / `extra-trusted-public-keys`, which works for every user without trusting anyone
- that single-user installs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)