### PR TITLE
fix(files): simplify atomic copy and seed publication with coreutils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed treefmt intermittently failing to stat managed files during shell entry by running it after `devenv:files`.
+- Regular files with `copyMode = "copy"` are now replaced atomically, so concurrent readers do not see missing or partial contents. Regular seed files are published without overwriting a concurrent creator's file.
 
 ## 2.3.1 (2026-09-11)
 

--- a/docs/src/content/docs/creating-files.md
+++ b/docs/src/content/docs/creating-files.md
@@ -158,6 +158,8 @@ The `copyMode` attribute accepts:
 - `seed`: copy the file into place once, only if it does not already exist, and make it writable. Existing files are left untouched, so your edits are preserved. This is useful for seeding configuration files from templates that the user can then edit to fit their project.
 - `copy`: copy the file into place as a writable file, overwriting it with fresh contents on every shell entry. This is useful when a tool must write to the file in place but devenv should remain the source of truth.
 
+Regular files are copied to a temporary sibling and made writable before publication. In `copy` mode, replacing a file or symlink is atomic, so concurrent readers see complete contents without a gap where the path is missing. In `seed` mode, publication leaves a file created concurrently untouched. Directory copies and conversion of an existing directory to a file are not atomic.
+
 :::tip[New in version 2.2]
 :::
 

--- a/src/modules/files.nix
+++ b/src/modules/files.nix
@@ -130,25 +130,48 @@ let
   # Copy the file into place as a writable file the user can edit.
   # "seed" only creates the file when missing; "copy" overwrites it every time.
   createCopyScript = filename: fileOption: ''
-    # Drop a previous devenv-managed symlink into the store so we can seed a writable copy
-    if [ -L "${filename}" ] && [[ "$(readlink "${filename}")" == /nix/store/* ]]; then
-      rm "${filename}"
-    fi
-    ${optionalString (fileOption.copyMode == "copy") ''
-      if [ -e "${filename}" ] || [ -L "${filename}" ]; then
-        echo "Overwriting ${filename}"
-        rm -rf "${filename}"
+    (
+      export PATH="${pkgs.coreutils}/bin:$PATH"
+      destination=${lib.escapeShellArg filename}
+      source=${lib.escapeShellArg (toString fileOption.file)}
+      ${optionalString (fileOption.copyMode == "seed") ''
+        # Convert an old store symlink to an editable seed.
+        if [ -L "$destination" ] && [[ "$(readlink "$destination")" == /nix/store/* ]]; then
+          rm -- "$destination"
+        fi
+        if [ -e "$destination" ] || [ -L "$destination" ]; then
+          echo "Keeping existing $destination"
+          exit 0
+        fi
+      ''}
+      echo "Writing $destination"
+      mkdir -p -- ${lib.escapeShellArg (dirOf filename)}
+      if [ -d "$source" ]; then
+        # Directory copies retain the existing recursive replacement behavior.
+        ${optionalString (fileOption.copyMode == "copy") ''rm -rf -- "$destination"''}
+        cp -RL -- "$source" "$destination"
+        chmod -R u+w -- "$destination"
+      else
+        # Stage beside the destination so publishing stays on one filesystem.
+        staging=$(mktemp -d -- ${lib.escapeShellArg "${dirOf filename}/.devenv-file.XXXXXX"})
+        trap 'rm -rf -- "$staging"' EXIT
+        cp -L -- "$source" "$staging/file"
+        chmod u+w -- "$staging/file"
+        ${if fileOption.copyMode == "copy" then ''
+          # A real directory must be removed; mv -T replaces symlinks themselves.
+          if [ -d "$destination" ] && [ ! -L "$destination" ]; then
+            rm -rf -- "$destination"
+          fi
+          mv -fT -- "$staging/file" "$destination"
+        '' else ''
+          # Hard-link publication leaves a concurrent creator's file untouched.
+          if ! ln -T -- "$staging/file" "$destination"; then
+            [ -e "$destination" ] || [ -L "$destination" ] || exit 1
+          fi
+        ''}
       fi
-    ''}
-    if [ -e "${filename}" ]; then
-      echo "Keeping existing ${filename}"
-    else
-      echo "Creating ${filename}"
-      mkdir -p "${dirOf filename}"
-      cp -RL ${fileOption.file} "${filename}"
-      chmod -R u+w "${filename}"
-    fi
-    echo "${filename}" >> "$DEVENV_FILES_CREATED"
+    )
+    echo ${lib.escapeShellArg filename} >> "$DEVENV_FILES_CREATED"
   '';
 
   createFileScript = filename: fileOption:

--- a/tests/files-copy-atomic/devenv.nix
+++ b/tests/files-copy-atomic/devenv.nix
@@ -1,0 +1,52 @@
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  source = pkgs.writeText "copy-source" "new content\n";
+  executable = pkgs.runCommand "executable-source" { } ''
+    cp ${source} $out
+    chmod 555 $out
+  '';
+  directory = pkgs.runCommand "directory-source" { } ''
+    mkdir $out
+    cp ${source} $out/child
+  '';
+  writer =
+    mode: file:
+    let
+      module = import "${inputs.devenv}/files.nix" {
+        inherit pkgs lib;
+        config = {
+          devenv.root = ".";
+          devenv.state = ".";
+          files.destination = {
+            inherit file;
+            copyMode = mode;
+          };
+        };
+      };
+    in
+    pkgs.writeShellScript "files-${mode}" (
+      ''
+        set -e
+      ''
+      + module.config.tasks."devenv:files".exec
+    );
+in
+{
+  packages = [ pkgs.python3 ];
+  env.FILE_COPY_WRITERS = builtins.toJSON {
+    copy = writer "copy" source;
+    seed = writer "seed" source;
+    executable = writer "copy" executable;
+    directory = writer "copy" directory;
+    seedDirectory = writer "seed" directory;
+  };
+  env.FILE_COPY_SOURCE = source;
+  enterTest = ''
+    python ${./test.py}
+  '';
+}

--- a/tests/files-copy-atomic/test.py
+++ b/tests/files-copy-atomic/test.py
@@ -1,0 +1,162 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import unittest
+
+
+WRITERS = json.loads(os.environ["FILE_COPY_WRITERS"])
+CONTENT = "new content\n"
+
+
+class CopyTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.destination = self.root / "destination"
+
+    def run_writer(self, kind="copy", **kwargs):
+        return subprocess.run(
+            [WRITERS[kind]], cwd=self.root, capture_output=True, timeout=10,
+            **kwargs,
+        )
+
+    def assert_clean(self):
+        self.assertEqual(list(self.root.glob(".devenv-file.*")), [])
+
+    def pause_writer(self, kind, name):
+        ready = self.root / f"{name}.ready"
+        release = self.root / f"{name}.release"
+        env = dict(os.environ, COPY_READY=str(ready), COPY_RELEASE=str(release))
+        # Bash functions let the test pause the real copy before publication,
+        # without depending on copy size or racing the scheduler.
+        env["BASH_FUNC_cp%%"] = '''() {
+            command cp "$@" || return
+            touch "$COPY_READY"
+            while [ ! -e "$COPY_RELEASE" ]; do sleep 0.01; done
+        }'''
+        process = subprocess.Popen(
+            [WRITERS[kind]], cwd=self.root, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+
+        def cleanup():
+            release.touch()
+            try:
+                process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.communicate()
+
+        self.addCleanup(cleanup)
+        deadline = time.monotonic() + 10
+        while not ready.exists():
+            self.assertIsNone(process.poll(), "writer exited before its copy")
+            self.assertLess(time.monotonic(), deadline, "copy did not reach barrier")
+            time.sleep(0.01)
+        return process, release
+
+    def finish_writer(self, process, release):
+        release.touch()
+        _, stderr = process.communicate(timeout=10)
+        self.assertEqual(process.returncode, 0, stderr.decode())
+
+    def test_copy_publishes_complete_file(self):
+        self.destination.write_text("old content\n")
+        process, release = self.pause_writer("copy", "copy")
+        self.assertEqual(self.destination.read_text(), "old content\n")
+        self.finish_writer(process, release)
+        self.assertEqual(self.destination.read_text(), CONTENT)
+        self.assertTrue(self.destination.stat().st_mode & 0o200)
+        self.assert_clean()
+
+    def test_concurrent_seed_preserves_winners_edits(self):
+        first, release_first = self.pause_writer("seed", "first")
+        second, release_second = self.pause_writer("seed", "second")
+        self.assertFalse(self.destination.exists())
+        self.finish_writer(first, release_first)
+        self.assertEqual(self.destination.read_text(), CONTENT)
+        self.destination.write_text("user edit\n")
+        self.finish_writer(second, release_second)
+        self.assertEqual(self.destination.read_text(), "user edit\n")
+        self.assert_clean()
+
+    def test_failed_copy_preserves_destination(self):
+        self.destination.write_text("old content\n")
+        env = dict(os.environ)
+        env["BASH_FUNC_cp%%"] = '() { return 1; }'
+        result = self.run_writer(env=env)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.destination.read_text(), "old content\n")
+        self.assertFalse((self.root / "files.json").exists())
+        self.assert_clean()
+
+    def test_copy_replaces_symlinks_without_touching_targets(self):
+        for target_kind in ("file", "directory", "missing", "store"):
+            with self.subTest(target=target_kind):
+                target = self.root / target_kind
+                if target_kind == "file":
+                    target.write_text("untouched\n")
+                elif target_kind == "directory":
+                    target.mkdir()
+                elif target_kind == "store":
+                    target = Path(os.environ["FILE_COPY_SOURCE"])
+                self.destination.symlink_to(target)
+                result = self.run_writer()
+                self.assertEqual(result.returncode, 0, result.stderr.decode())
+                self.assertFalse(self.destination.is_symlink())
+                self.assertEqual(self.destination.read_text(), CONTENT)
+                if target_kind == "file":
+                    self.assertEqual(target.read_text(), "untouched\n")
+                elif target_kind == "directory":
+                    self.assertEqual(list(target.iterdir()), [])
+                elif target_kind == "missing":
+                    self.assertFalse(target.exists())
+                self.destination.unlink()
+        self.assert_clean()
+
+    def test_seed_keeps_existing_file_and_dangling_symlink(self):
+        self.destination.write_text("user edit\n")
+        self.assertEqual(self.run_writer("seed").returncode, 0)
+        self.assertEqual(self.destination.read_text(), "user edit\n")
+        self.destination.unlink()
+        self.destination.symlink_to("missing")
+        self.assertEqual(self.run_writer("seed").returncode, 0)
+        self.assertEqual(os.readlink(self.destination), "missing")
+        self.assertFalse((self.root / "missing").exists())
+
+    def test_seed_converts_store_symlink(self):
+        self.destination.symlink_to(os.environ["FILE_COPY_SOURCE"])
+        self.assertEqual(self.run_writer("seed").returncode, 0)
+        self.assertFalse(self.destination.is_symlink())
+        self.assertEqual(self.destination.read_text(), CONTENT)
+        self.assertTrue(self.destination.stat().st_mode & 0o200)
+
+    def test_executable_mode_is_preserved(self):
+        self.assertEqual(self.run_writer("executable").returncode, 0)
+        self.assertEqual(self.destination.stat().st_mode & 0o700, 0o700)
+
+    def test_directory_replacement(self):
+        self.destination.mkdir()
+        (self.destination / "old").touch()
+        self.assertEqual(self.run_writer("directory").returncode, 0)
+        self.assertEqual([p.name for p in self.destination.iterdir()], ["child"])
+        self.assertEqual((self.destination / "child").read_text(), CONTENT)
+        self.assertTrue((self.destination / "child").stat().st_mode & 0o200)
+        self.assertEqual(self.run_writer().returncode, 0)
+        self.assertEqual(self.destination.read_text(), CONTENT)
+        self.assert_clean()
+
+    def test_directory_seed_keeps_edits(self):
+        self.assertEqual(self.run_writer("seedDirectory").returncode, 0)
+        (self.destination / "child").write_text("user edit\n")
+        self.assertEqual(self.run_writer("seedDirectory").returncode, 0)
+        self.assertEqual((self.destination / "child").read_text(), "user edit\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Regular copy-mode files are currently removed before copying, so concurrent readers can observe a missing path or partial contents. Stage the copy beside its destination, make it writable, then publish it with Nix-provided GNU coreutils: `mv -fT` for replacement and `ln -T` for seed creation. Concurrent seed publication preserves the winner's file and subsequent edits.

Using GNU `-T` removes the platform-specific symlink handling from #3173. A subshell-local EXIT trap cleans staging on success and failure. Existing dangling seed symlinks are kept untouched. Directory replacement and conversion of old store symlinks to seeds retain their existing non-atomic behavior; this does not introduce cross-process task locking.

The treefmt ordering fix from #3173 landed separately on main in 6e323832.

Validation: the existing `files-copy` integration test and the new `files-copy-atomic` fixture pass on Linux. The latter runs nine tests covering publication barriers, competing seed writers, failed copies, symlink targets, permissions, and directories; it fails against the previous implementation. Nix formatting hooks and `git diff --check` pass. macOS has not been tested.
