### PR TITLE
fix(cachix): fetch public signing keys for pull caches again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.3.1 (unreleased)
 
+### Bug Fixes
+
+- Fixed devenv no longer fetching the public signing keys of the caches in `cachix.pull`, a regression from the 2.0 rewrite. Only keys already present in `cachix_trusted_keys.json` were passed to Nix, so on a machine that had only ever run 2.x `extra-trusted-public-keys` was empty and Nix could not verify paths from those caches. The keys are fetched from the Cachix API again (using the resolved auth token for private caches) and cached ([#3176](https://github.com/cachix/devenv/issues/3176)).
+
 ## 2.3.0 (2026-09-07)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "reqwest 0.13.4",
  "rmcp",
  "schemars 1.2.1",
  "secrecy",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -8276,6 +8276,11 @@ rec {
             features = [ "rt-tokio" ];
           }
           {
+            name = "reqwest";
+            packageId = "reqwest 0.13.4";
+            features = [ "json" "query" "stream" ];
+          }
+          {
             name = "rmcp";
             packageId = "rmcp";
             features = [ "server" "transport-io" "transport-streamable-http-server" ];

--- a/devenv/Cargo.toml
+++ b/devenv/Cargo.toml
@@ -61,6 +61,7 @@ once_cell.workspace = true
 shell-escape.workspace = true
 rmcp.workspace = true
 axum.workspace = true
+reqwest.workspace = true
 secretspec.workspace = true
 secrecy.workspace = true
 url.workspace = true

--- a/devenv/src/devenv/cachix.rs
+++ b/devenv/src/devenv/cachix.rs
@@ -6,6 +6,8 @@
 //!
 //! - the post-init evaluation of `config.cachix.{enable,pull,push}`
 //!   that produces a [`CachixCacheInfo`]
+//! - fetching the public signing keys of pull caches from the Cachix API
+//!   and caching them in `cachix_trusted_keys.json`
 //! - the application of substituters/keys to the open store
 //! - the optional push daemon ([`OwnedDaemon`]) — the daemon owns its own
 //!   per-batch [`Activity`] internally, lazily started when work appears
@@ -25,15 +27,18 @@ use std::time::Duration;
 
 use devenv_activity::{Activity, ActivityInstrument, ActivityLevel, activity, message, start};
 use devenv_core::BuildOptions;
-use devenv_core::cachix::{CachixCacheInfo, CachixManager};
+use devenv_core::cachix::{CacheMetadata, CachixCacheInfo, CachixManager};
 use devenv_core::evaluator::Evaluator;
 use devenv_core::realized::RealizedPathsObserver;
 use devenv_core::settings::NixSettings;
 use devenv_nix_backend::NixCBackend;
 use devenv_nix_backend::cachix_daemon::{ConnectionParams, DaemonSpawnConfig, OwnedDaemon};
-use miette::{IntoDiagnostic, Result, WrapErr};
+use miette::{IntoDiagnostic, Result, WrapErr, bail};
 use tokio::sync::{Mutex, mpsc};
 use tracing::{debug, info, warn};
+
+const CACHIX_API_URL: &str = "https://cachix.org/api/v1";
+const CACHIX_API_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Runtime cachix integration.
 ///
@@ -89,7 +94,12 @@ impl CachixIntegration {
             let pull: Vec<String> = eval_field(cnix, "config.cachix.pull").await?;
             let push: Option<String> = eval_field(cnix, "config.cachix.push").await?;
 
-            let known_keys = load_known_keys(&cachix_manager.paths.trusted_keys).await;
+            let known_keys = ensure_known_keys(
+                &cachix_manager.paths.trusted_keys,
+                &pull,
+                cachix_manager.resolve_auth_token().as_deref(),
+            )
+            .await;
             let info = CachixCacheInfo {
                 caches: devenv_core::cachix::Cachix {
                     pull,
@@ -252,11 +262,126 @@ async fn eval_field<T: serde::de::DeserializeOwned>(cnix: &NixCBackend, attr: &s
         .wrap_err_with(|| format!("Failed to deserialize {attr}"))
 }
 
+/// The public signing keys of `pull_caches`, keyed by cache name.
+///
+/// Keys already cached in `path` are reused; the rest are fetched from the
+/// Cachix API and the merged map is written back. A cache whose key cannot
+/// be fetched is reported and left out: its substituter still gets
+/// registered, Nix just cannot verify the paths it serves.
+async fn ensure_known_keys(
+    path: &Path,
+    pull_caches: &[String],
+    auth_token: Option<&str>,
+) -> BTreeMap<String, String> {
+    let mut known_keys = load_known_keys(path).await;
+    let missing: Vec<&str> = pull_caches
+        .iter()
+        .filter(|cache| !known_keys.contains_key(*cache))
+        .map(String::as_str)
+        .collect();
+    if missing.is_empty() {
+        return known_keys;
+    }
+
+    let fetched = fetch_public_keys(&missing, auth_token).await;
+    if fetched.is_empty() {
+        return known_keys;
+    }
+    known_keys.extend(fetched);
+    if let Err(e) = persist_known_keys(path, &known_keys).await {
+        warn!(
+            "cachix: failed to save public keys to {}: {e}",
+            path.display()
+        );
+    }
+    known_keys
+}
+
 async fn load_known_keys(path: &Path) -> BTreeMap<String, String> {
     match tokio::fs::read_to_string(path).await {
         Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
         Err(_) => BTreeMap::new(),
     }
+}
+
+async fn persist_known_keys(path: &Path, known_keys: &BTreeMap<String, String>) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.into_diagnostic()?;
+    }
+    let json = serde_json::to_string_pretty(known_keys).into_diagnostic()?;
+    tokio::fs::write(path, json).await.into_diagnostic()?;
+    Ok(())
+}
+
+/// Fetch the public signing keys of `caches` concurrently. Failures are
+/// reported per cache and skipped, so one unreachable cache does not cost
+/// the others their keys.
+async fn fetch_public_keys(caches: &[&str], auth_token: Option<&str>) -> BTreeMap<String, String> {
+    let client = match reqwest::Client::builder()
+        .timeout(CACHIX_API_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            warn!("cachix: failed to create an HTTP client for the Cachix API: {e}");
+            return BTreeMap::new();
+        }
+    };
+
+    let fetches = caches.iter().map(|cache| {
+        let client = &client;
+        async move { (*cache, fetch_public_key(client, cache, auth_token).await) }
+    });
+
+    let mut keys = BTreeMap::new();
+    for (cache, result) in futures::future::join_all(fetches).await {
+        match result {
+            Ok(key) => {
+                debug!("cachix: fetched public signing key for cache '{cache}'");
+                keys.insert(cache.to_string(), key);
+            }
+            Err(e) => {
+                warn!("cachix: {e}");
+                message(ActivityLevel::Warn, format!("Cachix cache '{cache}': {e}"));
+            }
+        }
+    }
+    keys
+}
+
+/// The cache's public signing keys as one space-separated string, the form
+/// `extra-trusted-public-keys` takes.
+async fn fetch_public_key(
+    client: &reqwest::Client,
+    cache: &str,
+    auth_token: Option<&str>,
+) -> Result<String> {
+    let mut request = client.get(format!("{CACHIX_API_URL}/cache/{cache}"));
+    if let Some(token) = auth_token {
+        request = request.bearer_auth(token);
+    }
+    let response = request
+        .send()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to query the Cachix API")?;
+    if response.status().is_client_error() {
+        bail!(
+            "the cache does not exist or requires an auth token; \
+             paths it serves cannot be verified until one is configured"
+        );
+    }
+    let metadata: CacheMetadata = response
+        .error_for_status()
+        .into_diagnostic()?
+        .json()
+        .await
+        .into_diagnostic()
+        .wrap_err("failed to parse the Cachix API response")?;
+    if metadata.public_signing_keys.is_empty() {
+        bail!("the cache has no public signing keys");
+    }
+    Ok(metadata.public_signing_keys.join(" "))
 }
 
 async fn resolve_cachix_binary(cnix: &NixCBackend) -> Result<PathBuf> {

--- a/tests/cachix-public-keys/.test.sh
+++ b/tests/cachix-public-keys/.test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -xe
+
+# Start from a devenv home without cached keys so the fetch has to happen.
+DEVENV_HOME="$(mktemp -d)"
+export DEVENV_HOME
+
+devenv eval cachix.pull | jq -e '.["cachix.pull"] | index("devenv") != null'
+
+jq -e '.devenv | startswith("devenv.cachix.org-1:")' "$DEVENV_HOME/cachix_trusted_keys.json"

--- a/tests/cachix-public-keys/devenv.nix
+++ b/tests/cachix-public-keys/devenv.nix
@@ -1,0 +1,5 @@
+{ ... }:
+{
+  # The cachix module adds "devenv" to cachix.pull on its own; its public
+  # signing key must be fetched from the Cachix API and cached.
+}


### PR DESCRIPTION
## What happened

While tracing why `cachix.pull` had no effect on our multi-user Macs (#3175), we checked what devenv would hand the daemon once the substituters did get through, and found the key list is always empty. `CachixIntegration::init` only reads `known_keys` from `$XDG_DATA_HOME/devenv/cachix_trusted_keys.json`, and nothing in 2.x writes that file: on a machine that has only ever run 2.x, `~/.local/share/devenv/` contains just `gc/`. `CacheMetadata` (`publicSigningKeys`) in `devenv-core` has no consumer and there is no request to the Cachix API anywhere in the repo. Up to v1.11, `devenv/src/nix.rs` fetched `https://cachix.org/api/v1/cache/<name>`, stored the keys in that file and passed them as `--option extra-trusted-public-keys`; the fetch was lost in the 2.0 rewrite. Issue: #3176.

## Who else hits this

Everyone on 2.x, for every `cachix.pull` cache whose key is not already in `nix.conf`. Nix refuses paths signed by an unknown key (`ignoring substitute for '...' as it's not signed by any of the keys in 'trusted-public-keys'`) and builds them instead. On multi-user installs this is currently masked by #3175, and becomes the blocker as soon as that is fixed. On single-user installs, whose in-process Worker does use the runtime substituter list, the missing key is already the reason paths from a `cachix.pull` cache get built today.

## Change

Restore the fetch in `CachixIntegration::init`, mirroring 1.x: for each pull cache missing from the cached map, GET `https://cachix.org/api/v1/cache/<name>` with the resolved auth token as bearer (so private caches work), merge and persist to `cachix_trusted_keys.json`, then build the store settings as before. A cache that does not exist or needs a token is reported as a warning in the "Configuring cachix" activity and skipped, so one bad cache does not cost the others their keys. Fetches run concurrently with a 15s timeout.

Adds `reqwest` to the `devenv` crate (already a workspace dependency); `Cargo.lock` and `Cargo.nix` regenerated.

## Test plan

- [x] `cargo fmt --check`, `cargo check -p devenv`, `cargo build -p devenv` in the dev shell (aarch64-darwin). `cargo clippy` reports only a pre-existing lint in `devenv-core/src/cachix.rs`, untouched here.
- [x] End to end with the built binary and an empty `DEVENV_HOME`: `devenv eval cachix.pull` in a project with the default pull list produced `cachix_trusted_keys.json` containing `"devenv": "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="`.
- [x] New `tests/cachix-public-keys` asserts the same from a fresh `DEVENV_HOME`.
- [ ] CI

Fixes #3176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)